### PR TITLE
sent_bytes,received_bytes,trancieve_ip_packet: int->size_t

### DIFF
--- a/examples/bt-get2.cpp
+++ b/examples/bt-get2.cpp
@@ -85,7 +85,7 @@ int main(int argc, char const* argv[])
 		, std::istream_iterator<char>()};
 
 	lt::error_code ec;
-	lt::add_torrent_params atp = lt::read_resume_data(&buf[0], buf.size(), ec);
+	lt::add_torrent_params atp = lt::read_resume_data(&buf[0], int(buf.size()), ec);
 	atp.url = argv[1];
 	atp.save_path = "."; // save in current dir
 	ses.async_add_torrent(atp);

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -979,9 +979,9 @@ namespace libtorrent
 			stat m_stat;
 
 			// implements session_interface
-			virtual void sent_bytes(int bytes_payload, int bytes_protocol) TORRENT_OVERRIDE;
-			virtual void received_bytes(int bytes_payload, int bytes_protocol) TORRENT_OVERRIDE;
-			virtual void trancieve_ip_packet(int bytes, bool ipv6) TORRENT_OVERRIDE;
+			virtual void sent_bytes(size_t bytes_payload, size_t bytes_protocol) TORRENT_OVERRIDE;
+			virtual void received_bytes(size_t bytes_payload, size_t bytes_protocol) TORRENT_OVERRIDE;
+			virtual void trancieve_ip_packet(size_t bytes, bool ipv6) TORRENT_OVERRIDE;
 			virtual void sent_syn(bool ipv6) TORRENT_OVERRIDE;
 			virtual void received_synack(bool ipv6) TORRENT_OVERRIDE;
 

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -271,9 +271,9 @@ namespace libtorrent { namespace aux
 
 		virtual bandwidth_manager* get_bandwidth_manager(int channel) = 0;
 
-		virtual void sent_bytes(int bytes_payload, int bytes_protocol) = 0;
-		virtual void received_bytes(int bytes_payload, int bytes_protocol) = 0;
-		virtual void trancieve_ip_packet(int bytes, bool ipv6) = 0;
+		virtual void sent_bytes(size_t bytes_payload, size_t bytes_protocol) = 0;
+		virtual void received_bytes(size_t bytes_payload, size_t bytes_protocol) = 0;
+		virtual void trancieve_ip_packet(size_t bytes, bool ipv6) = 0;
 		virtual void sent_syn(bool ipv6) = 0;
 		virtual void received_synack(bool ipv6) = 0;
 

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -431,23 +431,23 @@ int snprintf(char* buf, int len, char const* fmt, ...)
 #ifdef _GLIBCXX_USE_NOEXCEPT
 #define TORRENT_EXCEPTION_THROW_SPECIFIER _GLIBCXX_USE_NOEXCEPT
 #else
-#if __cplusplus <= 199711L || defined BOOST_NO_CXX11_NOEXCEPT
-#define TORRENT_EXCEPTION_THROW_SPECIFIER throw()
-#else
+#if !defined BOOST_NO_CXX11_NOEXCEPT && (__cplusplus > 199711L || (defined _MSC_VER && _MSC_VER >= 1900)) 
 #define TORRENT_EXCEPTION_THROW_SPECIFIER noexcept
+#else
+#define TORRENT_EXCEPTION_THROW_SPECIFIER throw()
 #endif
 #endif // __GLIBC__
 
-#if __cplusplus <= 199711L || defined BOOST_NO_CXX11_FINAL
-#define TORRENT_FINAL
-#else
+#if !defined BOOST_NO_CXX11_FINAL && (__cplusplus > 199711L || (defined _MSC_VER && _MSC_VER >= 1700)) 
 #define TORRENT_FINAL final
+#else
+#define TORRENT_FINAL
 #endif
 
-#if __cplusplus <= 199711L || defined BOOST_NO_CXX11_FINAL
-#define TORRENT_OVERRIDE
-#else
+#if !defined BOOST_NO_CXX11_FINAL && (__cplusplus > 199711L || (defined _MSC_VER && _MSC_VER >= 1700)) 
 #define TORRENT_OVERRIDE override
+#else
+#define TORRENT_OVERRIDE
 #endif
 
 #ifndef TORRENT_ICONV_ARG

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -440,7 +440,7 @@ namespace libtorrent
 
 		// called after piece data has been sent to the peer
 		// this can be used for stats book keeping
-		virtual void sent_payload(int /* bytes */) {}
+		virtual void sent_payload(size_t /* bytes */) {}
 
 		// called when libtorrent think this peer should be disconnected.
 		// if the plugin returns false, the peer will not be disconnected.

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -458,9 +458,9 @@ namespace libtorrent
 
 		stat const& statistics() const { return m_statistics; }
 		void add_stat(boost::int64_t downloaded, boost::int64_t uploaded);
-		void sent_bytes(int bytes_payload, int bytes_protocol);
-		void received_bytes(int bytes_payload, int bytes_protocol);
-		void trancieve_ip_packet(int bytes, bool ipv6);
+		void sent_bytes(size_t bytes_payload, size_t bytes_protocol);
+		void received_bytes(size_t bytes_payload, size_t bytes_protocol);
+		void trancieve_ip_packet(size_t bytes, bool ipv6);
 		void sent_syn(bool ipv6);
 		void received_synack(bool ipv6);
 

--- a/include/libtorrent/stat.hpp
+++ b/include/libtorrent/stat.hpp
@@ -64,14 +64,14 @@ namespace libtorrent
 			m_total_counter += s.m_counter;
 		}
 
