### PR TITLE
fix save_resume_data in client_test

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -853,11 +853,8 @@ void scan_dir(std::string const& dir_path
 		h.pause();
 		// the alert handler for save_resume_data_alert
 		// will save it to disk
-		if (h.need_save_resume_data())
-		{
-			h.save_resume_data();
-			++num_outstanding_resume_data;
-		}
+		h.save_resume_data();
+		++num_outstanding_resume_data;
 
 		files.erase(i++);
 	}
@@ -1111,6 +1108,11 @@ bool handle_alert(libtorrent::session& ses, libtorrent::alert* a
 	{
 		--num_outstanding_resume_data;
 		torrent_handle h = p->handle;
+		if (h.is_valid())
+		{
+			fprintf(stderr, "FAILED TO SAVE RESUME DATA: %s\n"
+				, h.status().name.c_str());
+		}
 		if (h.is_valid()
 			&& non_files.find(h) == non_files.end()
 			&& std::find_if(files.begin(), files.end()

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -488,6 +488,11 @@ namespace libtorrent
 			return m_need_save_resume_data || m_ses.session_time() - m_last_saved_resume > 15 * 60;
 		}
 
+		void set_need_save_resume()
+		{
+			m_need_save_resume_data = true;
+		}
+
 		bool is_auto_managed() const { return m_auto_managed; }
 		void auto_managed(bool a);
 


### PR DESCRIPTION
 and make torrent a bit more instrumentable. This could be greatly simplified if resume data would not have file_sizes and timestamps