### PR TITLE
Fix iOS dead loop issue.

### DIFF
--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -311,6 +311,16 @@ void udp_socket::on_read(error_code const& ec, udp::socket* s)
 
 		if (err == boost::asio::error::would_block || err == boost::asio::error::try_again) break;
 		on_read_impl(ep, err, bytes_transferred);
+
+		// found on iOS, socket will be disconnected when app goes backgroud. try to reopen it.
+		if (err == boost::asio::error::not_connected || err == boost::asio::error::bad_descriptor)
+		{
+			ep = s->local_endpoint(err);
+			if (!err) {
+				bind(ep, err);
+			}
+			return;
+		}
 	}
 	call_drained_handler();
 	setup_read(s);


### PR DESCRIPTION
I run libtorrent on iOS, If the app goes background and then comes back, the libtorrent thread will use 100% CPU. It turns out there is a dead loop in udp_socket.
The reason is, when apps go background on iOS, iOS will closed all sockets. So the socket of libtorrent actually was closed when the app comes back to foreground. I printed out the error message, it's "the socket is not connected."

This PR is trying to point out this issue, but I'm not sure this PR is actually correct.
But the original code seems a little bit weird.  If there is a error, it always just return. If the error is not recoverable, should we just abort it?

