### PR TITLE
Add -l prefix to Boost.Python library name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -563,6 +563,8 @@ AS_CASE(["$ARG_ENABLE_PYTHON_BINDING"],
 
       AS_IF([test -z "$BOOST_PYTHON_LIB"],
             [AC_MSG_ERROR([Boost.Python library not found. Try using --with-boost-python=lib.])])
+
+      BOOST_PYTHON_LIB="-l$BOOST_PYTHON_LIB"
     ],
   ["no"], [
       AC_MSG_RESULT([no])


### PR DESCRIPTION
The new boost.python macro from 5bf3e62fe5bb024fce39e265f2b22bfa99fb1b3e
sets BOOST_PYTHON_LIB to the bare library name rather than the parameter
to use when linking to it. Add the link command back so it works like all
the other *_LIB variables.

Fixes #448