### PR TITLE
Using address::is_multicast instead of util function

### DIFF
--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -391,7 +391,7 @@ namespace libtorrent
 		boost::int64_t total_uploaded;
 		boost::int64_t total_downloaded;
 
-		// the numeber of seconds this torrent has spent in started, finished and
+		// the number of seconds this torrent has spent in started, finished and
 		// seeding state so far, respectively.
 		int active_time;
 		int finished_time;
@@ -415,7 +415,7 @@ namespace libtorrent
 		// swarm, as returned by the tracker (either when announcing to it or by
 		// sending a specific scrape request). ``num_complete`` is the number of
 		// peers in the swarm that are seeds, or have every piece in the torrent.
-		// ``num_inomplete`` is the number of peers in the swarm that do not have
+		// ``num_incomplete`` is the number of peers in the swarm that do not have
 		// every piece. ``num_downloaded`` is the number of times the torrent has
 		// been downloaded (not initiated, but the number of times a download has
 		// completed).

--- a/include/libtorrent/broadcast_socket.hpp
+++ b/include/libtorrent/broadcast_socket.hpp
@@ -52,7 +52,6 @@ namespace libtorrent
 
 	TORRENT_EXTRA_EXPORT bool is_local(address const& a);
 	TORRENT_EXTRA_EXPORT bool is_loopback(address const& addr);
-	TORRENT_EXTRA_EXPORT bool is_multicast(address const& addr);
 	TORRENT_EXTRA_EXPORT bool is_any(address const& addr);
 	TORRENT_EXTRA_EXPORT bool is_teredo(address const& addr);
 	TORRENT_EXTRA_EXPORT int cidr_distance(address const& a1, address const& a2);

--- a/include/libtorrent/session_settings.hpp
+++ b/include/libtorrent/session_settings.hpp
@@ -1503,7 +1503,7 @@ namespace libtorrent
 	// to peer protocol encryption.
 	struct TORRENT_EXPORT pe_settings
 	{
-		// initializes the encryption settings with the default vaues
+		// initializes the encryption settings with the default values
 		pe_settings()
 			: out_enc_policy(enabled)
 			, in_enc_policy(enabled)

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -97,20 +97,6 @@ namespace libtorrent
 #endif
 	}
 
-	bool is_multicast(address const& addr)
-	{
-#if TORRENT_USE_IPV6
-		TORRENT_TRY {
-			if (addr.is_v4())
-				return addr.to_v4().is_multicast();
-			else
-				return addr.to_v6().is_multicast();
-		} TORRENT_CATCH(std::exception&) { return false; }
-#else
-		return addr.to_v4().is_multicast();
-#endif
-	}
-
 	bool is_any(address const& addr)
 	{
 		TORRENT_TRY {
@@ -212,9 +198,7 @@ namespace libtorrent
 		, m_outstanding_operations(0)
 		, m_abort(false)
 	{
-		TORRENT_ASSERT(is_multicast(m_multicast_endpoint.address()));
-
-		using namespace boost::asio::ip::multicast;
+		TORRENT_ASSERT(m_multicast_endpoint.address().is_multicast());
 	}
 
 	void broadcast_socket::open(receive_handler_t const& handler
@@ -302,7 +286,6 @@ namespace libtorrent
 	void broadcast_socket::open_unicast_socket(io_service& ios, address const& addr
 		, address_v4 const& mask)
 	{
-		using namespace boost::asio::ip::multicast;
 		error_code ec;
 		boost::shared_ptr<udp::socket> s(new udp::socket(ios));
 		s->open(addr.is_v4() ? udp::v4() : udp::v6(), ec);

--- a/test/enum_if.cpp
+++ b/test/enum_if.cpp
@@ -91,7 +91,7 @@ int main()
 			, i->netmask.to_string(ec).c_str()
 			, i->name
 			, i->mtu
-			, (is_multicast(i->interface_address)?"multicast ":"")
+			, (i->interface_address.is_multicast()?"multicast ":"")
 			, (is_local(i->interface_address)?"local ":"")
 			, (is_loopback(i->interface_address)?"loopback ":"")
 			);


### PR DESCRIPTION
I wonder if you had any particular reason for the `if-else` here and if a similar reasoning is in `is_loopback`.