### PR TITLE
use 255 as the max filename length on posix systems

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* fix long filename issue (on unixes)
 	* fixed performance bug in DHT torrent eviction
 	* fixed win64 build (GetFileAttributesEx)
 	* fixed bug when deleting files for magnet links before they had metadata

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -305,14 +305,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #elif defined MAXPATH
 #define TORRENT_MAX_PATH MAXPATH
 
-// posix
-#elif defined NAME_MAX
-#define TORRENT_MAX_PATH NAME_MAX
-
 // none of the above
 #else
 // this is the maximum number of characters in a
-// path element / filename on windows
+// path element / filename on windows and also on many filesystems commonly used
+// on linux
 #define TORRENT_MAX_PATH 255
 
 #ifdef _MSC_VER


### PR DESCRIPTION
(in 1.0.x)