### PR TITLE
Fix warnings found by cppcheck

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -633,7 +633,7 @@ void load_torrent(libtorrent::sha1_hash const& ih, std::vector<char>& buf, libto
 		ec.assign(boost::system::errc::no_such_file_or_directory, boost::system::generic_category());
 		return;
 	}
-	load_file(i->second.c_str(), buf, ec);
+	load_file(i->second, buf, ec);
 }
 
 // if non-empty, a peer that will be added to all torrents
@@ -710,7 +710,7 @@ void add_torrent(libtorrent::session& ses
 		, leaf_path(torrent) + ".resume"));
 
 	error_code ec;
-	load_file(filename.c_str(), p.resume_data, ec);
+	load_file(filename, p.resume_data, ec);
 
 	p.url = path_to_url(torrent);
 	p.save_path = save_path;
@@ -745,7 +745,7 @@ std::vector<std::string> list_dir(std::string path
 		std::string p = fd.cFileName;
 		if (filter_fun(p))
 			ret.push_back(p);
-	
+
 	} while (FindNextFileA(handle, &fd));
 	FindClose(handle);
 #else
@@ -846,7 +846,7 @@ void scan_dir(std::string const& dir_path
 			files.erase(i++);
 			continue;
 		}
-		
+
 		h.auto_managed(false);
 		h.pause();
 		// the alert handler for save_resume_data_alert
@@ -1638,7 +1638,7 @@ int main(int argc, char* argv[])
 				std::string filename = path_append(save_path, path_append(".resume"
 					, to_hex(tmp.info_hash.to_string()) + ".resume"));
 
-				load_file(filename.c_str(), p.resume_data, ec);
+				load_file(filename, p.resume_data, ec);
 			}
 
 			printf("adding URL: %s\n", i->c_str());
@@ -1779,7 +1779,7 @@ int main(int argc, char* argv[])
 						std::string filename = path_append(save_path, path_append(".resume"
 								, to_hex(tmp.info_hash.to_string()) + ".resume"));
 
-						load_file(filename.c_str(), p.resume_data, ec);
+						load_file(filename, p.resume_data, ec);
 					}
 
 					printf("adding URL: %s\n", url);

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -991,6 +991,7 @@ int main(int argc, char* argv[])
 			if (ret != buf.size())
 			{
 				fprintf(stderr, "write returned: %d (expected %d)\n", int(ret), int(buf.size()));
+				fclose(f);
 				return 1;
 			}
 			printf("wrote %s\n", torrent_name);
@@ -1024,7 +1025,7 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 	tcp::endpoint ep(addr, destination_port);
-	
+
 #if !defined __APPLE__
 	// apparently darwin doesn't seems to let you bind to
 	// loopback on any other IP than 127.0.0.1
@@ -1065,7 +1066,7 @@ int main(int argc, char* argv[])
 
 	thread t1(boost::bind(&io_thread, &ios[0]));
 	thread t2(boost::bind(&io_thread, &ios[1]));
- 
+
 	t1.join();
 	t2.join();
 
@@ -1073,7 +1074,7 @@ int main(int argc, char* argv[])
 	float down = 0.f;
 	boost::uint64_t total_sent = 0;
 	boost::uint64_t total_received = 0;
-	
+
 	for (std::vector<peer_conn*>::iterator i = conns.begin()
 		, end(conns.end()); i != end; ++i)
 	{

--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -47,7 +47,7 @@ namespace libtorrent
 		TORRENT_ASSERT(tree_node > 0);
 		// even numbers have their sibling to the left
 		// odd numbers have their sibling to the right
-		return tree_node + (tree_node&1?1:-1);
+		return tree_node + ((tree_node&1)?1:-1);
 	}
 
 	int merkle_num_nodes(int leafs)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -190,7 +190,7 @@ EXPORT int main(int argc, char const* argv[])
 #ifdef WIN32
 	// try to suppress hanging the process by windows displaying
 	// modal dialogs.
-	SetErrorMode(SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOALIGNMENTFAULTEXCEPT
+	SetErrorMode( SEM_NOALIGNMENTFAULTEXCEPT
 		| SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
 #endif
 


### PR DESCRIPTION
Beside my commits, there are 2 lines of ambiguous code you might be interested.

file: src/disk_io_thread
line 3499
Variable 'pe' is reassigned a value before the old one has been used.
https://github.com/arvidn/libtorrent/blob/master/src/disk_io_thread.cpp#L3499

file src/peer_connection
line 866
Suspicious assertion that will never fail, you might want to rewrite this...
https://github.com/arvidn/libtorrent/blob/master/src/peer_connection.cpp#L866
