### PR TITLE
Replace all occurances of thread with libtorrent::thread to avoid ambiguity

### DIFF
--- a/test/dht_server.cpp
+++ b/test/dht_server.cpp
@@ -89,7 +89,7 @@ struct dht_server
 
 		fprintf(stderr, "%s: DHT initialized on port %d\n", time_now_string(), m_port);
 
-		m_thread.reset(new thread(boost::bind(&dht_server::thread_fun, this)));
+		m_thread.reset(new libtorrent::thread(boost::bind(&dht_server::thread_fun, this)));
 	}
 
 	~dht_server()

--- a/test/peer_server.cpp
+++ b/test/peer_server.cpp
@@ -92,7 +92,7 @@ struct peer_server
 
 		fprintf(stderr, "%s: PEER peer initialized on port %d\n", time_now_string(), m_port);
 
-		m_thread.reset(new thread(boost::bind(&peer_server::thread_fun, this)));
+		m_thread.reset(new libtorrent::thread(boost::bind(&peer_server::thread_fun, this)));
 	}
 
 	~peer_server()

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -258,7 +258,7 @@ TORRENT_TEST(wait_for_alert)
 	mgr.get_all(alerts);
 
 	start = clock_type::now();
-	thread posting_thread(boost::bind(&post_torrent_added, &mgr));
+	libtorrent::thread posting_thread(boost::bind(&post_torrent_added, &mgr));
 
 	a = mgr.wait_for_alert(seconds(10));
 	end = clock_type::now();

--- a/test/test_threads.cpp
+++ b/test/test_threads.cpp
@@ -77,11 +77,11 @@ TORRENT_TEST(threads)
 {
 	condition_variable cond;
 	libtorrent::mutex m;
-	std::list<thread*> threads;
+	std::list<libtorrent::thread*> threads;
 	int waiting = 0;
 	for (int i = 0; i < 20; ++i)
 	{
-		threads.push_back(new thread(boost::bind(&fun, &cond, &m, &waiting, i)));
+		threads.push_back(new libtorrent::thread(boost::bind(&fun, &cond, &m, &waiting, i)));
 	}
 
 	// make sure all threads are waiting on the condition_variable
@@ -96,7 +96,7 @@ TORRENT_TEST(threads)
 	cond.notify_all();
 	l.unlock();
 
-	for (std::list<thread*>::iterator i = threads.begin(); i != threads.end(); ++i)
+	for (std::list<libtorrent::thread*>::iterator i = threads.begin(); i != threads.end(); ++i)
 	{
 		(*i)->join();
 		delete *i;
@@ -107,8 +107,8 @@ TORRENT_TEST(threads)
 	boost::atomic<int> c(0);
 	for (int i = 0; i < 3; ++i)
 	{
-		threads.push_back(new thread(boost::bind(&increment, &cond, &m, &waiting, &c)));
-		threads.push_back(new thread(boost::bind(&decrement, &cond, &m, &waiting, &c)));
+		threads.push_back(new libtorrent::thread(boost::bind(&increment, &cond, &m, &waiting, &c)));
+		threads.push_back(new libtorrent::thread(boost::bind(&decrement, &cond, &m, &waiting, &c)));
 	}
 
 	// make sure all threads are waiting on the condition_variable
@@ -123,7 +123,7 @@ TORRENT_TEST(threads)
 	cond.notify_all();
 	l.unlock();
 
-	for (std::list<thread*>::iterator i = threads.begin(); i != threads.end(); ++i)
+	for (std::list<libtorrent::thread*>::iterator i = threads.begin(); i != threads.end(); ++i)
 	{
 		(*i)->join();
 		delete *i;

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -83,10 +83,10 @@ TORRENT_TEST(time)
 	
 	mutex m;
 	condition_variable cv;
-	thread t1(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
-	thread t2(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
-	thread t3(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
-	thread t4(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
+	libtorrent::thread t1(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
+	libtorrent::thread t2(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
+	libtorrent::thread t3(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
+	libtorrent::thread t4(boost::bind(&check_timer_loop, boost::ref(m), boost::ref(last), boost::ref(cv)));
 
 	test_sleep(100);
 

--- a/test/udp_tracker.cpp
+++ b/test/udp_tracker.cpp
@@ -164,7 +164,7 @@ struct udp_tracker
 
 		fprintf(stderr, "%s: UDP tracker initialized on port %d\n", time_now_string(), m_port);
 
-		m_thread.reset(new thread(boost::bind(&udp_tracker::thread_fun, this)));
+		m_thread.reset(new libtorrent::thread(boost::bind(&udp_tracker::thread_fun, this)));
 	}
 
 	~udp_tracker()


### PR DESCRIPTION
Without this compiling tests on FreeBSD-10 (using clang-3.4.1) fails because unqualified "thread" is ambiguous.