### PR TITLE
Moved disabled_storage and zero_storage for a private namespace in the compilation unit

### DIFF
--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -470,62 +470,6 @@ namespace libtorrent
 		bool m_allocate_files;
 	};
 
-	// this storage implementation does not write anything to disk
-	// and it pretends to read, and just leaves garbage in the buffers
-	// this is useful when simulating many clients on the same machine
-	// or when running stress tests and want to take the cost of the
-	// disk I/O out of the picture. This cannot be used for any kind
-	// of normal bittorrent operation, since it will just send garbage
-	// to peers and throw away all the data it downloads. It would end
-	// up being banned immediately
-	class disabled_storage final : public storage_interface, boost::noncopyable
-	{
-	public:
-		virtual bool has_any_file(storage_error&) override { return false; }
-		virtual void set_file_priority(std::vector<boost::uint8_t> const&
-			, storage_error&) override {}
-		virtual void rename_file(int, std::string const&, storage_error&) override {}
-		virtual void release_files(storage_error&) override {}
-		virtual void delete_files(int, storage_error&) override {}
-		virtual void initialize(storage_error&) override {}
-		virtual int move_storage(std::string const&, int, storage_error&) override { return 0; }
-
-		virtual int readv(file::iovec_t const* bufs, int num_bufs, int piece
-			, int offset, int flags, storage_error& ec) override;
-		virtual int writev(file::iovec_t const* bufs, int num_bufs, int piece
-			, int offset, int flags, storage_error& ec) override;
-
-		virtual bool verify_resume_data(add_torrent_params const&
-			, std::vector<std::string> const*
-			, storage_error&) override { return false; }
-	};
-
-	// this storage implementation always reads zeroes, and always discards
-	// anything written to it
-	struct zero_storage final : storage_interface
-	{
-		virtual void initialize(storage_error&) override {}
-
-		virtual int readv(file::iovec_t const* bufs, int num_bufs
-			, int piece, int offset, int flags, storage_error& ec) override;
-		virtual int writev(file::iovec_t const* bufs, int num_bufs
-			, int piece, int offset, int flags, storage_error& ec) override;
-
-		virtual bool has_any_file(storage_error&) override { return false; }
-		virtual void set_file_priority(std::vector<boost::uint8_t> const& /* prio */
-			, storage_error&) override {}
-		virtual int move_storage(std::string const& /* save_path */
-			, int /* flags */, storage_error&) override { return 0; }
-		virtual bool verify_resume_data(add_torrent_params const& /* rd */
-			, std::vector<std::string> const* /* links */
-			, storage_error&) override
-			{ return false; }
-		virtual void release_files(storage_error&) override {}
-		virtual void rename_file(int /* index */
-			, std::string const& /* new_filenamem */, storage_error&) override {}
-		virtual void delete_files(int, storage_error&) override {}
-	};
-
 	struct disk_io_thread;
 
 	// implements the disk I/O job fence used by the piece_manager

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1354,16 +1354,45 @@ namespace libtorrent
 		return new default_storage(params);
 	}
 
-	int disabled_storage::readv(file::iovec_t const* bufs
-		, int num_bufs, int, int, int, storage_error&)
-	{
-		return bufs_size(bufs, num_bufs);
-	}
+	// -- disabled_storage --------------------------------------------------
 
