### PR TITLE
Add the generated "libtool" file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ config*
 Makefile
 build-aux
 test_tmp_*
+libtool
 
 .DS_Store
 .idea


### PR DESCRIPTION
When we run ./configure, a file named "libtool" is generated. That file is listed as Untracked file by "git status". 