### PR TITLE
CMake build: Allow building with C++11/14 (use e.g. -D abi=c++11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,9 +161,17 @@ option(dht "enable support for Mainline DHT" ON)
 option(resolve-countries "enable support for resolving countries from peer IPs" ON)
 option(unicode "enable unicode support" ON)
 option(deprecated-functions "enable deprecated functions for backwards compatibility" ON)
+if (NOT MSVC)
+	# MSVC doesn't provide this option and has its own ABI issues anyway.
+	option(abi "pick one until libtorrent's ABI is robust: c++03, c++11, c++14, default (currently c++03)" "default")
+endif()
 option(exceptions "build with exception support" ON)
 option(logging "build with logging" OFF)
 option(build_tests "build tests" OFF)
+
+if (abi STREQUAL "default")
+	set(abi "c++03")
+endif()
 
 set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo)
 
@@ -306,6 +314,15 @@ else()
 	endif (MSVC)
 endif()
 
+if (NOT MSVC)
+	if (abi STREQUAL "c++03")
+		add_definitions(-std=${abi})
+	elseif (abi STREQUAL "c++11" OR abi STREQUAL "c++14")
+		# Also silence auto_ptr because it throws lots of warnings.
+		add_definitions(-std=${abi} -Wno-deprecated-declarations)
+	endif()
+endif()
+
 if (MSVC)
 # disable bogus deprecation warnings on msvc8
 	add_definitions(-D_SCL_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE)
@@ -317,7 +334,9 @@ if (MSVC)
 #$(SolutionDir)<toolset>msvc,<variant>release:<linkflags>/OPT:ICF=5
 #$(SolutionDir)<toolset>msvc,<variant>release:<linkflags>/OPT:REF
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	add_definitions(-Wno-c++11-extensions)
+	if (abi STREQUAL "c++03")
+		add_definitions(-Wno-c++11-extensions)
+	endif()
 	add_definitions(-fcolor-diagnostics)
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,11 @@ project(libtorrent-examples)
 cmake_minimum_required(VERSION 2.6)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
+if(NOT MSVC)
+    # MSVC doesn't provide this option and has its own ABI issues anyway.
+    option(abi "pick one until libtorrent's ABI is robust: c++03, c++11, c++14" "c++03")
+endif()
+
 # Add extra include and library search directories so examples can optionally
 # be built without a prior "make install" of libtorrent.
 list(INSERT CMAKE_INCLUDE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/../include")
@@ -20,6 +25,15 @@ find_package(Boost REQUIRED COMPONENTS system)
 
 include_directories(${LibtorrentRasterbar_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 add_definitions(${LibtorrentRasterbar_DEFINITIONS})
+
+if (NOT MSVC)
+    if (abi STREQUAL "c++03")
+        add_definitions(-std=${abi})
+    elseif (abi STREQUAL "c++11" OR abi STREQUAL "c++14")
+        # Also silence auto_ptr because it throws lots of warnings.
+        add_definitions(-std=${abi} -Wno-deprecated-declarations)
+    endif()
+endif()
 
 set(single_file_examples
     simple_client

--- a/examples/run_cmake.sh.in
+++ b/examples/run_cmake.sh.in
@@ -2,7 +2,7 @@
 
 cd ${libtorrent_BINARY_DIR}/examples
 cmake \
-    -D libtorrent_includes_asio_source=${asio_source} \
+    -D abi=${abi} \
     -G "${CMAKE_GENERATOR}" \
     $@ \
     ${libtorrent_SOURCE_DIR}/examples


### PR DESCRIPTION
I was originally reluctant to submit this as pull request, but then I saw that in the b2 build you've also got support and special handling for non-default standards. Since some Boost headers change their ABI based on C++ standard and libtorrent pulls in a number of those through public headers, this added CMake option has been coming in handy to allow building with other C++11 code.