### PR TITLE
announce/scrape alert usability fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* tracker response alerts from user initiated announces/scrapes are now
+	  posted regardless of alert mask
 	* improve DHT performance when changing external IP (primarily affects
 	  bootstrapping).
 	* add feature to stop torrents immediately after checking files is done

--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -157,6 +157,9 @@ namespace libtorrent
 		// this is false the stats sent to this tracker will be 0
 		bool send_stats:1;
 
+		// internal
+		bool triggered_manually:1;
+
 		// reset announce counters and clears the started sent flag.
 		// The announce_entry will look like we've never talked to
 		// the tracker.

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -722,7 +722,7 @@ namespace libtorrent
 
 		// forcefully sets next_announce to the current time
 		void force_tracker_request(time_point, int tracker_idx);
-		void scrape_tracker();
+		void scrape_tracker(bool user_triggered);
 		void announce_with_tracker(boost::uint8_t e
 			= tracker_request::none
 			, address const& bind_interface = address_v4::any());

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -99,6 +99,7 @@ namespace libtorrent
 			, key(0)
 			, num_want(0)
 			, send_stats(true)
+			, triggered_manually(false)
 #ifdef TORRENT_USE_OPENSSL
 			, ssl_ctx(0)
 #endif
@@ -154,6 +155,11 @@ namespace libtorrent
 		address bind_ip;
 
 		bool send_stats;
+
+		// this is set to true if this request was triggered by a "manual" call to
+		// scrape_tracker() or force_reannounce()
+		bool triggered_manually;
+
 #ifdef TORRENT_USE_OPENSSL
 		boost::asio::ssl::context* ssl_ctx;
 #endif

--- a/src/announce_entry.cpp
+++ b/src/announce_entry.cpp
@@ -62,6 +62,7 @@ namespace libtorrent
 		, start_sent(false)
 		, complete_sent(false)
 		, send_stats(true)
+		, triggered_manually(false)
 	{}
 
 	announce_entry::announce_entry()
@@ -79,6 +80,7 @@ namespace libtorrent
 		, start_sent(false)
 		, complete_sent(false)
 		, send_stats(true)
+		, triggered_manually(false)
 	{}
 
 	announce_entry::~announce_entry() {}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3219,7 +3219,9 @@ retry:
 					torrent& t = *want_scrape[m_next_scrape_torrent];
 					TORRENT_ASSERT(t.is_paused() && t.is_auto_managed());
 
-					t.scrape_tracker();
+					// false means it's not triggered by the user, but automatically
+					// by libtorrent
+					t.scrape_tracker(false);
 
 					++m_next_scrape_torrent;
 					if (m_next_scrape_torrent >= int(want_scrape.size()))

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -802,7 +802,7 @@ namespace libtorrent
 
 	void torrent_handle::scrape_tracker() const
 	{
-		TORRENT_ASYNC_CALL(scrape_tracker);
+		TORRENT_ASYNC_CALL1(scrape_tracker, true);
 	}
 
 	void torrent_handle::super_seeding(bool on) const


### PR DESCRIPTION
when a tracker is force announced or scraped by the user/client, the resulting response or failure alert is now posted regardless of the alert mask. Since it's user initiated, it's reasonable to expect the user to be interested in the response