### PR TITLE
DHT nodes can NOT share a receive buffer

### DIFF
--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -254,13 +254,8 @@ private:
 #endif
 	lt::udp::endpoint m_ep;
 	bool m_add_dead_nodes;
-	// since the simulation is single-threaded, only one socket at a time will
-	// actually be receiving a packet, so we can get away with just allocating
-	// one receive buffer, shared by all nodes
-	static char m_buffer[1300];
+	char m_buffer[1300];
 };
-
-char dht_node::m_buffer[1300];
 
 dht_network::dht_network(sim::simulation& sim, int num_nodes)
 {


### PR DESCRIPTION
While the simulation is single threaded, because async_receive_from_impl uses
post() to invoke the receive handler it is possible for multiple receive
handlers to be queued up in the io_service at the same time. If this happens
with a shared receive buffer, the last packet received will overwrite all the
other packets before they are handled.

The use of post() is necessary to avoid unbounded recursion in the read handler
so each node must get its own buffer.