### PR TITLE
make immutable/mutable items lifetime configurable.

### DIFF
--- a/bindings/python/src/session_settings.cpp
+++ b/bindings/python/src/session_settings.cpp
@@ -293,6 +293,7 @@ void bind_session_settings()
         .def_readwrite("block_timeout", &dht_settings::block_timeout)
         .def_readwrite("block_ratelimit", &dht_settings::block_ratelimit)
         .def_readwrite("read_only", &dht_settings::read_only)
+        .def_readwrite("item_lifetime", &dht_settings::item_lifetime)
     ;
 #endif
 

--- a/include/libtorrent/session_settings.hpp
+++ b/include/libtorrent/session_settings.hpp
@@ -1404,6 +1404,7 @@ namespace libtorrent
 			, block_timeout(5 * 60)
 			, block_ratelimit(5)
 			, read_only(false)
+			, item_lifetime(0)
 		{}
 
 		// the maximum number of peers to send in a reply to ``get_peers``
@@ -1498,6 +1499,10 @@ namespace libtorrent
 		// 'ro' key (value = 1) in the top-level message dictionary of outgoing
 		// query messages.
 		bool read_only;
+
+		// the number of seconds a immutable/mutable item will be expired.
+		// default is 0, means never expires.
+		int item_lifetime;
 	};
 
 

--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -474,19 +474,6 @@ namespace
 		{
 			time_point now(aux::time_now());
 
-			for (dht_immutable_table_t::iterator i = m_immutable_table.begin();
-				 i != m_immutable_table.end();)
-			{
-				if (i->second.last_seen + minutes(60) > now)
-				{
-					++i;
-					continue;
-				}
-				free(i->second.value);
-				m_immutable_table.erase(i++);
-				m_counters.immutable_data -= 1;
-			}
-
 			// look through all peers and see if any have timed out
 			for (table_t::iterator i = m_map.begin(), end(m_map.end()); i != end;)
 			{
@@ -504,6 +491,39 @@ namespace
 					m_map.erase(it);
 					m_counters.torrents -= 1;
 				}
+			}
+
+			if (0 == m_settings.item_lifetime) return;
+
+			time_duration lifetime = seconds(m_settings.item_lifetime);
+			// item lifetime must >= 120 minutes.
+			if (lifetime < minutes(120)) lifetime = minutes(120);
+
+			for (dht_immutable_table_t::iterator i = m_immutable_table.begin();
+				i != m_immutable_table.end();)
+			{
+				if (i->second.last_seen + lifetime > now)
+				{
+					++i;
+					continue;
+				}
+				free(i->second.value);
+				m_immutable_table.erase(i++);
+				m_counters.immutable_data -= 1;
+			}
+
+			for (dht_mutable_table_t::iterator i = m_mutable_table.begin();
+				i != m_mutable_table.end();)
+			{
+				if (i->second.last_seen + lifetime > now)
+				{
+					++i;
+					continue;
+				}
+				free(i->second.value);
+				free(i->second.salt);
+				m_mutable_table.erase(i++);
+				m_counters.mutable_data -= 1;
 			}
 		}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -713,6 +713,7 @@ namespace aux {
 			dht_sett["block_timeout"] = m_dht_settings.block_timeout;
 			dht_sett["block_ratelimit"] = m_dht_settings.block_ratelimit;
 			dht_sett["read_only"] = m_dht_settings.read_only;
+			dht_sett["item_lifetime"] = m_dht_settings.item_lifetime;
 		}
 
 		if (m_dht && (flags & session::save_dht_state))
@@ -796,6 +797,8 @@ namespace aux {
 			if (val) m_dht_settings.block_ratelimit = val.int_value();
 			val = settings.dict_find_int("read_only");
 			if (val) m_dht_settings.read_only = val.int_value();
+			val = settings.dict_find_int("item_lifetime");
+			if (val) m_dht_settings.item_lifetime = val.int_value();
 		}
 
 		settings = e->dict_find_dict("dht state");


### PR DESCRIPTION
Based on [bep 44] (http://bittorrent.org/beps/bep_0044.html)
>Expiration
>Without re-announcement, these items MAY expire in 2 hours. In order to keep items alive, they SHOULD be re-announced once an hour.