### PR TITLE
A node with an invalid node_id, shouldn't be added to routing table.

### DIFF
--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -1106,6 +1106,8 @@ void routing_table::add_router_node(udp::endpoint router)
 // pinged == false)
 void routing_table::heard_about(node_id const& id, udp::endpoint const& ep)
 {
+	// only when the node_id pass the verification, add it to routing table.
+	if (m_settings.enforce_node_id && !verify_id(id, ep.address())) return;
 	add_node(node_entry(id, ep));
 }
 


### PR DESCRIPTION
If a node enabled dht_settings.enforce_node_id, when it receives a request which can't pass the node_id verification, then it will response a error with "Invalid node id"; when it receives a response which can't pass the node_id verification, then it will just ignore it.

The thing is, if it knows that the id won't pass the verification, it shouldn't send the request at all, and even more, it shouldn't keep that node in his routing table at all.
