### PR TITLE
Save and load torrent priority from resume data.

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -321,6 +321,10 @@ The file format is a bencoded dictionary containing the following fields:
 +--------------------------+--------------------------------------------------------------+
 | ``seed_mode``            | integer. 1 if the torrent is in seed mode, 0 otherwise.      |
 +--------------------------+--------------------------------------------------------------+
+| ``priority``             | integer. The priority of a torrent determines how much       |
+|                          | bandwidth its peers are assigned when distributing upload    |
+|                          | and download rate quotas.                                    |
++--------------------------+--------------------------------------------------------------+
 | ``file_priority``        | list of integers. One entry per file in the torrent. Each    |
 |                          | entry is the priority of the file with the same index.       |
 +--------------------------+--------------------------------------------------------------+

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5266,7 +5266,10 @@ namespace libtorrent
 		m_complete = rd.dict_find_int_value("num_complete", 0xffffff);
 		m_incomplete = rd.dict_find_int_value("num_incomplete", 0xffffff);
 		m_downloaded = rd.dict_find_int_value("num_downloaded", 0xffffff);
-
+		int priorityValue = rd.dict_find_int_value("priority");
+		if (priorityValue >=0 && priorityValue < 256)
+			m_priority = priorityValue;
+			
 		if (!m_override_resume_data)
 		{
 			int up_limit_ = rd.dict_find_int_value("upload_rate_limit", -1);
@@ -5773,7 +5776,8 @@ namespace libtorrent
 		ret["announce_to_trackers"] = m_announce_to_trackers;
 		ret["announce_to_lsd"] = m_announce_to_lsd;
 		ret["auto_managed"] = m_auto_managed;
-
+		ret["priority"] = m_priority;
+		
 		// write piece priorities
 		entry::string_type& piece_priority = ret["piece_priority"].string();
 		piece_priority.resize(m_torrent_file->num_pieces());


### PR DESCRIPTION
Torrent priority not saved to resume data.