### PR TITLE
Resume data no timestamps

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* resume data no longer has timestamps of files
 
 1.1.0 release
 

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -110,7 +110,7 @@ namespace libtorrent {
 #endif
 
 		bool pending() const;
-		void get_all(std::vector<alert*>& alerts, int& num_resume);
+		void get_all(std::vector<alert*>& alerts);
 
 		template <class T>
 		bool should_post() const
@@ -147,8 +147,6 @@ namespace libtorrent {
 		void set_dispatch_function(boost::function<void(std::auto_ptr<alert>)> const&);
 #endif
 
-		int num_queued_resume() const;
-
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		void add_extension(boost::shared_ptr<plugin> ext);
 #endif
@@ -178,9 +176,6 @@ namespace libtorrent {
 		// notification function will be called again the next time an alert is
 		// posted to the queue
 		boost::function<void()> m_notify;
-
-		// the number of resume data alerts  in the alert queue
-		int m_num_queued_resume;
 
 		// this is either 0 or 1, it indicates which m_alerts and m_allocations
 		// the alert_manager is allowed to use right now. This is swapped when

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -781,16 +781,6 @@ namespace libtorrent
 
 			std::map<std::string, boost::shared_ptr<torrent> > m_uuids;
 
-			// when saving resume data for many torrents, torrents are
-			// queued up in this list in order to not have too many of them
-			// outstanding at any given time, since the resume data may use
-			// a lot of memory.
-			std::list<boost::shared_ptr<torrent> > m_save_resume_queue;
-
-			// the number of save resume data disk jobs that are currently
-			// outstanding
-			int m_num_save_resume;
-
 			// peer connections are put here when disconnected to avoid
 			// race conditions with the disk thread. It's important that
 			// peer connections are destructed from the network thread,
@@ -1161,12 +1151,6 @@ namespace libtorrent
 			// whe shutting down process
 			std::list<boost::shared_ptr<tracker_logger> > m_tracker_loggers;
 #endif
-
-			// TODO: 2 the throttling of saving resume data could probably be
-			// factored out into a separate class
-			virtual void queue_async_resume_data(boost::shared_ptr<torrent> const& t) TORRENT_OVERRIDE;
-			virtual void done_async_resume() TORRENT_OVERRIDE;
-			void async_resume_dispatched();
 
 			// state for keeping track of external IPs
 			external_ip m_external_ip;

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -166,8 +166,6 @@ namespace libtorrent { namespace aux
 		virtual bool has_connection(peer_connection* p) const = 0;
 		virtual void insert_peer(boost::shared_ptr<peer_connection> const& c) = 0;
 
-		virtual void queue_async_resume_data(boost::shared_ptr<torrent> const& t) = 0;
-		virtual void done_async_resume() = 0;
 		virtual void evict_torrent(torrent* t) = 0;
 
 		virtual void remove_torrent(torrent_handle const& h, int options = 0) = 0;

--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -86,8 +86,6 @@ namespace libtorrent
 			, boost::function<void(disk_io_job const*)> const& handler) = 0;
 		virtual void async_delete_files(piece_manager* storage
 			, boost::function<void(disk_io_job const*)> const& handler) = 0;
-		virtual void async_save_resume_data(piece_manager* storage
-			, boost::function<void(disk_io_job const*)> const& handler) = 0;
 		virtual void async_set_file_priority(piece_manager* storage
 			, std::vector<boost::uint8_t> const& prio
 			, boost::function<void(disk_io_job const*)> const& handler) = 0;

--- a/include/libtorrent/disk_io_job.hpp
+++ b/include/libtorrent/disk_io_job.hpp
@@ -89,7 +89,6 @@ namespace libtorrent
 			, release_files
 			, delete_files
 			, check_fastresume
-			, save_resume_data
 			, rename_file
 			, stop_torrent
 			, cache_piece
@@ -151,8 +150,6 @@ namespace libtorrent
 		// for other jobs, it may point to other job-specific types
 		// for move_storage and rename_file this is a string allocated
 		// with malloc()
-		// an entry* for save_resume_data
-		// for aiocb_complete this points to the aiocb that completed
 		// for get_cache_info this points to a cache_status object which
 		// is filled in
 		union

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -317,8 +317,6 @@ namespace libtorrent
 			, bdecode_node const* resume_data
 			, std::vector<std::string>& links
 			, boost::function<void(disk_io_job const*)> const& handler);
-		void async_save_resume_data(piece_manager* storage
-			, boost::function<void(disk_io_job const*)> const& handler);
 		void async_rename_file(piece_manager* storage, int index, std::string const& name
 			, boost::function<void(disk_io_job const*)> const& handler);
 		void async_stop_torrent(piece_manager* storage
@@ -414,7 +412,6 @@ namespace libtorrent
 		int do_release_files(disk_io_job* j, jobqueue_t& completed_jobs);
 		int do_delete_files(disk_io_job* j, jobqueue_t& completed_jobs);
 		int do_check_fastresume(disk_io_job* j, jobqueue_t& completed_jobs);
-		int do_save_resume_data(disk_io_job* j, jobqueue_t& completed_jobs);
 		int do_rename_file(disk_io_job* j, jobqueue_t& completed_jobs);
 		int do_stop_torrent(disk_io_job* j, jobqueue_t& completed_jobs);
 		int do_read_and_hash(disk_io_job* j, jobqueue_t& completed_jobs);

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -437,6 +437,7 @@ namespace libtorrent
 			enable_outgoing_tcp,
 			enable_incoming_tcp,
 
+#ifndef TORRENT_NO_DEPRECATE
 			// ``ignore_resume_timestamps`` determines if the storage, when
 			// loading resume data files, should verify that the file modification
 			// time with the timestamps in the resume data. This defaults to
@@ -447,6 +448,10 @@ namespace libtorrent
 			// redownload potentially missed pieces than to go through the whole
 			// storage to look for them.
 			ignore_resume_timestamps,
+#else
+			// hidden
+			deprecated8,
+#endif
 
 			// ``no_recheck_incomplete_resume`` determines if the storage should
 			// check the whole files when resume data is incomplete or missing or

--- a/include/libtorrent/stat_cache.hpp
+++ b/include/libtorrent/stat_cache.hpp
@@ -51,7 +51,7 @@ namespace libtorrent
 		~stat_cache();
 
 		void init(int num_files);
-		
+
 		enum
 		{
 			cache_error = -1,

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -113,7 +113,6 @@ POSSIBILITY OF SUCH DAMAGE.
 //		virtual bool verify_resume_data(bdecode_node const& rd
 //			, std::vector<std::string> const* links
 //			, storage_error& error) { return false; }
-//		virtual bool write_resume_data(entry& rd) const { return false; }
 //		virtual boost::int64_t physical_offset(int piece, int offset)
 //		{ return piece * m_files.piece_length() + offset; };
 //		virtual sha1_hash hash_for_slot(int piece, partial_hash& ph, int piece_size)
@@ -314,16 +313,6 @@ namespace libtorrent
 			, std::vector<std::string> const* links
 			, storage_error& ec) = 0;
 
-		// This function should fill in resume data, the current state of the
-		// storage, in ``rd``. The default storage adds file timestamps and
-		// sizes.
-		// 
-		// Returning ``true`` indicates an error occurred.
-		// 
-		// If an error occurs, ``storage_error`` should be set to reflect it.
-		// 
-		virtual void write_resume_data(entry& rd, storage_error& ec) const = 0;
-
 		// This function should release all the file handles that it keeps open
 		// to files belonging to this storage. The default implementation just
 		// calls file_pool::release_files().
@@ -433,7 +422,6 @@ namespace libtorrent
 		virtual bool verify_resume_data(bdecode_node const& rd
 			, std::vector<std::string> const* links
 			, storage_error& error) TORRENT_OVERRIDE;
-		virtual void write_resume_data(entry& rd, storage_error& ec) const TORRENT_OVERRIDE;
 		virtual bool tick() TORRENT_OVERRIDE;
 
 		int readv(file::iovec_t const* bufs, int num_bufs
@@ -518,7 +506,6 @@ namespace libtorrent
 		virtual bool verify_resume_data(bdecode_node const&
 			, std::vector<std::string> const*
 			, storage_error&) TORRENT_OVERRIDE { return false; }
-		virtual void write_resume_data(entry&, storage_error&) const TORRENT_OVERRIDE {}
 	};
 
 	// this storage implementation always reads zeroes, and always discards
@@ -541,7 +528,6 @@ namespace libtorrent
 			, std::vector<std::string> const* /* links */
 			, storage_error&) TORRENT_OVERRIDE
 			{ return false; }
-		virtual void write_resume_data(entry&, storage_error&) const TORRENT_OVERRIDE {}
 		virtual void release_files(storage_error&) TORRENT_OVERRIDE {}
 		virtual void rename_file(int /* index */
 			, std::string const& /* new_filenamem */, storage_error&) TORRENT_OVERRIDE {}
@@ -660,8 +646,6 @@ namespace libtorrent
 		};
 
 		storage_interface* get_storage_impl() { return m_storage.get(); }
-
-		void write_resume_data(entry& rd, storage_error& ec) const;
 
 #ifdef TORRENT_DEBUG
 		void assert_torrent_refcount() const;

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -480,7 +480,6 @@ namespace libtorrent
 		bool is_torrent_paused() const { return !m_allow_peers || m_graceful_pause_mode; }
 		void force_recheck();
 		void save_resume_data(int flags);
-		bool do_async_save_resume_data();
 
 		bool need_save_resume_data() const
 		{
@@ -1138,7 +1137,6 @@ namespace libtorrent
 		void on_files_deleted(disk_io_job const* j);
 		void on_torrent_paused(disk_io_job const* j);
 		void on_storage_moved(disk_io_job const* j);
-		void on_save_resume_data(disk_io_job const* j);
 		void on_file_renamed(disk_io_job const* j);
 		void on_cache_flushed(disk_io_job const* j);
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -219,6 +219,7 @@ namespace libtorrent
 		void rename_file(int index, std::string const& new_filename)
 		{
 			TORRENT_ASSERT(is_loaded());
+			if (m_files.file_name(index) == new_filename) return;
 			copy_on_write();
 			m_files.rename_file(index, new_filename);
 		}

--- a/src/block_cache.cpp
+++ b/src/block_cache.cpp
@@ -214,7 +214,6 @@ const char* const job_action_name[] =
 	"release_files",
 	"delete_files",
 	"check_fastresume",
-	"save_resume_data",
 	"rename_file",
 	"stop_torrent",
 	"cache_piece",

--- a/src/disk_buffer_holder.cpp
+++ b/src/disk_buffer_holder.cpp
@@ -52,7 +52,6 @@ namespace libtorrent
 		TORRENT_ASSERT(m_ref.storage == 0 || m_ref.block >= 0);
 		TORRENT_ASSERT(m_ref.storage == 0 || m_ref.piece < static_cast<piece_manager*>(m_ref.storage)->files()->num_pieces());
 		TORRENT_ASSERT(m_ref.storage == 0 || m_ref.block <= static_cast<piece_manager*>(m_ref.storage)->files()->piece_length() / 0x4000);
-		TORRENT_ASSERT(j.action != disk_io_job::save_resume_data);
 		TORRENT_ASSERT(j.action != disk_io_job::rename_file);
 		TORRENT_ASSERT(j.action != disk_io_job::move_storage);
 	}
@@ -69,7 +68,6 @@ namespace libtorrent
 		TORRENT_ASSERT(m_ref.block >= 0);
 		TORRENT_ASSERT(m_ref.piece < static_cast<piece_manager*>(m_ref.storage)->files()->num_pieces());
 		TORRENT_ASSERT(m_ref.block <= static_cast<piece_manager*>(m_ref.storage)->files()->piece_length() / 0x4000);
-		TORRENT_ASSERT(j.action != disk_io_job::save_resume_data);
 		TORRENT_ASSERT(j.action != disk_io_job::rename_file);
 		TORRENT_ASSERT(j.action != disk_io_job::move_storage);
 	}

