### PR TITLE
Use unique_ptr where possible

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -166,7 +166,8 @@ namespace libtorrent
 		// the actual sockets (TCP listen socket and UDP socket)
 		// An entry does not necessarily have a UDP or TCP socket. One of these
 		// pointers may be null!
-		// TODO: 3 make these unique_ptr<>
+		// These must be shared_ptr to avoid a dangling reference if an
+		// incoming packet is in the event queue when the socket is erased
 		boost::shared_ptr<tcp::acceptor> sock;
 		boost::shared_ptr<udp_socket> udp_sock;
 	};

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -760,7 +760,7 @@ namespace libtorrent
 
 			// a thread pool used for async_write_some calls,
 			// to distribute its cost to multiple threads
-			std::vector<boost::shared_ptr<network_thread_pool> > m_net_thread_pool;
+			std::vector<std::unique_ptr<network_thread_pool>> m_net_thread_pool;
 
 			// the bandwidth manager is responsible for
 			// handing out bandwidth to connections that

--- a/include/libtorrent/aux_/session_settings.hpp
+++ b/include/libtorrent/aux_/session_settings.hpp
@@ -77,8 +77,8 @@ namespace libtorrent { namespace aux
 		{
 			TORRENT_ASSERT((name & settings_pack::type_mask) == type);
 			if ((name & settings_pack::type_mask) != type) return;
-			int const index = name & settings_pack::index_mask;
-			TORRENT_ASSERT(index >= 0 && index < N);
+			size_t const index = name & settings_pack::index_mask;
+			TORRENT_ASSERT(index < N);
 			arr[index] = val;
 		}
 
@@ -88,8 +88,8 @@ namespace libtorrent { namespace aux
 			static T empty;
 			TORRENT_ASSERT((name & settings_pack::type_mask) == type);
 			if ((name & settings_pack::type_mask) != type) return empty;
-			int const index = name & settings_pack::index_mask;
-			TORRENT_ASSERT(index >= 0 && index < N);
+			size_t const index = name & settings_pack::index_mask;
+			TORRENT_ASSERT(index < N);
 			return arr[index];
 		}
 

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -401,7 +401,8 @@ namespace libtorrent
 		mutable std::mutex m_mutex;
 
 		// maps transactionid to the udp_tracker_connection
-		// TODO: this should be unique_ptr in the future
+		// These must use shared_ptr to avoid a dangling reference
+		// if a connection is erased while a timeout event is in the queue
 		typedef boost::unordered_map<boost::uint32_t
 			, boost::shared_ptr<udp_tracker_connection> > udp_conns_t;
 		udp_conns_t m_udp_conns;

--- a/include/libtorrent/udp_socket.hpp
+++ b/include/libtorrent/udp_socket.hpp
@@ -51,7 +51,6 @@ namespace libtorrent
 	{
 	public:
 		udp_socket(io_service& ios);
-		~udp_socket();
 
 		enum flags_t {
 			peer_connection = 1
@@ -135,10 +134,8 @@ namespace libtorrent
 
 		udp::socket m_socket;
 
-		// TODO: 2 this should probably be a scoped_ptr<> or unique_ptr
-		// with a hard coded size
-		int const m_buf_size;
-		char* m_buf;
+		using receive_buffer = std::array<char, 1500>;
+		std::unique_ptr<receive_buffer> m_buf;
 
 		boost::uint16_t m_bind_port;
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -6083,7 +6083,7 @@ namespace aux {
 		int num_pools = num_threads > 0 ? num_threads : 1;
 		while (num_pools > m_net_thread_pool.size())
 		{
-			m_net_thread_pool.push_back(boost::make_shared<network_thread_pool>());
+			m_net_thread_pool.emplace_back(new network_thread_pool());
 			m_net_thread_pool.back()->set_num_threads(num_threads > 0 ? 1 : 0);
 		}
 


### PR DESCRIPTION
There are disappointingly few places where shared_ptr can be trivially replaced with unique_ptr. boost::asio is a real buzzkill in this respect, pretty much anything which is bound to an event handler needs to be a shared_ptr to prevent dangling references.