### PR TITLE
Removed file::m_path windows specific field and some cleanup

### DIFF
--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -345,12 +345,6 @@ namespace libtorrent
 		boost::uint32_t m_file_id;
 #endif
 
-#if defined TORRENT_WINDOWS && TORRENT_USE_WSTRING
-		std::wstring m_path;
-#elif defined TORRENT_WINDOWS
-		std::string m_path;
-#endif // TORRENT_WINDOWS
-
 		int m_open_mode;
 #if defined TORRENT_WINDOWS
 		static bool has_manage_volume_privs;

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -451,7 +451,7 @@ namespace libtorrent
 			// ``no_recheck_incomplete_resume`` determines if the storage should
 			// check the whole files when resume data is incomplete or missing or
 			// whether it should simply assume we don't have any of the data. By
-			// default, this is determined by the existance of any of the files.
+			// default, this is determined by the existence of any of the files.
 			// By setting this setting to true, the files won't be checked, but
 			// will go straight to download mode.
 			no_recheck_incomplete_resume,

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -452,8 +452,6 @@ namespace libtorrent
 
 	private:
 
-		int sparse_end(int start) const;
-
 		void delete_one_file(std::string const& p, error_code& ec);
 
 		void need_partfile();

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -888,32 +888,6 @@ namespace libtorrent
 		}
 	}
 
-	int default_storage::sparse_end(int piece) const
-	{
-		TORRENT_ASSERT(piece >= 0);
-		TORRENT_ASSERT(piece < files().num_pieces());
-
-		boost::int64_t file_offset = boost::int64_t(piece) * files().piece_length();
-		int file_index = 0;
-
-		for (;;)
-		{
-			if (file_offset < files().file_size(file_index))
-				break;
-
-			file_offset -= files().file_size(file_index);
-			++file_index;
-			TORRENT_ASSERT(file_index != files().num_files());
-		}
-
-		error_code ec;
-		file_handle handle = open_file_impl(file_index, file::read_only, ec);
-		if (ec) return piece;
-
-		boost::int64_t data_start = handle->sparse_end(file_offset);
-		return int((data_start + files().piece_length() - 1) / files().piece_length());
-	}
-
 	bool default_storage::verify_resume_data(bdecode_node const& rd
 		, std::vector<std::string> const* links
 		, storage_error& ec)


### PR DESCRIPTION
I performed some cleanup related to sparse files in windows.

1- `SetFileValidData` was called in sparse files, but that shouldn't be the case per MSDN docs.
2- `default_storage::sparse_end` was a private function with no use.

Btw, removing so much code, give me the impression that maybe I'm missing something.