--- a/src/disk_io_job.cpp
+++ b/src/disk_io_job.cpp
@@ -62,8 +62,6 @@ namespace libtorrent
 	{
 		if (action == rename_file || action == move_storage)
 			free(buffer.string);
-		else if (action == save_resume_data)
-			delete static_cast<entry*>(buffer.resume_data);
 	}
 
 	bool disk_io_job::completed(cached_piece_entry const* pe, int block_size)

--- a/src/stat_cache.cpp
+++ b/src/stat_cache.cpp
@@ -32,22 +32,34 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/stat_cache.hpp"
 #include "libtorrent/assert.hpp"
+#include "libtorrent/error_code.hpp"
+#include "libtorrent/file.hpp"
+
+#include <string>
 
 namespace libtorrent
 {
+	class file_storage;
+
 	stat_cache::stat_cache() {}
 	stat_cache::~stat_cache() {}
 
-	// TODO: 4 improve this interface by fall back to the actual stat() call internally. Don't
-	// expose low-level functions to query the cache and set cache state. Also, we should
-	// probably cache the error_code too
-	void stat_cache::set_cache(int i, boost::int64_t size, time_t time)
+	void stat_cache::set_cache(int i, boost::int64_t size)
 	{
 		TORRENT_ASSERT(i >= 0);
 		if (i >= int(m_stat_cache.size()))
 			m_stat_cache.resize(i + 1, not_in_cache);
 		m_stat_cache[i].file_size = size;
-		m_stat_cache[i].file_time = time;
+	}
+
+	void stat_cache::set_error(int i, error_code const& ec)
+	{
+		TORRENT_ASSERT(i >= 0);
+		if (i >= int(m_stat_cache.size()))
+			m_stat_cache.resize(i + 1, not_in_cache);
+
+		int error_index = add_error(ec);
+		m_stat_cache[i].file_size = file_error - error_index;
 	}
 
 	void stat_cache::set_dirty(int i)
@@ -57,37 +69,38 @@ namespace libtorrent
 		m_stat_cache[i].file_size = not_in_cache;
 	}
 
