### PR TITLE
Avoid a possible null pointer error when logging in on_connection_complete

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -6227,7 +6227,7 @@ namespace libtorrent
 #ifndef TORRENT_DISABLE_LOGGING
 		{
 			boost::shared_ptr<torrent> t = m_torrent.lock();
-			t->debug_log("END connect [%p]", this);
+			if (t) t->debug_log("END connect [%p]", this);
 			m_connect_time = completed;
 		}
 #endif


### PR DESCRIPTION
I was getting native errors related to a null pointer error in this peer_connection::on_connection_complete. This change seems to solve the issue since I'm not getting the error.