### PR TITLE
restore the endpoint field in listen_failed_alert (but deprecated)

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -411,9 +411,10 @@ void bind_alert()
     class_<listen_failed_alert, bases<alert>, noncopyable>(
         "listen_failed_alert", no_init)
 #ifndef TORRENT_NO_DEPRECATE
-        .def_readonly("interface", &listen_failed_alert::interface)
+        .def_readonly("endpoint", &listen_failed_alert::endpoint)
 #endif
         .def("listen_interface", &listen_failed_alert::listen_interface)
+        .def_readonly("port", &listen_failed_alert::port)
         .def_readonly("error", &listen_failed_alert::error)
         .def_readonly("operation", &listen_failed_alert::operation)
         .def_readonly("sock_type", &listen_failed_alert::sock_type)

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1267,7 +1267,8 @@ namespace libtorrent
 		// internal
 		listen_failed_alert(
 			aux::stack_allocator& alloc
-			, std::string iface
+			, std::string const& iface
+			, int port
 			, int op
 			, error_code const& ec
 			, socket_type_t t);
@@ -1276,11 +1277,6 @@ namespace libtorrent
 
 		static const int static_category = alert::status_notification | alert::error_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
-
-#if !defined(TORRENT_NO_DEPRECATE) && !defined(TORRENT_WINRT)
-		// the interface libtorrent attempted to listen on
-		std::string interface;
-#endif
 
 		// the interface libtorrent attempted to listen on that failed.
 		char const* listen_interface() const;
@@ -1296,8 +1292,17 @@ namespace libtorrent
 		// the specific low level operation that failed. See op_t.
 		int operation;
 
+		// the port attempted to be opened for listening
+		int port;
+
 		// the type of listen socket this alert refers to.
 		socket_type_t sock_type;
+
+#ifndef TORRENT_NO_DEPRECATE
+		// the address and port libtorrent attempted to listen on
+		tcp::endpoint endpoint;
+#endif
+
 	private:
 		aux::stack_allocator const& m_alloc;
 		int m_interface_idx;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -786,21 +786,31 @@ namespace libtorrent {
 			"HTTPS",
 			"SSL/uTP"
 		};
+
+#ifndef TORRENT_NO_DEPRECATE
+		tcp::endpoint parse_interface(std::string const& iface, int port)
+		{
+			// ignore errors
+			error_code ec;
+			return tcp::endpoint(address::from_string(iface, ec), port);
+		}
+#endif
 	}
 
 	listen_failed_alert::listen_failed_alert(
 		aux::stack_allocator& alloc
-		, std::string iface
+		, std::string const& iface
+		, int prt
 		, int op
 		, error_code const& ec
 		, socket_type_t t)
-		:
-#if !defined(TORRENT_NO_DEPRECATE) && !defined(TORRENT_WINRT)
-			interface(iface),
-#endif
-		error(ec)
+		: error(ec)
 		, operation(op)
+		, port(prt)
 		, sock_type(t)
