### PR TITLE
Avoid pass nodes with IPv6 address to current DHT

### DIFF
--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -403,7 +403,7 @@ namespace libtorrent
 	public:
 		// constructs the default_storage based on the give file_storage (fs).
 		// ``mapped`` is an optional argument (it may be NULL). If non-NULL it
-		// represents the file mappsing that have been made to the torrent before
+		// represents the file mapping that have been made to the torrent before
 		// adding it. That's where files are supposed to be saved and looked for
 		// on disk. ``save_path`` is the root save folder for this torrent.
 		// ``file_pool`` is the cache of file handles that the storage will use.

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -291,6 +291,8 @@ namespace libtorrent { namespace dht
 		}
 
 		if (size <= 20 || *buf != 'd' || buf[size-1] != 'e') return false;
+		// remove this line/check once the DHT supports IPv6
+		if (!ep.address().is_v4()) return false;
 
 		m_counters.inc_stats_counter(counters::dht_bytes_in, size);
 		// account for IP and UDP overhead


### PR DESCRIPTION
This is to fix the crash reported in issue https://github.com/arvidn/libtorrent/issues/370

@arvidn I made some additional change related to `heard_about`. Now both conditions inside `verify_node_address` are checked in both `heard_about` and `node_seen`.

Hi @ssiloti, if this PR get into master, I think you should delete a couple of lines here.