-	int disabled_storage::writev(file::iovec_t const* bufs
-		, int num_bufs, int, int, int, storage_error&)
+	namespace
 	{
-		return bufs_size(bufs, num_bufs);
+		// this storage implementation does not write anything to disk
+		// and it pretends to read, and just leaves garbage in the buffers
+		// this is useful when simulating many clients on the same machine
+		// or when running stress tests and want to take the cost of the
+		// disk I/O out of the picture. This cannot be used for any kind
+		// of normal bittorrent operation, since it will just send garbage
+		// to peers and throw away all the data it downloads. It would end
+		// up being banned immediately
+		class disabled_storage final : public storage_interface, boost::noncopyable
+		{
+		public:
+			virtual bool has_any_file(storage_error&) override { return false; }
+			virtual void set_file_priority(std::vector<boost::uint8_t> const&
+				, storage_error&) override {}
+			virtual void rename_file(int, std::string const&, storage_error&) override {}
+			virtual void release_files(storage_error&) override {}
+			virtual void delete_files(int, storage_error&) override {}
+			virtual void initialize(storage_error&) override {}
+			virtual int move_storage(std::string const&, int, storage_error&) override { return 0; }
+
+			virtual int readv(file::iovec_t const* bufs, int num_bufs
+				, int, int, int, storage_error&) override
+			{
+				return bufs_size(bufs, num_bufs);
+			}
+			virtual int writev(file::iovec_t const* bufs, int num_bufs
+				, int, int, int, storage_error&) override
+			{
+				return bufs_size(bufs, num_bufs);
+			}
+
+			virtual bool verify_resume_data(add_torrent_params const&
+				, std::vector<std::string> const*
+				, storage_error&) override { return false; }
+		};
 	}
 
 	storage_interface* disabled_storage_constructor(storage_params const& params)
@@ -1374,25 +1403,48 @@ namespace libtorrent
 
 	// -- zero_storage ------------------------------------------------------
 
-	int zero_storage::readv(file::iovec_t const* bufs, int num_bufs
-		, int /* piece */, int /* offset */, int /* flags */, storage_error&)
+	namespace
 	{
-		int ret = 0;
-		for (int i = 0; i < num_bufs; ++i)
+		// this storage implementation always reads zeroes, and always discards
+		// anything written to it
+		struct zero_storage final : storage_interface
 		{
-			memset(bufs[i].iov_base, 0, bufs[i].iov_len);
-			ret += int(bufs[i].iov_len);
-		}
-		return 0;
-	}
+			virtual void initialize(storage_error&) override {}
 
-	int zero_storage::writev(file::iovec_t const* bufs, int num_bufs
-		, int /* piece */, int /* offset */, int /* flags */, storage_error&)
-	{
-		int ret = 0;
-		for (int i = 0; i < num_bufs; ++i)
-			ret += int(bufs[i].iov_len);
-		return 0;
+			virtual int readv(file::iovec_t const* bufs, int num_bufs
+				, int, int, int, storage_error&) override
+			{
+				int ret = 0;
+				for (int i = 0; i < num_bufs; ++i)
+				{
+					memset(bufs[i].iov_base, 0, bufs[i].iov_len);
+					ret += int(bufs[i].iov_len);
+				}
+				return 0;
+			}
+			virtual int writev(file::iovec_t const* bufs, int num_bufs
+				, int, int, int, storage_error&) override
+			{
+				int ret = 0;
+				for (int i = 0; i < num_bufs; ++i)
+					ret += int(bufs[i].iov_len);
+				return 0;
+			}
+
+			virtual bool has_any_file(storage_error&) override { return false; }
+			virtual void set_file_priority(std::vector<boost::uint8_t> const& /* prio */
+				, storage_error&) override {}
+			virtual int move_storage(std::string const& /* save_path */
+				, int /* flags */, storage_error&) override { return 0; }
+			virtual bool verify_resume_data(add_torrent_params const& /* rd */
+				, std::vector<std::string> const* /* links */
+				, storage_error&) override
+			{ return false; }
+			virtual void release_files(storage_error&) override {}
+			virtual void rename_file(int /* index */
+				, std::string const& /* new_filenamem */, storage_error&) override {}
+			virtual void delete_files(int, storage_error&) override {}
+		};
 	}
 
 	storage_interface* zero_storage_constructor(storage_params const&)


### PR DESCRIPTION
I think this makes sense, but the original motivation is that swig is having a hard time with the `final` keyword in the class declaration.