### PR TITLE
Direct dht reqests

### DIFF
--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -178,6 +178,7 @@ nobase_include_HEADERS = \
   \
   kademlia/dht_tracker.hpp          \
   kademlia/dht_observer.hpp         \
+  kademlia/direct_request.hpp       \
   kademlia/dos_blocker.hpp          \
   kademlia/find_data.hpp            \
   kademlia/msg.hpp                  \

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2395,7 +2395,7 @@ namespace libtorrent
 		void* userdata;
 		udp::endpoint addr;
 
-		void response(bdecode_node& ret) const;
+		bdecode_node response() const;
 
 	private:
 		aux::stack_allocator& m_alloc;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2389,6 +2389,10 @@ namespace libtorrent
 		dht_direct_response_alert(aux::stack_allocator& alloc, void* userdata
 			, udp::endpoint const& addr, bdecode_node const& response);
 
+		// for when there was a timeout so we don't have a response
+		dht_direct_response_alert(aux::stack_allocator& alloc, void* userdata
+			, udp::endpoint const& addr);
+
 		TORRENT_DEFINE_ALERT(dht_direct_response_alert, 88)
 
 		static const int static_category = alert::dht_notification;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2382,12 +2382,27 @@ namespace libtorrent
 		int m_peers_idx;
 	};
 
+	struct TORRENT_EXPORT dht_direct_response_alert: alert
+	{
+		dht_direct_response_alert(aux::stack_allocator& alloc, void* userdata
+			, udp::endpoint const& addr, entry const& response);
+
+		TORRENT_DEFINE_ALERT(dht_direct_response_alert, 88)
+
+		static const int static_category = alert::dht_notification;
+		virtual std::string message() const;
+
+		void* userdata;
+		udp::endpoint addr;
+		entry response;
+	};
+
 #undef TORRENT_DEFINE_ALERT_IMPL
 #undef TORRENT_DEFINE_ALERT
 #undef TORRENT_DEFINE_ALERT_PRIO
 #undef TORRENT_CLONE
 
-	enum { num_alert_types = 88 };
+	enum { num_alert_types = 89 };
 }
 
 

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2385,7 +2385,7 @@ namespace libtorrent
 	struct TORRENT_EXPORT dht_direct_response_alert: alert
 	{
 		dht_direct_response_alert(aux::stack_allocator& alloc, void* userdata
-			, udp::endpoint const& addr, entry const& response);
+			, udp::endpoint const& addr, bdecode_node const& response);
 
 		TORRENT_DEFINE_ALERT(dht_direct_response_alert, 88)
 
@@ -2394,7 +2394,13 @@ namespace libtorrent
 
 		void* userdata;
 		udp::endpoint addr;
-		entry response;
+
+		void response(bdecode_node& ret) const;
+
+	private:
+		aux::stack_allocator& m_alloc;
+		int m_response_idx;
+		int m_response_size;
 	};
 
 #undef TORRENT_DEFINE_ALERT_IMPL

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2382,6 +2382,8 @@ namespace libtorrent
 		int m_peers_idx;
 	};
 