-		void add(int count)
+		void add(size_t count)
 		{
 			TORRENT_ASSERT(count >= 0);
-
-			TORRENT_ASSERT(m_counter < (std::numeric_limits<boost::uint32_t>::max)() - count);
-			m_counter += count;
-			TORRENT_ASSERT(m_total_counter < (std::numeric_limits<boost::uint64_t>::max)() - count);
-			m_total_counter += count;
+			boost::uint32_t local_count = boost::uint32_t(count); 
+			TORRENT_ASSERT(m_counter < (std::numeric_limits<boost::uint32_t>::max)() - local_count);
+			m_counter += local_count;
+			TORRENT_ASSERT(m_total_counter < (std::numeric_limits<boost::uint64_t>::max)() - local_count);
+			m_total_counter += local_count;
 		}
 
 		// should be called once every second
@@ -102,6 +102,7 @@ namespace libtorrent
 		boost::uint64_t m_total_counter;
 
 		// the accumulator for this second.
+		// size_t candidate?
 		boost::uint32_t m_counter;
 
 		// sliding average
@@ -130,7 +131,7 @@ namespace libtorrent
 			m_stat[upload_ip_protocol].add(ipv6 ? 60 : 40);
 		}
 
-		void received_bytes(int bytes_payload, int bytes_protocol)
+		void received_bytes(size_t bytes_payload, size_t bytes_protocol)
 		{
 			TORRENT_ASSERT(bytes_payload >= 0);
 			TORRENT_ASSERT(bytes_protocol >= 0);
@@ -139,7 +140,7 @@ namespace libtorrent
 			m_stat[download_protocol].add(bytes_protocol);
 		}
 
