### PR TITLE
remove fallocate hack

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix fallocate hack on linux (fixes corruption on some architectures)
 	* fix auto-manage bug with announce to tracker/lsd/dht limits
 	* improve DHT routing table to not create an unbalanced tree
 	* fix bug in uTP that would cause any connection taking more than one second

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -193,6 +193,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #else
 #define TORRENT_USE_IFADDRS 1
 #define TORRENT_USE_POSIX_MEMALIGN 1
+
+// posix_fallocate() is available under this condition
+#if _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L
+#define TORRENT_HAS_FALLOCATE 1
+#else
+#define TORRENT_HAS_FALLOCATE 0
+#endif
+
 #endif
 
 #if __amd64__ || __i386__

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -106,23 +106,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #define lseek lseek64
 #endif
 
-#include <asm/unistd.h> // For __NR_fallocate
-
-// circumvent the lack of support in glibc
-static int my_fallocate(int fd, int mode, loff_t offset, loff_t len)
-{
-#ifdef __NR_fallocate
-	// the man page on fallocate differes between versions of linux.
-	// it appears that fallocate in fact sets errno and returns -1
-	// on failure.
-	return syscall(__NR_fallocate, fd, mode, offset, len);
-#else
-	// pretend that the system call doesn't exist
-	errno = ENOSYS;
-	return -1;
-#endif
-}
-
 #elif defined __APPLE__ && defined __MACH__ && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 // mac specifics
 
@@ -2292,23 +2275,6 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 			int ret;
 #endif
 
-#if defined TORRENT_LINUX
-			ret = my_fallocate(m_fd, 0, 0, s);
-			// if we return 0, everything went fine
-			// the fallocate call succeeded
-			if (ret == 0) return true;
-			// otherwise, something went wrong. If the error
-			// is ENOSYS, just keep going and do it the old-fashioned
-			// way. If fallocate failed with some other error, it
-			// probably means the user should know about it, error out
-			// and report it.
-			if (errno != ENOSYS && errno != EOPNOTSUPP && errno != EINVAL)
-			{
-				ec.assign(errno, get_posix_category());
-				return false;
-			}
-#endif // TORRENT_LINUX
-
 #if TORRENT_HAS_FALLOCATE
 			// if fallocate failed, we have to use posix_fallocate
 			// which can be painfully slow
@@ -2316,7 +2282,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 			// define TORRENT_HAS_FALLOCATE to 0.
 			ret = posix_fallocate(m_fd, 0, s);
 			// posix_allocate fails with EINVAL in case the underlying
-			// filesystem does bot support this operation
+			// filesystem does not support this operation
 			if (ret != 0 && ret != EINVAL)
 			{
 				ec.assign(ret, get_posix_category());


### PR DESCRIPTION
 to make the system call directly (appears to not be portable to all architectures). instead rely on posix_fallocate, which should be safe in this day and age