### PR TITLE
Add read-only support in dht_settings and outgoing query messages.

### DIFF
--- a/bindings/python/src/session_settings.cpp
+++ b/bindings/python/src/session_settings.cpp
@@ -290,6 +290,9 @@ void bind_session_settings()
         .def_readwrite("privacy_lookups", &dht_settings::privacy_lookups)
         .def_readwrite("enforce_node_id", &dht_settings::enforce_node_id)
         .def_readwrite("ignore_dark_internet", &dht_settings::ignore_dark_internet)
+        .def_readwrite("block_timeout", &dht_settings::block_timeout)
+        .def_readwrite("block_ratelimit", &dht_settings::block_ratelimit)
+        .def_readwrite("read_only", &dht_settings::read_only)
     ;
 #endif
 

--- a/include/libtorrent/kademlia/rpc_manager.hpp
+++ b/include/libtorrent/kademlia/rpc_manager.hpp
@@ -83,7 +83,8 @@ public:
 	rpc_manager(node_id const& our_id
 		, routing_table& table
 		, udp_socket_interface* sock
-		, dht_logger* log);
+		, dht_logger* log
+		, bool read_only = false);
 	~rpc_manager();
 
 	void unreachable(udp::endpoint const& ep);
@@ -130,6 +131,7 @@ private:
 	node_id m_our_id;
 	boost::uint32_t m_allocated_observers:31;
 	boost::uint32_t m_destructing:1;
+	bool m_read_only;
 };
 
 } } // namespace libtorrent::dht

--- a/include/libtorrent/kademlia/rpc_manager.hpp
+++ b/include/libtorrent/kademlia/rpc_manager.hpp
@@ -81,17 +81,17 @@ class TORRENT_EXTRA_EXPORT rpc_manager
 public:
 
 	rpc_manager(node_id const& our_id
+		, dht_settings const& settings
 		, routing_table& table
 		, udp_socket_interface* sock
-		, dht_logger* log
-		, bool read_only = false);
+		, dht_logger* log);
 	~rpc_manager();
 
 	void unreachable(udp::endpoint const& ep);
 
 	// returns true if the node needs a refresh
 	// if so, id is assigned the node id to refresh
-	bool incoming(msg const&, node_id* id, libtorrent::dht_settings const& settings);
+	bool incoming(msg const&, node_id* id);
 	time_duration tick();
 
 	bool invoke(entry& e, udp::endpoint target
@@ -126,12 +126,12 @@ private:
 	
 	udp_socket_interface* m_sock;
 	dht_logger* m_log;
+	dht_settings const& m_settings;
 	routing_table& m_table;
 	time_point m_timer;
 	node_id m_our_id;
 	boost::uint32_t m_allocated_observers:31;
 	boost::uint32_t m_destructing:1;
-	bool m_read_only;
 };
 
 } } // namespace libtorrent::dht

--- a/include/libtorrent/session_settings.hpp
+++ b/include/libtorrent/session_settings.hpp
@@ -1490,7 +1490,7 @@ namespace libtorrent
 		// without getting banned.
 		int block_ratelimit;
 
-		// when set, the other nodes won't kept this node in their routing
+		// when set, the other nodes won't keep this node in their routing
 		// tables, it's meant for low-power and/or ephemeral devices that
 		// cannot support the DHT, it is also useful for mobile devices which
 		// are sensitive to network traffic and battery life.

--- a/include/libtorrent/session_settings.hpp
+++ b/include/libtorrent/session_settings.hpp
@@ -1403,6 +1403,7 @@ namespace libtorrent
 			, ignore_dark_internet(true)
 			, block_timeout(5 * 60)
 			, block_ratelimit(5)
+			, read_only(false)
 		{}
 
 		// the maximum number of peers to send in a reply to ``get_peers``
@@ -1488,6 +1489,15 @@ namespace libtorrent
 		// the max number of packets per second a DHT node is allowed to send
 		// without getting banned.
 		int block_ratelimit;
+
+		// when set, the other nodes won't kept this node in their routing
+		// tables, it's meant for low-power and/or ephemeral devices that
+		// cannot support the DHT, it is also useful for mobile devices which
+		// are sensitive to network traffic and battery life.
+		// this node no longer responds to 'query' messages, and will place a
+		// 'ro' key (value = 1) in the top-level message dictionary of outgoing
+		// query messages.
+		bool read_only;
 	};
 
 

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -109,7 +109,7 @@ node::node(udp_socket_interface* sock
 	: m_settings(settings)
 	, m_id(calculate_node_id(nid, observer))
 	, m_table(m_id, 8, settings, observer)
-	, m_rpc(m_id, m_table, sock, observer, settings.read_only)
+	, m_rpc(m_id, m_settings, m_table, sock, observer)
 	, m_observer(observer)
 	, m_last_tracker_tick(aux::time_now())
 	, m_last_self_refresh(min_time())
@@ -274,7 +274,7 @@ void node::incoming(msg const& m)
 		case 'r':
 		{
 			node_id id;
-			m_rpc.incoming(m, &id, m_settings);
+			m_rpc.incoming(m, &id);
 			break;
 		}
 		case 'q':
@@ -300,7 +300,7 @@ void node::incoming(msg const& m)
 			}
 #endif
 			node_id id;
