### PR TITLE
Fix compilation with BOOST_NO_IOSTREAM

### DIFF
--- a/include/libtorrent/sha1_hash.hpp
+++ b/include/libtorrent/sha1_hash.hpp
@@ -42,8 +42,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/byteswap.hpp"
 
-#if TORRENT_USE_IOSTREAM
 #include "libtorrent/hex.hpp" // to_hex, from_hex
+#if TORRENT_USE_IOSTREAM
 #include <iostream>
 #include <iomanip>
 #endif


### PR DESCRIPTION
It is either this, or start hunting all over the code when the `to_hex` and `from_hex` are used.