### PR TITLE
fix file_storage::m_paths memory reuse

### DIFF
--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -168,6 +168,10 @@ namespace libtorrent
 			// and the branch path
 			branch_path = path.c_str();
 			branch_len = leaf - path.c_str();
+
+			// trim trailing slashes
+			if (branch_len > 0 && branch_path[branch_len-1] == TORRENT_SEPARATOR)
+				--branch_len;
 		}
 		if (branch_len <= 0)
 		{
@@ -201,10 +205,6 @@ namespace libtorrent
 			// no, we don't. add it
 			e.path_index = int(m_paths.size());
 			TORRENT_ASSERT(branch_path[0] != '/');
-
-			// trim trailing slashes
-			if (branch_len > 0 && branch_path[branch_len-1] == TORRENT_SEPARATOR)
-				--branch_len;
 
 			// poor man's emplace back
 			m_paths.resize(m_paths.size() + 1);

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -1306,6 +1306,18 @@ TORRENT_TEST(move_storage_into_self)
 		, combine_path("_folder3", "test4.tmp")))));
 }
 
+TORRENT_TEST(storage_paths_string_pooling)
+{
+	file_storage file_storage;
+	file_storage.add_file(combine_path("test_storage", "root.txt"), 0x4000);
+	file_storage.add_file(combine_path("test_storage", combine_path("sub", "test1.txt")), 0x4000);
+	file_storage.add_file(combine_path("test_storage", combine_path("sub", "test2.txt")), 0x4000);
+	file_storage.add_file(combine_path("test_storage", combine_path("sub", "test3.txt")), 0x4000);
+
+	// "sub" paths should point to same string item, so paths.size() must not grow 
+	TEST_CHECK(file_storage.paths().size() <= 2);
+}
+
 TORRENT_TEST(dont_move_intermingled_files)
 {
 	std::string const save_path = combine_path(current_working_directory(), "save_path_1");


### PR DESCRIPTION
after rename_file with path delimiter - file_storage::m_paths should be searched for branch_path without torrent_separtor