### PR TITLE
fix segfault in put_data

### DIFF
--- a/include/libtorrent/kademlia/put_data.hpp
+++ b/include/libtorrent/kademlia/put_data.hpp
@@ -58,7 +58,7 @@ struct put_data: traversal_algorithm
 	put_data(node& node, put_callback const& callback);
 
 	virtual char const* name() const;
-	virtual void start();
+	virtual void start() TORRENT_OVERRIDE;
 
 	void set_data(item const& data) { m_data = data; }
 

--- a/include/libtorrent/kademlia/put_data.hpp
+++ b/include/libtorrent/kademlia/put_data.hpp
@@ -58,6 +58,7 @@ struct put_data: traversal_algorithm
 	put_data(node& node, put_callback const& callback);
 
 	virtual char const* name() const;
+	virtual void start();
 
 	void set_data(item const& data) { m_data = data; }
 

--- a/src/kademlia/put_data.cpp
+++ b/src/kademlia/put_data.cpp
@@ -47,6 +47,14 @@ put_data::put_data(node& dht_node, put_callback const& callback)
 
 char const* put_data::name() const { return "put_data"; }
 
+void put_data::start()
+{
+	// router nodes must not be added to puts
+	init();
+	bool is_done = add_requests();
+	if (is_done) done();
+}
+
 void put_data::set_targets(std::vector<std::pair<node_entry, std::string> > const& targets)
 {
 	for (std::vector<std::pair<node_entry, std::string> >::const_iterator i = targets.begin()

--- a/src/kademlia/put_data.cpp
+++ b/src/kademlia/put_data.cpp
@@ -93,6 +93,9 @@ bool put_data::invoke(observer_ptr o)
 		m_invoke_count = -1;
 		return false;
 	}
+
+	// TODO: what if o is not an isntance of put_data_observer? This need to be
+	// redesigned for better type saftey.
 	put_data_observer* po = static_cast<put_data_observer*>(o.get());
 
 	entry e;


### PR DESCRIPTION
If less than three nodes are found to put an item to then traversal_algorithm::start
will add router nodes. This leads to a crash in put_data::invoke when it tries to
read a token from uninitialized memory in a null_observer.