### PR TITLE
Fix out of srcdir build

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -33,15 +33,15 @@ EXTRA_DIST = \
 if ENABLE_PYTHON_BINDING
 
 all-local:
-	$(PYTHON) setup.py build
+	$(PYTHON) $(srcdir)/setup.py build
 
 install-exec-local:
-	$(PYTHON) setup.py install @PYTHON_INSTALL_PARAMS@
+	$(PYTHON) $(srcdir)/setup.py install @PYTHON_INSTALL_PARAMS@
 
 uninstall-local:
 	rm -rf $(DESTDIR)$(libdir)/python*/*-packages/*libtorrent*
 
 clean-local:
-	$(PYTHON) setup.py clean --all
+	$(PYTHON) $(srcdir)/setup.py clean --all
 
 endif

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -92,7 +92,7 @@ if '--bjam' in sys.argv or ldflags == None or extra_cmd == None:
 else:
 
 	source_list = os.listdir(os.path.join(os.path.dirname(__file__), "src"))
-	source_list = [os.path.join("src", s) for s in source_list if s.endswith(".cpp")]
+	source_list = [os.path.abspath(os.path.join(os.path.dirname(__file__), "src", s)) for s in source_list if s.endswith(".cpp")]
 
 	ext = [Extension('libtorrent',
 		sources = source_list,


### PR DESCRIPTION
Python bindings doesn't build out of srcdir, this PR fixes that.