### PR TITLE
Extend i2p handshake timeout and fail to find i2p peers

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -1446,7 +1446,7 @@ int main(int argc, char* argv[])
 			case 'i':
 				{
 					settings.set_str(settings_pack::i2p_hostname, arg);
-					settings.set_int(settings_pack::i2p_port, 7650);
+					settings.set_int(settings_pack::i2p_port, 7656);
 					settings.set_int(settings_pack::proxy_type, settings_pack::i2p_proxy);
 					break;
 				}

--- a/include/libtorrent/peer_list.hpp
+++ b/include/libtorrent/peer_list.hpp
@@ -183,6 +183,10 @@ namespace libtorrent
 
 		std::pair<iterator, iterator> find_peers(address const& a)
 		{
+#if TORRENT_USE_I2P
+			if (a == address())
+				return std::pair<iterator, iterator>(m_peers.end(), m_peers.end());
+#endif
 			return std::equal_range(
 				m_peers.begin(), m_peers.end(), a, peer_address_compare());
 		}

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4706,10 +4706,14 @@ namespace libtorrent
 		}
 
 		// do not stall waiting for a handshake
+		int timeout = m_settings.get_int (settings_pack::handshake_timeout);
+#if TORRENT_USE_I2P
+		timeout *= is_i2p(*m_socket) ? 4 : 1;
+#endif
 		if (may_timeout
 			&& !m_connecting
 			&& in_handshake()
-			&& d > seconds(m_settings.get_int(settings_pack::handshake_timeout)))
+			&& d > seconds(timeout))
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, "NO_HANDSHAKE", "waited %d seconds"

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3042,8 +3042,11 @@ retry:
 			if (!p->associated_torrent().expired()) continue;
 
 			// TODO: have a separate list for these connections, instead of having to loop through all of them
-			if (m_last_tick - p->connected_time()
-				> seconds(m_settings.get_int(settings_pack::handshake_timeout)))
+			int timeout = m_settings.get_int(settings_pack::handshake_timeout);
+#if TORRENT_USE_I2P
+			timeout *= is_i2p(*p->get_socket()) ? 4 : 1;
+#endif
+			if (m_last_tick - p->connected_time () > seconds(timeout))
 				p->disconnect(errors::timed_out, op_bittorrent);
 		}
 


### PR DESCRIPTION
Extending handshake timeout subjectively judging by wireshark helps. I didn't measure %% drop of reset connections though.
Another fix isn't perfect, but it works. It would be nice if we could extend *destination* as boost address.