### PR TITLE
get version of run-time libtorrent, not compile-time version

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -621,6 +621,7 @@ SOURCES =
 	ConvertUTF
 	thread
 	xml_parse
+	version
 
 # -- extensions --
 	metadata_transfer

--- a/bindings/python/src/version.cpp
+++ b/bindings/python/src/version.cpp
@@ -6,11 +6,16 @@
 #include <boost/python.hpp>
 
 using namespace boost::python;
+using libtorrent::version;
 
 void bind_version()
 {
+    scope().attr("__version__") = version();
+
+#ifndef TORRENT_NO_DEPRECATE
     scope().attr("version") = LIBTORRENT_VERSION;
     scope().attr("version_major") = LIBTORRENT_VERSION_MAJOR;
     scope().attr("version_minor") = LIBTORRENT_VERSION_MINOR;
+#endif
 }
 

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -32,6 +32,8 @@ class test_bencoder(unittest.TestCase):
 		decoded = lt.bdecode(encoded)
 		self.assertEqual(decoded, {'a': 1, 'b': [1,2,3], 'c': 'foo'})
 
+
 if __name__ == '__main__':
-    unittest.main()
+	print lt.__version__
+	unittest.main()
 

--- a/set_version.py
+++ b/set_version.py
@@ -5,6 +5,8 @@ import glob
 
 version = (int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]))
 
+revision = os.popen('git log -1 --format=format:%h').read().strip()
+
 def substitute_file(name):
 	subst = ''
 	f = open(name)
@@ -17,6 +19,8 @@ def substitute_file(name):
 			l = '#define LIBTORRENT_VERSION_TINY %d\n' % version[2]
 		elif '#define LIBTORRENT_VERSION ' in l and name.endswith('.hpp'):
 			l = '#define LIBTORRENT_VERSION "%d.%d.%d.%d"\n' % (version[0], version[1], version[2], version[3])
+		elif '#define LIBTORRENT_REVISION ' in l and name.endswith('.hpp'):
+			l = '#define LIBTORRENT_REVISION "%s"' % revision
 		elif 'AC_INIT([libtorrent-rasterbar]' in l and name.endswith('.ac'):
 			l = 'AC_INIT([libtorrent-rasterbar],[%d.%d.%d],[arvid@libtorrent.org],\n' % (version[0], version[1], version[2])
 		elif 'set (VERSION ' in l and name.endswith('.txt'):

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,6 +120,7 @@ libtorrent_rasterbar_la_SOURCES = \
   utp_stream.cpp                  \
   web_peer_connection.cpp         \
   xml_parse.cpp                   \
+  version.cpp                     \
   \
   $(KADEMLIA_SOURCES)             \
   $(GEOIP_SOURCES)                \

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2003-2014, Arvid Norberg
+Copyright (c) 2015, Arvid Norberg
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -30,27 +30,14 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#ifndef TORRENT_VERSION_HPP_INCLUDED
-#define TORRENT_VERSION_HPP_INCLUDED
+#include "libtorrent/version.hpp"
 
-#include "libtorrent/export.hpp"
-
-#define LIBTORRENT_VERSION_MAJOR 1
-#define LIBTORRENT_VERSION_MINOR 0
-#define LIBTORRENT_VERSION_TINY 7
-
-// the format of this version is: MMmmtt
-// M = Major version, m = minor version, t = tiny version
-#define LIBTORRENT_VERSION_NUM ((LIBTORRENT_VERSION_MAJOR * 10000) + (LIBTORRENT_VERSION_MINOR * 100) + LIBTORRENT_VERSION_TINY)
-
-#define LIBTORRENT_VERSION "1.0.7.0"
-#define LIBTORRENT_REVISION "a10289a"
 namespace libtorrent {
 
-	// returns the libtorrent version as string form in this format:
-	// "<major>.<minor>.<tiny>.<tag>.<revision>"
-	TORRENT_EXPORT char const* version();
+char const* version()
+{
+	return LIBTORRENT_VERSION "." LIBTORRENT_REVISION ;
+}
 
 }
 
-#endif


### PR DESCRIPTION
add a proper function to query the version of libtorrent, to know the… version of what's loaded, not what's linked against