### PR TITLE
allow each peer have at least 2 allocated disk blocks at any given time

### DIFF
--- a/include/libtorrent/disk_buffer_pool.hpp
+++ b/include/libtorrent/disk_buffer_pool.hpp
@@ -135,7 +135,7 @@ namespace libtorrent
 		// of buffers in use drops below the low watermark,
 		// we start calling these functions back
 		// TODO: try to remove the observers, only using the async_allocate handlers
-		std::vector<boost::shared_ptr<disk_observer> > m_observers;
+		std::vector<boost::weak_ptr<disk_observer> > m_observers;
 
 		// these handlers are executed when a new buffer is available
 		std::vector<handler_t> m_handlers;

--- a/include/libtorrent/disk_io_job.hpp
+++ b/include/libtorrent/disk_io_job.hpp
@@ -136,11 +136,7 @@ namespace libtorrent
 			in_progress = 0x20,
 
 			// turns into file::coalesce_buffers in the file operation
-			coalesce_buffers = 0x40,
-
-			// the disk cache was enabled when this job was issued, it should use
-			// the disk cache once it's handled by a disk thread
-			use_disk_cache = 0x80
+			coalesce_buffers = 0x40
 		};
 
 		// for write jobs, returns true if its block

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2007-2016, Arvid Norberg
+Copyright (c) 2007-2016, Arvid Norberg, Steven Siloti
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -259,14 +259,16 @@ namespace libtorrent
 			// passes the hash check, it is taken out of parole mode.
 			use_parole_mode,
 
-			// enable and disable caching of read blocks and blocks to be written
-			// to disk respsectively. the purpose of the read cache is partly
-			// read-ahead of requests but also to avoid reading blocks back from
-			// the disk multiple times for popular pieces. the write cache purpose
-			// is to hold off writing blocks to disk until they have been hashed,
-			// to avoid having to read them back in again.
+			// enable and disable caching of blocks read from disk. the purpose of
+			// the read cache is partly read-ahead of requests but also to avoid
+			// reading blocks back from the disk multiple times for popular
+			// pieces.
 			use_read_cache,
+#ifndef TORRENT_NO_DEPRECATED
 			use_write_cache,
+#else
+			deprecated7,
+#endif
 
 			// this will make the disk cache never flush a write piece if it would
 			// cause is to have to re-read it once we want to calculate the piece

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2611,7 +2611,13 @@ namespace libtorrent
 			return;
 		}
 
-		if (exceeded)
+		// every peer is entitled to have two disk blocks allocated at any given
+		// time, regardless of whether the cache size is exceeded or not. If this
+		// was not the case, when the cache size setting is very small, most peers
+		// would be blocked most of the time, because the disk cache would
+		// continously be in exceeded state. Only rarely would it actually drop
+		// down to 0 and unblock all peers.
+		if (exceeded && m_outstanding_writing_bytes > 0)
 		{
 			if ((m_channel_state[download_channel] & peer_info::bw_disk) == 0)
 				m_counters.inc_stats_counter(counters::num_peers_down_disk);
@@ -4541,7 +4547,9 @@ namespace libtorrent
 			return false;
 		}
 
-		if (exceeded)
+		// to understand why m_outstanding_writing_bytes is here, see comment by
+		// the other call to allocate_disk_buffer()
+		if (exceeded && m_outstanding_writing_bytes > 0)
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, "DISK", "exceeded disk buffer watermark");

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1153,17 +1153,6 @@ namespace aux {
 			TORRENT_ASSERT_VAL(conn == int(m_connections.size()) + 1, conn);
 		}
 
-		m_download_rate.close();
-		m_upload_rate.close();
-
-		// #error closing the udp socket here means that
-		// the uTP connections cannot be closed gracefully
-		m_udp_socket.close();
-		m_external_udp_port = 0;
-#ifdef TORRENT_USE_OPENSSL
-		m_ssl_udp_socket.close();
-#endif
-
 		// we need to give all the sockets an opportunity to actually have their handlers
 		// called and cancelled before we continue the shutdown. This is a bit
 		// complicated, if there are no "undead" peers, it's safe tor resume the
@@ -1179,6 +1168,15 @@ namespace aux {
 
 	void session_impl::abort_stage2()
 	{
+		m_download_rate.close();
+		m_upload_rate.close();
+
+		m_udp_socket.close();
+		m_external_udp_port = 0;
+#ifdef TORRENT_USE_OPENSSL
+		m_ssl_udp_socket.close();
+#endif
+
 		// it's OK to detach the threads here. The disk_io_thread
 		// has an internal counter and won't release the network
 		// thread until they're all dead (via m_work).

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -150,7 +150,7 @@ namespace libtorrent
 		SET(upnp_ignore_nonrouters, false, 0),
 		SET(use_parole_mode, true, 0),
 		SET(use_read_cache, true, 0),
-		SET(use_write_cache, true, 0),
+		DEPRECATED_SET(use_write_cache, true, 0),
 		SET(dont_flush_write_cache, false, 0),
 		SET(explicit_read_cache, false, 0),
 		SET(coalesce_reads, false, 0),
@@ -603,14 +603,14 @@ namespace libtorrent
 				&& std::find(callbacks.begin(), callbacks.end(), sa.fun) == callbacks.end())
 				callbacks.push_back(sa.fun);
 		}
-	
+
 		for (std::vector<std::pair<boost::uint16_t, int> >::const_iterator i = pack->m_ints.begin()
 			, end(pack->m_ints.end()); i != end; ++i)
 		{
 			// disregard setting indices that are not int types
 			if ((i->first & settings_pack::type_mask) != settings_pack::int_type_base)
 				continue;
-		
+
 			// ignore settings that are out of bounds
 			int index = i->first & settings_pack::index_mask;
 			if (index < 0 || index >= settings_pack::num_int_settings)
@@ -629,7 +629,7 @@ namespace libtorrent
 			// disregard setting indices that are not bool types
 			if ((i->first & settings_pack::type_mask) != settings_pack::bool_type_base)
 				continue;
-		
+
 			// ignore settings that are out of bounds
 			int index = i->first & settings_pack::index_mask;
 			if (index < 0 || index >= settings_pack::num_bool_settings)


### PR DESCRIPTION
to avoid stalling when cache_size setting is small. also deprecate use_write_cache