### PR TITLE
Expose rss_notification alert and get_feeds method to Python

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -185,6 +185,7 @@ void bind_alert()
             .value("session_log_notification", alert::session_log_notification)
             .value("torrent_log_notification", alert::torrent_log_notification)
             .value("peer_log_notification", alert::peer_log_notification)
+            .value("rss_notification", alert::rss_notification)
             // deliberately not INT_MAX. Arch linux crash while throwing an exception
             .value("all_categories", (alert::category_t)0xfffffff)
             ;

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -392,6 +392,21 @@ namespace
         return ret;
     }
 
+    list get_feeds(session& s)
+    {
+        list ret;
+        std::vector<feed_handle> feeds;
+        {
+            allow_threading_guard guard;
+            s.get_feeds(feeds);
+        }
+        for (std::vector<feed_handle>::iterator i = feeds.begin(); i != feeds.end(); ++i)
+        {
+            ret.append(*i);
+        }
+        return ret;
+    }
+
 	 cache_status get_cache_info1(lt::session& s, torrent_handle h, int flags)
 	 {
 	 	cache_status ret;
@@ -733,6 +748,7 @@ void bind_session()
         .def("get_ip_filter", allow_threads(&lt::session::get_ip_filter))
         .def("find_torrent", allow_threads(&lt::session::find_torrent))
         .def("get_torrents", &get_torrents)
+        .def("get_feeds", &get_feeds)
         .def("pause", allow_threads(&lt::session::pause))
         .def("resume", allow_threads(&lt::session::resume))
         .def("is_paused", allow_threads(&lt::session::is_paused))


### PR DESCRIPTION
Currently you cannot work with RSS-feeds adequately from Python because the necessary alert and method are inaccessible from Python bindings. This patch should fix the issue.