### PR TITLE
Restore the option to compile with target Windows XP.

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -413,9 +413,10 @@ feature.compose <asserts>production : <define>TORRENT_PRODUCTION_ASSERTS=1 <defi
 feature.compose <asserts>off : <define>TORRENT_USE_ASSERTS=0 ;
 feature.compose <asserts>system : <define>TORRENT_USE_SYSTEM_ASSERTS=1 ;
 
-feature windows-version : vista win7 : composite propagated link-incompatible ;
+feature windows-version : vista win7 xp : composite propagated link-incompatible ;
 feature.compose <windows-version>vista : <define>_WIN32_WINNT=0x0600 ;
 feature.compose <windows-version>win7 : <define>_WIN32_WINNT=0x0601 ;
+feature.compose <windows-version>xp : <define>_WIN32_WINNT=0x0501 ;
 
 feature extensions : on off : composite propagated link-incompatible ;
 feature.compose <extensions>off : <define>TORRENT_DISABLE_EXTENSIONS ;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -105,7 +105,11 @@ namespace libtorrent
 	condition_variable::condition_variable()
 		: m_num_waiters(0)
 	{
+#if _WIN32_WINNT == 0x0501
+		m_sem = CreateSemaphore(0, 0, INT_MAX, 0);
+#else
 		m_sem = CreateSemaphoreEx(0, 0, INT_MAX, 0, 0, SEMAPHORE_ALL_ACCESS);
+#endif
 	}
 
 	condition_variable::~condition_variable()


### PR DESCRIPTION
This revert the unnecessary requirement hike to windows vista https://github.com/arvidn/libtorrent/pull/21
Windows XP currently amounts for a 11% of market share.
The option is at the end of windows-version flag to make it not default.