### PR TITLE
Removed kademlia/logging source code reference from CMakeLists.txt and removed compiler warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ set(kademlia_sources
 	node_id
 	routing_table
 	traversal_algorithm
-	logging
 	item
 	get_peers
 	get_item

--- a/include/libtorrent/storage_defs.hpp
+++ b/include/libtorrent/storage_defs.hpp
@@ -58,8 +58,9 @@ namespace libtorrent
 		storage_mode_sparse,
 
 		// internal
-		internal_storage_mode_compact_deprecated,
+		internal_storage_mode_compact_deprecated
 #ifndef TORRENT_NO_DEPRECATE
+		, // comma here to avoid compiler warning
 		storage_mode_compact = internal_storage_mode_compact_deprecated
 #endif
 	};


### PR DESCRIPTION
This minor change allow the import libtorrent inside CLion IDE (a lot more easier to work).