### PR TITLE
fix bug deleting files for a torrent before it had metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+
+	* fixed bug when deleting files for magnet links before they had metadata
+
 1.0.7 release
 
 	* fix bug where loading settings via load_state() would not trigger all

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7366,6 +7366,17 @@ namespace libtorrent
 		disconnect_all(errors::torrent_removed);
 		stop_announcing();
 
+		// if we don't have metadata yet, we don't know anything about the file
+		// structure and we have to assume we don't have any file. Deleting files
+		// in this mode would cause us to (recursively) delete m_save_path, which
+		// is bad.
+		if (!valid_metadata())
+		{
+			alerts().post_alert(torrent_deleted_alert(get_handle(), m_torrent_file->info_hash()));
+			return true;
+		}
+
+		if (m_torrent_file)
 		// storage may be NULL during shutdown
 		if (m_owning_storage.get())
 		{


### PR DESCRIPTION
it would delete the download directory (one level too high)