### PR TITLE
Disable preadv/pwritev for android

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -216,6 +216,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 // ===== ANDROID ===== (almost linux, sort of)
 #if defined __ANDROID__
+#define TORRENT_USE_PREADV 0
+#define TORRENT_USE_PREAD 1
 #define TORRENT_ANDROID
 #define TORRENT_HAS_FALLOCATE 0
 #define TORRENT_USE_ICONV 0


### PR DESCRIPTION
This syscalls were recently added to the bionic library, but they are not present in the NDK. This is a problem at compilation time, since the LINUX_VERSION_CODE does not really represent the lack of these functions in android.