### PR TITLE
Bypass sync IPC path when called in the network thread

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -579,6 +579,8 @@ namespace libtorrent
 			mutable libtorrent::mutex mut;
 			mutable libtorrent::condition_variable cond;
 
+			bool in_thread() const { return m_thread_id == thread_id::self(); }
+
 			// cork a peer and schedule a delayed uncork
 			// does nothing if the peer is already corked
 			void cork_burst(peer_connection* p);
@@ -709,6 +711,9 @@ namespace libtorrent
 			// it means we need to request new alerts from the main thread.
 			mutable int m_alert_pointer_pos;
 #endif
+
+			// the id of the thread the session is running in
+			thread_id m_thread_id;
 
 			// handles disk io requests asynchronously
 			// peers have pointers into the disk buffer

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -565,6 +565,8 @@ namespace aux {
 
 	void session_impl::init(boost::shared_ptr<settings_pack> pack)
 	{
+		m_thread_id = thread_id::self();
+
 		// this is a debug facility
 		// see single_threaded in debug.hpp
 		thread_started();


### PR DESCRIPTION
This is step one in removing private symbol usage in the reputation plugin. For torrents I could use the public torrent_handle interface except that the synchronous IPC can deadlock if invoked from the network thread. This patch detects when we're already in the network thread and bypasses the IPC entirely.

TODO: Replace the debug-only single_threaded class with thread_id.