-	void stat_cache::set_noexist(int i)
+	boost::int64_t stat_cache::get_filesize(int i, file_storage const& fs
+		, std::string const& save_path, error_code& ec)
 	{
-		TORRENT_ASSERT(i >= 0);
-		if (i >= int(m_stat_cache.size()))
-			m_stat_cache.resize(i + 1, not_in_cache);
-		m_stat_cache[i].file_size = no_exist;
+		TORRENT_ASSERT(i < int(fs.num_files()));
+		if (i >= int(m_stat_cache.size())) m_stat_cache.resize(i + 1, not_in_cache);
+		boost::int64_t sz = m_stat_cache[i].file_size;
+		if (sz < not_in_cache)
+		{
+			ec = m_errors[-sz + file_error];
+			return file_error;
+		}
+		else if (sz == not_in_cache)
+		{
+			// query the filesystem
+			file_status s;
+			std::string file_path = fs.file_path(i, save_path);
+			stat_file(file_path, &s, ec);
+			if (ec)
+			{
+				set_error(i, ec);
+				sz = file_error;
+			}
+			else
+			{
+				set_cache(i, s.file_size);
+				sz = s.file_size;
+			}
+		}
+		return sz;
 	}
 
-	void stat_cache::set_error(int i)
-	{
-		TORRENT_ASSERT(i >= 0);
-		if (i >= int(m_stat_cache.size()))
-			m_stat_cache.resize(i + 1, not_in_cache);
-		m_stat_cache[i].file_size = cache_error;
-	}
-
-	boost::int64_t stat_cache::get_filesize(int i) const
-	{
-		if (i >= int(m_stat_cache.size())) return not_in_cache;
-		return m_stat_cache[i].file_size;
-	}
-
-	// TODO: 4 file_time can probably be removed from the cache now
-	time_t stat_cache::get_filetime(int i) const
-	{
-		if (i >= int(m_stat_cache.size())) return not_in_cache;
-		if (m_stat_cache[i].file_size < 0) return m_stat_cache[i].file_size;
-		return m_stat_cache[i].file_time;
-	}
-
-	void stat_cache::init(int num_files)
+	void stat_cache::reserve(int num_files)
 	{
 		m_stat_cache.resize(num_files, not_in_cache);
 	}
