### PR TITLE
Create dht_storage_counters to avoid internal counter in future public API

### DIFF
--- a/include/libtorrent/kademlia/dht_storage.hpp
+++ b/include/libtorrent/kademlia/dht_storage.hpp
@@ -50,6 +50,15 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 namespace dht
 {
+	// This structure hold the relevant counters for the storage
+	struct TORRENT_EXPORT dht_storage_counters
+	{
+		boost::int32_t torrents;
+		boost::int32_t peers;
+		boost::int32_t immutable_data;
+		boost::int32_t mutable_data;
+	};
+
 	// The DHT storage interface is a pure virtual class that can
 	// be implemented to customize how the data for the DHT is stored.
 	//
@@ -186,12 +195,13 @@ namespace dht
 		//
 		virtual void tick() = 0;
 
+		virtual dht_storage_counters counters() const = 0;
+
 		virtual ~dht_storage_interface() {}
 	};
 
 	TORRENT_EXPORT dht_storage_interface* dht_default_storage_constructor(sha1_hash const& id
-		, dht_settings const& settings
-		, counters& counters);
+		, dht_settings const& settings);
 
 } } // namespace libtorrent::dht
 

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -114,6 +114,7 @@ namespace libtorrent { namespace dht
 #endif
 		void dht_status(std::vector<dht_routing_bucket>& table
 			, std::vector<dht_lookup>& requests);
+		void update_stats_counters(counters& c) const;
 
 		// translate bittorrent kademlia message into the generic kademlia message
 		// used by the library

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -214,6 +214,8 @@ public:
 	void status(std::vector<dht_routing_bucket>& table
 		, std::vector<dht_lookup>& requests);
 
+	void update_stats_counters(counters& c) const;
+
 #ifndef TORRENT_NO_DEPRECATE
 	void status(libtorrent::session_status& s);
 #endif

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -171,6 +171,11 @@ namespace libtorrent { namespace dht
 		m_dht.status(table, requests);
 	}
 
+	void dht_tracker::update_stats_counters(counters& c) const
+	{
+		m_dht.update_stats_counters(c);
+	}
+
 	void dht_tracker::connection_timeout(error_code const& e)
 	{
 		if (e || m_abort) return;

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -98,7 +98,7 @@ node::node(udp_socket_interface* sock
 	, m_last_self_refresh(min_time())
 	, m_sock(sock)
 	, m_counters(cnt)
-	, m_storage(dht_default_storage_constructor(m_id, m_settings, m_counters))
+	, m_storage(dht_default_storage_constructor(m_id, m_settings))
 {
 	m_secret[0] = random();
 	m_secret[1] = random();
@@ -601,6 +601,18 @@ void node::status(std::vector<dht_routing_bucket>& table
 		dht_lookup& lookup = requests.back();
 		(*i)->status(lookup);
 	}
+}
+
+// TODO: in the future, this function should update all the
+// dht related counter. For now, it just update the storage
+// related ones.
+void node::update_stats_counters(counters& c) const
+{
+	const dht_storage_counters& dht_cnt = m_storage->counters();
+	c.set_value(counters::dht_torrents, dht_cnt.torrents);
+	c.set_value(counters::dht_peers, dht_cnt.peers);
+	c.set_value(counters::dht_immutable_data, dht_cnt.immutable_data);
+	c.set_value(counters::dht_mutable_data, dht_cnt.mutable_data);
 }
 
 #ifndef TORRENT_NO_DEPRECATE
@@ -1154,4 +1166,5 @@ void node::incoming_request(msg const& m, entry& e)
 		return;
 	}
 }
+
 } } // namespace libtorrent::dht

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4417,6 +4417,11 @@ retry:
 	{
 		m_disk_thread.update_stats_counters(m_stats_counters);
 
+#ifndef TORRENT_DISABLE_DHT
+		if (m_dht)
+			m_dht->update_stats_counters(m_stats_counters);
+#endif
+
 		m_stats_counters.set_value(counters::sent_ip_overhead_bytes
 			, m_stat.total_transfer(stat::upload_ip_protocol));
 

--- a/test/test_dht_storage.cpp
+++ b/test/test_dht_storage.cpp
@@ -74,8 +74,7 @@ namespace
 TORRENT_TEST(dht_storage)
 {
 	dht_settings sett = test_settings();
-	counters cnt;
-	dht_storage_interface* s = dht_default_storage_constructor(node_id(0), sett, cnt);
+	dht_storage_interface* s = dht_default_storage_constructor(node_id(0), sett);
 
 	TEST_CHECK(s != NULL);
 


### PR DESCRIPTION
Hi @arvidn, I know you are very concerned about adding more structures to the public API, but I didn't find another efficient way to keep track of the counters.

If this gets merged, I need to fix the counter peers in purge_peers. Currently it is ignored.