-			m_rpc.incoming(m, &id, m_settings);
+			m_rpc.incoming(m, &id);
 			break;
 		}
 	}

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -109,7 +109,7 @@ node::node(udp_socket_interface* sock
 	: m_settings(settings)
 	, m_id(calculate_node_id(nid, observer))
 	, m_table(m_id, 8, settings, observer)
-	, m_rpc(m_id, m_table, sock, observer)
+	, m_rpc(m_id, m_table, sock, observer, settings.read_only)
 	, m_observer(observer)
 	, m_last_tracker_tick(aux::time_now())
 	, m_last_self_refresh(min_time())
@@ -280,6 +280,10 @@ void node::incoming(msg const& m)
 		case 'q':
 		{
 			TORRENT_ASSERT(m.message.dict_find_string_value("y") == "q");
+			// When a DHT node enters the read-only state, it no longer
+			// responds to 'query' messages that it receives.
+			if (m_settings.read_only) break;
+
 			entry e;
 			incoming_request(m, e);
 			m_sock->send_packet(e, m.addr, 0);

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -163,18 +163,18 @@ enum { observer_size = max3<
 };
 
 rpc_manager::rpc_manager(node_id const& our_id
+	, dht_settings const& settings
 	, routing_table& table, udp_socket_interface* sock
-	, dht_logger* log
-	, bool read_only)
+	, dht_logger* log)
 	: m_pool_allocator(observer_size, 10)
 	, m_sock(sock)
 	, m_log(log)
+	, m_settings(settings)
 	, m_table(table)
 	, m_timer(aux::time_now())
 	, m_our_id(our_id)
 	, m_allocated_observers(0)
 	, m_destructing(false)
-	, m_read_only(read_only)
 {}
 
 rpc_manager::~rpc_manager()
@@ -246,8 +246,7 @@ void rpc_manager::unreachable(udp::endpoint const& ep)
 	}
 }
 
-bool rpc_manager::incoming(msg const& m, node_id* id
-	, libtorrent::dht_settings const& settings)
+bool rpc_manager::incoming(msg const& m, node_id* id)
 {
 	INVARIANT_CHECK;
 
@@ -337,7 +336,7 @@ bool rpc_manager::incoming(msg const& m, node_id* id
 	}
 
 	node_id nid = node_id(node_id_ent.string_ptr());
-	if (settings.enforce_node_id && !verify_id(nid, m.addr.address()))
+	if (m_settings.enforce_node_id && !verify_id(nid, m.addr.address()))
 	{
 		o->timeout();
 		return false;
@@ -443,7 +442,7 @@ bool rpc_manager::invoke(entry& e, udp::endpoint target_addr
 
 	// When a DHT node enters the read-only state, in each outgoing query message,
 	// places a 'ro' key in the top-level message dictionary and sets its value to 1.
-	if (m_read_only) e["ro"] = 1;
+	if (m_settings.read_only) e["ro"] = 1;
 
 	o->set_target(target_addr);
 	o->set_transaction_id(tid);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -704,7 +704,15 @@ namespace aux {
 			dht_sett["max_dht_items"] = m_dht_settings.max_dht_items;
 			dht_sett["max_torrent_search_reply"] = m_dht_settings.max_torrent_search_reply;
 			dht_sett["restrict_routing_ips"] = m_dht_settings.restrict_routing_ips;
+			dht_sett["restrict_search_ips"] = m_dht_settings.restrict_search_ips;
 			dht_sett["extended_routing_table"] = m_dht_settings.extended_routing_table;
+			dht_sett["aggressive_lookups"] = m_dht_settings.aggressive_lookups;
+			dht_sett["privacy_lookups"] = m_dht_settings.privacy_lookups;
+			dht_sett["enforce_node_id"] = m_dht_settings.enforce_node_id;
+			dht_sett["ignore_dark_internet"] = m_dht_settings.ignore_dark_internet;
+			dht_sett["block_timeout"] = m_dht_settings.block_timeout;
+			dht_sett["block_ratelimit"] = m_dht_settings.block_ratelimit;
+			dht_sett["read_only"] = m_dht_settings.read_only;
 		}
 
 		if (m_dht && (flags & session::save_dht_state))
@@ -769,8 +777,24 @@ namespace aux {
 			if (val) m_dht_settings.max_torrent_search_reply = val.int_value();
 			val = settings.dict_find_int("restrict_routing_ips");
 			if (val) m_dht_settings.restrict_routing_ips = val.int_value();
+			val = settings.dict_find_int("restrict_search_ips");
+			if (val) m_dht_settings.restrict_search_ips = val.int_value();
 			val = settings.dict_find_int("extended_routing_table");
 			if (val) m_dht_settings.extended_routing_table = val.int_value();
+			val = settings.dict_find_int("aggressive_lookups");
+			if (val) m_dht_settings.aggressive_lookups = val.int_value();
+			val = settings.dict_find_int("privacy_lookups");
+			if (val) m_dht_settings.privacy_lookups = val.int_value();
+			val = settings.dict_find_int("enforce_node_id");
+			if (val) m_dht_settings.enforce_node_id = val.int_value();
+			val = settings.dict_find_int("ignore_dark_internet");
+			if (val) m_dht_settings.ignore_dark_internet = val.int_value();
+			val = settings.dict_find_int("block_timeout");
+			if (val) m_dht_settings.block_timeout = val.int_value();
+			val = settings.dict_find_int("block_ratelimit");
+			if (val) m_dht_settings.block_ratelimit = val.int_value();
+			val = settings.dict_find_int("read_only");
+			if (val) m_dht_settings.read_only = val.int_value();
 		}
 #endif
 


### PR DESCRIPTION
Not sure why we only handle 'ro' in incoming_request, should we support read-only in outgoing messages?
