### PR TITLE
fix traversal_algorithm::done() being invoked more than once

### DIFF
--- a/include/libtorrent/kademlia/traversal_algorithm.hpp
+++ b/include/libtorrent/kademlia/traversal_algorithm.hpp
@@ -67,7 +67,6 @@ struct traversal_algorithm : boost::noncopyable
 	void failed(observer_ptr o, int flags = 0);
 	virtual ~traversal_algorithm();
 	void status(dht_lookup& l);
-	void abort();
 
 	void* allocate_observer();
 	void free_observer(void* ptr);

--- a/src/kademlia/find_data.cpp
+++ b/src/kademlia/find_data.cpp
@@ -135,8 +135,6 @@ char const* find_data::name() const { return "find_data"; }
 
 void find_data::done()
 {
-	if (m_invoke_count != 0) return;
-
 	m_done = true;
 
 #ifndef TORRENT_DISABLE_LOGGING

--- a/src/kademlia/get_item.cpp
+++ b/src/kademlia/get_item.cpp
@@ -111,7 +111,7 @@ void get_item::got_data(bdecode_node const& v,
 			// There can only be one true immutable item with a given id
 			// Now that we've got it and the user doesn't want to do a put
 			// there's no point in continuing to query other nodes
-			abort();
+			done();
 		}
 	}
 }


### PR DESCRIPTION
A traversal can be done while there are still outstanding queries (i.e.
m_invoke_count is non-zero) if K good responses have already been received and
none of the outstanding queries are closer than the nodes which have responded.

When this happens and the outstanding queries eventually complete or timeout
they call traversal_algorithm::failed() or traversal_algorithm::finished() as
usual which will cause traversal_algorithm::done() to be called yet again.

The fix is to always set the done flag on all queried observers in
traversal_algorithm::done() so that the observers will refrain from calling
back into the traversal.

This also makes traversal_algorithm::abort() redundant since this was the only
thing it did before it called into done().