+	// This is posted exactly once for every call to session_handle::dht_direct_request.
+	// If the request failed, response() will return a default constructed bdecode_node.
 	struct TORRENT_EXPORT dht_direct_response_alert: alert
 	{
 		dht_direct_response_alert(aux::stack_allocator& alloc, void* userdata

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -120,6 +120,9 @@ namespace libtorrent
 
 	struct bencode_map_entry;
 
+	typedef boost::function<bool(udp::endpoint const& source
+		, bdecode_node const& request, entry& response)> dht_extension_handler_t;
+
 	struct listen_socket_t
 	{
 		listen_socket_t(): external_port(0), ssl(false) {}
@@ -167,6 +170,8 @@ namespace libtorrent
 		{
 			// the size of each allocation that is chained in the send buffer
 			enum { send_buffer_size_impl = 128 };
+			// maximum length of query names which can be registered by extensions
+			enum { max_dht_query_length = 15 };
 
 #ifdef TORRENT_DEBUG
 //			friend class ::libtorrent::peer_connection;
@@ -316,6 +321,8 @@ namespace libtorrent
 
 			void dht_get_peers(sha1_hash const& info_hash);
 			void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
+
+			void dht_direct_request(boost::asio::ip::udp::endpoint ep, entry& e, void* userdata);
 
 #ifndef TORRENT_NO_DEPRECATE
 			entry dht_state() const;
@@ -572,6 +579,9 @@ namespace libtorrent
 				TORRENT_OVERRIDE TORRENT_FORMAT(3,4);
 			virtual void log_packet(message_direction_t dir, char const* pkt, int len
 				, udp::endpoint node) TORRENT_OVERRIDE;
+
+			virtual bool on_dht_request(char const* query, int query_len
+				, dht::msg const& request, entry& response);
 
 			void set_external_address(address const& ip
 				, int source_type, address const& source);
@@ -1135,6 +1145,17 @@ namespace libtorrent
 			// this is a list to allow extensions to potentially remove themselves.
 			typedef std::list<boost::shared_ptr<plugin> > ses_extension_list_t;
 			ses_extension_list_t m_ses_extensions;
+
+			// std::string could be used for the query names if only all common implementations used SSO
+			// *glares at gcc*
+			struct extention_dht_query
+			{
+				uint8_t query_len;
+				boost::array<char, max_dht_query_length> query;
+				dht_extension_handler_t handler;
+			};
+			typedef std::vector<extention_dht_query> m_extension_dht_queries_t;
+			m_extension_dht_queries_t m_extension_dht_queries;
 #endif
 
 			// if this function is set, it indicates that torrents are allowed

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -192,9 +192,12 @@ namespace libtorrent
 	struct peer_connection_handle;
 	struct torrent_handle;
 
+	// Functions of this type are called to handle incoming DHT requests
 	typedef boost::function<bool(udp::endpoint const& source
 		, bdecode_node const& request, entry& response)> dht_extension_handler_t;
 
+	// Map of query strings to handlers. Note that query strings are limited to 15 bytes.
+	// see max_dht_query_length
 	typedef std::vector<std::pair<std::string, dht_extension_handler_t> > dht_extensions_t;
 
 	// this is the base class for a session plugin. One primary feature

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -192,6 +192,11 @@ namespace libtorrent
 	struct peer_connection_handle;
 	struct torrent_handle;
 
+	typedef boost::function<bool(udp::endpoint const& source
+		, bdecode_node const& request, entry& response)> dht_extension_handler_t;
+
+	typedef std::vector<std::pair<std::string, dht_extension_handler_t> > dht_extensions_t;
+
 	// this is the base class for a session plugin. One primary feature
 	// is that it is notified of all torrents that are added to the session,
 	// and can add its own torrent_plugins.
@@ -213,6 +218,10 @@ namespace libtorrent
 
 		// called when plugin is added to a session
 		virtual void added(session_handle) {}
+
+		// called after a plugin is added
+		// allows the plugin to register DHT requests it would like to handle
+		virtual void register_dht_extensions(dht_extensions_t&) {}
 
 		// called when an alert is posted alerts that are filtered are not posted
 		virtual void on_alert(alert const*) {}

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -106,6 +106,10 @@ namespace libtorrent { namespace dht
 		void put_item(char const* key
 			, boost::function<void(item&)> cb, std::string salt = std::string());
 
+		// send an arbitrary DHT request directly to a node
+		void direct_request(boost::asio::ip::udp::endpoint ep, entry& e
+			, boost::function<void(msg const&)> f);
+
 #ifndef TORRENT_NO_DEPRECATE
 		void dht_status(session_status& s);
 #endif

--- a/include/libtorrent/kademlia/direct_request.hpp
+++ b/include/libtorrent/kademlia/direct_request.hpp
@@ -40,16 +40,16 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent { namespace dht
 {
 
-struct direct_trasversal : traversal_algorithm
+struct direct_traversal : traversal_algorithm
 {
-	direct_trasversal(node& node
+	direct_traversal(node& node
 		, node_id target
 		, boost::function<void(msg const&)> cb)
 		: traversal_algorithm(node, target)
 		, m_cb(cb)
 	{}
 
-	virtual char const* name() const { return "direct_trasversal"; }
+	virtual char const* name() const { return "direct_traversal"; }
 
 	void invoke_cb(msg const& m)
 	{
@@ -75,7 +75,7 @@ struct direct_observer : observer
 	virtual void reply(msg const& m)
 	{
 		flags |= flag_done;
-		static_cast<direct_trasversal*>(algorithm())->invoke_cb(m);
+		static_cast<direct_traversal*>(algorithm())->invoke_cb(m);
 	}
 
 	virtual void timeout()
@@ -86,12 +86,12 @@ struct direct_observer : observer
 		if (flags & flag_ipv6_address)
 		{
 			msg m(e, target_ep());
-			static_cast<direct_trasversal*>(algorithm())->invoke_cb(m);
+			static_cast<direct_traversal*>(algorithm())->invoke_cb(m);
 		}
 		else
 		{
 			msg m(e, target_ep());
-			static_cast<direct_trasversal*>(algorithm())->invoke_cb(m);
+			static_cast<direct_traversal*>(algorithm())->invoke_cb(m);
 		}
 	}
 };

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -245,6 +245,9 @@ public:
 	void announce(sha1_hash const& info_hash, int listen_port, int flags
 		, boost::function<void(std::vector<tcp::endpoint> const&)> f);
 
+	void direct_request(boost::asio::ip::udp::endpoint ep, entry& e
+		, boost::function<void(msg const&)> f);
+
 	void get_item(sha1_hash const& target, boost::function<bool(item&, bool)> f);
 	void get_item(char const* pk, std::string const& salt, boost::function<bool(item&, bool)> f);
 

--- a/include/libtorrent/kademlia/observer.hpp
+++ b/include/libtorrent/kademlia/observer.hpp
@@ -96,7 +96,7 @@ struct observer : boost::noncopyable
 
 	// this is called when no reply has been received within
 	// some timeout
-	void timeout();
+	virtual void timeout();
 
 	// if this is called the destructor should
 	// not invoke any new messages, and should

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -108,6 +108,13 @@ struct TORRENT_EXPORT peer_connection_handle
 	time_t last_seen_complete() const;
 	time_point time_of_last_unchoke() const;
 
+	bool operator==(peer_connection_handle const& o) const
+	{ return m_connection.lock() == o.m_connection.lock(); }
+	bool operator!=(peer_connection_handle const& o) const
+	{ return m_connection.lock() != o.m_connection.lock(); }
+	bool operator<(peer_connection_handle const& o) const
+	{ return m_connection.lock() < o.m_connection.lock(); }
+
 	boost::shared_ptr<peer_connection> native_handle() const
 	{
 		return m_connection.lock();

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -431,6 +431,12 @@ namespace libtorrent
 		void dht_get_peers(sha1_hash const& info_hash);
 		void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
+		// Send an arbitrary DHT request directly to the specified endpoint. This
+		// function is intended for use by plugins. Whan a response is received
+		// or the request times out, a dht_direct_response_alert will be posted
+		// with the response (if any) and the userdata pointer passed in here.
+		// Since this alert is a reponse to an explicit call, it will always be
+		// posted, regardless of the alert mask.
 		void dht_direct_request(boost::asio::ip::udp::endpoint ep, entry const& e, void* userdata);
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -431,6 +431,8 @@ namespace libtorrent
 		void dht_get_peers(sha1_hash const& info_hash);
 		void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
+		void dht_direct_request(boost::asio::ip::udp::endpoint ep, entry const& e, void* userdata);
+
 #ifndef TORRENT_NO_DEPRECATE
 		// deprecated in 0.15
 		// use save_state and load_state instead

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1848,13 +1848,15 @@ namespace libtorrent {
 		return msg;
 	}
 
-	void dht_direct_response_alert::response(bdecode_node& ret) const
+	bdecode_node dht_direct_response_alert::response() const
 	{
 		char const* start = m_alloc.ptr(m_response_idx);
 		char const* end = start + m_response_size;
 		error_code ec;
+		bdecode_node ret;
 		bdecode(start, end, ret, ec);
 		TORRENT_ASSERT(!ec);
+		return ret;
 	}
 
 } // namespace libtorrent

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1839,17 +1839,26 @@ namespace libtorrent {
 		, m_response_size(response.data_section().second)
 	{}
 
+	dht_direct_response_alert::dht_direct_response_alert(
+		aux::stack_allocator& alloc
+		, void* userdata
+		, udp::endpoint const& addr)
+		: userdata(userdata), addr(addr), m_alloc(alloc)
+		, m_response_idx(-1), m_response_size(0)
+	{}
+
 	std::string dht_direct_response_alert::message() const
 	{
 		char msg[1050];
 		snprintf(msg, sizeof(msg), "DHT direct response (address=%s) [ %s ]"
 			, addr.address().to_string().c_str()
-			, std::string(m_alloc.ptr(m_response_idx), m_response_size).c_str());
+			, m_response_size ? std::string(m_alloc.ptr(m_response_idx), m_response_size).c_str() : "");
 		return msg;
 	}
 
 	bdecode_node dht_direct_response_alert::response() const
 	{
+		if (m_response_size == 0) return bdecode_node();
 		char const* start = m_alloc.ptr(m_response_idx);
 		char const* end = start + m_response_size;
 		error_code ec;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1831,5 +1831,20 @@ namespace libtorrent {
 		}
 	}
 
+	dht_direct_response_alert::dht_direct_response_alert(
+		aux::stack_allocator&, void* userdata
+		, udp::endpoint const& addr, entry const& response)
+		: userdata(userdata), addr(addr), response(response)
+	{}
+
+	std::string dht_direct_response_alert::message() const
+	{
+		char msg[1050];
+		snprintf(msg, sizeof(msg), "DHT direct response (address=%s) [ %s ]"
+			, addr.address().to_string().c_str()
+			, response.to_string().c_str());
+		return msg;
+	}
+
 } // namespace libtorrent
 

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -311,6 +311,12 @@ namespace libtorrent { namespace dht
 			, _1, _2, cb));
 	}
 
+	void dht_tracker::direct_request(boost::asio::ip::udp::endpoint ep, entry& e
+		, boost::function<void(msg const&)> f)
+	{
+		m_dht.direct_request(ep, e, f);
+	}
+
 	// translate bittorrent kademlia message into the generice kademlia message
 	// used by the library
 	bool dht_tracker::incoming_packet(error_code const& ec

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -416,8 +416,8 @@ void node::direct_request(boost::asio::ip::udp::endpoint ep, entry& e
 	, boost::function<void(msg const&)> f)
 {
 	// not really a traversal
-	boost::intrusive_ptr<direct_trasversal> algo(
-		new direct_trasversal(*this, (node_id::min)(), f));
+	boost::intrusive_ptr<direct_traversal> algo(
+		new direct_traversal(*this, (node_id::min)(), f));
 
 	void* ptr = m_rpc.allocate_observer();
 	if (ptr == 0) return;

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -396,6 +396,13 @@ namespace libtorrent
 #endif
 	}
 
+	void session_handle::dht_direct_request(boost::asio::ip::udp::endpoint ep, entry const& e, void* userdata)
+	{
+#ifndef TORRENT_DISABLE_DHT
+		TORRENT_ASYNC_CALL3(dht_direct_request, ep, e, userdata);
+#endif
+	}
+
 #ifndef TORRENT_NO_DEPRECATE
 	entry session_handle::dht_state() const
 	{

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -895,6 +895,9 @@ namespace aux {
 		m_alerts.add_extension(ext);
 		ext->added(session_handle(this));
 
+		// get any DHT queries the plugin would like to handle
+		// and record them in m_extension_dht_queries for lookup
+		// later
 		dht_extensions_t dht_ext;
 		ext->register_dht_extensions(dht_ext);
 		for (dht_extensions_t::iterator e = dht_ext.begin();

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5549,9 +5549,7 @@ retry:
 
 		void on_direct_response(alert_manager& alerts, void* userdata, dht::msg const& msg)
 		{
-			entry e;
-			e = msg.message;
-			alerts.emplace_alert<dht_direct_response_alert>(userdata, msg.addr, e);
+			alerts.emplace_alert<dht_direct_response_alert>(userdata, msg.addr, msg.message);
 		}
 
 	} // anonymous namespace

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5552,7 +5552,10 @@ retry:
 
 		void on_direct_response(alert_manager& alerts, void* userdata, dht::msg const& msg)
 		{
-			alerts.emplace_alert<dht_direct_response_alert>(userdata, msg.addr, msg.message);
+			if (msg.message.type() == bdecode_node::none_t)
+				alerts.emplace_alert<dht_direct_response_alert>(userdata, msg.addr);
+			else
+				alerts.emplace_alert<dht_direct_response_alert>(userdata, msg.addr, msg.message);
 		}
 
 	} // anonymous namespace

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -894,7 +894,22 @@ namespace aux {
 		m_ses_extensions.push_back(ext);
 		m_alerts.add_extension(ext);
 		ext->added(session_handle(this));
+
+		dht_extensions_t dht_ext;
+		ext->register_dht_extensions(dht_ext);
+		for (dht_extensions_t::iterator e = dht_ext.begin();
+			e != dht_ext.end(); ++e)
+		{
+			TORRENT_ASSERT(e->first.size() <= max_dht_query_length);
+			if (e->first.size() > max_dht_query_length) continue;
+			extention_dht_query registration;
+			registration.query_len = e->first.size();
+			std::copy(e->first.begin(), e->first.end(), registration.query.begin());
+			registration.handler = e->second;
+			m_extension_dht_queries.push_back(registration);
+		}
 	}
+
 #endif // TORRENT_DISABLE_EXTENSIONS
 
 #ifndef TORRENT_NO_DEPRECATE
@@ -5532,6 +5547,13 @@ retry:
 				alerts.emplace_alert<dht_get_peers_reply_alert>(info_hash, peers);
 		}
 
+		void on_direct_response(alert_manager& alerts, void* userdata, dht::msg const& msg)
+		{
+			entry e;
+			e = msg.message;
+			alerts.emplace_alert<dht_direct_response_alert>(userdata, msg.addr, e);
+		}
+
 	} // anonymous namespace
 
 	void session_impl::dht_put_immutable_item(entry data, sha1_hash target)
@@ -5561,6 +5583,12 @@ retry:
 	{
 		if (!m_dht) return;
 		m_dht->announce(info_hash, port, flags, boost::bind(&on_dht_get_peers, boost::ref(m_alerts), info_hash, _1));
+	}
+
+	void session_impl::dht_direct_request(boost::asio::ip::udp::endpoint ep, entry& e, void* userdata)
+	{
+		if (!m_dht) return;
+		m_dht->direct_request(ep, e, boost::bind(&on_direct_response, boost::ref(m_alerts), userdata, _1));
 	}
 
 #endif
@@ -6494,6 +6522,24 @@ retry:
 			? dht_pkt_alert::incoming : dht_pkt_alert::outgoing;
 
 		m_alerts.emplace_alert<dht_pkt_alert>(pkt, len, d, node);
+	}
+
+	bool session_impl::on_dht_request(char const* query, int query_len
+		, dht::msg const& request, entry& response)
+	{
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		if (query_len > max_dht_query_length) return false;
+
+		for (m_extension_dht_queries_t::iterator i = m_extension_dht_queries.begin();
+			i != m_extension_dht_queries.end(); ++i)
+		{
+			if (query_len == i->query_len
+				&& memcmp(i->query.data(), query, query_len) == 0
+				&& i->handler(request.addr, request.message, response))
+				return true;
+		}
+#endif
+		return false;
 	}
 
 	void session_impl::set_external_address(address const& ip

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -438,6 +438,8 @@ struct obs : dht::dht_observer
 	virtual void log(dht_logger::module_t l, char const* fmt, ...) TORRENT_OVERRIDE {}
 	virtual void log_packet(message_direction_t dir, char const* pkt, int len
 		, udp::endpoint node) TORRENT_OVERRIDE {}
+	virtual bool on_dht_request(char const* query, int query_len
+		, dht::msg const& request, entry& response) TORRENT_OVERRIDE { return false; }
 };
 
 // TODO: test obfuscated_get_peers


### PR DESCRIPTION
If you're wondering why I used an alert for handling responses but not requests, it's because the former was easy to do that way but the latter would have involved some major refactoring or kludging because the DHT node code is written with the (IMO reasonable) 