### PR TITLE
fix the fix for python binding backwards compat

### DIFF
--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -810,7 +810,7 @@ void bind_session()
 #ifndef TORRENT_NO_DEPRECATE
         .def("add_feed", &add_feed)
         .def("status", allow_threads(&lt::session::status))
-        .def("settings", &session_get_settings)
+        .def("settings", &lt::session::settings)
         .def("set_settings", &session_set_settings)
 #endif
         .def("get_settings", &session_get_settings)


### PR DESCRIPTION
f409a5ab caused session.settings to return a setting pack dict rather than the
1.0 compatibile session_settings class.