### PR TITLE
Removed unnecessary full namespace reference to udp::endpoint in new dht_direct_request feature.

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -322,7 +322,7 @@ namespace libtorrent
 			void dht_get_peers(sha1_hash const& info_hash);
 			void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
-			void dht_direct_request(boost::asio::ip::udp::endpoint ep, entry& e, void* userdata);
+			void dht_direct_request(udp::endpoint ep, entry& e, void* userdata = 0);
 
 #ifndef TORRENT_NO_DEPRECATE
 			entry dht_state() const;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -107,7 +107,7 @@ namespace libtorrent { namespace dht
 			, boost::function<void(item&)> cb, std::string salt = std::string());
 
 		// send an arbitrary DHT request directly to a node
-		void direct_request(boost::asio::ip::udp::endpoint ep, entry& e
+		void direct_request(udp::endpoint ep, entry& e
 			, boost::function<void(msg const&)> f);
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -432,12 +432,12 @@ namespace libtorrent
 		void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
 		// Send an arbitrary DHT request directly to the specified endpoint. This
-		// function is intended for use by plugins. Whan a response is received
+		// function is intended for use by plugins. When a response is received
 		// or the request times out, a dht_direct_response_alert will be posted
 		// with the response (if any) and the userdata pointer passed in here.
-		// Since this alert is a reponse to an explicit call, it will always be
+		// Since this alert is a response to an explicit call, it will always be
 		// posted, regardless of the alert mask.
-		void dht_direct_request(boost::asio::ip::udp::endpoint ep, entry const& e, void* userdata);
+		void dht_direct_request(udp::endpoint ep, entry const& e, void* userdata = 0);
 
 #ifndef TORRENT_NO_DEPRECATE
 		// deprecated in 0.15

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -311,7 +311,7 @@ namespace libtorrent { namespace dht
 			, _1, _2, cb));
 	}
 
-	void dht_tracker::direct_request(boost::asio::ip::udp::endpoint ep, entry& e
+	void dht_tracker::direct_request(udp::endpoint ep, entry& e
 		, boost::function<void(msg const&)> f)
 	{
 		m_dht.direct_request(ep, e, f);

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -396,7 +396,7 @@ namespace libtorrent
 #endif
 	}
 
-	void session_handle::dht_direct_request(boost::asio::ip::udp::endpoint ep, entry const& e, void* userdata)
+	void session_handle::dht_direct_request(udp::endpoint ep, entry const& e, void* userdata)
 	{
 #ifndef TORRENT_DISABLE_DHT
 		TORRENT_ASYNC_CALL3(dht_direct_request, ep, e, userdata);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5589,7 +5589,7 @@ retry:
 		m_dht->announce(info_hash, port, flags, boost::bind(&on_dht_get_peers, boost::ref(m_alerts), info_hash, _1));
 	}
 
-	void session_impl::dht_direct_request(boost::asio::ip::udp::endpoint ep, entry& e, void* userdata)
+	void session_impl::dht_direct_request(udp::endpoint ep, entry& e, void* userdata)
 	{
 		if (!m_dht) return;
 		m_dht->direct_request(ep, e, boost::bind(&on_direct_response, boost::ref(m_alerts), userdata, _1));


### PR DESCRIPTION
Add default value to userdata argument in dht_direct_request.
Minor spelling fix.

This helps a lot in building the swig wrapper.