### PR TITLE
make DHT routing table refresh interval configurable.

### DIFF
--- a/bindings/python/src/session_settings.cpp
+++ b/bindings/python/src/session_settings.cpp
@@ -294,6 +294,7 @@ void bind_session_settings()
         .def_readwrite("block_ratelimit", &dht_settings::block_ratelimit)
         .def_readwrite("read_only", &dht_settings::read_only)
         .def_readwrite("item_lifetime", &dht_settings::item_lifetime)
+        .def_readwrite("refresh_timeout", &dht_settings::refresh_timeout)
     ;
 #endif
 

--- a/include/libtorrent/session_settings.hpp
+++ b/include/libtorrent/session_settings.hpp
@@ -1405,6 +1405,7 @@ namespace libtorrent
 			, block_ratelimit(5)
 			, read_only(false)
 			, item_lifetime(0)
+			, refresh_timeout(5)
 		{}
 
 		// the maximum number of peers to send in a reply to ``get_peers``
@@ -1503,6 +1504,10 @@ namespace libtorrent
 		// the number of seconds a immutable/mutable item will be expired.
 		// default is 0, means never expires.
 		int item_lifetime;
+
+		// the number of seconds DHT routing table need to be refreshed, to
+		// maintain enough fresh nodes in routing table.
+		int refresh_timeout;
 	};
 
 

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -197,7 +197,7 @@ namespace libtorrent { namespace dht
 		m_blocker.set_rate_limit(m_settings.block_ratelimit);
 
 		error_code ec;
-		m_refresh_timer.expires_from_now(seconds(5), ec);
+		m_refresh_timer.expires_from_now(seconds(m_settings.refresh_timeout), ec);
 		m_refresh_timer.async_wait(
 			boost::bind(&dht_tracker::refresh_timeout, self(), _1));
 	}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -714,6 +714,7 @@ namespace aux {
 			dht_sett["block_ratelimit"] = m_dht_settings.block_ratelimit;
 			dht_sett["read_only"] = m_dht_settings.read_only;
 			dht_sett["item_lifetime"] = m_dht_settings.item_lifetime;
+			dht_sett["refresh_timeout"] = m_dht_settings.refresh_timeout;
 		}
 
 		if (m_dht && (flags & session::save_dht_state))
@@ -799,6 +800,8 @@ namespace aux {
 			if (val) m_dht_settings.read_only = val.int_value();
 			val = settings.dict_find_int("item_lifetime");
 			if (val) m_dht_settings.item_lifetime = val.int_value();
+			val = settings.dict_find_int("refresh_timeout");
+			if (val) m_dht_settings.refresh_timeout = val.int_value();
 		}
 
 		settings = e->dict_find_dict("dht state");


### PR DESCRIPTION
As I have mentioned in #129, I am testing how to reduce bandwidth usage without performance lost. 
I changed refresh interval to 30 seconds, seems it works fine. So I think maybe we can make the refresh interval also configurable?

Here is the result on 4 computers. (github support upload image now. :+1: )
- Default means enable 'readonly', all other settings are default.
- Tuning means enable 'readonly'(#128), disable re-bootstrap(#162), using 'ping' instead of 'get_peers' (#155) and set refresh interval to 30 seconds (this PR :smile:)

There is one exception in performance test, if removed that one, then get_immutable_item average response will be received in 200 ~ 300 ms. ( :+1: )

![performance ms](https://cloud.githubusercontent.com/assets/13663657/10029240/e65a9fac-613e-11e5-8ccd-7c932b435f14.png)
![performance ms 2](https://cloud.githubusercontent.com/assets/13663657/10029187/a384b12c-613e-11e5-8ee0-b826b56c0b77.png)
![routingtable](https://cloud.githubusercontent.com/assets/13663657/10029226/d7d94d16-613e-11e5-8dd2-5fa3487004dc.png)