### PR TITLE
Remove leftover TORRENT_COMPACT_PICKER definition

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -601,12 +601,6 @@ int snprintf(char* buf, int len, char const* fmt, ...)
 #endif
 #endif
 
-// if set to true, piece picker will use less RAM
-// but only support up to ~260000 pieces in a torrent
-#ifndef TORRENT_COMPACT_PICKER
-#define TORRENT_COMPACT_PICKER 0
-#endif
-
 #ifndef TORRENT_USE_I2P
 #define TORRENT_USE_I2P 1
 #endif


### PR DESCRIPTION
Found this orphaned definition when comparing RC_1_0 to master branch. Due to switch from TORRENT_COMPACT_PICKER to TORRENT_OPTIMIZE_MEMORY_USAGE.