### PR TITLE
clean up use of getrlimit()

### DIFF
--- a/include/libtorrent/platform_util.hpp
+++ b/include/libtorrent/platform_util.hpp
@@ -5,6 +5,8 @@
 
 namespace libtorrent
 {
+	int max_open_files();
+
 	boost::uint64_t total_physical_ram();
 }
 

--- a/src/disk_buffer_pool.cpp
+++ b/src/disk_buffer_pool.cpp
@@ -56,25 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/sysctl.h>
 #endif
 
-#if TORRENT_USE_RLIMIT
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wlong-long"
-#endif // __GNUC__
-
-#include <sys/resource.h>
-
-// capture this here where warnings are disabled (the macro generates warnings)
-const rlim_t rlimit_as = RLIMIT_AS;
-const rlim_t rlim_infinity = RLIM_INFINITY;
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
-
-#endif // TORRENT_USE_RLIMIT
-
 #ifdef TORRENT_LINUX
 #include <linux/unistd.h>
 #endif


### PR DESCRIPTION
by wrapping it and move it to platform_util.cpp. Also take the opportunity to make it simulator friendly (consistent in simulation)