### PR TITLE
peer_connection_handle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(sources
 	bt_peer_connection
 	web_peer_connection
 	http_seed_connection
+	peer_connection_handle
 	instantiate_connection
 	merkle
 	natpmp

--- a/Jamfile
+++ b/Jamfile
@@ -627,6 +627,7 @@ SOURCES =
 	web_connection_base
 	web_peer_connection
 	http_seed_connection
+	peer_connection_handle
 	i2p_stream
 	instantiate_connection
 	natpmp

--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -85,6 +85,7 @@ nobase_include_HEADERS = \
   pe_crypto.hpp                \
   performance_counters.hpp     \
   peer_connection.hpp          \
+  peer_connection_handle.hpp   \
   peer_connection_interface.hpp \
   peer.hpp                     \
   peer_class.hpp               \

--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -41,10 +41,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/peer_id.hpp" // sha1_hash
 #include "libtorrent/version.hpp"
 
-#ifndef TORRENT_DISABLE_EXTENSIONS
-#include "libtorrent/extensions.hpp"
-#endif
-
 namespace libtorrent
 {
 	class torrent_info;

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -177,15 +177,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/socket.hpp"
 #include "libtorrent/sha1_hash.hpp" // for sha1_hash
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/peer_connection_handle.hpp"
 
 namespace libtorrent
 {
 	namespace aux { struct session_impl; }
 
 	struct peer_plugin;
-	class bt_peer_connection;
 	struct peer_request;
-	class peer_connection;
 	class entry;
 	struct bdecode_node;
 	struct disk_buffer_holder;
@@ -223,7 +222,7 @@ namespace libtorrent
 
 		// return true if the add_torrent_params should be added
 		virtual bool on_unknown_torrent(sha1_hash const& /* info_hash */
-			, peer_connection* /* pc */, add_torrent_params& /* p */)
+			, peer_connection_handle /* pc */, add_torrent_params& /* p */)
 		{ return false; }
 
 		// called once per second
@@ -262,13 +261,13 @@ namespace libtorrent
 		// are supposed to return an instance of your peer_plugin class. Which in
 		// turn will have its hook functions called on event specific to that peer.
 		// 
-		// The ``peer_connection`` will be valid as long as the ``shared_ptr`` is being
-		// held by the torrent object. So, it is generally a good idea to not keep a
-		// ``shared_ptr`` to your own peer_plugin. If you want to keep references to it,
-		// use ``weak_ptr``.
+		// The ``peer_connection_handle`` will be valid as long as the ``shared_ptr``
+		// is being held by the torrent object. So, it is generally a good idea to not
+		// keep a ``shared_ptr`` to your own peer_plugin. If you want to keep references
+		// to it, use ``weak_ptr``.
 		// 
 		// If this function throws an exception, the connection will be closed.
-		virtual boost::shared_ptr<peer_plugin> new_connection(peer_connection*)
+		virtual boost::shared_ptr<peer_plugin> new_connection(peer_connection_handle)
 		{ return boost::shared_ptr<peer_plugin>(); }
 
 		// These hooks are called when a piece passes the hash check or fails the hash

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -270,7 +270,7 @@ namespace libtorrent
 		, public bandwidth_socket
 		, public peer_class_set
 		, public disk_observer
-		, public peer_connection_interface 
+		, public peer_connection_interface
 		, public boost::enable_shared_from_this<peer_connection>
 	{
 	friend class invariant_access;
@@ -665,7 +665,7 @@ namespace libtorrent
 			, void* userdata = NULL, block_cache_reference ref
 			= block_cache_reference());
 
-#ifndef TORRENT_DISABLE_RESOLVE_COUNTRIES	
+#ifndef TORRENT_DISABLE_RESOLVE_COUNTRIES
 		void set_country(char const* c)
 		{
 			TORRENT_ASSERT(strlen(c) == 2);

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -63,20 +63,9 @@ struct TORRENT_EXPORT peer_connection_handle
 	peer_plugin const* find_plugin(char const* type);
 #endif
 
-	bool no_download() const;
-	bool ignore_stats() const;
-
-	boost::uint32_t peer_rank() const;
-
-	bool can_write() const;
 	bool is_seed() const;
-	bool share_mode() const;
 
-	void set_upload_only(bool u);
 	bool upload_only() const;
-
-	// will send a keep-alive message to the peer
-	void keep_alive();
 
 	peer_id const& pid() const;
 	bool has_piece(int i) const;
@@ -102,14 +91,10 @@ struct TORRENT_EXPORT peer_connection_handle
 	bool is_connecting() const;
 	bool is_outgoing() const;
 
-	bool received_listen_port() const;
-
 	bool on_local_network() const;
 	bool ignore_unchoke_slots() const;
 
 	bool failed() const;
-
-	bool disconnect_if_redundant();
 
 #ifndef TORRENT_DISABLE_LOGGING
 	void peer_log(peer_log_alert::direction_t direction
@@ -119,12 +104,6 @@ struct TORRENT_EXPORT peer_connection_handle
 	bool can_disconnect(error_code const& ec) const;
 
 	bool has_metadata() const;
-
-	bool send_choke();
-	bool send_unchoke();
-	void send_interested();
-	void send_not_interested();
-	void send_suggest(int piece);
 
 	bool in_handshake() const;
 

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -1,0 +1,166 @@
+/*
+
+Copyright (c) 2015, Arvid Norberg, Steven Siloti
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_PEER_CONNECTION_HANDLE_HPP_INCLUDED
+#define TORRENT_PEER_CONNECTION_HANDLE_HPP_INCLUDED
+
+#include "libtorrent/config.hpp"
+#include "libtorrent/peer_id.hpp"
+#include "libtorrent/operations.hpp"
+#include "libtorrent/alert_types.hpp"
+
+namespace libtorrent
+{
+
+class peer_connection;
+class bt_peer_connection;
+struct torrent_handle;
+struct peer_plugin;
+struct peer_info;
+struct crypto_plugin;
+
+typedef boost::system::error_code error_code;
+
+struct TORRENT_EXPORT peer_connection_handle
+{
+	peer_connection_handle(boost::weak_ptr<peer_connection> impl)
+		: m_connection(impl)
+	{}
+
+	int type() const;
+
+#ifndef TORRENT_DISABLE_EXTENSIONS
+	void add_extension(boost::shared_ptr<peer_plugin>);
+	peer_plugin const* find_plugin(char const* type);
+#endif
+
+	bool no_download() const;
+	bool ignore_stats() const;
+
+	boost::uint32_t peer_rank() const;
+
+	bool can_write() const;
+	bool is_seed() const;
+	bool share_mode() const;
+
+	void set_upload_only(bool u);
+	bool upload_only() const;
+
+	// will send a keep-alive message to the peer
+	void keep_alive();
+
+	peer_id const& pid() const;
+	bool has_piece(int i) const;
+
+	bool is_interesting() const;
+	bool is_choked() const;
+
+	bool is_peer_interested() const;
+	bool has_peer_choked() const;
+
+	void choke_this_peer();
+	void maybe_unchoke_this_peer();
+
+	void get_peer_info(peer_info& p) const;
+
+	torrent_handle associated_torrent() const;
+
+	tcp::endpoint const& remote() const;
+	tcp::endpoint local_endpoint() const;
+
+	void disconnect(error_code const& ec, operation_t op, int error = 0);
+	bool is_disconnecting() const;
+	bool is_connecting() const;
+	bool is_outgoing() const;
+
+	bool received_listen_port() const;
+
+	bool on_local_network() const;
+	bool ignore_unchoke_slots() const;
+
+	bool failed() const;
+
+	bool disconnect_if_redundant();
+
+#ifndef TORRENT_DISABLE_LOGGING
+	void peer_log(peer_log_alert::direction_t direction
+		, char const* event, char const* fmt = "", ...) const TORRENT_FORMAT(4,5);
+#endif
+
+	bool can_disconnect(error_code const& ec) const;
+
+	bool has_metadata() const;
+
+	bool send_choke();
+	bool send_unchoke();
+	void send_interested();
+	void send_not_interested();
+	void send_suggest(int piece);
+
+	bool in_handshake() const;
+
+	void send_buffer(char const* begin, int size, int flags = 0);
+
+	time_t last_seen_complete() const;
+	time_point time_of_last_unchoke() const;
+
+	boost::shared_ptr<peer_connection> native_handle() const
+	{
+		return m_connection.lock();
+	}
+
+private:
+	boost::weak_ptr<peer_connection> m_connection;
+};
+
+struct TORRENT_EXPORT bt_peer_connection_handle : public peer_connection_handle
+{
+	explicit bt_peer_connection_handle(peer_connection_handle pc)
+		: peer_connection_handle(pc)
+	{}
+
+	bool packet_finished() const;
+	bool support_extensions() const;
+
+#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
+	bool supports_encryption() const;
+
+	void switch_send_crypto(boost::shared_ptr<crypto_plugin> crypto);
+	void switch_recv_crypto(boost::shared_ptr<crypto_plugin> crypto);
+#endif
+
+	boost::shared_ptr<bt_peer_connection> native_handle() const;
+};
+
+} // namespace libtorrent
+
+#endif // TORRENT_PEER_CONNECTION_HANDLE_HPP_INCLUDED

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -58,10 +58,8 @@ struct TORRENT_EXPORT peer_connection_handle
 
 	int type() const;
 
-#ifndef TORRENT_DISABLE_EXTENSIONS
 	void add_extension(boost::shared_ptr<peer_plugin>);
 	peer_plugin const* find_plugin(char const* type);
-#endif
 
 	bool is_seed() const;
 
@@ -96,10 +94,8 @@ struct TORRENT_EXPORT peer_connection_handle
 
 	bool failed() const;
 
-#ifndef TORRENT_DISABLE_LOGGING
 	void peer_log(peer_log_alert::direction_t direction
 		, char const* event, char const* fmt = "", ...) const TORRENT_FORMAT(4,5);
-#endif
 
 	bool can_disconnect(error_code const& ec) const;
 
@@ -130,12 +126,10 @@ struct TORRENT_EXPORT bt_peer_connection_handle : public peer_connection_handle
 	bool packet_finished() const;
 	bool support_extensions() const;
 
-#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 	bool supports_encryption() const;
 
 	void switch_send_crypto(boost::shared_ptr<crypto_plugin> crypto);
 	void switch_recv_crypto(boost::shared_ptr<crypto_plugin> crypto);
-#endif
 
 	boost::shared_ptr<bt_peer_connection> native_handle() const;
 };

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,6 +93,7 @@ libtorrent_rasterbar_la_SOURCES = \
   pe_crypto.cpp                   \
   performance_counters.cpp        \
   peer_connection.cpp             \
+  peer_connection_handle.cpp      \
   peer_class.cpp                  \
   peer_class_set.cpp              \
   piece_picker.cpp                \

--- a/src/lt_trackers.cpp
+++ b/src/lt_trackers.cpp
@@ -79,7 +79,7 @@ namespace libtorrent { namespace
 		}
 
 		virtual boost::shared_ptr<peer_plugin> new_connection(
-			peer_connection* pc);
+			peer_connection_handle pc);
 		
 		virtual void tick()
 		{
@@ -360,15 +360,15 @@ namespace libtorrent { namespace
 	};
 
 	boost::shared_ptr<peer_plugin> lt_tracker_plugin::new_connection(
-		peer_connection* pc)
+		peer_connection_handle pc)
 	{
-		if (pc->type() != peer_connection::bittorrent_connection)
+		if (pc.type() != peer_connection::bittorrent_connection)
 			return boost::shared_ptr<peer_plugin>();
 
 		if (m_torrent.valid_metadata() && m_torrent.torrent_file().priv())
 			return boost::shared_ptr<peer_plugin>();
 
-		bt_peer_connection* c = static_cast<bt_peer_connection*>(pc);
+		bt_peer_connection* c = static_cast<bt_peer_connection*>(pc.native_handle().get());
 		return boost::shared_ptr<peer_plugin>(new lt_tracker_peer_plugin(m_torrent, *c, *this));
 	}
 

--- a/src/metadata_transfer.cpp
+++ b/src/metadata_transfer.cpp
@@ -128,7 +128,7 @@ namespace libtorrent { namespace
 		}
 
 		virtual boost::shared_ptr<peer_plugin> new_connection(
-			peer_connection* pc);
+			peer_connection_handle pc);
 		
 		buffer::const_interval metadata() const
 		{
@@ -543,12 +543,12 @@ namespace libtorrent { namespace
 	};
 
 	boost::shared_ptr<peer_plugin> metadata_plugin::new_connection(
-		peer_connection* pc)
+		peer_connection_handle pc)
 	{
-		if (pc->type() != peer_connection::bittorrent_connection)
+		if (pc.type() != peer_connection::bittorrent_connection)
 			return boost::shared_ptr<peer_plugin>();
 
-		return boost::shared_ptr<peer_plugin>(new metadata_peer_plugin(m_torrent, *pc, *this));
+		return boost::shared_ptr<peer_plugin>(new metadata_peer_plugin(m_torrent, *pc.native_handle().get(), *this));
 	}
 
 	std::pair<int, int> metadata_plugin::metadata_request()

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -48,6 +48,7 @@ int peer_connection_handle::type() const
 	return pc->type();
 }
 
+#ifndef TORRENT_DISABLE_EXTENSIONS
 void peer_connection_handle::add_extension(boost::shared_ptr<peer_plugin> ext)
 {
 	boost::shared_ptr<peer_connection> pc = native_handle();
@@ -61,34 +62,7 @@ peer_plugin const* peer_connection_handle::find_plugin(char const* type)
 	TORRENT_ASSERT(pc);
 	return pc->find_plugin(type);
 }
-
-bool peer_connection_handle::no_download() const
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->no_download();
-}
-
-bool peer_connection_handle::ignore_stats() const
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->ignore_stats();
-}
-
-boost::uint32_t peer_connection_handle::peer_rank() const
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->peer_rank();
-}
-
-bool peer_connection_handle::can_write() const
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->can_write();
-}
+#endif
 
 bool peer_connection_handle::is_seed() const
 {
@@ -97,18 +71,18 @@ bool peer_connection_handle::is_seed() const
 	return pc->is_seed();
 }
 
-bool peer_connection_handle::share_mode() const
+bool peer_connection_handle::upload_only() const
 {
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
-	return pc->share_mode();
+	return pc->upload_only();
 }
 
-void peer_connection_handle::set_upload_only(bool u)
+peer_id const& peer_connection_handle::pid() const
 {
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
-	pc->set_upload_only(u);
+	return pc->pid();
 }
 
 bool peer_connection_handle::has_piece(int i) const
@@ -218,13 +192,6 @@ bool peer_connection_handle::is_outgoing() const
 	return pc->is_outgoing();
 }
 
-bool peer_connection_handle::received_listen_port() const
-{
-	boost::shared_ptr<peer_connection const> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->received_listen_port();
-}
-
 bool peer_connection_handle::on_local_network() const
 {
 	boost::shared_ptr<peer_connection> pc = native_handle();
@@ -244,13 +211,6 @@ bool peer_connection_handle::failed() const
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	return pc->failed();
-}
-
-bool peer_connection_handle::disconnect_if_redundant()
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->disconnect_if_redundant();
 }
 
 #ifndef TORRENT_DISABLE_LOGGING
@@ -278,34 +238,6 @@ bool peer_connection_handle::has_metadata() const
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	return pc->has_metadata();
-}
-
-bool peer_connection_handle::send_choke()
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->send_choke();
-}
-
-bool peer_connection_handle::send_unchoke()
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->send_unchoke();
-}
-
-void peer_connection_handle::send_interested()
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	pc->send_interested();
-}
-
-void peer_connection_handle::send_suggest(int piece)
-{
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	pc->send_suggest(piece);
 }
 
 bool peer_connection_handle::in_handshake() const
@@ -350,12 +282,7 @@ bool bt_peer_connection_handle::support_extensions() const
 	return pc->support_extensions();
 }
 
-boost::shared_ptr<bt_peer_connection> bt_peer_connection_handle::native_handle() const
-{
-	return boost::static_pointer_cast<bt_peer_connection>(
-		peer_connection_handle::native_handle());
-}
-
+#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 bool bt_peer_connection_handle::supports_encryption() const
 {
 	boost::shared_ptr<bt_peer_connection> pc = native_handle();
@@ -375,6 +302,13 @@ void bt_peer_connection_handle::switch_recv_crypto(boost::shared_ptr<crypto_plug
 	boost::shared_ptr<bt_peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	pc->switch_recv_crypto(crypto);
+}
+#endif
+
+boost::shared_ptr<bt_peer_connection> bt_peer_connection_handle::native_handle() const
+{
+	return boost::static_pointer_cast<bt_peer_connection>(
+		peer_connection_handle::native_handle());
 }
 
 } // namespace libtorrent

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -48,21 +48,25 @@ int peer_connection_handle::type() const
 	return pc->type();
 }
 
-#ifndef TORRENT_DISABLE_EXTENSIONS
 void peer_connection_handle::add_extension(boost::shared_ptr<peer_plugin> ext)
 {
+#ifndef TORRENT_DISABLE_EXTENSIONS
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	pc->add_extension(ext);
+#endif
 }
 
 peer_plugin const* peer_connection_handle::find_plugin(char const* type)
 {
+#ifndef TORRENT_DISABLE_EXTENSIONS
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	return pc->find_plugin(type);
-}
+#else
+	return NULL;
 #endif
+}
 
 bool peer_connection_handle::is_seed() const
 {
@@ -213,18 +217,18 @@ bool peer_connection_handle::failed() const
 	return pc->failed();
 }
 
-#ifndef TORRENT_DISABLE_LOGGING
 void peer_connection_handle::peer_log(peer_log_alert::direction_t direction
 	, char const* event, char const* fmt, ...) const
 {
+#ifndef TORRENT_DISABLE_LOGGING
 	boost::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	va_list v;
 	va_start(v, fmt);
 	pc->peer_log(direction, event, fmt, v);
 	va_end(v);
-}
 #endif
+}
 
 bool peer_connection_handle::can_disconnect(error_code const& ec) const
 {
@@ -282,28 +286,34 @@ bool bt_peer_connection_handle::support_extensions() const
 	return pc->support_extensions();
 }
 
-#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 bool bt_peer_connection_handle::supports_encryption() const
 {
+#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 	boost::shared_ptr<bt_peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	return pc->supports_encryption();
+#else
+	return false;
+#endif
 }
 
 void bt_peer_connection_handle::switch_send_crypto(boost::shared_ptr<crypto_plugin> crypto)
 {
+#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 	boost::shared_ptr<bt_peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	pc->switch_send_crypto(crypto);
+#endif
 }
 
 void bt_peer_connection_handle::switch_recv_crypto(boost::shared_ptr<crypto_plugin> crypto)
 {
+#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 	boost::shared_ptr<bt_peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
 	pc->switch_recv_crypto(crypto);
-}
 #endif
+}
 
 boost::shared_ptr<bt_peer_connection> bt_peer_connection_handle::native_handle() const
 {

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -1,0 +1,380 @@
+/*
+
+Copyright (c) 2015, Arvid Norberg, Steven Siloti
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/peer_connection_handle.hpp"
+#include "libtorrent/peer_connection.hpp"
+#include "libtorrent/bt_peer_connection.hpp"
+
+#ifndef TORRENT_DISABLE_LOGGING
+#include <stdarg.h> // for va_start, va_end
+#endif
+
+namespace libtorrent
+{
+
+int peer_connection_handle::type() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->type();
+}
+
+void peer_connection_handle::add_extension(boost::shared_ptr<peer_plugin> ext)
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->add_extension(ext);
+}
+
+peer_plugin const* peer_connection_handle::find_plugin(char const* type)
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->find_plugin(type);
+}
+
+bool peer_connection_handle::no_download() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->no_download();
+}
+
+bool peer_connection_handle::ignore_stats() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->ignore_stats();
+}
+
+boost::uint32_t peer_connection_handle::peer_rank() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->peer_rank();
+}
+
+bool peer_connection_handle::can_write() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->can_write();
+}
+
+bool peer_connection_handle::is_seed() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_seed();
+}
+
+bool peer_connection_handle::share_mode() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->share_mode();
+}
+
+void peer_connection_handle::set_upload_only(bool u)
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->set_upload_only(u);
+}
+
+bool peer_connection_handle::has_piece(int i) const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->has_piece(i);
+}
+
+bool peer_connection_handle::is_interesting() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_interesting();
+}
+
+bool peer_connection_handle::is_choked() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_choked();
+}
+
+bool peer_connection_handle::is_peer_interested() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_peer_interested();
+}
+
+bool peer_connection_handle::has_peer_choked() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->has_peer_choked();
+}
+
+void peer_connection_handle::choke_this_peer()
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->choke_this_peer();
+}
+
+void peer_connection_handle::maybe_unchoke_this_peer()
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->maybe_unchoke_this_peer();
+}
+
+void peer_connection_handle::get_peer_info(peer_info& p) const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->get_peer_info(p);
+}
+
+torrent_handle peer_connection_handle::associated_torrent() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	if (!pc) return torrent_handle();
+	boost::shared_ptr<torrent> t = pc->associated_torrent().lock();
+	if (!t) return torrent_handle();
+	return t->get_handle();
+}
+
+tcp::endpoint const& peer_connection_handle::remote() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->remote();
+}
+
+tcp::endpoint peer_connection_handle::local_endpoint() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->local_endpoint();
+}
+
+void peer_connection_handle::disconnect(error_code const& ec, operation_t op, int error)
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->disconnect(ec, op, error);
+}
+
+bool peer_connection_handle::is_disconnecting() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_disconnecting();
+}
+
+bool peer_connection_handle::is_connecting() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_connecting();
+}
+
+bool peer_connection_handle::is_outgoing() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->is_outgoing();
+}
+
+bool peer_connection_handle::received_listen_port() const
+{
+	boost::shared_ptr<peer_connection const> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->received_listen_port();
+}
+
+bool peer_connection_handle::on_local_network() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->on_local_network();
+}
+
+bool peer_connection_handle::ignore_unchoke_slots() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->ignore_unchoke_slots();
+}
+
+bool peer_connection_handle::failed() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->failed();
+}
+
+bool peer_connection_handle::disconnect_if_redundant()
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->disconnect_if_redundant();
+}
+
+#ifndef TORRENT_DISABLE_LOGGING
+void peer_connection_handle::peer_log(peer_log_alert::direction_t direction
+	, char const* event, char const* fmt, ...) const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	va_list v;
+	va_start(v, fmt);
+	pc->peer_log(direction, event, fmt, v);
+	va_end(v);
+}
+#endif
+
+bool peer_connection_handle::can_disconnect(error_code const& ec) const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->can_disconnect(ec);
+}
+
+bool peer_connection_handle::has_metadata() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->has_metadata();
+}
+
+bool peer_connection_handle::send_choke()
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->send_choke();
+}
+
+bool peer_connection_handle::send_unchoke()
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->send_unchoke();
+}
+
+void peer_connection_handle::send_interested()
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->send_interested();
+}
+
+void peer_connection_handle::send_suggest(int piece)
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->send_suggest(piece);
+}
+
+bool peer_connection_handle::in_handshake() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->in_handshake();
+}
+
+void peer_connection_handle::send_buffer(char const* begin, int size, int flags)
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->send_buffer(begin, size, flags);
+}
+
+time_t peer_connection_handle::last_seen_complete() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->last_seen_complete();
+}
+
+time_point peer_connection_handle::time_of_last_unchoke() const
+{
+	boost::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->time_of_last_unchoke();
+}
+
+bool bt_peer_connection_handle::packet_finished() const
+{
+	boost::shared_ptr<bt_peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->packet_finished();
+}
+
+bool bt_peer_connection_handle::support_extensions() const
+{
+	boost::shared_ptr<bt_peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->support_extensions();
+}
+
+boost::shared_ptr<bt_peer_connection> bt_peer_connection_handle::native_handle() const
+{
+	return boost::static_pointer_cast<bt_peer_connection>(
+		peer_connection_handle::native_handle());
+}
+
+bool bt_peer_connection_handle::supports_encryption() const
+{
+	boost::shared_ptr<bt_peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->supports_encryption();
+}
+
+void bt_peer_connection_handle::switch_send_crypto(boost::shared_ptr<crypto_plugin> crypto)
+{
+	boost::shared_ptr<bt_peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->switch_send_crypto(crypto);
+}
+
+void bt_peer_connection_handle::switch_recv_crypto(boost::shared_ptr<crypto_plugin> crypto)
+{
+	boost::shared_ptr<bt_peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	pc->switch_recv_crypto(crypto);
+}
+
+} // namespace libtorrent

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4049,7 +4049,7 @@ retry:
 			, end(m_ses_extensions.end()); i != end; ++i)
 		{
 			add_torrent_params p;
-			if ((*i)->on_unknown_torrent(info_hash, pc, p))
+			if ((*i)->on_unknown_torrent(info_hash, peer_connection_handle(pc->self()), p))
 			{
 				error_code ec;
 				torrent_handle handle = add_torrent(p, ec);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1509,7 +1509,7 @@ namespace libtorrent
 			i != m_connections.end(); ++i)
 		{
 			peer_connection* p = *i;
-			boost::shared_ptr<peer_plugin> pp(tp->new_connection(p));
+			boost::shared_ptr<peer_plugin> pp(tp->new_connection(peer_connection_handle(p->self())));
 			if (pp) p->add_extension(pp);
 		}
 
@@ -6401,7 +6401,7 @@ namespace libtorrent
 			, end(m_extensions.end()); i != end; ++i)
 		{
 			boost::shared_ptr<peer_plugin>
-				pp((*i)->new_connection(c.get()));
+				pp((*i)->new_connection(peer_connection_handle(c.get()->self())));
 			if (pp) c->add_extension(pp);
 		}
 #endif
@@ -7463,7 +7463,8 @@ namespace libtorrent
 				, end(m_extensions.end()); i != end; ++i)
 			{
 				TORRENT_TRY {
-					boost::shared_ptr<peer_plugin> pp((*i)->new_connection(c.get()));
+					boost::shared_ptr<peer_plugin> pp((*i)->new_connection(
+						peer_connection_handle(c.get()->self())));
 					if (pp) c->add_extension(pp);
 				} TORRENT_CATCH (std::exception&) {}
 			}
@@ -7765,7 +7766,8 @@ namespace libtorrent
 			for (extension_list_t::iterator i = m_extensions.begin()
 				, end(m_extensions.end()); i != end; ++i)
 			{
-				boost::shared_ptr<peer_plugin> pp((*i)->new_connection(p));
+				boost::shared_ptr<peer_plugin> pp((*i)->new_connection(
+					peer_connection_handle(p->self())));
 				if (pp) p->add_extension(pp);
 			}
 #endif

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -124,7 +124,7 @@ namespace libtorrent { namespace
 		}
 
 		virtual boost::shared_ptr<peer_plugin> new_connection(
-			peer_connection* pc);
+			peer_connection_handle pc);
 
 		int get_metadata_size() const
 		{
@@ -500,12 +500,12 @@ namespace libtorrent { namespace
 	};
 
 	boost::shared_ptr<peer_plugin> ut_metadata_plugin::new_connection(
-		peer_connection* pc)
+		peer_connection_handle pc)
 	{
-		if (pc->type() != peer_connection::bittorrent_connection)
+		if (pc.type() != peer_connection::bittorrent_connection)
 			return boost::shared_ptr<peer_plugin>();
 
-		bt_peer_connection* c = static_cast<bt_peer_connection*>(pc);
+		bt_peer_connection* c = static_cast<bt_peer_connection*>(pc.native_handle().get());
 		return boost::shared_ptr<peer_plugin>(new ut_metadata_peer_plugin(m_torrent, *c, *this));
 	}
 

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -90,7 +90,7 @@ namespace libtorrent { namespace
 			, m_last_msg(min_time())
 			, m_peers_in_message(0) {}
 	
-		virtual boost::shared_ptr<peer_plugin> new_connection(peer_connection* pc);
+		virtual boost::shared_ptr<peer_plugin> new_connection(peer_connection_handle pc);
 
 		std::vector<char>& get_ut_pex_msg()
 		{
@@ -646,13 +646,13 @@ namespace libtorrent { namespace
 		bool m_first_time;
 	};
 
-	boost::shared_ptr<peer_plugin> ut_pex_plugin::new_connection(peer_connection* pc)
+	boost::shared_ptr<peer_plugin> ut_pex_plugin::new_connection(peer_connection_handle pc)
 	{
-		if (pc->type() != peer_connection::bittorrent_connection)
+		if (pc.type() != peer_connection::bittorrent_connection)
 			return boost::shared_ptr<peer_plugin>();
 
 		return boost::shared_ptr<peer_plugin>(new ut_pex_peer_plugin(m_torrent
-			, *pc, *this));
+			, *pc.native_handle(), *this));
 	}
 } }
 


### PR DESCRIPTION
This should be the last big change to support external plugins. Next up will be the removal of the remaining non-exported symbols from the plugin API (torrent, session_impl, torrent_peer).