### PR TITLE
Refactor to expose a more convenient get_peers function as part of the DHT api.

### DIFF
--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -238,6 +238,10 @@ public:
 #endif
 
 	enum flags_t { flag_seed = 1, flag_implied_port = 2 };
+	void get_peers(sha1_hash const& info_hash
+		, boost::function<void(std::vector<tcp::endpoint> const&)> dcallback
+		, boost::function<void(std::vector<std::pair<node_entry, std::string> > const&)> ncallback
+		, bool noseeds);
 	void announce(sha1_hash const& info_hash, int listen_port, int flags
 		, boost::function<void(std::vector<tcp::endpoint> const&)> f);
 


### PR DESCRIPTION
Now announce (a particular case of get_peers DHT operation) uses the function get_peers and semantically is a bit more clear.

The main goal of this PR is to pave the path to two more functions at the session_impl level (dht_announce and dht_get_peers).