### PR TITLE
Using the standard log method for round trip time in rcp_manager.

### DIFF
--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -296,7 +296,7 @@ bool rpc_manager::incoming(msg const& m, node_id* id
 	time_point now = clock_type::now();
 
 #ifndef TORRENT_DISABLE_LOGGING
-    m_log->log(dht_logger::rpc_manager, "round trip time(ms): %lld from %s"
+    m_log->log(dht_logger::rpc_manager, "round trip time(ms): %" PRId64 " from %s"
         , total_milliseconds(now - o->sent()), print_endpoint(m.addr).c_str());
 #endif
 

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -57,10 +57,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/time.hpp>
 #include <libtorrent/aux_/time.hpp> // for aux::time_now
 
-#ifndef TORRENT_DISABLE_LOGGING
-#include <fstream>
-#endif
-
 namespace libtorrent { namespace dht
 {
 
@@ -300,9 +296,8 @@ bool rpc_manager::incoming(msg const& m, node_id* id
 	time_point now = clock_type::now();
 
 #ifndef TORRENT_DISABLE_LOGGING
-	std::ofstream reply_stats("round_trip_ms.log", std::ios::app);
-	reply_stats << m.addr << "\t" << total_milliseconds(now - o->sent())
-		<< std::endl;
+    m_log->log(dht_logger::rpc_manager, "round trip time(ms): %lld from %s"
+        , total_milliseconds(now - o->sent()), print_endpoint(m.addr).c_str());
 #endif
 
 	bdecode_node ret_ent = m.message.dict_find_dict("r");


### PR DESCRIPTION
This avoid the creation of the file round_trip_ms.log.