+#ifndef TORRENT_NO_DEPRECATE
+		, endpoint(parse_interface(iface, prt))
+#endif
 		, m_alloc(alloc)
 		, m_interface_idx(alloc.copy_string(iface))
 	{}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1698,7 +1698,8 @@ namespace aux {
 		if (ec)
 		{
 			if (m_alerts.should_post<listen_failed_alert>())
-				m_alerts.emplace_alert<listen_failed_alert>(device, last_op, ec, sock_type);
+				m_alerts.emplace_alert<listen_failed_alert>(device, port, last_op
+					, ec, sock_type);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			session_log("failed to open socket: %s: %s"
@@ -1773,7 +1774,7 @@ namespace aux {
 
 			// not even that worked, give up
 			if (m_alerts.should_post<listen_failed_alert>())
-				m_alerts.emplace_alert<listen_failed_alert>(device, last_op, ec, sock_type);
+				m_alerts.emplace_alert<listen_failed_alert>(device, port, last_op, ec, sock_type);
 #ifndef TORRENT_DISABLE_LOGGING
 			session_log("cannot to bind to interface [%s %d] \"%s : %s\": %s"
 				, device.c_str(), port, bind_ip.to_string(ec).c_str()
@@ -1792,7 +1793,7 @@ namespace aux {
 		if (ec)
 		{
 			if (m_alerts.should_post<listen_failed_alert>())
-				m_alerts.emplace_alert<listen_failed_alert>(device, last_op, ec, sock_type);
+				m_alerts.emplace_alert<listen_failed_alert>(device, port, last_op, ec, sock_type);
 #ifndef TORRENT_DISABLE_LOGGING
 			session_log("cannot listen on interface \"%s\": %s"
 				, device.c_str(), ec.message().c_str());
@@ -1809,7 +1810,7 @@ namespace aux {
 			if (ec)
 			{
 				if (m_alerts.should_post<listen_failed_alert>())
-					m_alerts.emplace_alert<listen_failed_alert>(device, last_op, ec, sock_type);
+					m_alerts.emplace_alert<listen_failed_alert>(device, port, last_op, ec, sock_type);
 #ifndef TORRENT_DISABLE_LOGGING
 				session_log("failed to get peer name \"%s\": %s"
 					, device.c_str(), ec.message().c_str());
@@ -2018,8 +2019,11 @@ retry:
 				goto retry;
 			}
 			if (m_alerts.should_post<listen_failed_alert>())
-				m_alerts.emplace_alert<listen_failed_alert>(print_endpoint(m_listen_interface)
-					, listen_failed_alert::bind, ec, listen_failed_alert::udp);
+				m_alerts.emplace_alert<listen_failed_alert>(
+					m_listen_interface.address().to_string()
+					, m_listen_interface.port()
+					, listen_failed_alert::bind
+					, ec, listen_failed_alert::udp);
 			return;
 		}
 
@@ -2041,8 +2045,8 @@ retry:
 				if (m_alerts.should_post<listen_failed_alert>())
 				{
 					error_code err;
-					m_alerts.emplace_alert<listen_failed_alert>(print_endpoint(ssl_bind_if)
-							, listen_failed_alert::bind, ec, listen_failed_alert::utp_ssl);
+					m_alerts.emplace_alert<listen_failed_alert>(ssl_bind_if.address().to_string()
+						, ssl_port, listen_failed_alert::bind, ec, listen_failed_alert::utp_ssl);
 				}
 				ec.clear();
 			}
@@ -2068,8 +2072,10 @@ retry:
 			if (m_alerts.should_post<listen_failed_alert>())
 			{
 				error_code err;
-				m_alerts.emplace_alert<listen_failed_alert>(print_endpoint(m_listen_interface)
-					, listen_failed_alert::bind, ec, listen_failed_alert::udp);
+				m_alerts.emplace_alert<listen_failed_alert>(m_listen_interface.address().to_string()
+					, m_listen_interface.port()
+					, listen_failed_alert::bind
+					, ec, listen_failed_alert::udp);
 			}
 			return;
 		}
@@ -2283,8 +2289,10 @@ retry:
 		if (e)
 		{
 			if (m_alerts.should_post<listen_failed_alert>())
-				m_alerts.emplace_alert<listen_failed_alert>("i2p", listen_failed_alert::accept
-						, e, listen_failed_alert::i2p);
+				m_alerts.emplace_alert<listen_failed_alert>("i2p"
+					, m_listen_interface.port()
+					, listen_failed_alert::accept
+					, e, listen_failed_alert::i2p);
 #ifndef TORRENT_DISABLE_LOGGING
 			session_log("cannot bind to port %d: %s"
 				, m_listen_interface.port(), e.message().c_str());
@@ -2422,7 +2430,8 @@ retry:
 			if (m_alerts.should_post<listen_failed_alert>())
 			{
 				error_code err;
-				m_alerts.emplace_alert<listen_failed_alert>(print_endpoint(ep), listen_failed_alert::accept, e
+				m_alerts.emplace_alert<listen_failed_alert>(ep.address().to_string()
+					, ep.port(), listen_failed_alert::accept, e
 					, ssl ? listen_failed_alert::tcp_ssl : listen_failed_alert::tcp);
 			}
 			return;
@@ -2757,8 +2766,9 @@ retry:
 		if (e)
 		{
 			if (m_alerts.should_post<listen_failed_alert>())
-				m_alerts.emplace_alert<listen_failed_alert>("socks5", listen_failed_alert::accept, e
-						, listen_failed_alert::socks5);
+				m_alerts.emplace_alert<listen_failed_alert>("socks5"
+					, -1, listen_failed_alert::accept, e
+					, listen_failed_alert::socks5);
 			return;
 		}
 		open_new_incoming_socks_connection();


### PR DESCRIPTION
 and add a port field