### PR TITLE
Removed unnecessary call to node_id copy constructor.

### DIFF
--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -87,7 +87,7 @@ namespace libtorrent { namespace dht
 		entry const* nid = e->find_key("node-id");
 		if (nid == 0 || nid->type() != entry::string_t || nid->string().length() != 20)
 			return (node_id::min)();
-		return node_id(node_id(nid->string().c_str()));
+		return node_id(nid->string().c_str());
 	}
 
 	} // anonymous namespace


### PR DESCRIPTION
Or is there a reason for it?