### PR TITLE
Release alert manager mutex before notifying plugins

### DIFF
--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -73,13 +73,6 @@ namespace libtorrent
 
 	void alert_manager::maybe_notify(alert* a, mutex::scoped_lock& lock)
 	{
-#ifndef TORRENT_DISABLE_EXTENSIONS
-		for (ses_extension_list_t::iterator i = m_ses_extensions.begin()
-			, end(m_ses_extensions.end()); i != end; ++i)
-		{
-			(*i)->on_alert(a);
-		}
-#endif
 		if (a->type() == save_resume_data_failed_alert::alert_type
 			|| a->type() == save_resume_data_alert::alert_type)
 			++m_num_queued_resume;
@@ -98,6 +91,18 @@ namespace libtorrent
 			// > 0 notify them
 			m_condition.notify_all();
 		}
+		else
+		{
+			lock.unlock();
+		}
+
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		for (ses_extension_list_t::iterator i = m_ses_extensions.begin()
+			, end(m_ses_extensions.end()); i != end; ++i)
+		{
+			(*i)->on_alert(a);
+		}
+#endif
 	}
 
 #ifndef TORRENT_NO_DEPRECATE


### PR DESCRIPTION
A plugin might respond to an alert by doing something which itself generates
an alert. This has become increasingly likely with the use of alerts for
logging. This would cause a deadlock due to trying to recursively acquire the
alert manager mutex.