@@ -95,7 +108,15 @@ namespace libtorrent
 	void stat_cache::clear()
 	{
 		std::vector<stat_cache_t>().swap(m_stat_cache);
+		std::vector<error_code>().swap(m_errors);
 	}
 
+	int stat_cache::add_error(error_code const& ec)
+	{
+		std::vector<error_code>::iterator i = std::find(m_errors.begin(), m_errors.end(), ec);
+		if (i != m_errors.end()) return i - m_errors.begin();
+		m_errors.push_back(ec);
+		return m_errors.size() - 1;
+	}
 }
 

--- a/src/stat_cache.cpp
+++ b/src/stat_cache.cpp
@@ -38,6 +38,9 @@ namespace libtorrent
 	stat_cache::stat_cache() {}
 	stat_cache::~stat_cache() {}
 
+	// TODO: 4 improve this interface by fall back to the actual stat() call internally. Don't
+	// expose low-level functions to query the cache and set cache state. Also, we should
+	// probably cache the error_code too
 	void stat_cache::set_cache(int i, boost::int64_t size, time_t time)
 	{
 		TORRENT_ASSERT(i >= 0);
@@ -76,6 +79,7 @@ namespace libtorrent
 		return m_stat_cache[i].file_size;
 	}
 
+	// TODO: 4 file_time can probably be removed from the cache now
 	time_t stat_cache::get_filetime(int i) const
 	{
 		if (i >= int(m_stat_cache.size())) return not_in_cache;

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -734,19 +734,6 @@ namespace libtorrent
 	{
 		entry ret(entry::dictionary_t);
 		TORRENT_SYNC_CALL1(write_resume_data, boost::ref(ret));
-		t = m_torrent.lock();
-		if (t)
-		{
-			bool done = false;
-			session_impl& ses = static_cast<session_impl&>(t->session());
-			storage_error ec;
-			ses.get_io_service().dispatch(boost::bind(&aux::fun_wrap, boost::ref(done), boost::ref(ses.cond)
-				, boost::ref(ses.mut), boost::function<void(void)>(boost::bind(
-					&piece_manager::write_resume_data, &t->storage(), boost::ref(ret), boost::ref(ec)))));
-			t.reset();
-			aux::torrent_wait(done, ses);
-		}
-
 		return ret;
 	}
 

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -664,7 +664,7 @@ TORRENT_TEST(fastresume)
 		{
 			print_alerts(ses, "ses");
 			s = h.status();
-			if (s.progress == 1.0f) 
+			if (s.progress == 1.0f)
 			{
 				std::cout << "progress: 1.0f" << std::endl;
 				break;
@@ -692,7 +692,6 @@ TORRENT_TEST(fastresume)
 		return;
 
 	std::cerr << resume.to_string() << "\n";
-	TEST_CHECK(resume.dict().find("file sizes") != resume.dict().end());
 
 	// make sure the fast resume check fails! since we removed the file
 	{
@@ -795,7 +794,6 @@ TORRENT_TEST(rename_file_fastresume)
 	TEST_CHECK(!exists(combine_path(test_path, "tmp2/temporary")));
 	TEST_CHECK(exists(combine_path(test_path, "tmp2/testing_renamed_files")));
 	TEST_CHECK(resume.dict().find("mapped_files") != resume.dict().end());
-	TEST_CHECK(resume.dict().find("file sizes") != resume.dict().end());
 
 	std::cerr << resume.to_string() << "\n";
 


### PR DESCRIPTION
remove the timestamps from resume data, now that there's no compact allocation, it's not important