### PR TITLE
Missing alert categories and support for dht_get_peers_reply_alert in python binding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+1.1.1 release
+
+	* Added missing alert categories in python binding
+	* Added dht_get_peers_reply_alert alert in python binding
 
 1.1.0 release
 

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -194,6 +194,22 @@ dict session_stats_values(session_stats_alert const& alert)
     return d;
 }
 
+list dht_get_peers_reply_alert_peers(dht_get_peers_reply_alert const& a)
+{
+    list result;
+
+    std::vector<tcp::endpoint> v;
+    a.peers(v);
+
+    for (std::vector<tcp::endpoint>::const_iterator i = v.begin();
+         i != v.end(); ++i)
+    {
+        result.append(endpoint_to_tuple(*i));
+    }
+
+    return result;
+}
+
 void bind_alert()
 {
     using boost::noncopyable;
@@ -239,10 +255,16 @@ void bind_alert()
             .value("progress_notification", alert::progress_notification)
             .value("ip_block_notification", alert::ip_block_notification)
             .value("performance_warning", alert::performance_warning)
+            .value("dht_notification", alert::dht_notification)
             .value("stats_notification", alert::stats_notification)
             .value("session_log_notification", alert::session_log_notification)
             .value("torrent_log_notification", alert::torrent_log_notification)
             .value("peer_log_notification", alert::peer_log_notification)
+            .value("incoming_request_notification", alert::incoming_request_notification)
+            .value("dht_log_notification", alert::dht_log_notification)
+            .value("dht_operation_notification", alert::dht_operation_notification)
+            .value("port_mapping_log_notification", alert::port_mapping_log_notification)
+            .value("picker_log_notification", alert::picker_log_notification)
             // deliberately not INT_MAX. Arch linux crash while throwing an exception
             .value("all_categories", (alert::category_t)0xfffffff)
             ;
@@ -744,5 +766,12 @@ void bind_alert()
     class_<session_stats_alert, bases<alert>, noncopyable>(
         "session_stats_alert", no_init)
         .add_property("values", &session_stats_values)
+        ;
+
+    class_<dht_get_peers_reply_alert, bases<alert>, noncopyable>(
+        "dht_get_peers_reply_alert", no_init)
+        .def_readonly("info_hash", &dht_get_peers_reply_alert::info_hash)
+        .def("num_peers", &dht_get_peers_reply_alert::num_peers)
+        .add_property("peers", &dht_get_peers_reply_alert_peers)
         ;
 }

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1033,7 +1033,7 @@ namespace libtorrent
 			// 
 			// ``active_loaded_limit`` is the number of torrents that are allowed
 			// to be *loaded* at any given time. Note that a torrent can be active
-			// even though it's not loaded. if an unloaded torrents finds a peer
+			// even though it's not loaded. If an unloaded torrents finds a peer
 			// that wants to access it, the torrent will be loaded on demand,
 			// using a user-supplied callback function. If the feature of
 			// unloading torrents is not enabled, this setting have no effect. If


### PR DESCRIPTION
I'm not sure if you like the ChangeLog change