### PR TITLE
Added dht_get_peers and dht_announce at session_impl level.

### DIFF
--- a/include/libtorrent/alert.hpp
+++ b/include/libtorrent/alert.hpp
@@ -192,6 +192,9 @@ namespace libtorrent {
 			// enables dht_log_alert, debug logging for the DHT
 			dht_log_notification = 0x20000,
 
+			// enable events from pure dht operations not related to torrents
+			dht_operation_notification = 0x40000,
+
 			// The full bitmask, representing all available categories.
 			//
 			// since the enum is signed, make sure this isn't

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2356,12 +2356,27 @@ namespace libtorrent
 		int m_size;
 	};
 
+	struct TORRENT_EXPORT dht_get_peers_reply_alert: alert {
+
+		dht_get_peers_reply_alert(aux::stack_allocator& alloc
+			, sha1_hash const& ih
+			, std::vector<tcp::endpoint> const& v);
+
+		const static int static_category = alert::dht_notification;
+		TORRENT_DEFINE_ALERT(dht_get_peers_reply_alert, 87)
+
+		virtual std::string message() const;
+
+		sha1_hash info_hash;
+		std::vector<tcp::endpoint> peers;
+	};
+
 #undef TORRENT_DEFINE_ALERT_IMPL
 #undef TORRENT_DEFINE_ALERT
 #undef TORRENT_DEFINE_ALERT_PRIO
 #undef TORRENT_CLONE
 
-	enum { num_alert_types = 87 };
+	enum { num_alert_types = 88 };
 }
 
 

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2370,12 +2370,12 @@ namespace libtorrent
 		sha1_hash info_hash;
 
 		int num_peers() const;
-		tcp::endpoint get_peer(int index) const;
+		void peers(std::vector<tcp::endpoint>& peers) const;
 
 	private:
 		aux::stack_allocator& m_alloc;
 		int m_num_peers;
-		int m_peers_idx; // coded like a pair of (index to actual endpoint bytes, size of endpoint)
+		int m_peers_idx;
 	};
 
 #undef TORRENT_DEFINE_ALERT_IMPL

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2362,7 +2362,7 @@ namespace libtorrent
 			, sha1_hash const& ih
 			, std::vector<tcp::endpoint> const& v);
 
-		const static int static_category = alert::dht_notification;
+		const static int static_category = alert::dht_operation_notification;
 		TORRENT_DEFINE_ALERT(dht_get_peers_reply_alert, 87)
 
 		virtual std::string message() const;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2362,13 +2362,20 @@ namespace libtorrent
 			, sha1_hash const& ih
 			, std::vector<tcp::endpoint> const& v);
 
-		const static int static_category = alert::dht_operation_notification;
+		static const int static_category = alert::dht_operation_notification;
 		TORRENT_DEFINE_ALERT(dht_get_peers_reply_alert, 87)
 
 		virtual std::string message() const;
 
 		sha1_hash info_hash;
-		std::vector<tcp::endpoint> peers;
+
+		int num_peers() const;
+		tcp::endpoint get_peer(int index) const;
+
+	private:
+		aux::stack_allocator& m_alloc;
+		int m_num_peers;
+		int m_peers_idx; // coded like a pair of (index to actual endpoint bytes, size of endpoint)
 	};
 
 #undef TORRENT_DEFINE_ALERT_IMPL

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -311,8 +311,11 @@ namespace libtorrent
 
 			void dht_put_mutable_item(boost::array<char, 32> key
 				, boost::function<void(entry&, boost::array<char,64>&
-					, boost::uint64_t&, std::string const&)> cb
+				, boost::uint64_t&, std::string const&)> cb
 				, std::string salt = std::string());
