### PR TITLE
The constant siocgifmtu is used in the context of all these macros.

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -88,7 +88,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <ifaddrs.h>
 #endif
 
-#if TORRENT_USE_IFADDRS
+#if TORRENT_USE_IFADDRS || TORRENT_USE_IFCONF || TORRENT_USE_NETLINK || TORRENT_USE_SYSCTL
 // capture this here where warnings are disabled (the macro generates warnings)
 const int siocgifmtu = SIOCGIFMTU;
 #endif


### PR DESCRIPTION
Without this, the compilation is android fails. The same should happens in others not so common OSes.