### PR TITLE
Fix IPv6 DHT entry in changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* added support for BEP 32, "IPv6 extension for DHT"
 	* overhauled listen socket and UDP socket handling, improving multi-home
 	  support and bind-to-device
 	* added new read_resume_data() function, initializing add_torrent_params
@@ -101,8 +102,6 @@
 	* added support for asynchronous disk I/O
 	* almost completely changed the storage interface (for custom storage)
 	* added support for hashing pieces in multiple threads
-	* added support for BEP 32, "IPv6 extension for DHT"
-
 	* fix division by zero in super-seeding logic
 
 1.0.9 release


### PR DESCRIPTION
I forgot to update this when I rebased the dht-ipv6 branch.