### PR TITLE
Added missing dependencies to fix examples build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,7 @@ AS_IF([test -z "$BOOST_RANDOM_LIB"],
 
 CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
+LIBS="$BOOST_CHRONO_LIB $BOOST_RANDOM_LIB $LIBS"
 
 ###############################################################################
 # Checking for functions and other stuffs


### PR DESCRIPTION
Main examples like 'simple_client' failed to build as they
were not linked against boost chrono and boost random libraries