### PR TITLE
Recoded torrent_alert constructor logic to build the name.

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -60,16 +60,19 @@ namespace libtorrent {
 		: handle(h)
 		, m_alloc(alloc)
 	{
-		std::string name_str;
-		if (h.native_handle())
+		boost::shared_ptr<torrent> t = h.native_handle();
+		if (t)
 		{
-			m_name_idx = alloc.copy_string(h.native_handle()->name());
-		}
-		else if (h.is_valid())
-		{
-			char msg[41];
-			to_hex(h.native_handle()->info_hash().data(), 20, msg);
-			m_name_idx = alloc.copy_string(msg);
+			std::string name_str = t->name();
+			if (!name_str.empty()) {
+				m_name_idx = alloc.copy_string(name_str);
+			}
+			else
+			{
+				char msg[41];
+				to_hex(t->info_hash().data(), 20, msg);
+				m_name_idx = alloc.copy_string(msg);
+			}
 		}
 		else
 		{

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -74,7 +74,7 @@ namespace libtorrent
 	{
 		TORRENT_ASSERT(l.locked());
 		// wow, this is quite a hack
-		pthread_cond_wait(&m_cond, reinterpret_cast<::pthread_mutex_t*>(&l.mutex()));
+		pthread_cond_wait(&m_cond, reinterpret_cast<pthread_mutex_t*>(&l.mutex()));
 	}
 
 	void condition_variable::wait_for(mutex::scoped_lock& l, time_duration rel_time)
@@ -89,7 +89,7 @@ namespace libtorrent
 		ts.tv_sec = tv.tv_sec + total_seconds(rel_time) + microseconds / 1000000;
 
 		// wow, this is quite a hack
-		pthread_cond_timedwait(&m_cond, reinterpret_cast<::pthread_mutex_t*>(&l.mutex()), &ts);
+		pthread_cond_timedwait(&m_cond, reinterpret_cast<pthread_mutex_t*>(&l.mutex()), &ts);
 	}
 
 	void condition_variable::notify_all()


### PR DESCRIPTION
Previously, didn't seem to me quite right since `h.native_handle()` and `h.is_valid()` should be the same under the `if (cond)`.

Fixed compilation issue in Mac OS X.