### PR TITLE
Fix opening empty torrent files

### DIFF
--- a/src/lazy_bdecode.cpp
+++ b/src/lazy_bdecode.cpp
@@ -126,10 +126,11 @@ namespace libtorrent
 	{
 		char const* const orig_start = start;
 		ret.clear();
-		if (start == end) return 0;
-
+		
 		std::vector<lazy_entry*> stack;
-
+		
+		if (start == end) return TORRENT_FAIL_BDECODE(bdecode_errors::unexpected_eof);
+		
 		stack.push_back(&ret);
 		while (start <= end)
 		{

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -812,7 +812,7 @@ namespace libtorrent
 		if (ret < 0) return;
 
 		lazy_entry e;
-		if (buf.size() == 0 || lazy_bdecode(&buf[0], &buf[0] + buf.size(), e, ec) != 0)
+		if (lazy_bdecode(&buf[0], &buf[0] + buf.size(), e, ec) != 0)
 			return;
 		parse_torrent_file(e, ec, flags);
 


### PR DESCRIPTION
I have a problem with libtorrent when trying to open an empty file when libtorrent was build with boost without exception support. libtorrent return badly intilized torrent_info class. This fixes my issue.
