### PR TITLE
Fixed to make it more cross compile friendly

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -94,6 +94,7 @@ rule linking ( properties * )
 		# exclude gcc from a regular windows build to make mingw
 		# link against the regular unix library name
 		if <target-os>windows in $(properties)
+		   && ! <toolset>gcc in $(properties)
 		{
 			result += <library>ssleay32
 				<library>libeay32
@@ -105,13 +106,7 @@ rule linking ( properties * )
 		}
 		else
 		{
-			result += <library>crypto <library>ssl <library>z ;
-		}
-
-		if <target-os>linux in $(properties)
-		{
-			# linker library on linux, required when using openssl
-			result += <library>dl ;
+			result += <library>crypto <library>ssl ;
 		}
 	}
 
@@ -173,12 +168,6 @@ rule linking ( properties * )
 	if <target-os>solaris in $(properties)
 	{
 		result += <library>libsocket <library>libnsl ;
-	}
-
-	# clock_gettime on linux requires librt
-	if <target-os>linux in $(properties)
-	{
-		result += <library>librt ;
 	}
 
 	if <iconv>on in $(properties)
@@ -555,8 +544,8 @@ variant test_barebones : debug
 # required for openssl on windows
 lib ssleay32 : : <name>ssleay32 ;
 lib libeay32 : : <name>libeay32 ;
-lib advapi32 : : <name>Advapi32 ;
-lib user32 : : <name>User32 ;
+lib advapi32 : : <name>advapi32 ;
+lib user32 : : <name>user32 ;
 lib shell32 : : <name>shell32 ;
 lib gdi32 : : <name>gdi32 ;
 lib dbghelp : : <name>dbghelp ;

--- a/ed25519/src/seed.cpp
+++ b/ed25519/src/seed.cpp
@@ -15,8 +15,8 @@ using namespace Windows::Security::Cryptography;
 using namespace Windows::Storage::Streams;
 using namespace Microsoft::WRL;
 #elif defined _WIN32
-#include <Windows.h>
-#include <Wincrypt.h>
+#include <windows.h>
+#include <wincrypt.h>
 #else
 #include <stdio.h>
 #endif

--- a/include/libtorrent/aux_/byteswap.hpp
+++ b/include/libtorrent/aux_/byteswap.hpp
@@ -43,7 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/cstdint.hpp>
 
 #ifdef TORRENT_WINDOWS
-#include <Winsock2.h>
+#include <winsock2.h>
 #else
 // posix header
 // for ntohl and htonl

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -349,7 +349,7 @@ namespace libtorrent
 	void session::start(int flags, settings_pack const& pack, io_service* ios)
 	{
 #if defined _MSC_VER && defined TORRENT_DEBUG
-		// workaround for microsofts
+		// workaround for microsoft's
 		// hardware exceptions that makes
 		// it hard to debug stuff
 		::_set_se_translator(straight_to_debugger);


### PR DESCRIPTION
I compiled the library in 9 linux based hosts and there was no need of libz, libdl, and librt. This removal easy the task of making the library binary as portable as possible.

I added an additional filter if openssl is active in windows, because the libraries using gcc should be named like in linux.

The lower casing of headers and libraries associated to windows is because working with mingw-w64, if the host is linux, then the filesystem is case sensitive.