### PR TITLE
Missing <map> include in add_torrent_params.hpp

### DIFF
--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <string>
 #include <vector>
+#include <map>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/shared_ptr.hpp>


### PR DESCRIPTION
This is necessary when `add_torrent_params` is used in a more isolated include (like a swig wrapper).