### PR TITLE
fix seed timing-out unchoked peers for not sending requests

### DIFF
--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -937,6 +937,10 @@ namespace libtorrent
 		time_point m_last_receive;
 		time_point m_last_sent;
 
+		// the last time we filled our send buffer with payload
+		// this is used for timeouts
+		time_point m_last_sent_payload;
+
 		// the time when the first entry in the request queue was requested. Used
 		// for request timeout. it doesn't necessarily represent the time when a
 		// specific request was made. Since requests can be handled out-of-order,

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -109,7 +109,7 @@ TORRENT_TEST(session_stats)
 		, [](int ticks, lt::session& ses) -> bool
 		{
 			ses.post_session_stats();
-			if (ticks > 75)
+			if (ticks > 80)
 			{
 				TEST_ERROR("timeout");
 				return true;

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -68,7 +68,7 @@ TORRENT_TEST(plain)
 		// terminate
 		, [](int ticks, lt::session& ses) -> bool
 		{
-			if (ticks > 75)
+			if (ticks > 80)
 			{
 				TEST_ERROR("timeout");
 				return true;
@@ -135,7 +135,7 @@ TORRENT_TEST(suggest)
 		// terminate
 		, [](int ticks, lt::session& ses) -> bool
 		{
-			if (ticks > 75)
+			if (ticks > 80)
 			{
 				TEST_ERROR("timeout");
 				return true;
@@ -163,7 +163,7 @@ TORRENT_TEST(utp_only)
 		// terminate
 		, [](int ticks, lt::session& ses) -> bool
 		{
-			if (ticks > 75)
+			if (ticks > 80)
 			{
 				TEST_ERROR("timeout");
 				return true;
@@ -322,7 +322,7 @@ TORRENT_TEST(explicit_cache)
 		// terminate
 		, [](int ticks, lt::session& ses) -> bool
 		{
-			if (ticks > 75)
+			if (ticks > 80)
 			{
 				TEST_ERROR("timeout");
 				return true;

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4829,7 +4829,7 @@ namespace libtorrent
 		// the last 60 seconds, and we haven't been working on servicing a request
 		// for more than 60 seconds.
 		// but only if we're a seed
-		d = now - (std::min)((std::max)(m_last_unchoke, m_last_incoming_request)
+		d = now - (std::max)((std::max)(m_last_unchoke, m_last_incoming_request)
 			, m_last_sent_payload);
 
 		if (may_timeout

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -65,7 +65,9 @@ static struct utp_logger
 	FILE* utp_log_file;
 	mutex utp_log_mutex;
 
-	utp_logger() : utp_log_file(NULL) {}
+	utp_logger() : utp_log_file(NULL) {
+		utp_log_file = fopen("utp.log", "w+");
+	}
 	~utp_logger()
 	{
 		if (utp_log_file) fclose(utp_log_file);


### PR DESCRIPTION
despite being busy servicing requests from the peer (and time out immediately when m_requests is drained)