-		void sent_bytes(int bytes_payload, int bytes_protocol)
+		void sent_bytes(size_t bytes_payload, size_t bytes_protocol)
 		{
 			TORRENT_ASSERT(bytes_payload >= 0);
 			TORRENT_ASSERT(bytes_protocol >= 0);
@@ -150,16 +151,16 @@ namespace libtorrent
 
 		// and IP packet was received or sent
 		// account for the overhead caused by it
-		void trancieve_ip_packet(int bytes_transferred, bool ipv6)
+		void trancieve_ip_packet(size_t bytes_transferred, bool ipv6)
 		{
 			// one TCP/IP packet header for the packet
 			// sent or received, and one for the ACK
 			// The IPv4 header is 20 bytes
 			// and IPv6 header is 40 bytes
-			const int header = (ipv6 ? 40 : 20) + 20;
-			const int mtu = 1500;
-			const int packet_size = mtu - header;
-			const int overhead = (std::max)(1, (bytes_transferred + packet_size - 1) / packet_size) * header;
+			const size_t header = (ipv6 ? 40 : 20) + 20;
+			const size_t mtu = 1500;
+			const size_t packet_size = mtu - header;
+			const size_t overhead = (std::max)(size_t(1), (bytes_transferred + packet_size - 1) / packet_size) * header;
 			m_stat[download_ip_protocol].add(overhead);
 			m_stat[upload_ip_protocol].add(overhead);
 		}

--- a/include/libtorrent/stat.hpp
+++ b/include/libtorrent/stat.hpp
@@ -66,7 +66,6 @@ namespace libtorrent
 
 		void add(size_t count)
 		{
-			TORRENT_ASSERT(count >= 0);
 			boost::uint32_t local_count = boost::uint32_t(count); 
 			TORRENT_ASSERT(m_counter < (std::numeric_limits<boost::uint32_t>::max)() - local_count);
 			m_counter += local_count;
@@ -133,18 +132,12 @@ namespace libtorrent
 
 		void received_bytes(size_t bytes_payload, size_t bytes_protocol)
 		{
-			TORRENT_ASSERT(bytes_payload >= 0);
-			TORRENT_ASSERT(bytes_protocol >= 0);
-
 			m_stat[download_payload].add(bytes_payload);
 			m_stat[download_protocol].add(bytes_protocol);
 		}
 
 		void sent_bytes(size_t bytes_payload, size_t bytes_protocol)
 		{
-			TORRENT_ASSERT(bytes_payload >= 0);
-			TORRENT_ASSERT(bytes_protocol >= 0);
-
 			m_stat[upload_payload].add(bytes_payload);
 			m_stat[upload_protocol].add(bytes_protocol);
 		}

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -432,9 +432,9 @@ namespace libtorrent
 		void bytes_done(torrent_status& st, bool accurate) const;
 		boost::int64_t quantized_bytes_done() const;
 
-		void sent_bytes(int bytes_payload, int bytes_protocol);
-		void received_bytes(int bytes_payload, int bytes_protocol);
-		void trancieve_ip_packet(int bytes, bool ipv6);
+		void sent_bytes(size_t bytes_payload, size_t bytes_protocol);
+		void received_bytes(size_t bytes_payload, size_t bytes_protocol);
+		void trancieve_ip_packet(size_t bytes, bool ipv6);
 		void sent_syn(bool ipv6);
 		void received_synack(bool ipv6);
 

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -313,8 +313,8 @@ namespace libtorrent
 		virtual void start() = 0;
 		virtual void close();
 		address const& bind_interface() const { return m_req.bind_ip; }
-		void sent_bytes(int bytes);
-		void received_bytes(int bytes);
+		void sent_bytes(size_t bytes);
+		void received_bytes(size_t bytes);
 		virtual bool on_receive(udp::endpoint const&
 			, char const* /* buf */, int /* size */) { return false; }
 		virtual bool on_receive_hostname(char const* /* hostname */
@@ -374,8 +374,8 @@ namespace libtorrent
 		bool empty() const;
 		int num_requests() const;
 
-		void sent_bytes(int bytes);
-		void received_bytes(int bytes);
+		void sent_bytes(size_t bytes);
+		void received_bytes(size_t bytes);
 
 		void incoming_error(error_code const& ec, udp::endpoint const& ep);
 		bool incoming_packet(udp::endpoint const& ep, char const* buf, int size);

--- a/include/libtorrent/utp_socket_manager.hpp
+++ b/include/libtorrent/utp_socket_manager.hpp
@@ -104,7 +104,7 @@ namespace libtorrent
 		int loss_multiplier() const { return m_sett.get_int(settings_pack::utp_loss_multiplier); }
 
 		void mtu_for_dest(address const& addr, int& link_mtu, int& utp_mtu);
-		int num_sockets() const { return m_utp_sockets.size(); }
+		int num_sockets() const { return int(m_utp_sockets.size()); }
 
 		void defer_ack(utp_socket_impl* s);
 		void subscribe_drained(utp_socket_impl* s);

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -637,7 +637,7 @@ namespace libtorrent { namespace dht
 		m_send_quota -= int(m_send_buf.size());
 
 		error_code ec;
-		m_send_fun(addr, aux::array_view<char const>(&m_send_buf[0], m_send_buf.size()), ec, 0);
+		m_send_fun(addr, aux::array_view<char const>(&m_send_buf[0], int(m_send_buf.size())), ec, 0);
 		if (ec)
 		{
 			m_counters.inc_stats_counter(counters::dht_messages_out_dropped);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1052,7 +1052,7 @@ namespace libtorrent
 		m_statistics.add_stat(downloaded, uploaded);
 	}
 
-	void peer_connection::received_bytes(int bytes_payload, int bytes_protocol)
+	void peer_connection::received_bytes(size_t bytes_payload, size_t bytes_protocol)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.received_bytes(bytes_payload, bytes_protocol);
@@ -1062,7 +1062,7 @@ namespace libtorrent
 		t->received_bytes(bytes_payload, bytes_protocol);
 	}
 
-	void peer_connection::sent_bytes(int bytes_payload, int bytes_protocol)
+	void peer_connection::sent_bytes(size_t bytes_payload, size_t bytes_protocol)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.sent_bytes(bytes_payload, bytes_protocol);
@@ -1082,7 +1082,7 @@ namespace libtorrent
 		t->sent_bytes(bytes_payload, bytes_protocol);
 	}
 
-	void peer_connection::trancieve_ip_packet(int bytes, bool ipv6)
+	void peer_connection::trancieve_ip_packet(size_t bytes, bool ipv6)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.trancieve_ip_packet(bytes, ipv6);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2419,7 +2419,7 @@ namespace aux {
 				}
 
 				char* buf = packet.data.data();
-				int const len = packet.data.size();
+				int const len = int(packet.data.size());
 
 				// give the uTP socket manager first dis on the packet. Presumably
 				// the majority of packets are uTP packets.
@@ -3072,17 +3072,17 @@ namespace aux {
 	}
 #endif
 
-	void session_impl::sent_bytes(int bytes_payload, int bytes_protocol)
+	void session_impl::sent_bytes(size_t bytes_payload, size_t bytes_protocol)
 	{
 		m_stats_counters.inc_stats_counter(counters::sent_bytes
 			, bytes_payload + bytes_protocol);
 		m_stats_counters.inc_stats_counter(counters::sent_payload_bytes
 			, bytes_payload);
 
-		m_stat.sent_bytes(bytes_payload, bytes_protocol);
+		m_stat.sent_bytes(int(bytes_payload), bytes_protocol);
 	}
 
-	void session_impl::received_bytes(int bytes_payload, int bytes_protocol)
+	void session_impl::received_bytes(size_t bytes_payload, size_t bytes_protocol)
 	{
 		m_stats_counters.inc_stats_counter(counters::recv_bytes
 			, bytes_payload + bytes_protocol);
@@ -3092,7 +3092,7 @@ namespace aux {
 		m_stat.received_bytes(bytes_payload, bytes_protocol);
 	}
 
-	void session_impl::trancieve_ip_packet(int bytes, bool ipv6)
+	void session_impl::trancieve_ip_packet(size_t bytes, bool ipv6)
 	{
 		m_stat.trancieve_ip_packet(bytes, ipv6);
 	}

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10138,19 +10138,19 @@ namespace libtorrent
 	}
 #endif // TORRENT_NO_DEPRECATE
 
-	void torrent::sent_bytes(int bytes_payload, int bytes_protocol)
+	void torrent::sent_bytes(size_t bytes_payload, size_t bytes_protocol)
 	{
 		m_stat.sent_bytes(bytes_payload, bytes_protocol);
 		m_ses.sent_bytes(bytes_payload, bytes_protocol);
 	}
 
-	void torrent::received_bytes(int bytes_payload, int bytes_protocol)
+	void torrent::received_bytes(size_t bytes_payload, size_t bytes_protocol)
 	{
 		m_stat.received_bytes(bytes_payload, bytes_protocol);
 		m_ses.received_bytes(bytes_payload, bytes_protocol);
 	}
 
-	void torrent::trancieve_ip_packet(int bytes, bool ipv6)
+	void torrent::trancieve_ip_packet(size_t bytes, bool ipv6)
 	{
 		m_stat.trancieve_ip_packet(bytes, ipv6);
 		m_ses.trancieve_ip_packet(bytes, ipv6);

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -177,12 +177,12 @@ namespace libtorrent
 		close();
 	}
 
-	void tracker_connection::sent_bytes(int bytes)
+	void tracker_connection::sent_bytes(size_t bytes)
 	{
 		m_man.sent_bytes(bytes);
 	}
 
-	void tracker_connection::received_bytes(int bytes)
+	void tracker_connection::received_bytes(size_t bytes)
 	{
 		m_man.received_bytes(bytes);
 	}
@@ -219,13 +219,13 @@ namespace libtorrent
 		abort_all_requests(true);
 	}
 
-	void tracker_manager::sent_bytes(int bytes)
+	void tracker_manager::sent_bytes(size_t bytes)
 	{
 		TORRENT_ASSERT(m_ses.is_single_thread());
 		m_stats_counters.inc_stats_counter(counters::sent_tracker_bytes, bytes);
 	}
 
-	void tracker_manager::received_bytes(int bytes)
+	void tracker_manager::received_bytes(size_t bytes)
 	{
 		TORRENT_ASSERT(m_ses.is_single_thread());
 		m_stats_counters.inc_stats_counter(counters::recv_tracker_bytes, bytes);
@@ -464,6 +464,6 @@ namespace libtorrent
 	int tracker_manager::num_requests() const
 	{
 		mutex::scoped_lock l(m_mutex);
-		return m_http_conns.size() + m_udp_conns.size();
+		return int(m_http_conns.size() + m_udp_conns.size());
 	}
 }

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -176,14 +176,14 @@ udp_socket::~udp_socket()
 
 int udp_socket::read(array_view<packet> pkts, error_code& ec)
 {
-	int const num = pkts.size();
+	int const num = int(pkts.size());
 	int ret = 0;
 	packet p;
 
 	while (ret < num)
 	{
-		int const len = m_socket.receive_from(boost::asio::buffer(m_buf, m_buf_size)
-			, p.from, 0, ec);
+		int const len = int(m_socket.receive_from(boost::asio::buffer(m_buf, m_buf_size)
+			, p.from, 0, ec));
 
 		if (ec == error::would_block
 			|| ec == error::try_again
@@ -340,7 +340,7 @@ void udp_socket::wrap(char const* hostname, int const port, array_view<char cons
 	write_uint16(0, h); // reserved
 	write_uint8(0, h); // fragment
 	write_uint8(3, h); // atyp
-	int hostlen = (std::min)(strlen(hostname), size_t(255));
+	int hostlen = int((std::min)(strlen(hostname), size_t(255)));
 	write_uint8(hostlen, h); // hostname len
 	memcpy(h, hostname, hostlen);
 	h += hostlen;
@@ -366,7 +366,7 @@ bool udp_socket::unwrap(udp::endpoint& from, array_view<char>& buf)
 	using namespace libtorrent::detail;
 
 	// the minimum socks5 header size
-	int const size = buf.size();
+	int const size = int(buf.size());
 	if (size <= 10) return false;
 
 	char* p = buf.data();


### PR DESCRIPTION
- change sent_bytes,received_bytes,trancieve_ip_packet arguments from int to size_t
- fix rest size_t to int conversion warns
- fix ms c++ override,final,noexcept detection