### PR TITLE
Remove un-needed line break that causes errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ DOCS_IMAGES = \
   docs/img/blue_top.png           \
   docs/img/dotline.gif            \
   docs/img/minus.gif              \
-  docs/img/orange.png             \
+  docs/img/orange.png
 
 DOCS_PAGES = \
   docs/building.html              \


### PR DESCRIPTION
I had an error while running `./autotool.sh` and I took a look at `Makefile.am` and found this problem. I've tested it and it fixed the build process.