### PR TITLE
attempt to make the alert type backwards compatible

### DIFF
--- a/include/libtorrent/alert.hpp
+++ b/include/libtorrent/alert.hpp
@@ -80,6 +80,9 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 
 	// The ``alert`` class is the base class that specific messages are derived from.
+	// alert types are not copyable, and cannot be constructed by the client. The
+	// pointers returned by libtorrent are short lived (the details are described
+	// under session_handle::pop_alerts())
 	class TORRENT_EXPORT alert
 	{
 	public:
@@ -283,10 +286,10 @@ namespace libtorrent {
 #endif // TORRENT_NO_DEPRECATE
 
 	protected:
+		// the alert is not copyable (but for backwards compatibility reasons it
+		// retains the ability to clone itself, for now).
 #if __cplusplus >= 201103L
-		alert(alert const&) = default;
-#else
-		alert(alert const&);
+		alert(alert const& rhs) = default;
 #endif
 
 	private:

--- a/include/libtorrent/alert.hpp
+++ b/include/libtorrent/alert.hpp
@@ -77,22 +77,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/time.hpp"
 #include "libtorrent/config.hpp"
 
-#ifndef TORRENT_NO_DEPRECATE
-#ifndef BOOST_NO_TYPEID
-#include <typeinfo>
-#endif
-#endif // TORRENT_NO_DEPRECATE
-
-#ifndef TORRENT_MAX_ALERT_TYPES
-#define TORRENT_MAX_ALERT_TYPES 15
-#endif
-
-#ifndef TORRENT_NO_DEPRECATE
-#ifndef BOOST_NO_TYPEID
-#include <typeinfo>
-#endif
-#endif
-
 namespace libtorrent {
 
 	// The ``alert`` class is the base class that specific messages are derived from.
@@ -216,9 +200,6 @@ namespace libtorrent {
 		alert();
 		// hidden
 		virtual ~alert();
-#if __cplusplus >= 201103L
-		alert(alert const&) = default;
-#endif
 
 		// a timestamp is automatically created in the constructor
 		time_point timestamp() const;
@@ -301,8 +282,15 @@ namespace libtorrent {
 
 #endif // TORRENT_NO_DEPRECATE
 
+	protected:
+#if __cplusplus >= 201103L
+		alert(alert const&) = default;
+#else
+		alert(alert const&);
+#endif
+
 	private:
-		// explicitly disallow assignment, to silence msvc warning
+		// explicitly disallow assignment and copyconstruction
 		alert& operator=(alert const&);
 
 		time_point m_timestamp;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -87,7 +87,11 @@ namespace libtorrent {
 
 	char const* torrent_alert::torrent_name() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return name.c_str();
+#else
 		return m_alloc.ptr(m_name_idx);
+#endif
 	}
 
 	std::string torrent_alert::message() const
@@ -124,7 +128,11 @@ namespace libtorrent {
 
 	char const* tracker_alert::tracker_url() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return url.c_str();
+#else
 		return m_alloc.ptr(m_url_idx);
+#endif
 	}
 
 	std::string tracker_alert::message() const
@@ -195,7 +203,11 @@ namespace libtorrent {
 
 	char const* file_renamed_alert::new_name() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return name.c_str();
+#else
 		return m_alloc.ptr(m_name_idx);
+#endif
 	}
 
 	std::string file_renamed_alert::message() const
@@ -292,7 +304,11 @@ namespace libtorrent {
 
 	char const* tracker_error_alert::error_message() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return msg.c_str();
+#else
 		return m_alloc.ptr(m_msg_idx);
+#endif
 	}
 
 	std::string tracker_error_alert::message() const
@@ -320,7 +336,11 @@ namespace libtorrent {
 
 	char const* tracker_warning_alert::warning_message() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return msg.c_str();
+#else
 		return m_alloc.ptr(m_msg_idx);
+#endif
 	}
 
 	std::string tracker_warning_alert::message() const
@@ -378,8 +398,12 @@ namespace libtorrent {
 
 	char const* scrape_failed_alert::error_message() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return msg.c_str();
+#else
 		if (m_msg_idx == -1) return "";
 		else return m_alloc.ptr(m_msg_idx);
+#endif
 	}
 
 	std::string scrape_failed_alert::message() const
@@ -649,7 +673,11 @@ namespace libtorrent {
 
 	char const* storage_moved_alert::storage_path() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return path.c_str();
+#else
 		return m_alloc.ptr(m_path_idx);
+#endif
 	}
 
 	storage_moved_failed_alert::storage_moved_failed_alert(
@@ -669,7 +697,11 @@ namespace libtorrent {
 
 	char const* storage_moved_failed_alert::file_path() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return file.c_str();
+#else
 		return m_alloc.ptr(m_file_idx);
+#endif
 	}
 
 	std::string storage_moved_failed_alert::message() const
@@ -939,7 +971,11 @@ namespace libtorrent {
 
 	char const* portmap_log_alert::log_message() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return msg.c_str();
+#else
 		return m_alloc.ptr(m_log_idx);
+#endif
 	}
 
 	std::string portmap_log_alert::message() const
@@ -980,7 +1016,11 @@ namespace libtorrent {
 
 	char const* fastresume_rejected_alert::file_path() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return file.c_str();
+#else
 		return m_alloc.ptr(m_path_idx);
+#endif
 	}
 
 	peer_blocked_alert::peer_blocked_alert(aux::stack_allocator& alloc
@@ -1145,7 +1185,11 @@ namespace libtorrent {
 
 	char const* trackerid_alert::tracker_id() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return trackerid.c_str();
+#else
 		return m_alloc.ptr(m_tracker_idx);
+#endif
 	}
 
 	std::string trackerid_alert::message() const
@@ -1710,8 +1754,12 @@ namespace libtorrent {
 
 	char const* url_seed_alert::error_message() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return msg.c_str();
+#else
 		if (m_msg_idx == -1) return "";
 		return m_alloc.ptr(m_msg_idx);
+#endif
 	}
 
 	file_error_alert::file_error_alert(aux::stack_allocator& alloc
@@ -1734,7 +1782,11 @@ namespace libtorrent {
 
 	char const* file_error_alert::filename() const
 	{
+#ifndef TORRENT_NO_DEPRECATE
+		return file.c_str();
+#else
 		return m_alloc.ptr(m_file_idx);
+#endif
 	}
 
 	std::string file_error_alert::message() const


### PR DESCRIPTION
 with cloning the state when building with deprecated functions enabled. This is especially relevant when returning clones of alerts in std::auto_ptr