### PR TITLE
Remove extra `\` in test/Makefile.am

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,7 +111,7 @@ libtest_la_SOURCES = main.cpp \
   web_seed_suite.cpp \
   swarm_suite.cpp \
   test_utils.cpp \
-  settings.cpp \
+  settings.cpp
 
 test_primitives_SOURCES = \
   test_primitives.cpp \


### PR DESCRIPTION
With extra slash `autotool.sh` errors with
`test/Makefile.am:115: error: blank line following trailing backslash`