+
+			void dht_get_peers(sha1_hash const& info_hash);
+			void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
 #ifndef TORRENT_NO_DEPRECATE
 			entry dht_state() const;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -86,6 +86,8 @@ namespace libtorrent { namespace dht
 		entry state() const;
 
 		enum flags_t { flag_seed = 1, flag_implied_port = 2 };
+		void get_peers(sha1_hash const& ih
+			, boost::function<void(std::vector<tcp::endpoint> const&)> f);
 		void announce(sha1_hash const& ih, int listen_port, int flags
 			, boost::function<void(std::vector<tcp::endpoint> const&)> f);
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1777,5 +1777,20 @@ namespace libtorrent {
 		return buf;
 	}
 
+	dht_get_peers_reply_alert::dht_get_peers_reply_alert(aux::stack_allocator&
+		, sha1_hash const& ih
+		, std::vector<tcp::endpoint> const& v)
+		: info_hash(ih), peers(v)
+	{}
+
+	std::string dht_get_peers_reply_alert::message() const
+	{
+		char ih_hex[41];
+		to_hex((const char*)&info_hash[0], 20, ih_hex);
+		char msg[200];
+		snprintf(msg, sizeof(msg), "incoming dht get_peers reply: %s, peers %ld", ih_hex, peers.size());
+		return msg;
+	}
+
 } // namespace libtorrent
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1789,8 +1789,8 @@ namespace libtorrent {
 			tcp::endpoint endp = peers[i];
 			int size = endp.size();
 			int idx = alloc.copy_buffer((char*)endp.data(), size);
-			memcpy(alloc.ptr(sizeof(int) * (2 * i))    , (void*)&idx , sizeof(int));
-			memcpy(alloc.ptr(sizeof(int) * (2 * i + 1)), (void*)&size, sizeof(int));
+			memcpy(alloc.ptr(m_peers_idx + sizeof(int) * (2 * i))    , (void*)&idx , sizeof(int));
+			memcpy(alloc.ptr(m_peers_idx + sizeof(int) * (2 * i + 1)), (void*)&size, sizeof(int));
 		}
 	}
 
@@ -1811,8 +1811,8 @@ namespace libtorrent {
 	tcp::endpoint dht_get_peers_reply_alert::get_peer(int index) const
 	{
 		int idx, size;
-		memcpy((void*)&idx , m_alloc.ptr(sizeof(int) * (2 * index))    , sizeof(int));
-		memcpy((void*)&size, m_alloc.ptr(sizeof(int) * (2 * index + 1)), sizeof(int));
+		memcpy((void*)&idx , m_alloc.ptr(m_peers_idx + sizeof(int) * (2 * index))    , sizeof(int));
+		memcpy((void*)&size, m_alloc.ptr(m_peers_idx + sizeof(int) * (2 * index + 1)), sizeof(int));
 
 		tcp::endpoint endp;
 

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -222,6 +222,12 @@ namespace libtorrent { namespace dht
 #endif
 	}
 
+	void dht_tracker::get_peers(sha1_hash const& ih
+		, boost::function<void(std::vector<tcp::endpoint> const&)> f)
+	{
+		m_dht.get_peers(ih, f, NULL, false);
+	}
+
 	void dht_tracker::announce(sha1_hash const& ih, int listen_port, int flags
 		, boost::function<void(std::vector<tcp::endpoint> const&)> f)
 	{

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5565,16 +5565,6 @@ retry:
 	void session_impl::dht_announce(sha1_hash const& info_hash, int port, int flags)
 	{
 		if (!m_dht) return;
-
-		port = port <= 0 ? listen_port() : port;
-
-		// if incoming uTP connections are allowed, set the implied_port
-		// argument in the announce, this will make the DHT node use
-		// our source port in the packet as our listen port, which is
-		// likely more accurate when behind a NAT
-		if (settings().get_bool(settings_pack::enable_incoming_utp))
-			flags |= dht::dht_tracker::flag_implied_port;
-
 		m_dht->announce(info_hash, port, flags, boost::bind(&on_dht_get_peers, boost::ref(m_alerts), info_hash, _1));
 	}
 


### PR DESCRIPTION
The dht_tracker class seems to me like a still a low level DHT interface and the set of DHT functions in session_impl is exactly the set of functions that could be refactored in a kind of dht_interface struct, allowing the future separation of the DHT library.

Now, there is a little of code repetition inside torrent.cpp related to the announce, but I'm not sure if you want torrent call session_impl for this, triggering the dht_get_peers_reply_alert alert.

dht_announce trigger a dht_get_peers_reply_alert because get_peers is part of the announce operation, and this information is already there. dht_announce is not intended to be called with high frequency.