### PR TITLE
DHT polishing

### DIFF
--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -66,7 +66,7 @@ namespace libtorrent { namespace dht
 {
 	struct dht_tracker;
 
-	struct dht_tracker
+	struct dht_tracker TORRENT_FINAL
 		: udp_socket_interface
 		, udp_socket_observer
 		, boost::enable_shared_from_this<dht_tracker>
@@ -74,7 +74,7 @@ namespace libtorrent { namespace dht
 		dht_tracker(dht_observer* observer, rate_limited_udp_socket& sock
 			, dht_settings const& settings, counters& cnt
 			, dht_storage_constructor_type storage_constructor
-			, entry const* state = 0);
+			, entry const& state);
 		virtual ~dht_tracker();
 
 		void start(entry const& bootstrap
@@ -137,7 +137,7 @@ namespace libtorrent { namespace dht
 
 		void connection_timeout(error_code const& e);
 		void refresh_timeout(error_code const& e);
-		void tick(error_code const& e);
+		void refresh_key(error_code const& e);
 
 		// implements udp_socket_interface
 		virtual bool has_quota();
@@ -157,7 +157,6 @@ namespace libtorrent { namespace dht
 		std::vector<char> m_send_buf;
 		dos_blocker m_blocker;
 
-		time_point m_last_new_key;
 		deadline_timer m_timer;
 		deadline_timer m_connection_timer;
 		deadline_timer m_refresh_timer;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -157,7 +157,7 @@ namespace libtorrent { namespace dht
 		std::vector<char> m_send_buf;
 		dos_blocker m_blocker;
 
-		deadline_timer m_timer;
+		deadline_timer m_key_refresh_timer;
 		deadline_timer m_connection_timer;
 		deadline_timer m_refresh_timer;
 		dht_settings const& m_settings;

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -202,7 +202,7 @@ public:
 	counters& stats_counters() const { return m_counters; }
 
 	dht_observer* observer() const { return m_observer; }
-protected:
+private:
 
 	void send_single_refresh(udp::endpoint const& ep, int bucket
 		, node_id const& id = node_id());
@@ -213,7 +213,6 @@ protected:
 
 	libtorrent::dht_settings const& m_settings;
 
-private:
 	typedef libtorrent::mutex mutex_t;
 	mutex_t m_mutex;
 

--- a/include/libtorrent/kademlia/node_entry.hpp
+++ b/include/libtorrent/kademlia/node_entry.hpp
@@ -49,7 +49,7 @@ struct TORRENT_EXTRA_EXPORT node_entry
 	node_entry(udp::endpoint ep);
 	node_entry();
 	void update_rtt(int new_rtt);
-	
+
 	bool pinged() const { return timeout_count != 0xff; }
 	void set_pinged() { if (timeout_count == 0xff) timeout_count = 0; }
 	void timed_out() { if (pinged() && timeout_count < 0xfe) ++timeout_count; }

--- a/include/libtorrent/kademlia/routing_table.hpp
+++ b/include/libtorrent/kademlia/routing_table.hpp
@@ -86,6 +86,9 @@ struct routing_table_node
 class TORRENT_EXTRA_EXPORT routing_table : boost::noncopyable
 {
 public:
+	// TODO: 3 to improve memory locality and scanning performance, turn the
+	// routing table into a single vector with boundaries for the nodes instead.
+	// Perhaps replacement nodes should be in a separate vector.
 	typedef std::vector<routing_table_node> table_t;
 
 	routing_table(node_id const& id, int bucket_size

--- a/include/libtorrent/sha1_hash.hpp
+++ b/include/libtorrent/sha1_hash.hpp
@@ -231,7 +231,7 @@ namespace libtorrent
 		}
 
 		// returns a bit-wise negated copy of the sha1-hash
-		sha1_hash operator~()
+		sha1_hash operator~() const
 		{
 			sha1_hash ret;
 			for (int i = 0; i < number_size; ++i)

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -98,7 +98,7 @@ namespace libtorrent { namespace dht
 		, m_dht(this, settings, extract_node_id(state), observer, cnt, storage_constructor)
 		, m_sock(sock)
 		, m_log(observer)
-		, m_timer(sock.get_io_service())
+		, m_key_refresh_timer(sock.get_io_service())
 		, m_connection_timer(sock.get_io_service())
 		, m_refresh_timer(sock.get_io_service())
 		, m_settings(settings)
@@ -145,7 +145,7 @@ namespace libtorrent { namespace dht
 	{
 		m_abort = true;
 		error_code ec;
-		m_timer.cancel(ec);
+		m_key_refresh_timer.cancel(ec);
 		m_connection_timer.cancel(ec);
 		m_refresh_timer.cancel(ec);
 		m_host_resolver.cancel();
@@ -200,8 +200,8 @@ namespace libtorrent { namespace dht
 		if (e || m_abort) return;
 
 		error_code ec;
-		m_timer.expires_from_now(key_refresh, ec);
-		m_timer.async_wait(boost::bind(&dht_tracker::refresh_key, self(), _1));
+		m_key_refresh_timer.expires_from_now(key_refresh, ec);
+		m_key_refresh_timer.async_wait(boost::bind(&dht_tracker::refresh_key, self(), _1));
 
 		m_dht.new_write_key();
 #ifndef TORRENT_DISABLE_LOGGING

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -77,9 +77,17 @@ node_id calculate_node_id(node_id const& nid, dht_observer* observer)
 {
 	address external_address;
 	if (observer) external_address = observer->external_address();
+
+	// if we don't have an observer, don't pretend that external_address is valid
+	// generating an ID based on 0.0.0.0 would be terrible. random is better
+	if (!observer || external_address == address())
+	{
+		return generate_random_id();
+	}
+
 	if (nid == (node_id::min)() || !verify_id(nid, external_address))
 		return generate_id(external_address);
-  	
+
 	return nid;
 }
 
@@ -583,7 +591,6 @@ struct ping_observer : observer
 		}
 	}
 };
-
 
 void node::tick()
 {

--- a/src/kademlia/node_entry.cpp
+++ b/src/kademlia/node_entry.cpp
@@ -75,7 +75,7 @@ namespace libtorrent { namespace dht
 		first_seen = aux::time_now();
 #endif
 	}
-	
+
 	void node_entry::update_rtt(int new_rtt)
 	{
 		TORRENT_ASSERT(new_rtt <= 0xffff);

--- a/src/kademlia/node_id.cpp
+++ b/src/kademlia/node_id.cpp
@@ -51,6 +51,7 @@ node_id distance(node_id const& n1, node_id const& n2)
 {
 	node_id ret;
 	node_id::iterator k = ret.begin();
+	// TODO: 3 the XORing should be done at full words instead of bytes
 	for (node_id::const_iterator i = n1.begin(), j = n2.begin()
 		, end(n1.end()); i != end; ++i, ++j, ++k)
 	{
@@ -62,6 +63,7 @@ node_id distance(node_id const& n1, node_id const& n2)
 // returns true if: distance(n1, ref) < distance(n2, ref)
 bool compare_ref(node_id const& n1, node_id const& n2, node_id const& ref)
 {
+	// TODO: 3 the XORing should be done at full words instead of bytes
 	for (node_id::const_iterator i = n1.begin(), j = n2.begin()
 		, k = ref.begin(), end(n1.end()); i != end; ++i, ++j, ++k)
 	{
@@ -77,6 +79,8 @@ bool compare_ref(node_id const& n1, node_id const& n2, node_id const& ref)
 // useful for finding out which bucket a node belongs to
 int distance_exp(node_id const& n1, node_id const& n2)
 {
+	// TODO: 3 the xoring should be done at full words and _builtin_clz() could
+	// be used as the last step
 	int byte = node_id::size - 1;
 	for (node_id::const_iterator i = n1.begin(), j = n2.begin()
 		, end(n1.end()); i != end; ++i, ++j, --byte)
@@ -87,7 +91,7 @@ int distance_exp(node_id const& n1, node_id const& n2)
 		// we have found the first non-zero byte
 		// return the bit-number of the first bit
 		// that differs
-		int bit = byte * 8;
+		int const bit = byte * 8;
 		for (int b = 7; b >= 0; --b)
 			if (t >= (1 << b)) return bit + b;
 		return bit;

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -475,7 +475,7 @@ bool rpc_manager::invoke(entry& e, udp::endpoint target_addr
 
 	if (m_sock->send_packet(e, target_addr, 1))
 	{
-		m_transactions.insert(std::make_pair(tid,o));
+		m_transactions.insert(std::make_pair(tid, o));
 #if TORRENT_USE_ASSERTS
 		o->m_was_sent = true;
 #endif

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5516,7 +5516,7 @@ retry:
 			, boost::ref(m_udp_socket), boost::cref(m_dht_settings)
 			, boost::ref(m_stats_counters)
 			, m_dht_storage_constructor
-			, &startup_state);
+			, startup_state);
 
 		for (std::vector<udp::endpoint>::iterator i = m_dht_router_nodes.begin()
 			, end(m_dht_router_nodes.end()); i != end; ++i)
@@ -6731,12 +6731,17 @@ retry:
 
 		// since we have a new external IP now, we need to
 		// restart the DHT with a new node ID
+
 #ifndef TORRENT_DISABLE_DHT
 		// TODO: 1 we only need to do this if our global IPv4 address has changed
 		// since the DHT (currently) only supports IPv4. Since restarting the DHT
 		// is kind of expensive, it would be nice to not do it unnecessarily
 		if (m_dht)
 		{
+			// TODO: 3 instead of restarting the whole DHT, change the external IP,
+			// node ID and re-jiggle the routing table in-place. A complete restart
+			// throws away all outstanding requests, which may be significant
+			// during bootstrap
 			entry s = m_dht->state();
 			int cur_state = 0;
 			int prev_state = 0;


### PR DESCRIPTION
simplify and improve unit test for distance_exp. make some immutable variables const in the DHT implementation. instead of waking up periodically just to check if it's time to refresh the DHT secret key, set the timer to only wake up to refresh the key. If we don't have a DHT observer (to ask for our external IP) or if we don't know our external IP, don't generate a node ID based on 0.0.0.0, just generate a random ID instead. Simplified and improved node replacement logic in the routing table a little bit