### PR TITLE
factor out includes from config.hpp into the files actually using it

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -717,6 +717,10 @@ local usage-requirements =
 	<toolset>msvc,<variant>release:<linkflags>/OPT:ICF=5
 	<toolset>msvc,<variant>release:<linkflags>/OPT:REF
 
+	# disable bogus deprecation warnings on msvc8
+	<toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
+	<toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
+
 	<cxxflags>$(CXXFLAGS)
 	<linkflags>$(LDFLAGS)
 	;
@@ -742,10 +746,6 @@ lib torrent
 	<conditional>@building
 	<conditional>@warnings
 	<cxxflags>$(CXXFLAGS)
-
-	# disable bogus deprecation warnings on msvc8
-	<toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
-	<toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
 
 	<tag>@tag
 

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -55,6 +55,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/extensions/ut_pex.hpp"
 #include "libtorrent/extensions/smart_ban.hpp"
 
+#include "libtorrent/aux_/max_path.hpp"
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/announce_entry.hpp"
 #include "libtorrent/entry.hpp"
@@ -161,7 +162,7 @@ retry:
 
 	if (ret < 0 && errno != 0 && errno != ETIMEDOUT)
 	{
-		fprintf(stderr, "select failed: %s\n", strerror(errno));
+		std::fprintf(stderr, "select failed: %s\n", strerror(errno));
 		sleep_ms(500);
 	}
 
@@ -204,7 +205,7 @@ int load_file(std::string const& filename, std::vector<char>& v
 	, libtorrent::error_code& ec, int limit = 8000000)
 {
 	ec.clear();
-	FILE* f = fopen(filename.c_str(), "rb");
+	FILE* f = std::fopen(filename.c_str(), "rb");
 	if (f == NULL)
 	{
 		ec.assign(errno, boost::system::system_category());
@@ -215,20 +216,20 @@ int load_file(std::string const& filename, std::vector<char>& v
 	if (r != 0)
 	{
 		ec.assign(errno, boost::system::system_category());
-		fclose(f);
+		std::fclose(f);
 		return -1;
 	}
 	long s = ftell(f);
 	if (s < 0)
 	{
 		ec.assign(errno, boost::system::system_category());
-		fclose(f);
+		std::fclose(f);
 		return -1;
 	}
 
 	if (s > limit)
 	{
-		fclose(f);
+		std::fclose(f);
 		return -2;
 	}
 
@@ -236,26 +237,26 @@ int load_file(std::string const& filename, std::vector<char>& v
 	if (r != 0)
 	{
 		ec.assign(errno, boost::system::system_category());
-		fclose(f);
+		std::fclose(f);
 		return -1;
 	}
 
 	v.resize(s);
 	if (s == 0)
 	{
-		fclose(f);
+		std::fclose(f);
 		return 0;
 	}
 
-	r = int(fread(&v[0], 1, v.size(), f));
+	r = int(std::fread(&v[0], 1, v.size(), f));
 	if (r < 0)
 	{
 		ec.assign(errno, boost::system::system_category());
-		fclose(f);
+		std::fclose(f);
 		return -1;
 	}
 
-	fclose(f);
+	std::fclose(f);
 
 	if (r != s) return -3;
 
@@ -349,10 +350,10 @@ std::string print_endpoint(libtorrent::tcp::endpoint const& ep)
 	address const& addr = ep.address();
 #if TORRENT_USE_IPV6
 	if (addr.is_v6())
-		snprintf(buf, sizeof(buf), "[%s]:%d", addr.to_string(ec).c_str(), ep.port());
+		std::snprintf(buf, sizeof(buf), "[%s]:%d", addr.to_string(ec).c_str(), ep.port());
 	else
 #endif
-		snprintf(buf, sizeof(buf), "%s:%d", addr.to_string(ec).c_str(), ep.port());
+		std::snprintf(buf, sizeof(buf), "%s:%d", addr.to_string(ec).c_str(), ep.port());
 	return buf;
 }
 
@@ -412,7 +413,7 @@ int print_peer_info(std::string& out
 
 		if (print_ip)
 		{
-			snprintf(str, sizeof(str), "%-30s ", (::print_endpoint(i->ip) +
+			std::snprintf(str, sizeof(str), "%-30s ", (::print_endpoint(i->ip) +
 				(i->flags & peer_info::utp_socket ? " [uTP]" : "") +
 				(i->flags & peer_info::i2p_socket ? " [i2p]" : "")
 				).c_str());
@@ -420,14 +421,14 @@ int print_peer_info(std::string& out
 		}
 
 		char temp[10];
-		snprintf(temp, sizeof(temp), "%d/%d"
+		std::snprintf(temp, sizeof(temp), "%d/%d"
 			, i->download_queue_length
 			, i->target_dl_queue_length);
 		temp[7] = 0;
 
 		char peer_progress[10];
-		snprintf(peer_progress, sizeof(peer_progress), "%.1f%%", i->progress_ppm / 10000.f);
-		snprintf(str, sizeof(str)
+		std::snprintf(peer_progress, sizeof(peer_progress), "%.1f%%", i->progress_ppm / 10000.f);
+		std::snprintf(str, sizeof(str)
 			, "%s %s%s (%s|%s) %s%s (%s|%s) %s%7s %4d%4d%4d %s%s%s%s%s%s%s%s%s%s%s%s%s %s%s%s %s%s%s %s%s%s%s%s%s "
 			, progress_bar(i->progress_ppm / 1000, 15, col_green, '#', '-', peer_progress).c_str()
 			, esc("32"), add_suffix(i->down_speed, "/s").c_str()
@@ -471,13 +472,13 @@ int print_peer_info(std::string& out
 
 		if (print_fails)
 		{
-			snprintf(str, sizeof(str), "%3d %3d "
+			std::snprintf(str, sizeof(str), "%3d %3d "
 				, i->failcount, i->num_hashfails);
 			out += str;
 		}
 		if (print_send_bufs)
 		{
-			snprintf(str, sizeof(str), "%2d %6d %6d%5dkB "
+			std::snprintf(str, sizeof(str), "%2d %6d %6d%5dkB "
 				, i->requests_in_buffer, i->used_send_buffer
 				, i->used_receive_buffer
 				, i->queue_bytes / 1000);
@@ -489,16 +490,16 @@ int print_peer_info(std::string& out
 			// timeout is only meaningful if there is at least one outstanding
 			// request to the peer
 			if (i->download_queue_length > 0)
-				snprintf(req_timeout, sizeof(req_timeout), "%d", i->request_timeout);
+				std::snprintf(req_timeout, sizeof(req_timeout), "%d", i->request_timeout);
 
-			snprintf(str, sizeof(str), "%8d %4d %7s %6d "
+			std::snprintf(str, sizeof(str), "%8d %4d %7s %6d "
 				, int(total_seconds(i->last_active))
 				, int(total_seconds(i->last_request))
 				, req_timeout
 				, int(total_seconds(i->download_queue_time)));
 			out += str;
 		}
-		snprintf(str, sizeof(str), "%s|%s %5d "
+		std::snprintf(str, sizeof(str), "%s|%s %5d "
 			, add_suffix(i->pending_disk_bytes).c_str()
 			, add_suffix(i->pending_disk_read_bytes).c_str()
 			, i->rtt);
@@ -509,7 +510,7 @@ int print_peer_info(std::string& out
 			if (i->downloading_piece_index >= 0)
 			{
 				char buf[50];
-				snprintf(buf, sizeof(buf), "%d:%d", i->downloading_piece_index, i->downloading_block_index);
+				std::snprintf(buf, sizeof(buf), "%d:%d", i->downloading_piece_index, i->downloading_block_index);
 				out += progress_bar(
 					i->downloading_progress * 1000 / i->downloading_total, 14, col_green, '-', '#', buf);
 			}
@@ -523,7 +524,7 @@ int print_peer_info(std::string& out
 		{
 			bool unchoked = (i->flags & peer_info::choked) == 0;
 
-			snprintf(str, sizeof(str), " %s %s"
+			std::snprintf(str, sizeof(str), " %s %s"
 				, add_suffix(i->remote_dl_rate, "/s").c_str()
 				, unchoked ? add_suffix(i->estimated_reciprocation_rate, "/s").c_str() : "      ");
 			out += str;
@@ -642,7 +643,7 @@ void print_settings(int const start, int const num
 	{
 		char const* name = libtorrent::name_for_setting(i);
 		if (!name || name[0] == '\0') continue;
-		printf(fmt, name);
+		std::printf(fmt, name);
 	}
 }
 
@@ -653,7 +654,7 @@ void add_torrent(libtorrent::session& ses
 	using namespace libtorrent;
 	static int counter = 0;
 
-	printf("[%d] %s\n", counter++, torrent.c_str());
+	std::printf("[%d] %s\n", counter++, torrent.c_str());
 
 	error_code ec;
 	add_torrent_params p;
@@ -665,7 +666,7 @@ void add_torrent(libtorrent::session& ses
 	if (!ec)
 	{
 		p = read_resume_data(&resume_data[0], int(resume_data.size()), ec);
-		if (ec) printf("  failed to load resume data: %s\n", ec.message().c_str());
+		if (ec) std::printf("  failed to load resume data: %s\n", ec.message().c_str());
 	}
 	ec.clear();
 
@@ -677,7 +678,7 @@ void add_torrent(libtorrent::session& ses
 	p.save_path = save_path;
 	p.storage_mode = (storage_mode_t)allocation_mode;
 	p.flags &= ~add_torrent_params::flag_duplicate_is_error;
-	p.userdata = (void*)strdup(torrent.c_str());
+	p.userdata = static_cast<void*>(new std::string(torrent));
 	ses.async_add_torrent(p);
 	files.insert(std::pair<const std::string, torrent_handle>(torrent, torrent_handle()));
 }
@@ -760,7 +761,7 @@ void scan_dir(std::string const& dir_path
 	std::vector<std::string> ents = list_dir(dir_path, filter_fun, ec);
 	if (ec)
 	{
-		fprintf(stderr, "failed to list directory: (%s : %d) %s\n"
+		std::fprintf(stderr, "failed to list directory: (%s : %d) %s\n"
 			, ec.category().name(), ec.value(), ec.message().c_str());
 		return;
 	}
@@ -839,17 +840,17 @@ void print_alert(libtorrent::alert const* a, std::string& str)
 	str += esc("0");
 
 	if (g_log_file)
-		fprintf(g_log_file, "[%s] %s\n", timestamp(),  a->message().c_str());
+		std::fprintf(g_log_file, "[%s] %s\n", timestamp(),  a->message().c_str());
 }
 
 int save_file(std::string const& filename, std::vector<char>& v)
 {
-	FILE* f = fopen(filename.c_str(), "wb");
+	FILE* f = std::fopen(filename.c_str(), "wb");
 	if (f == NULL)
 		return -1;
 
-	int w = int(fwrite(&v[0], 1, v.size(), f));
-	fclose(f);
+	int w = int(std::fwrite(&v[0], 1, v.size(), f));
+	std::fclose(f);
 
 	if (w < 0) return -1;
 	if (w != int(v.size())) return -3;
@@ -898,8 +899,9 @@ bool handle_alert(libtorrent::session& ses, libtorrent::alert* a
 #endif
 		{
 			char msg[256];
-			snprintf(msg, sizeof(msg), "ERROR. could not load certificate %s: %s\n", cert.c_str(), strerror(errno));
-			if (g_log_file) fprintf(g_log_file, "[%s] %s\n", timestamp(), msg);
+			std::snprintf(msg, sizeof(msg), "ERROR. could not load certificate %s: %s\n"
+				, cert.c_str(), std::strerror(errno));
+			if (g_log_file) std::fprintf(g_log_file, "[%s] %s\n", timestamp(), msg);
 			return true;
 		}
 
@@ -912,14 +914,15 @@ bool handle_alert(libtorrent::session& ses, libtorrent::alert* a
 #endif
 		{
 			char msg[256];
-			snprintf(msg, sizeof(msg), "ERROR. could not load private key %s: %s\n", priv.c_str(), strerror(errno));
-			if (g_log_file) fprintf(g_log_file, "[%s] %s\n", timestamp(), msg);
+			std::snprintf(msg, sizeof(msg), "ERROR. could not load private key %s: %s\n"
+				, priv.c_str(), std::strerror(errno));
+			if (g_log_file) std::fprintf(g_log_file, "[%s] %s\n", timestamp(), msg);
 			return true;
 		}
 
 		char msg[256];
-		snprintf(msg, sizeof(msg), "loaded certificate %s and key %s\n", cert.c_str(), priv.c_str());
-		if (g_log_file) fprintf(g_log_file, "[%s] %s\n", timestamp(), msg);
+		std::snprintf(msg, sizeof(msg), "loaded certificate %s and key %s\n", cert.c_str(), priv.c_str());
+		if (g_log_file) std::fprintf(g_log_file, "[%s] %s\n", timestamp(), msg);
 
 		h.set_ssl_certificate(cert, priv, "certificates/dhparams.pem", "1234");
 		h.resume();
@@ -974,13 +977,14 @@ bool handle_alert(libtorrent::session& ses, libtorrent::alert* a
 		std::string filename;
 		if (p->params.userdata)
 		{
-			filename = (char*)p->params.userdata;
-			free(p->params.userdata);
+			std::string* f = static_cast<std::string*>(p->params.userdata);
+			filename.swap(*f);
+			delete f;
 		}
 
 		if (p->error)
 		{
-			fprintf(stderr, "failed to add torrent: %s %s\n", filename.c_str()
+			std::fprintf(stderr, "failed to add torrent: %s %s\n", filename.c_str()
 				, p->error.message().c_str());
 		}
 		else
@@ -1064,7 +1068,7 @@ bool handle_alert(libtorrent::session& ses, libtorrent::alert* a
 		torrent_handle h = p->handle;
 		if (h.is_valid())
 		{
-			fprintf(stderr, "FAILED TO SAVE RESUME DATA: %s\n"
+			std::fprintf(stderr, "FAILED TO SAVE RESUME DATA: %s\n"
 				, h.status().name.c_str());
 		}
 		if (h.is_valid()
@@ -1107,7 +1111,7 @@ void print_piece(libtorrent::partial_piece_info* pp
 	int piece = pp ? pp->piece_index : cs->piece;
 	int num_blocks = pp ? pp->blocks_in_piece : int(cs->blocks.size());
 
-	snprintf(str, sizeof(str), "%5d:[", piece);
+	std::snprintf(str, sizeof(str), "%5d:[", piece);
 	out += str;
 	char const* last_color = 0;
 	for (int j = 0; j < num_blocks; ++j)
@@ -1143,7 +1147,7 @@ void print_piece(libtorrent::partial_piece_info* pp
 		}
 		if (last_color == 0 || strcmp(last_color, color) != 0)
 		{
-			snprintf(str, sizeof(str), "%s%c", color, chr);
+			std::snprintf(str, sizeof(str), "%s%c", color, chr);
 			out += str;
 		}
 		else
@@ -1165,7 +1169,7 @@ int main(int argc, char* argv[])
 
 	if (argc == 1)
 	{
-		fprintf(stderr, "usage: client_test [OPTIONS] [TORRENT|MAGNETURL|URL]\n\n"
+		std::fprintf(stderr, "usage: client_test [OPTIONS] [TORRENT|MAGNETURL|URL]\n\n"
 			"OPTIONS:\n"
 			"\n CLIENT OPTIONS\n"
 			"  -f <log file>         logs all events to the given file\n"
@@ -1293,7 +1297,7 @@ int main(int argc, char* argv[])
 			int const sett_name = setting_by_name(key);
 			if (sett_name < 0)
 			{
-				fprintf(stderr, "unknown setting: \"%s\"\n", key.c_str());
+				std::fprintf(stderr, "unknown setting: \"%s\"\n", key.c_str());
 				return 1;
 			}
 
@@ -1310,7 +1314,7 @@ int main(int argc, char* argv[])
 					}
 					else
 					{
-						fprintf(stderr, "invalid value for \"%s\". expected 0 or 1\n"
+						std::fprintf(stderr, "invalid value for \"%s\". expected 0 or 1\n"
 							, key.c_str());
 						return 1;
 					}
@@ -1329,7 +1333,7 @@ int main(int argc, char* argv[])
 
 		switch (argv[i][1])
 		{
-			case 'f': g_log_file = fopen(arg, "w+"); break;
+			case 'f': g_log_file = std::fopen(arg, "w+"); break;
 			case 'k': high_performance_seed(settings); --i; break;
 			case 'G': seed_mode = true; --i; break;
 			case 's': save_path = arg; break;
@@ -1345,11 +1349,12 @@ int main(int argc, char* argv[])
 				break;
 			case 'x':
 				{
-					FILE* filter = fopen(arg, "r");
+					FILE* filter = std::fopen(arg, "r");
 					if (filter)
 					{
 						unsigned int a,b,c,d,e,f,g,h, flags;
-						while (fscanf(filter, "%u.%u.%u.%u - %u.%u.%u.%u %u\n", &a, &b, &c, &d, &e, &f, &g, &h, &flags) == 9)
+						while (std::fscanf(filter, "%u.%u.%u.%u - %u.%u.%u.%u %u\n"
+							, &a, &b, &c, &d, &e, &f, &g, &h, &flags) == 9)
 						{
 							address_v4 start((a << 24) + (b << 16) + (c << 8) + d);
 							address_v4 last((e << 24) + (f << 16) + (g << 8) + h);
@@ -1357,7 +1362,7 @@ int main(int argc, char* argv[])
 							else flags = 0;
 							loaded_ip_filter.add_rule(start, last, flags);
 						}
-						fclose(filter);
+						std::fclose(filter);
 					}
 				}
 				break;
@@ -1381,7 +1386,7 @@ int main(int argc, char* argv[])
 	int ret = mkdir(path_append(save_path, ".resume").c_str(), 0777);
 #endif
 	if (ret < 0)
-		fprintf(stderr, "failed to create resume file directory: (%d) %s\n"
+		std::fprintf(stderr, "failed to create resume file directory: (%d) %s\n"
 			, errno, strerror(errno));
 
 	settings.set_str(settings_pack::user_agent, "client_test/" LIBTORRENT_VERSION);
@@ -1471,7 +1476,7 @@ int main(int argc, char* argv[])
 				if (!ec)
 				{
 					p = read_resume_data(&resume_data[0], int(resume_data.size()), ec);
-					if (ec) printf("  failed to load resume data: %s\n", ec.message().c_str());
+					if (ec) std::printf("  failed to load resume data: %s\n", ec.message().c_str());
 				}
 				ec.clear();
 			}
@@ -1483,7 +1488,7 @@ int main(int argc, char* argv[])
 			p.storage_mode = (storage_mode_t)allocation_mode;
 			p.url = *i;
 
-			printf("adding URL: %s\n", i->c_str());
+			std::printf("adding URL: %s\n", i->c_str());
 			ses.async_add_torrent(p);
 			continue;
 		}
@@ -1598,7 +1603,7 @@ int main(int argc, char* argv[])
 				{
 					char url[4096];
 					puts("Enter magnet link:\n");
-					scanf("%4095s", url);
+					std::scanf("%4095s", url);
 
 					add_torrent_params p;
 					if (std::strstr(url, "magnet:") == url)
@@ -1616,7 +1621,7 @@ int main(int argc, char* argv[])
 						if (!ec)
 						{
 							p = read_resume_data(&resume_data[0], int(resume_data.size()), ec);
-							if (ec) printf("  failed to load resume data: %s\n", ec.message().c_str());
+							if (ec) std::printf("  failed to load resume data: %s\n", ec.message().c_str());
 						}
 						ec.clear();
 					}
@@ -1628,7 +1633,7 @@ int main(int argc, char* argv[])
 					p.storage_mode = (storage_mode_t)allocation_mode;
 					p.url = url;
 
-					printf("adding URL: %s\n", url);
+					std::printf("adding URL: %s\n", url);
 					ses.async_add_torrent(p);
 				}
 
@@ -1654,10 +1659,10 @@ int main(int argc, char* argv[])
 				if (c == 'D' && h.is_valid())
 				{
 					torrent_status const& st = view.get_active_torrent();
-					printf("\n\nARE YOU SURE YOU WANT TO DELETE THE FILES FOR '%s'. THIS OPERATION CANNOT BE UNDONE. (y/N)"
+					std::printf("\n\nARE YOU SURE YOU WANT TO DELETE THE FILES FOR '%s'. THIS OPERATION CANNOT BE UNDONE. (y/N)"
 						, st.name.c_str());
 					char response = 'n';
-					scanf("%c", &response);
+					std::scanf("%c", &response);
 					if (response == 'y')
 					{
 						// also delete the .torrent file from the torrent directory
@@ -1670,7 +1675,7 @@ int main(int argc, char* argv[])
 							if (is_absolute_path(i->first)) path = i->first;
 							else path = path_append(monitor_dir, i->first);
 							if (::remove(path.c_str()) < 0)
-								printf("failed to delete .torrent file: %s\n", err.message().c_str());
+								std::printf("failed to delete .torrent file: %s\n", err.message().c_str());
 							files.erase(i);
 						}
 						if (st.handle.is_valid())
@@ -1856,7 +1861,7 @@ int main(int argc, char* argv[])
 		{
 			// TODO: 3 expose these counters as performance counters
 /*
-			snprintf(str, sizeof(str), "DHT nodes: %d DHT cached nodes: %d "
+			std::snprintf(str, sizeof(str), "DHT nodes: %d DHT cached nodes: %d "
 				"total DHT size: %" PRId64 " total observers: %d\n"
 				, sess_stat.dht_nodes, sess_stat.dht_node_cache, sess_stat.dht_global_nodes
 				, sess_stat.dht_total_allocations);
@@ -1873,7 +1878,7 @@ int main(int argc, char* argv[])
 					"################################"
 					"################################";
 				char const* short_progress_bar = "--------";
-				snprintf(str, sizeof(str)
+				std::snprintf(str, sizeof(str)
 					, "%3d [%3d, %d] %s%s\x1b[K\n"
 					, bucket, i->num_nodes, i->num_replacements
 					, progress_bar + (128 - i->num_nodes)
@@ -1885,7 +1890,7 @@ int main(int argc, char* argv[])
 			for (std::vector<dht_lookup>::iterator i = dht_active_requests.begin()
 				, end(dht_active_requests.end()); i != end; ++i)
 			{
-				snprintf(str, sizeof(str)
+				std::snprintf(str, sizeof(str)
 					, "  %10s [limit: %2d] "
 					"in-flight: %-2d "
 					"left: %-3d "
@@ -1928,7 +1933,7 @@ int main(int argc, char* argv[])
 					, end(tr.end()); i != end; ++i)
 				{
 					if (pos + 1 >= terminal_height) break;
-					snprintf(str, sizeof(str), "%2d %-55s fails: %-3d (%-3d) %s %s %5d \"%s\" %s\x1b[K\n"
+					std::snprintf(str, sizeof(str), "%2d %-55s fails: %-3d (%-3d) %s %s %5d \"%s\" %s\x1b[K\n"
 						, i->tier, i->url.c_str(), i->fails, i->fail_limit, i->verified?"OK ":"-  "
 						, i->updating?"updating"
 							:to_string(int(total_seconds(i->next_announce - now)), 8).c_str()
@@ -2026,7 +2031,7 @@ int main(int argc, char* argv[])
 					pos += 1;
 				}
 
-				snprintf(str, sizeof(str), "%s %s read cache | %s %s downloading | %s %s cached | %s %s flushed | %s %s snubbed\x1b[K\n"
+				std::snprintf(str, sizeof(str), "%s %s read cache | %s %s downloading | %s %s cached | %s %s flushed | %s %s snubbed\x1b[K\n"
 					, esc("34;7"), esc("0") // read cache
 					, esc("33;7"), esc("0") // downloading
 					, esc("36;7"), esc("0") // cached
@@ -2057,7 +2062,7 @@ int main(int argc, char* argv[])
 					{
 						if (show_pad_files)
 						{
-							snprintf(str, sizeof(str), "\x1b[34m%-70s %s\x1b[0m\x1b[K\n"
+							std::snprintf(str, sizeof(str), "\x1b[34m%-70s %s\x1b[0m\x1b[K\n"
 								, ti->files().file_name(i).c_str()
 								, add_suffix(ti->files().file_size(i)).c_str());
 							out += str;
@@ -2074,7 +2079,7 @@ int main(int argc, char* argv[])
 					std::string title = ti->files().file_name(i);
 					if (!complete)
 					{
-						snprintf(str, sizeof(str), " (%.1f%%)", progress / 10.f);
+						std::snprintf(str, sizeof(str), " (%.1f%%)", progress / 10.f);
 						title += str;
 					}
 
@@ -2101,7 +2106,7 @@ int main(int argc, char* argv[])
 						p = 0;
 					}
 
-					snprintf(str, sizeof(str), "%s %7s p: %d ",
+					std::snprintf(str, sizeof(str), "%s %7s p: %d ",
 						progress_bar(progress, file_progress_width, complete ? col_green : col_yellow, '-', '#'
 							, title.c_str()).c_str()
 						, add_suffix(file_progress[i]).c_str()
@@ -2146,7 +2151,7 @@ int main(int argc, char* argv[])
 	}
 
 	ses.pause();
-	printf("saving resume data\n");
+	std::printf("saving resume data\n");
 	std::vector<torrent_status> temp;
 	ses.get_torrent_status(&temp, &yes, 0);
 	for (std::vector<torrent_status>::iterator i = temp.begin();
@@ -2155,26 +2160,26 @@ int main(int argc, char* argv[])
 		torrent_status& st = *i;
 		if (!st.handle.is_valid())
 		{
-			printf("  skipping, invalid handle\n");
+			std::printf("  skipping, invalid handle\n");
 			continue;
 		}
 		if (!st.has_metadata)
 		{
-			printf("  skipping %s, no metadata\n", st.name.c_str());
+			std::printf("  skipping %s, no metadata\n", st.name.c_str());
 			continue;
 		}
 		if (!st.need_save_resume)
 		{
-			printf("  skipping %s, resume file up-to-date\n", st.name.c_str());
+			std::printf("  skipping %s, resume file up-to-date\n", st.name.c_str());
 			continue;
 		}
 
 		// save_resume_data will generate an alert when it's done
 		st.handle.save_resume_data();
 		++num_outstanding_resume_data;
-		printf("\r%d  ", num_outstanding_resume_data);
+		std::printf("\r%d  ", num_outstanding_resume_data);
 	}
-	printf("\nwaiting for resume data [%d]\n", num_outstanding_resume_data);
+	std::printf("\nwaiting for resume data [%d]\n", num_outstanding_resume_data);
 
 	while (num_outstanding_resume_data > 0)
 	{
@@ -2196,11 +2201,11 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	if (g_log_file) fclose(g_log_file);
+	if (g_log_file) std::fclose(g_log_file);
 
 	// we're just saving the DHT state
 #ifndef TORRENT_DISABLE_DHT
-	printf("\nsaving session state\n");
+	std::printf("\nsaving session state\n");
 	{
 		entry session_state;
 		ses.save_state(session_state, session::save_dht_state);
@@ -2211,7 +2216,7 @@ int main(int argc, char* argv[])
 	}
 #endif
 
-	printf("closing session");
+	std::printf("closing session");
 
 	return 0;
 }

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -420,7 +420,7 @@ struct peer_conn
 	{
 		end_time = clock_type::now();
 		char tmp[1024];
-		snprintf(tmp, sizeof(tmp), fmt, ec.message().c_str());
+		std::snprintf(tmp, sizeof(tmp), fmt, ec.message().c_str());
 		int time = int(total_milliseconds(end_time - start_time));
 		if (time == 0) time = 1;
 		float up = (boost::int64_t(blocks_sent) * 0x4000) / time / 1000.f;
@@ -431,13 +431,13 @@ struct peer_conn
 		address const& addr = s.local_endpoint(e).address();
 #if TORRENT_USE_IPV6
 		if (addr.is_v6())
-			snprintf(ep_str, sizeof(ep_str), "[%s]:%d", addr.to_string(e).c_str()
+			std::snprintf(ep_str, sizeof(ep_str), "[%s]:%d", addr.to_string(e).c_str()
 				, s.local_endpoint(e).port());
 		else
 #endif
-			snprintf(ep_str, sizeof(ep_str), "%s:%d", addr.to_string(e).c_str()
+			std::snprintf(ep_str, sizeof(ep_str), "%s:%d", addr.to_string(e).c_str()
 				, s.local_endpoint(e).port());
-		printf("%s ep: %s sent: %d received: %d duration: %d ms up: %.1fMB/s down: %.1fMB/s\n"
+		std::printf("%s ep: %s sent: %d received: %d duration: %d ms up: %.1fMB/s down: %.1fMB/s\n"
 			, tmp, ep_str, blocks_sent, blocks_received, time, up, down);
 		if (seed) --num_seeds;
 	}
@@ -483,7 +483,7 @@ struct peer_conn
 		unsigned int length = read_uint32(ptr);
 		if (length > sizeof(buffer))
 		{
-			fprintf(stderr, "len: %d\n", length);
+			std::fprintf(stderr, "len: %d\n", length);
 			close("ERROR RECEIVE MESSAGE PREFIX: packet too big", error_code());
 			return;
 		}
@@ -515,7 +515,7 @@ struct peer_conn
 			return;
 		}
 
-		//printf("msg: %d len: %d\n", msg, int(bytes_transferred));
+		//std::printf("msg: %d len: %d\n", msg, int(bytes_transferred));
 
 		if (seed)
 		{
@@ -637,7 +637,7 @@ struct peer_conn
 					}
 				}
 				--outstanding_requests;
-				fprintf(stderr, "REJECT: [ piece: %d start: %d length: %d ]\n", piece, start, length);
+				std::fprintf(stderr, "REJECT: [ piece: %d start: %d length: %d ]\n", piece, start, length);
 			}
 			else if (msg == 0) // choke
 			{
@@ -669,7 +669,7 @@ struct peer_conn
 		{
 			if (buf[i] != fill)
 			{
-				fprintf(stderr, "received invalid block. piece %d block %d\n", piece, start / 0x4000);
+				std::fprintf(stderr, "received invalid block. piece %d block %d\n", piece, start / 0x4000);
 				exit(1);
 			}
 		}
@@ -719,7 +719,7 @@ struct peer_conn
 
 void print_usage()
 {
-	fprintf(stderr, "usage: connection_tester command [options]\n\n"
+	std::fprintf(stderr, "usage: connection_tester command [options]\n\n"
 		"command is one of:\n"
 		"  gen-torrent        generate a test torrent\n"
 		"    options for this command:\n"
@@ -757,7 +757,7 @@ void print_usage()
 
 void hasher_thread(libtorrent::create_torrent* t, int start_piece, int end_piece, int piece_size, bool print)
 {
-	if (print) fprintf(stderr, "\n");
+	if (print) std::fprintf(stderr, "\n");
 	boost::uint32_t piece[0x4000 / 4];
 	for (int i = start_piece; i < end_piece; ++i)
 	{
@@ -768,9 +768,9 @@ void hasher_thread(libtorrent::create_torrent* t, int start_piece, int end_piece
 			ph.update((char*)piece, 0x4000);
 		}
 		t->set_hash(i, ph.final());
-		if (print && (i & 1)) fprintf(stderr, "\r%.1f %% ", float((i-start_piece) * 100) / float(end_piece-start_piece));
+		if (print && (i & 1)) std::fprintf(stderr, "\r%.1f %% ", float((i-start_piece) * 100) / float(end_piece-start_piece));
 	}
-	if (print) fprintf(stderr, "\n");
+	if (print) std::fprintf(stderr, "\n");
 }
 
 // size is in megabytes
@@ -789,7 +789,7 @@ void generate_torrent(std::vector<char>& buf, int size, int num_files
 	while (s > 0)
 	{
 		char b[100];
-		snprintf(b, sizeof(b), "%s/stress_test%d", torrent_name, i);
+		std::snprintf(b, sizeof(b), "%s/stress_test%d", torrent_name, i);
 		++i;
 		fs.add_file(b, (std::min)(s, boost::int64_t(file_size)));
 		s -= file_size;
@@ -845,9 +845,9 @@ void generate_data(char const* path, torrent_info const& ti)
 			storage_error error;
 			st->writev(&b, 1, i, j, 0, error);
 			if (error)
-				fprintf(stderr, "storage error: %s\n", error.ec.message().c_str());
+				std::fprintf(stderr, "storage error: %s\n", error.ec.message().c_str());
 		}
-		if (i & 1) fprintf(stderr, "\r%.1f %% ", float(i * 100) / float(ti.num_pieces()));
+		if (i & 1) std::fprintf(stderr, "\r%.1f %% ", float(i * 100) / float(ti.num_pieces()));
 	}
 }
 
@@ -855,7 +855,7 @@ void io_thread(io_service* ios)
 {
 	error_code ec;
 	ios->run(ec);
-	if (ec) fprintf(stderr, "ERROR: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "ERROR: %s\n", ec.message().c_str());
 }
 
 int main(int argc, char* argv[])
@@ -884,7 +884,7 @@ int main(int argc, char* argv[])
 
 		if (optname[0] != '-' || strlen(optname) != 2)
 		{
-			fprintf(stderr, "unknown option: %s\n", optname);
+			std::fprintf(stderr, "unknown option: %s\n", optname);
 			continue;
 		}
 
@@ -896,7 +896,7 @@ int main(int argc, char* argv[])
 
 		if (argc == 0)
 		{
-			fprintf(stderr, "missing argument for option: %s\n", optname);
+			std::fprintf(stderr, "missing argument for option: %s\n", optname);
 			break;
 		}
 
@@ -915,7 +915,7 @@ int main(int argc, char* argv[])
 			case 'p': destination_port = atoi(optarg); break;
 			case 'd': destination_ip = optarg; break;
 			case 'r': churn = atoi(optarg); break;
-			default: fprintf(stderr, "unknown option: %s\n", optname);
+			default: std::fprintf(stderr, "unknown option: %s\n", optname);
 		}
 	}
 
@@ -924,23 +924,24 @@ int main(int argc, char* argv[])
 		std::vector<char> tmp;
 		std::string name = leaf_path(torrent_file);
 		name = name.substr(0, name.find_last_of('.'));
-		printf("generating torrent: %s\n", name.c_str());
+		std::printf("generating torrent: %s\n", name.c_str());
 		generate_torrent(tmp, size ? size : 1024, num_files ? num_files : 1
 			, name.c_str());
 
 		FILE* output = stdout;
 		if (strcmp("-", torrent_file) != 0)
 		{
-			if( (output = fopen(torrent_file, "wb+")) == 0)
+			if( (output = std::fopen(torrent_file, "wb+")) == 0)
 			{
-				fprintf(stderr, "Could not open file '%s' for writing: %s\n", torrent_file, strerror(errno));
+				std::fprintf(stderr, "Could not open file '%s' for writing: %s\n"
+					, torrent_file, std::strerror(errno));
 				exit(2);
 			}
 		}
-		fprintf(stderr, "writing file to: %s\n", torrent_file);
+		std::fprintf(stderr, "writing file to: %s\n", torrent_file);
 		fwrite(&tmp[0], 1, tmp.size(), output);
 		if (output != stdout)
-			fclose(output);
+			std::fclose(output);
 
 		return 0;
 	}
@@ -950,7 +951,7 @@ int main(int argc, char* argv[])
 		torrent_info ti(torrent_file, ec);
 		if (ec)
 		{
-			fprintf(stderr, "ERROR LOADING .TORRENT: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "ERROR LOADING .TORRENT: %s\n", ec.message().c_str());
 			return 1;
 		}
 		generate_data(data_path, ti);
@@ -962,13 +963,13 @@ int main(int argc, char* argv[])
 		for (int i = 0; i < num_torrents; ++i)
 		{
 			char torrent_name[100];
-			snprintf(torrent_name, sizeof(torrent_name), "%s-%d.torrent", torrent_file, i);
+			std::snprintf(torrent_name, sizeof(torrent_name), "%s-%d.torrent", torrent_file, i);
 
 			file_storage fs;
 			for (int j = 0; j < num_files; ++j)
 			{
 				char file_name[100];
-				snprintf(file_name, sizeof(file_name), "%s-%d/file-%d", torrent_file, i, j);
+				std::snprintf(file_name, sizeof(file_name), "%s-%d/file-%d", torrent_file, i, j);
 				fs.add_file(file_name, boost::int64_t(j + i + 1) * 251);
 			}
 			// 1 MiB piece size
@@ -982,21 +983,22 @@ int main(int argc, char* argv[])
 			buf.clear();
 			std::back_insert_iterator<std::vector<char> > out(buf);
 			bencode(out, t.generate());
-			FILE* f = fopen(torrent_name, "w+");
+			FILE* f = std::fopen(torrent_name, "w+");
 			if (f == 0)
 			{
-				fprintf(stderr, "Could not open file '%s' for writing: %s\n", torrent_name, strerror(errno));
+				std::fprintf(stderr, "Could not open file '%s' for writing: %s\n"
+					, torrent_name, std::strerror(errno));
 				return 1;
 			}
 			size_t ret = fwrite(&buf[0], 1, buf.size(), f);
 			if (ret != buf.size())
 			{
-				fprintf(stderr, "write returned: %d (expected %d)\n", int(ret), int(buf.size()));
-				fclose(f);
+				std::fprintf(stderr, "write returned: %d (expected %d)\n", int(ret), int(buf.size()));
+				std::fclose(f);
 				return 1;
 			}
-			printf("wrote %s\n", torrent_name);
-			fclose(f);
+			std::printf("wrote %s\n", torrent_name);
+			std::fclose(f);
 		}
 		return 0;
 	}
@@ -1014,7 +1016,7 @@ int main(int argc, char* argv[])
 	}
 	else
 	{
-		fprintf(stderr, "unknown command: %s\n\n", command);
+		std::fprintf(stderr, "unknown command: %s\n\n", command);
 		print_usage();
 	}
 
@@ -1022,7 +1024,7 @@ int main(int argc, char* argv[])
 	address_v4 addr = address_v4::from_string(destination_ip, ec);
 	if (ec)
 	{
-		fprintf(stderr, "ERROR RESOLVING %s: %s\n", destination_ip, ec.message().c_str());
+		std::fprintf(stderr, "ERROR RESOLVING %s: %s\n", destination_ip, ec.message().c_str());
 		return 1;
 	}
 	tcp::endpoint ep(addr, boost::uint16_t(destination_port));
@@ -1040,7 +1042,7 @@ int main(int argc, char* argv[])
 	torrent_info ti(torrent_file, ec);
 	if (ec)
 	{
-		fprintf(stderr, "ERROR LOADING .TORRENT: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "ERROR LOADING .TORRENT: %s\n", ec.message().c_str());
 		return 1;
 	}
 
@@ -1060,7 +1062,7 @@ int main(int argc, char* argv[])
 		ios[i % num_threads].poll_one(ec);
 		if (ec)
 		{
-			fprintf(stderr, "ERROR: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "ERROR: %s\n", ec.message().c_str());
 			break;
 		}
 	}
@@ -1088,7 +1090,7 @@ int main(int argc, char* argv[])
 		delete p;
 	}
 
-	printf("=========================\n"
+	std::printf("=========================\n"
 		"suggests: %d suggested-requests: %d\n"
 		"total sent: %.1f %% received: %.1f %%\n"
 		"rate sent: %.1f MB/s received: %.1f MB/s\n"

--- a/examples/print.cpp
+++ b/examples/print.cpp
@@ -44,7 +44,7 @@ char const* esc(char const* code)
 std::string to_string(int v, int width)
 {
 	char buf[100];
-	snprintf(buf, sizeof(buf), "%*d", width, v);
+	std::snprintf(buf, sizeof(buf), "%*d", width, v);
 	return buf;
 }
 
@@ -67,7 +67,7 @@ std::string add_suffix_float(float val, char const* suffix)
 		if (std::fabs(val) < 1000.f) break;
 	}
 	char ret[100];
-	snprintf(ret, sizeof(ret), "%4.*f%s%s", val < 99 ? 1 : 0, val, prefix[i], suffix ? suffix : "");
+	std::snprintf(ret, sizeof(ret), "%4.*f%s%s", val < 99 ? 1 : 0, val, prefix[i], suffix ? suffix : "");
 	return ret;
 }
 
@@ -77,7 +77,7 @@ std::string color(std::string const& s, color_code c)
 	if (std::count(s.begin(), s.end(), ' ') == int(s.size())) return s;
 
 	char buf[1024];
-	snprintf(buf, sizeof(buf), "\x1b[3%dm%s\x1b[39m", c, s.c_str());
+	std::snprintf(buf, sizeof(buf), "\x1b[3%dm%s\x1b[39m", c, s.c_str());
 	return buf;
 }
 
@@ -93,7 +93,7 @@ std::string const& progress_bar(int progress, int width, color_code c
 	if (caption.empty())
 	{
 		char code[10];
-		snprintf(code, sizeof(code), "\x1b[3%dm", c);
+		std::snprintf(code, sizeof(code), "\x1b[3%dm", c);
 		bar = code;
 		std::fill_n(std::back_inserter(bar), progress_chars, fill);
 		std::fill_n(std::back_inserter(bar), width - progress_chars, bg);
@@ -116,11 +116,11 @@ std::string const& progress_bar(int progress, int width, color_code c
 
 		char str[256];
 		if (flags & progress_invert)
-			snprintf(str, sizeof(str), "\x1b[%sm\x1b[37m%s\x1b[4%d;3%dm%s\x1b[49;39m"
+			std::snprintf(str, sizeof(str), "\x1b[%sm\x1b[37m%s\x1b[4%d;3%dm%s\x1b[49;39m"
 				, background, caption.substr(0, progress_chars).c_str(), c, tc
 				, caption.substr(progress_chars).c_str());
 		else
-			snprintf(str, sizeof(str), "\x1b[4%d;3%dm%s\x1b[%sm\x1b[37m%s\x1b[49;39m"
+			std::snprintf(str, sizeof(str), "\x1b[4%d;3%dm%s\x1b[%sm\x1b[37m%s\x1b[49;39m"
 				, c, tc, caption.substr(0, progress_chars).c_str(), background
 				, caption.substr(progress_chars).c_str());
 		bar = str;
@@ -186,7 +186,7 @@ std::string const& piece_bar(libtorrent::bitfield const& p, int width)
 				if (color[i] != last_color[i])
 				{
 					char buf[40];
-					snprintf(buf, sizeof(buf), "\x1b[%d;5;%dm", bg[i & 1], 232 + color[i]);
+					std::snprintf(buf, sizeof(buf), "\x1b[%d;5;%dm", bg[i & 1], 232 + color[i]);
 					last_color[i] = color[i];
 					bar += buf;
 				}
@@ -299,7 +299,7 @@ void set_cursor_pos(int x, int y)
 	COORD c = {SHORT(x), SHORT(y)};
 	SetConsoleCursorPosition(out, c);
 #else
-	printf("\033[%d;%dH", y + 1, x + 1);
+	std::printf("\033[%d;%dH", y + 1, x + 1);
 #endif
 }
 
@@ -315,7 +315,7 @@ void clear_screen()
 	FillConsoleOutputCharacter(out, ' ', si.dwSize.X * si.dwSize.Y, c, &n);
 	FillConsoleOutputAttribute(out, 0x7, si.dwSize.X * si.dwSize.Y, c, &n);
 #else
-	printf("\033[2J");
+	std::printf("\033[2J");
 #endif
 }
 
@@ -336,7 +336,7 @@ void clear_rows(int y1, int y2)
 	FillConsoleOutputAttribute(out, 0x7, num_chars, c, &n);
 #else
 	for (int i = y1; i < y2; ++i)
-		printf("\033[%d;1H\033[2K", i + 1);
+		std::printf("\033[%d;1H\033[2K", i + 1);
 #endif
 }
 

--- a/examples/print.hpp
+++ b/examples/print.hpp
@@ -2,6 +2,8 @@
 #define PRINT_HPP_
 
 #include <string>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 #include "libtorrent/bitfield.hpp"
 
 enum color_code

--- a/examples/session_view.cpp
+++ b/examples/session_view.cpp
@@ -75,7 +75,7 @@ void session_view::render()
 	int upload_rate = int((m_cnt[0][m_sent_payload_idx] - m_cnt[1][m_sent_payload_idx])
 		/ seconds);
 
-	pos += snprintf(str, sizeof(str), "%s%s fail: %s down: %s (%s) "
+	pos += std::snprintf(str, sizeof(str), "%s%s fail: %s down: %s (%s) "
 		"  bw queue: %s | %s conns: %3d  unchoked: %2d / %2d "
 		"                                      %s\x1b[K"
 		, esc("48;5;238")
@@ -93,7 +93,7 @@ void session_view::render()
 	set_cursor_pos(0, y++);
 	print(str);
 
-	snprintf(str, sizeof(str), "%s%swaste: %s   up: %s (%s) "
+	std::snprintf(str, sizeof(str), "%s%swaste: %s   up: %s (%s) "
 		"disk queue: %s | %s cache w: %3d%% r: %3d%% "
 		"size: w: %s r: %s total: %s       %s\x1b[K"
 #ifdef _WIN32
@@ -119,7 +119,7 @@ void session_view::render()
 	print(str);
 
 /*
-	snprintf(str, sizeof(str), "| timing - "
+	std::snprintf(str, sizeof(str), "| timing - "
 		" read: %6d ms | write: %6d ms | hash: %6d"
 		, cs.average_read_time / 1000, cs.average_write_time / 1000
 		, cs.average_hash_time / 1000);
@@ -127,7 +127,7 @@ void session_view::render()
 	set_cursor_pos(0, y++);
 	print(str);
 
-	snprintf(str, sizeof(str), "| jobs   - queued: %4d (%4d) pending: %4d blocked: %4d "
+	std::snprintf(str, sizeof(str), "| jobs   - queued: %4d (%4d) pending: %4d blocked: %4d "
 		"queued-bytes: %5" PRId64 " kB"
 		, cs.queued_jobs, cs.peak_queued, cs.pending_jobs, cs.blocked_jobs
 		, m_cnt[0][m_queued_bytes_idx] / 1000);
@@ -135,7 +135,7 @@ void session_view::render()
 	set_cursor_pos(0, y++);
 	print(str);
 
-	snprintf(str, sizeof(str), "|  cache  - total: %4d read: %4d write: %4d pinned: %4d write-queue: %4d"
+	std::snprintf(str, sizeof(str), "|  cache  - total: %4d read: %4d write: %4d pinned: %4d write-queue: %4d"
 		, cs.read_cache_size + cs.write_cache_size, cs.read_cache_size
 		, cs.write_cache_size, cs.pinned_blocks
 		, int(m_cnt[0][m_queued_bytes_idx] / 0x4000));
@@ -147,38 +147,38 @@ void session_view::render()
 	int arc_size = mru_size + mfu_size;
 
 	char mru_caption[100];
-	snprintf(mru_caption, sizeof(mru_caption), "MRU: %d (%d)"
+	std::snprintf(mru_caption, sizeof(mru_caption), "MRU: %d (%d)"
 		, int(m_cnt[0][m_mru_size_idx]), int(m_cnt[0][m_mru_ghost_idx]));
 	char mfu_caption[100];
-	snprintf(mfu_caption, sizeof(mfu_caption), "MFU: %d (%d)"
+	std::snprintf(mfu_caption, sizeof(mfu_caption), "MFU: %d (%d)"
 		, int(m_cnt[0][m_mfu_size_idx]), int(m_cnt[0][m_mfu_ghost_idx]));
 
-	pos = snprintf(str, sizeof(str), "cache: ");
+	pos = std::snprintf(str, sizeof(str), "cache: ");
 	if (arc_size > 0)
 	{
 		if (mru_size > 0)
 		{
-			pos += snprintf(str + pos, sizeof(str) - pos, "%s"
+			pos += std::snprintf(str + pos, sizeof(str) - pos, "%s"
 				, progress_bar(int(m_cnt[0][m_mru_ghost_idx] * 1000 / mru_size)
 					, mru_size * (m_width-8) / arc_size, col_yellow, '-', '#'
 					, mru_caption, progress_invert).c_str());
 		}
-		pos += snprintf(str + pos, sizeof(str) - pos, "|");
+		pos += std::snprintf(str + pos, sizeof(str) - pos, "|");
 		if (mfu_size)
 		{
-			pos += snprintf(str + pos, sizeof(str) - pos, "%s"
+			pos += std::snprintf(str + pos, sizeof(str) - pos, "%s"
 				, progress_bar(int(m_cnt[0][m_mfu_size_idx] * 1000 / mfu_size)
 					, mfu_size * (m_width-8) / arc_size, col_green, '#', '-'
 					, mfu_caption).c_str());
 		}
 	}
-	pos += snprintf(str + pos, sizeof(str) - pos, "\x1b[K");
+	pos += std::snprintf(str + pos, sizeof(str) - pos, "\x1b[K");
 	set_cursor_pos(0, y++);
 	print(str);
 
 	if (m_print_utp_stats)
 	{
-		snprintf(str, sizeof(str), "uTP idle: %d syn: %d est: %d fin: %d wait: %d\x1b[K"
+		std::snprintf(str, sizeof(str), "uTP idle: %d syn: %d est: %d fin: %d wait: %d\x1b[K"
 			, int(m_cnt[0][m_utp_idle])
 			, int(m_cnt[0][m_utp_syn_sent])
 			, int(m_cnt[0][m_utp_connected])

--- a/examples/simple_client.cpp
+++ b/examples/simple_client.cpp
@@ -30,7 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include "libtorrent/entry.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/session.hpp"
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 	error_code ec;
 	if (ec)
 	{
-		fprintf(stderr, "failed to open listen socket: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "failed to open listen socket: %s\n", ec.message().c_str());
 		return 1;
 	}
 	add_torrent_params p;
@@ -73,19 +73,19 @@ int main(int argc, char* argv[])
 	p.ti = boost::make_shared<torrent_info>(std::string(argv[1]), boost::ref(ec), 0);
 	if (ec)
 	{
-		fprintf(stderr, "%s\n", ec.message().c_str());
+		std::fprintf(stderr, "%s\n", ec.message().c_str());
 		return 1;
 	}
 	s.add_torrent(p, ec);
 	if (ec)
 	{
-		fprintf(stderr, "%s\n", ec.message().c_str());
+		std::fprintf(stderr, "%s\n", ec.message().c_str());
 		return 1;
 	}
 
 	// wait for the user to end
 	char a;
-	scanf("%c\n", &a);
+	std::scanf("%c\n", &a);
 	return 0;
 }
 

--- a/examples/stats_counters.cpp
+++ b/examples/stats_counters.cpp
@@ -30,8 +30,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#include <stdio.h>
 #include "libtorrent/session_stats.hpp"
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 using namespace libtorrent;
 
@@ -40,7 +41,7 @@ int main()
 	std::vector<stats_metric> m = session_stats_metrics();
 	for (int i = 0; i < int(m.size()); ++i)
 	{
-		printf("%s: %s (%d)\n"
+		std::printf("%s: %s (%d)\n"
 			, m[i].type == stats_metric::type_counter ? "CNTR" : "GAUG"
 			, m[i].name, m[i].value_index);
 	}

--- a/examples/torrent_view.cpp
+++ b/examples/torrent_view.cpp
@@ -18,7 +18,7 @@ std::string torrent_state(lt::torrent_status const& s)
 	else ret += state_str[s.state];
 	if (!s.paused && !s.auto_managed) ret += " [F]";
 	char buf[10];
-	snprintf(buf, sizeof(buf), " (%.1f%%)", s.progress_ppm / 10000.f);
+	std::snprintf(buf, sizeof(buf), " (%.1f%%)", s.progress_ppm / 10000.f);
 	ret += buf;
 	return ret;
 }
@@ -257,11 +257,11 @@ void torrent_view::print_tabs()
 		, "seeding", "queued", "stopped", "checking", "loaded"};
 	for (int i = 0; i < int(sizeof(filter_names)/sizeof(filter_names[0])); ++i)
 	{
-		pos += snprintf(str+ pos, sizeof(str) - pos, "%s[%s]%s"
+		pos += std::snprintf(str+ pos, sizeof(str) - pos, "%s[%s]%s"
 			, m_torrent_filter == i?esc("7"):""
 			, filter_names[i], m_torrent_filter == i?esc("0"):"");
 	}
-	pos += snprintf(str + pos, sizeof(str) - pos, "\x1b[K");
+	pos += std::snprintf(str + pos, sizeof(str) - pos, "\x1b[K");
 
 	if (m_width + 1 < int(sizeof(str)))
 		str[m_width + 1] = '\0';
@@ -275,7 +275,7 @@ void torrent_view::print_headers()
 	char str[400];
 
 	// print title bar for torrent list
-	snprintf(str, sizeof(str)
+	std::snprintf(str, sizeof(str)
 		, " %-3s %-50s %-35s %-17s %-17s %-11s %-6s %-6s %-4s\x1b[K"
 		, "#", "Name", "Progress", "Download", "Upload", "Peers (D:S)"
 		, "Down", "Up", "Flags");
@@ -299,9 +299,9 @@ void torrent_view::print_torrent(lt::torrent_status const& s, bool selected)
 
 	char queue_pos[16] = {0};
 	if (s.queue_position == -1)
-		snprintf(queue_pos, sizeof(queue_pos), "-");
+		std::snprintf(queue_pos, sizeof(queue_pos), "-");
 	else
-		snprintf(queue_pos, sizeof(queue_pos), "%d", s.queue_position);
+		std::snprintf(queue_pos, sizeof(queue_pos), "%d", s.queue_position);
 
 	std::string name = s.name;
 	if (name.size() > 50) name.resize(50);
@@ -314,7 +314,7 @@ void torrent_view::print_torrent(lt::torrent_status const& s, bool selected)
 	else if (s.current_tracker.empty())
 		progress_bar_color = col_green;
 
-	pos += snprintf(str + pos, sizeof(str) - pos, "%s%c%-3s %-50s %s%s %s (%s) "
+	pos += std::snprintf(str + pos, sizeof(str) - pos, "%s%c%-3s %-50s %s%s %s (%s) "
 		"%s (%s) %5d:%-5d %s %s %c"
 		, selection
 		, s.is_loaded ? 'L' : ' '
@@ -333,9 +333,9 @@ void torrent_view::print_torrent(lt::torrent_status const& s, bool selected)
 
 	// if this is the selected torrent, restore the background color
 	if (selected)
-		pos += snprintf(str + pos, sizeof(str) - pos, "%s", esc("0"));
+		pos += std::snprintf(str + pos, sizeof(str) - pos, "%s", esc("0"));
 
-	pos += snprintf(str + pos, sizeof(str) - pos, "\x1b[K");
+	pos += std::snprintf(str + pos, sizeof(str) - pos, "\x1b[K");
 
 	print(str);
 }

--- a/examples/upnp_test.cpp
+++ b/examples/upnp_test.cpp
@@ -30,14 +30,14 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include "libtorrent/session.hpp"
 #include "libtorrent/alert_types.hpp"
 
 char const* timestamp()
 {
-	time_t t = std::time(0);
-	tm* timeinfo = std::localtime(&t);
+	std::time_t t = std::time(0);
+	std::tm* timeinfo = std::localtime(&t);
 	static char str[200];
 	std::strftime(str, 200, "%b %d %X", timeinfo);
 	return str;
@@ -49,15 +49,15 @@ void print_alert(libtorrent::alert const* a)
 
 	if (alert_cast<portmap_error_alert>(a))
 	{
-		printf("%s","\x1b[32m");
+		std::printf("%s","\x1b[32m");
 	}
 	else if (alert_cast<portmap_alert>(a))
 	{
-		printf("%s","\x1b[33m");
+		std::printf("%s","\x1b[33m");
 	}
 
-	printf("[%s] %s\n", timestamp(), a->message().c_str());
-	printf("%s", "\x1b[0m");
+	std::printf("[%s] %s\n", timestamp(), a->message().c_str());
+	std::printf("%s", "\x1b[0m");
 }
 
 int main(int argc, char* argv[])
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	printf("\x1b[1m\n\n===================== done mapping. Now deleting mappings ========================\n\n\n\x1b[0m");
+	std::printf("\x1b[1m\n\n===================== done mapping. Now deleting mappings ========================\n\n\n\x1b[0m");
 
 	for (;;)
 	{

--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -162,6 +162,7 @@ nobase_include_HEADERS = \
   aux_/disable_warnings_pop.hpp     \
   aux_/escape_string.hpp            \
   aux_/io.hpp                       \
+  aux_/max_path.hpp                 \
   aux_/merkle.hpp                   \
   aux_/session_call.hpp             \
   aux_/session_impl.hpp             \

--- a/include/libtorrent/aux_/max_path.hpp
+++ b/include/libtorrent/aux_/max_path.hpp
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2011-2016, Arvid Norberg
+Copyright (c) 2016, Arvid Norberg
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -30,46 +30,39 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#include "libtorrent/config.hpp"
-#include "libtorrent/random.hpp"
-#include "libtorrent/assert.hpp"
+#ifndef TORRENT_MAX_PATH_HPP_INCLUDED
+#define TORRENT_MAX_PATH_HPP_INCLUDED
 
-#include <random>
+// on windows, NAME_MAX refers to Unicode characters
+// on linux it refers to bytes (utf-8 encoded)
+// TODO: Make this count Unicode characters instead of bytes on windows
 
-namespace libtorrent
-{
-	using std::random_device;
-	using std::mt19937;
-	using std::uniform_int_distribution;
+// windows
+#if defined FILENAME_MAX
+#define TORRENT_MAX_PATH FILENAME_MAX
 
-#ifdef TORRENT_BUILD_SIMULATOR
+// beos
+#elif defined B_PATH_NAME_LENGTH
+#define TORRENT_MAX_PATH B_PATH_NAME_LENGTH
 
-	boost::uint32_t random()
-	{
-		// make sure random numbers are deterministic. Seed with a fixed number
-		static mt19937 random_engine(4040);
-		return uniform_int_distribution<boost::uint32_t>(0
-			, (std::numeric_limits<boost::uint32_t>::max)())(random_engine);
-	}
+// solaris
+#elif defined MAXPATH
+#define TORRENT_MAX_PATH MAXPATH
 
+// none of the above
 #else
+// this is the maximum number of characters in a
+// path element / filename on windows and also on many filesystems commonly used
+// on linux
+#define TORRENT_MAX_PATH 255
 
-	boost::uint32_t random()
-	{
-		// TODO: versions prior to msvc-14 (visual studio 2015) do
-		// not generate thread safe initialization of statics
-		static random_device dev;
-		static mt19937 random_engine(dev());
-		return uniform_int_distribution<boost::uint32_t>(0
-			, (std::numeric_limits<boost::uint32_t>::max)())(random_engine);
-	}
+#ifdef _MSC_VER
+#pragma message ( "unknown platform, assuming the longest path is 255" )
+#else
+#warning "unknown platform, assuming the longest path is 255"
+#endif
 
-#endif // TORRENT_BUILD_SIMULATOR
+#endif // FILENAME_MAX
 
-	boost::uint32_t randint(int i)
-	{
-		return random() % i;
-	}
-
-}
+#endif // TORRENT_MAX_PATH_HPP_INCLUDED
 

--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -66,7 +66,7 @@ public:
 		int left() const
 		{
 			TORRENT_ASSERT(end >= begin);
-			TORRENT_ASSERT(end - begin < INT_MAX);
+			TORRENT_ASSERT(end - begin < (std::numeric_limits<int>::max)());
 			return int(end - begin);
 		}
 
@@ -101,7 +101,7 @@ public:
 		int left() const
 		{
 			TORRENT_ASSERT(end >= begin);
-			TORRENT_ASSERT(end - begin < INT_MAX);
+			TORRENT_ASSERT(end - begin < (std::numeric_limits<int>::max)());
 			return int(end - begin);
 		}
 

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -40,13 +40,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/config.hpp>
 #include <boost/asio/detail/config.hpp>
 #include <boost/version.hpp>
-#include <boost/detail/endian.hpp>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
-
-#include <stdio.h> // for snprintf
-#include <limits.h> // for IOV_MAX
-#include <cinttypes> // for PRId64 et.al.
 
 #include "libtorrent/export.hpp"
 
@@ -108,8 +103,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 // class X needs to have dll-interface to be used by clients of class Y
 #pragma warning(disable:4251)
-// '_vsnprintf': This function or variable may be unsafe
-#pragma warning(disable:4996)
 
 #if (defined(_MSC_VER) && _MSC_VER < 1310)
 #define TORRENT_COMPLETE_TYPES_REQUIRED 1
@@ -328,62 +321,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_BSD
 #endif
 
-// on windows, NAME_MAX refers to Unicode characters
-// on linux it refers to bytes (utf-8 encoded)
-// TODO: Make this count Unicode characters instead of bytes on windows
-
-// windows
-#if defined FILENAME_MAX
-#define TORRENT_MAX_PATH FILENAME_MAX
-
-// beos
-#elif defined B_PATH_NAME_LENGTH
-#define TORRENT_MAX_PATH B_PATH_NAME_LENGTH
-
-// solaris
-#elif defined MAXPATH
-#define TORRENT_MAX_PATH MAXPATH
-
-// none of the above
-#else
-// this is the maximum number of characters in a
-// path element / filename on windows and also on many filesystems commonly used
-// on linux
-#define TORRENT_MAX_PATH 255
-
-#ifdef _MSC_VER
-#pragma message ( "unknown platform, assuming the longest path is 255" )
-#else
-#warning "unknown platform, assuming the longest path is 255"
-#endif
-
-#endif
-
 #define TORRENT_UNUSED(x) (void)(x)
-
-#if (defined _MSC_VER && _MSC_VER < 1900) && !defined TORRENT_MINGW
-
-#include <stdarg.h>
-
-// internal
-#ifdef __cplusplus
-inline
-#else
-static
-#endif
-int snprintf(char* buf, int len, char const* fmt, ...)
-{
-	va_list lp;
-	int ret;
-	va_start(lp, fmt);
-	ret = _vsnprintf(buf, len, fmt, lp);
-	va_end(lp);
-	if (ret < 0) { buf[len-1] = 0; ret = len-1; }
-	return ret;
-}
-
-#define strtoll _strtoi64
-#endif
 
 // at the highest warning level, clang actually warns about functions
 // that could be marked noreturn.
@@ -392,16 +330,6 @@ int snprintf(char* buf, int len, char const* fmt, ...)
 #else
 #define TORRENT_NO_RETURN
 #endif
-
-#ifdef _GLIBCXX_USE_NOEXCEPT
-#define TORRENT_EXCEPTION_THROW_SPECIFIER _GLIBCXX_USE_NOEXCEPT
-#else
-#if __cplusplus <= 199711L || defined BOOST_NO_CXX11_NOEXCEPT
-#define TORRENT_EXCEPTION_THROW_SPECIFIER throw()
-#else
-#define TORRENT_EXCEPTION_THROW_SPECIFIER noexcept
-#endif
-#endif // __GLIBC__
 
 #ifndef TORRENT_ICONV_ARG
 #define TORRENT_ICONV_ARG (char**)
@@ -540,14 +468,6 @@ int snprintf(char* buf, int len, char const* fmt, ...)
 
 #ifndef TORRENT_USE_I2P
 #define TORRENT_USE_I2P 1
-#endif
-
-#if !defined TORRENT_IOV_MAX
-#ifdef IOV_MAX
-#define TORRENT_IOV_MAX IOV_MAX
-#else
-#define TORRENT_IOV_MAX INT_MAX
-#endif
 #endif
 
 #if !defined(TORRENT_READ_HANDLER_MAX_SIZE)

--- a/include/libtorrent/debug.hpp
+++ b/include/libtorrent/debug.hpp
@@ -157,7 +157,7 @@ namespace libtorrent
 		{
 			if (i->second.refs <= _async_ops_nthreads - 1) continue;
 			ret += i->second.refs;
-			printf("%s: (%d)\n%s\n", i->first.c_str(), i->second.refs, i->second.stack.c_str());
+			std::printf("%s: (%d)\n%s\n", i->first.c_str(), i->second.refs, i->second.stack.c_str());
 		}
 		return ret;
 	}

--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -70,6 +70,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/types.h>
 #include <dirent.h> // for DIR
 
+#include "libtorrent/aux_/max_path.hpp" // for TORRENT_MAX_PATH
+
 #undef _FILE_OFFSET_BITS
 
 #endif

--- a/include/libtorrent/fingerprint.hpp
+++ b/include/libtorrent/fingerprint.hpp
@@ -97,7 +97,7 @@ namespace libtorrent
 		std::string to_string() const
 		{
 			char s[100];
-			snprintf(s, 100, "-%c%c%c%c%c%c-"
+			std::snprintf(s, 100, "-%c%c%c%c%c%c-"
 				, name[0], name[1]
 				, version_to_char(major_version)
 				, version_to_char(minor_version)

--- a/include/libtorrent/lazy_entry.hpp
+++ b/include/libtorrent/lazy_entry.hpp
@@ -40,6 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstring>
 #include <algorithm>
+#include <limits>
 #include "libtorrent/config.hpp"
 #include "libtorrent/assert.hpp"
 #include "libtorrent/error_code.hpp"
@@ -106,7 +107,7 @@ namespace libtorrent
 		// construct a string pointing to the characters at ``p``
 		// of length ``l`` characters. No NULL termination is required.
 		pascal_string(char const* p, int l): len(l), ptr(p) {}
-		
+
 		// the number of characters in the string.
 		int len;
 
@@ -319,10 +320,10 @@ namespace libtorrent
 		void set_end(char const* end)
 		{
 			TORRENT_ASSERT(end > m_begin);
-			TORRENT_ASSERT(end - m_begin < INT_MAX);
+			TORRENT_ASSERT(end - m_begin < (std::numeric_limits<int>::max)());
 			m_len = int(end - m_begin);
 		}
-		
+
 		// internal
 		void clear();
 

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -839,7 +839,7 @@ namespace libtorrent
 #ifdef TORRENT_OPTIMIZE_MEMORY_USAGE
 		enum { max_pieces = piece_pos::we_have_index - 1 };
 #else
-		enum { max_pieces = INT_MAX - 1 };
+		enum { max_pieces = (std::numeric_limits<int>::max)() - 1 };
 #endif
 
 	};

--- a/include/libtorrent/session.hpp
+++ b/include/libtorrent/session.hpp
@@ -37,16 +37,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <thread>
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-
-#include <boost/limits.hpp>
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #include "libtorrent/config.hpp"
 #include "libtorrent/version.hpp"
 #include "libtorrent/build_config.hpp"
-#include "libtorrent/settings_pack.hpp"
 #include "libtorrent/io_service.hpp"
 
 #include "libtorrent/storage.hpp"
@@ -54,7 +47,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/session_handle.hpp"
 
 #ifndef TORRENT_NO_DEPRECATE
+#include "libtorrent/settings_pack.hpp"
 #include "libtorrent/fingerprint.hpp"
+#include <cstdio> // for snprintf
 #endif
 
 #ifdef TORRENT_USE_OPENSSL
@@ -240,7 +235,7 @@ namespace libtorrent
 			char if_string[100];
 
 			if (listen_interface == NULL) listen_interface = "0.0.0.0";
-			snprintf(if_string, sizeof(if_string), "%s:%d", listen_interface, listen_port_range.first);
+			std::snprintf(if_string, sizeof(if_string), "%s:%d", listen_interface, listen_port_range.first);
 			pack.set_str(settings_pack::listen_interfaces, if_string);
 
 			if ((flags & start_default_features) == 0)

--- a/simulation/create_torrent.cpp
+++ b/simulation/create_torrent.cpp
@@ -41,7 +41,7 @@ std::string save_path(int idx)
 {
 	int swarm_id = test_counter();
 	char path[200];
-	snprintf(path, sizeof(path), "swarm-%04d-peer-%02d"
+	std::snprintf(path, sizeof(path), "swarm-%04d-peer-%02d"
 		, swarm_id, idx);
 	return path;
 }
@@ -53,11 +53,11 @@ lt::add_torrent_params create_torrent(int idx, bool seed)
 	lt::add_torrent_params params;
 	int swarm_id = test_counter();
 	char name[200];
-	snprintf(name, sizeof(name), "temp-%02d", swarm_id);
+	std::snprintf(name, sizeof(name), "temp-%02d", swarm_id);
 	std::string path = save_path(idx);
 	lt::error_code ec;
 	lt::create_directory(path, ec);
-	if (ec) fprintf(stderr, "failed to create directory: \"%s\": %s\n"
+	if (ec) std::fprintf(stderr, "failed to create directory: \"%s\": %s\n"
 		, path.c_str(), ec.message().c_str());
 	std::ofstream file(lt::combine_path(path, name).c_str());
 	params.ti = ::create_torrent(&file, name, 0x4000, 9 + idx, false);

--- a/simulation/fake_peer.hpp
+++ b/simulation/fake_peer.hpp
@@ -34,6 +34,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define SIMULATION_FAKE_PEER_HPP
 
 #include <array>
+#include <cstdio> // for snprintf
+
 #include "test.hpp"
 #include "simulator/simulator.hpp"
 #include "libtorrent/session.hpp"
@@ -94,7 +96,7 @@ private:
 	void write_handshake(boost::system::error_code const& ec, lt::sha1_hash ih)
 	{
 		asio::ip::tcp::endpoint ep = m_out_socket.remote_endpoint();
-		printf("fake_peer::connect (%s) -> (%d) %s\n"
+		std::printf("fake_peer::connect (%s) -> (%d) %s\n"
 			, lt::print_endpoint(ep).c_str(), ec.value()
 			, ec.message().c_str());
 		static char const handshake[]
@@ -109,7 +111,7 @@ private:
 		asio::async_write(m_out_socket, asio::const_buffers_1(&m_out_buffer[0]
 			, len), [=](boost::system::error_code const& ec, size_t bytes_transferred)
 		{
-			printf("fake_peer::write_handshake(%s) -> (%d) %s\n"
+			std::printf("fake_peer::write_handshake(%s) -> (%d) %s\n"
 				, lt::print_endpoint(ep).c_str(), ec.value()
 				, ec.message().c_str());
 			this->m_out_socket.close();
@@ -131,7 +133,7 @@ inline void add_fake_peers(lt::torrent_handle h)
 	for (int i = 0; i < 5; ++i)
 	{
 		char ep[30];
-		snprintf(ep, sizeof(ep), "60.0.0.%d", i);
+		std::snprintf(ep, sizeof(ep), "60.0.0.%d", i);
 		h.connect_peer(lt::tcp::endpoint(
 			lt::address_v4::from_string(ep), 6881));
 	}

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -206,7 +206,7 @@ struct dht_node final : lt::dht::udp_socket_interface
 			if (n.first == id) continue;
 			int const bucket = 159 - dht::distance_exp(id, n.first);
 
-/*			printf("%s ^ %s = %s %d\n"
+/*			std::printf("%s ^ %s = %s %d\n"
 				, to_hex(id.to_string()).c_str()
 				, to_hex(n.first.to_string()).c_str()
 				, to_hex(dht::distance(id, n.first).to_string()).c_str()
@@ -230,9 +230,9 @@ struct dht_node final : lt::dht::udp_socket_interface
 /*
 		for (int i = 0; i < 40; ++i)
 		{
-			printf("%d ", nodes_per_bucket[i]);
+			std::printf("%d ", nodes_per_bucket[i]);
 		}
-		printf("\n");
+		std::printf("\n");
 */
 //#error add invalid IPs as well, to simulate churn
 	}
@@ -313,7 +313,7 @@ void print_routing_table(std::vector<lt::dht_routing_bucket> const& rt)
 			"################################"
 			"################################";
 		char const* short_progress_bar = "--------";
-		printf("%3d [%3d, %d] %s%s\n"
+		std::printf("%3d [%3d, %d] %s%s\n"
 			, bucket, i->num_nodes, i->num_replacements
 			, progress_bar + (128 - i->num_nodes)
 			, short_progress_bar + (8 - (std::min)(8, i->num_replacements)));

--- a/simulation/setup_swarm.cpp
+++ b/simulation/setup_swarm.cpp
@@ -101,7 +101,7 @@ sim::route dsl_config::outgoing_route(asio::ip::address ip)
 std::string save_path(int swarm_id, int idx)
 {
 	char path[200];
-	snprintf(path, sizeof(path), "swarm-%04d-peer-%02d"
+	std::snprintf(path, sizeof(path), "swarm-%04d-peer-%02d"
 		, swarm_id, idx);
 	return path;
 }
@@ -115,7 +115,7 @@ void add_extra_peers(lt::session& ses)
 	for (int i = 0; i < 30; ++i)
 	{
 		char ep[30];
-		snprintf(ep, sizeof(ep), "60.0.0.%d", i + 1);
+		std::snprintf(ep, sizeof(ep), "60.0.0.%d", i + 1);
 		h.connect_peer(lt::tcp::endpoint(addr(ep), 6881));
 	}
 }
@@ -245,7 +245,7 @@ void setup_swarm(int num_nodes
 	int swarm_id = test_counter();
 	std::string path = save_path(swarm_id, 0);
 	lt::create_directory(path, ec);
-	if (ec) fprintf(stderr, "failed to create directory: \"%s\": %s\n"
+	if (ec) std::fprintf(stderr, "failed to create directory: \"%s\": %s\n"
 		, path.c_str(), ec.message().c_str());
 	std::ofstream file(lt::combine_path(path, "temporary").c_str());
 	auto ti = ::create_torrent(&file, "temporary", 0x4000, 9, false);
@@ -258,9 +258,9 @@ void setup_swarm(int num_nodes
 		// create a new io_service
 		std::vector<asio::ip::address> ips;
 		char ep[30];
-		snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
+		std::snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
 		ips.push_back(addr(ep));
-		snprintf(ep, sizeof(ep), "2000::%X%X", (i + 1) >> 8, (i + 1) & 0xff);
+		std::snprintf(ep, sizeof(ep), "2000::%X%X", (i + 1) >> 8, (i + 1) & 0xff);
 		ips.push_back(addr(ep));
 		io_service.push_back(boost::make_shared<sim::asio::io_service>(
 			boost::ref(sim), ips));
@@ -328,7 +328,7 @@ void setup_swarm(int num_nodes
 					// only print alerts from the session under test
 					lt::time_duration d = a->timestamp() - start_time;
 					boost::uint32_t millis = lt::duration_cast<lt::milliseconds>(d).count();
-					printf("%4d.%03d: %-25s %s\n", millis / 1000, millis % 1000
+					std::printf("%4d.%03d: %-25s %s\n", millis / 1000, millis % 1000
 						, a->what()
 						, a->message().c_str());
 
@@ -345,7 +345,7 @@ void setup_swarm(int num_nodes
 							// string and an integer is common. It should probably be
 							// factored out into its own function
 							char ep[30];
-							snprintf(ep, sizeof(ep), "50.0.%d.%d", (k + 1) >> 8, (k + 1) & 0xff);
+							std::snprintf(ep, sizeof(ep), "50.0.%d.%d", (k + 1) >> 8, (k + 1) & 0xff);
 							h.connect_peer(lt::tcp::endpoint(addr(ep), 6881));
 						}
 					}
@@ -378,7 +378,7 @@ void setup_swarm(int num_nodes
 
 		if (shut_down)
 		{
-			printf("TERMINATING\n");
+			std::printf("TERMINATING\n");
 
 			// terminate simulation
 			for (int i = 0; i < int(nodes.size()); ++i)

--- a/simulation/test_auto_manage.cpp
+++ b/simulation/test_auto_manage.cpp
@@ -52,7 +52,7 @@ using sim::asio::ip::address_v4;
 std::unique_ptr<sim::asio::io_service> make_io_service(sim::simulation& sim, int i)
 {
 	char ep[30];
-	snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
+	std::snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
 	return std::unique_ptr<sim::asio::io_service>(new sim::asio::io_service(
 		sim, asio::ip::address_v4::from_string(ep)));
 }
@@ -127,7 +127,7 @@ TORRENT_TEST(dont_count_slow_torrents)
 			int num_started = 0;
 			for (alert* a : alerts)
 			{
-				printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (alert_cast<torrent_resumed_alert>(a) == nullptr) continue;
 
@@ -186,7 +186,7 @@ TORRENT_TEST(count_slow_torrents)
 			int num_started = 0;
 			for (alert* a : alerts)
 			{
-				printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (alert_cast<torrent_resumed_alert>(a) == nullptr) continue;
 				++num_started;
@@ -236,7 +236,7 @@ TORRENT_TEST(force_stopped_download)
 
 			for (alert* a : alerts)
 			{
-				printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				// we don't expect any torrents being started or stopped, since
 				// they're all force stopped
@@ -284,7 +284,7 @@ TORRENT_TEST(force_started)
 
 			for (alert* a : alerts)
 			{
-				printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				// we don't expect any torrents being started or stopped, since
 				// they're all force started
@@ -336,13 +336,13 @@ TORRENT_TEST(seed_limit)
 			int num_seeding = 0;
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (alert_cast<torrent_resumed_alert>(a))
 				{
 					++num_started;
 
-					fprintf(stderr, "started: %d checking: %d seeding: %d\n"
+					std::fprintf(stderr, "started: %d checking: %d seeding: %d\n"
 						, num_started, num_checking, num_seeding);
 				}
 				else if (alert_cast<torrent_paused_alert>(a))
@@ -350,7 +350,7 @@ TORRENT_TEST(seed_limit)
 					TEST_CHECK(num_started > 0);
 					--num_started;
 
-					fprintf(stderr, "started: %d checking: %d seeding: %d\n"
+					std::fprintf(stderr, "started: %d checking: %d seeding: %d\n"
 						, num_started, num_checking, num_seeding);
 				}
 				else if (state_changed_alert* sc = alert_cast<state_changed_alert>(a))
@@ -365,7 +365,7 @@ TORRENT_TEST(seed_limit)
 					else if (sc->state == torrent_status::seeding)
 						++num_seeding;
 
-					fprintf(stderr, "started: %d checking: %d seeding: %d\n"
+					std::fprintf(stderr, "started: %d checking: %d seeding: %d\n"
 						, num_started, num_checking, num_seeding);
 
 					// while at least one torrent is checking, there may be another
@@ -425,13 +425,13 @@ TORRENT_TEST(download_limit)
 			int num_downloading = 0;
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (alert_cast<torrent_resumed_alert>(a))
 				{
 					++num_started;
 
-					fprintf(stderr, "started: %d checking: %d downloading: %d\n"
+					std::fprintf(stderr, "started: %d checking: %d downloading: %d\n"
 						, num_started, num_checking, num_downloading);
 				}
 				else if (alert_cast<torrent_paused_alert>(a))
@@ -439,7 +439,7 @@ TORRENT_TEST(download_limit)
 					TEST_CHECK(num_started > 0);
 					--num_started;
 
-					fprintf(stderr, "started: %d checking: %d downloading: %d\n"
+					std::fprintf(stderr, "started: %d checking: %d downloading: %d\n"
 						, num_started, num_checking, num_downloading);
 				}
 				else if (state_changed_alert* sc = alert_cast<state_changed_alert>(a))
@@ -454,7 +454,7 @@ TORRENT_TEST(download_limit)
 					else if (sc->state == torrent_status::downloading)
 						++num_downloading;
 
-					fprintf(stderr, "started: %d checking: %d downloading: %d\n"
+					std::fprintf(stderr, "started: %d checking: %d downloading: %d\n"
 						, num_started, num_checking, num_downloading);
 
 					// while at least one torrent is checking, there may be another
@@ -521,7 +521,7 @@ TORRENT_TEST(checking_announce)
 			int num_announce = 0;
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (alert_cast<tracker_announce_alert>(a))
 					++num_announce;
@@ -571,7 +571,7 @@ TORRENT_TEST(paused_checking)
 
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (state_changed_alert* sc = alert_cast<state_changed_alert>(a))
 				{
@@ -620,7 +620,7 @@ TORRENT_TEST(stop_when_ready)
 			int num_paused = 0;
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 
 				if (alert_cast<torrent_paused_alert>(a))
@@ -692,7 +692,7 @@ TORRENT_TEST(resume_reject_when_paused)
 
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %-25s %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %-25s %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count())
 					, a->what()
 					, a->message().c_str());
@@ -763,7 +763,7 @@ TORRENT_TEST(no_resume_when_paused)
 
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %-25s %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %-25s %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count())
 					, a->what()
 					, a->message().c_str());
@@ -825,7 +825,7 @@ TORRENT_TEST(no_resume_when_started)
 
 			for (alert* a : alerts)
 			{
-				fprintf(stderr, "%-3d %-25s %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::fprintf(stderr, "%-3d %-25s %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count())
 					, a->what()
 					, a->message().c_str());
@@ -881,7 +881,7 @@ TORRENT_TEST(pause_completed_torrents)
 			lt::time_point paused;
 			for (alert* a : alerts)
 			{
-				printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+				std::printf("%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
 						- start_time).count()), a->message().c_str());
 				if (alert_cast<torrent_resumed_alert>(a))
 					++num_started;

--- a/simulation/test_dht.cpp
+++ b/simulation/test_dht.cpp
@@ -136,7 +136,7 @@ TORRENT_TEST(dht_bootstrap)
 			}
 			if (ticks > 2)
 			{
-				printf("depth: %d nodes: %d\n", routing_table_depth, num_nodes);
+				std::printf("depth: %d nodes: %d\n", routing_table_depth, num_nodes);
 				TEST_CHECK(routing_table_depth >= 9);
 				TEST_CHECK(num_nodes >= 115);
 				dht.stop();

--- a/simulation/test_dht_rate_limit.cpp
+++ b/simulation/test_dht_rate_limit.cpp
@@ -186,7 +186,7 @@ TORRENT_TEST(dht_rate_limit)
 	float const average_upload_rate = (num_bytes_received - target_upload_rate)
 		/ (duration_cast<chrono::milliseconds>(end - start).count() * 0.001f);
 
-	printf("send %d packets. received %d packets (%d bytes). average rate: %f (target: %f)\n"
+	std::printf("send %d packets. received %d packets (%d bytes). average rate: %f (target: %f)\n"
 		, num_packets_sent, num_packets_received, num_bytes_received
 		, average_upload_rate, target_upload_rate);
 

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -96,7 +96,7 @@ std::string chunk_string(std::string s)
 	{
 		i = std::min(i, s.size());
 		char header[50];
-		snprintf(header, sizeof(header), "%x\r\n", int(i));
+		std::snprintf(header, sizeof(header), "%x\r\n", int(i));
 		ret += header;
 		ret += s.substr(0, i);
 		s.erase(s.begin(), s.begin() + i);
@@ -118,14 +118,14 @@ boost::shared_ptr<http_connection> test_request(io_service& ios
 	, int* handler_called
 	, std::string const& auth = std::string())
 {
-	fprintf(stderr, " ===== TESTING: %s =====\n", url.c_str());
+	std::fprintf(stderr, " ===== TESTING: %s =====\n", url.c_str());
 
 	auto h = boost::make_shared<http_connection>(ios
 		, res
 		, [=](error_code const& ec, http_parser const& parser
 			, char const* data, const int size, http_connection& c)
 		{
-			printf("RESPONSE: %s\n", url.c_str());
+			std::printf("RESPONSE: %s\n", url.c_str());
 			++*handler_called;
 
 			// this is pretty gross. Since boost.asio is a header-only library, when this test is
@@ -138,7 +138,7 @@ boost::shared_ptr<http_connection> test_request(io_service& ios
 
 			if (!error_ok)
 			{
-				printf("ERROR: %s (expected: %s)\n"
+				std::printf("ERROR: %s (expected: %s)\n"
 					, ec.message().c_str()
 					, expected_error.message().c_str());
 			}
@@ -165,7 +165,7 @@ boost::shared_ptr<http_connection> test_request(io_service& ios
 		{
 			++*connect_handler_called;
 			TEST_CHECK(c.socket().is_open());
-			printf("CONNECTED: %s\n", url.c_str());
+			std::printf("CONNECTED: %s\n", url.c_str());
 		});
 
 	h->get(url, seconds(1), 0, &ps, 5, "test/user-agent", address_v4::any()
@@ -178,7 +178,7 @@ void print_http_header(std::map<std::string, std::string> const& headers)
 	for (std::map<std::string, std::string>::const_iterator i
 		= headers.begin(), end(headers.end()); i != end; ++i)
 	{
-		printf("%s: %s\n", i->first.c_str(), i->second.c_str());
+		std::printf("%s: %s\n", i->first.c_str(), i->second.c_str());
 	}
 }
 
@@ -401,7 +401,7 @@ void run_test(lt::aux::proxy_settings ps, std::string url, int expect_size, int 
 	TEST_EQUAL(counters.size(), expect_counters.size());
 	for (int i = 0; i < int(counters.size()); ++i)
 	{
-		if (counters[i] != expect_counters[i]) fprintf(stderr, "i=%d\n", i);
+		if (counters[i] != expect_counters[i]) std::fprintf(stderr, "i=%d\n", i);
 		TEST_EQUAL(counters[i], expect_counters[i]);
 	}
 }

--- a/simulation/test_optimistic_unchoke.cpp
+++ b/simulation/test_optimistic_unchoke.cpp
@@ -98,7 +98,7 @@ TORRENT_TEST(optimistic_unchoke)
 		{
 			// create a new io_service
 			char ep[30];
-			snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
+			std::snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
 			io_service.push_back(std::make_shared<sim::asio::io_service>(
 				std::ref(sim), addr(ep)));
 			peers.push_back(std::make_shared<peer_conn>(std::ref(*io_service.back())

--- a/simulation/test_pe_crypto.cpp
+++ b/simulation/test_pe_crypto.cpp
@@ -56,11 +56,11 @@ char const* pe_policy(boost::uint8_t policy)
 
 void display_pe_settings(libtorrent::settings_pack const& s)
 {
-	fprintf(stderr, "out_enc_policy - %s\tin_enc_policy - %s\n"
+	std::fprintf(stderr, "out_enc_policy - %s\tin_enc_policy - %s\n"
 		, pe_policy(s.get_int(settings_pack::out_enc_policy))
 		, pe_policy(s.get_int(settings_pack::in_enc_policy)));
 
-	fprintf(stderr, "enc_level - %s\t\tprefer_rc4 - %s\n"
+	std::fprintf(stderr, "enc_level - %s\t\tprefer_rc4 - %s\n"
 		, s.get_int(settings_pack::allowed_enc_level) == settings_pack::pe_plaintext ? "plaintext"
 		: s.get_int(settings_pack::allowed_enc_level) == settings_pack::pe_rc4 ? "rc4"
 		: s.get_int(settings_pack::allowed_enc_level) == settings_pack::pe_both ? "both" : "unknown"
@@ -191,7 +191,7 @@ TORRENT_TEST(disabled_failing)
 #else
 TORRENT_TEST(disabled)
 {
-	fprintf(stderr, "PE test not run because it's disabled\n");
+	std::fprintf(stderr, "PE test not run because it's disabled\n");
 }
 #endif
 

--- a/simulation/test_socks5.cpp
+++ b/simulation/test_socks5.cpp
@@ -54,7 +54,7 @@ namespace lt = libtorrent;
 std::unique_ptr<sim::asio::io_service> make_io_service(sim::simulation& sim, int i)
 {
 	char ep[30];
-	snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
+	std::snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
 	return std::unique_ptr<sim::asio::io_service>(new sim::asio::io_service(
 		sim, address_v4::from_string(ep)));
 }
@@ -99,7 +99,7 @@ void run_test(Setup const& setup
 	// happened
 	sim::timer t(sim, lt::seconds(100), [&](boost::system::error_code const& ec)
 	{
-		fprintf(stderr, "shutting down\n");
+		std::fprintf(stderr, "shutting down\n");
 		// shut down
 		ses->set_alert_notify([] {});
 		zombie = ses->abort();

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -76,7 +76,7 @@ TORRENT_TEST(plain)
 				return true;
 			}
 			if (!is_seed(ses)) return false;
-			printf("completed in %d ticks\n", ticks);
+			std::printf("completed in %d ticks\n", ticks);
 			return true;
 		});
 }
@@ -117,7 +117,7 @@ TORRENT_TEST(session_stats)
 				return true;
 			}
 			if (!is_seed(ses)) return false;
-			printf("completed in %d ticks\n", ticks);
+			std::printf("completed in %d ticks\n", ticks);
 			return true;
 		});
 }
@@ -143,7 +143,7 @@ TORRENT_TEST(suggest)
 				return true;
 			}
 			if (!is_seed(ses)) return false;
-			printf("completed in %d ticks\n", ticks);
+			std::printf("completed in %d ticks\n", ticks);
 			return true;
 		});
 }
@@ -201,7 +201,7 @@ void test_stop_start_download(swarm_test type, bool graceful)
 			if (auto tp = lt::alert_cast<lt::torrent_paused_alert>(a))
 			{
 				TEST_EQUAL(resumed, false);
-				printf("\nSTART\n\n");
+				std::printf("\nSTART\n\n");
 				tp->handle.resume();
 				resumed = true;
 			}
@@ -218,14 +218,14 @@ void test_stop_start_download(swarm_test type, bool graceful)
 
 				if (limit_reached)
 				{
-					printf("\nSTOP\n\n");
+					std::printf("\nSTOP\n\n");
 					auto h = ses.get_torrents()[0];
 					h.pause(graceful ? torrent_handle::graceful_pause : 0);
 					paused_once = true;
 				}
 			}
 
-			printf("tick: %d\n", ticks);
+			std::printf("tick: %d\n", ticks);
 
 			const int timeout = type == swarm_test::download ? 20 : 91;
 			if (ticks > timeout)
@@ -235,7 +235,7 @@ void test_stop_start_download(swarm_test type, bool graceful)
 			}
 			if (type == swarm_test::upload) return false;
 			if (!is_seed(ses)) return false;
-			printf("completed in %d ticks\n", ticks);
+			std::printf("completed in %d ticks\n", ticks);
 			return true;
 		});
 
@@ -268,7 +268,7 @@ TORRENT_TEST(stop_start_download_graceful_no_peers)
 			if (auto tp = lt::alert_cast<lt::torrent_paused_alert>(a))
 			{
 				TEST_EQUAL(resumed, false);
-				printf("\nSTART\n\n");
+				std::printf("\nSTART\n\n");
 				tp->handle.resume();
 				resumed = true;
 			}
@@ -279,13 +279,13 @@ TORRENT_TEST(stop_start_download_graceful_no_peers)
 			if (paused_once == false
 				&& ticks == 6)
 			{
-				printf("\nSTOP\n\n");
+				std::printf("\nSTOP\n\n");
 				auto h = ses.get_torrents()[0];
 				h.pause(torrent_handle::graceful_pause);
 				paused_once = true;
 			}
 
-			printf("tick: %d\n", ticks);
+			std::printf("tick: %d\n", ticks);
 
 			// when there's only one node (i.e. no peers) we won't ever download
 			// the torrent. It's just a test to make sure we still get the
@@ -352,7 +352,7 @@ TORRENT_TEST(delete_files)
 	file_status st;
 	error_code ec;
 	stat_file(combine_path(save_path, "temporary"), &st, ec);
-	printf("expecting \"%s/temporary\" to NOT exist [%s | %s]\n"
+	std::printf("expecting \"%s/temporary\" to NOT exist [%s | %s]\n"
 		, save_path.c_str()
 		, ec.category().name()
 		, ec.message().c_str());
@@ -383,7 +383,7 @@ TORRENT_TEST(delete_partfile)
 	file_status st;
 	error_code ec;
 	stat_file(combine_path(save_path, "temporary"), &st, ec);
-	printf("expecting \"%s/temporary\" to exist [%s]\n", save_path.c_str()
+	std::printf("expecting \"%s/temporary\" to exist [%s]\n", save_path.c_str()
 		, ec.message().c_str());
 	TEST_CHECK(!ec);
 }

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -76,7 +76,7 @@ void test_interval(int interval)
 		announces.push_back(seconds);
 
 		char response[500];
-		int size = snprintf(response, sizeof(response), "d8:intervali%de5:peers0:e", interval);
+		int size = std::snprintf(response, sizeof(response), "d8:intervali%de5:peers0:e", interval);
 		return sim::send_response(200, "OK", size) + response;
 	});
 
@@ -144,7 +144,7 @@ TORRENT_TEST(event_completed)
 		announces.push_back({timestamp, req});
 
 		char response[500];
-		int size = snprintf(response, sizeof(response), "d8:intervali%de5:peers0:e", interval);
+		int size = std::snprintf(response, sizeof(response), "d8:intervali%de5:peers0:e", interval);
 		return sim::send_response(200, "OK", size) + response;
 	});
 
@@ -192,7 +192,7 @@ TORRENT_TEST(event_completed)
 		// we there can only be one event
 		const bool has_event = str.find("&event=") != std::string::npos;
 
-		fprintf(stderr, "- %s\n", str.c_str());
+		std::fprintf(stderr, "- %s\n", str.c_str());
 
 		// there is exactly 0 or 1 events.
 		TEST_EQUAL(int(has_start) + int(has_completed) + int(has_stopped)
@@ -269,7 +269,7 @@ void on_alert_notify(lt::session* ses)
 		{
 			lt::time_duration d = a->timestamp().time_since_epoch();
 			boost::uint32_t millis = lt::duration_cast<lt::milliseconds>(d).count();
-			printf("%4d.%03d: %s\n", millis / 1000, millis % 1000,
+			std::printf("%4d.%03d: %s\n", millis / 1000, millis % 1000,
 				a->message().c_str());
 		}
 	});
@@ -301,7 +301,7 @@ TORRENT_TEST(ipv6_support)
 		TEST_EQUAL(method, "GET");
 
 		char response[500];
-		int size = snprintf(response, sizeof(response), "d8:intervali1800e5:peers0:e");
+		int size = std::snprintf(response, sizeof(response), "d8:intervali1800e5:peers0:e");
 		return sim::send_response(200, "OK", size) + response;
 	});
 
@@ -313,7 +313,7 @@ TORRENT_TEST(ipv6_support)
 		TEST_EQUAL(method, "GET");
 
 		char response[500];
-		int size = snprintf(response, sizeof(response), "d8:intervali1800e5:peers0:e");
+		int size = std::snprintf(response, sizeof(response), "d8:intervali1800e5:peers0:e");
 		return sim::send_response(200, "OK", size) + response;
 	});
 
@@ -468,7 +468,7 @@ TORRENT_TEST(test_error)
 			TEST_EQUAL(method, "GET");
 
 			char response[500];
-			int size = snprintf(response, sizeof(response), "d14:failure reason4:teste");
+			int size = std::snprintf(response, sizeof(response), "d14:failure reason4:teste");
 			return sim::send_response(200, "OK", size) + response;
 		}
 		, [](announce_entry const& ae)
@@ -491,7 +491,7 @@ TORRENT_TEST(test_warning)
 			TEST_EQUAL(method, "GET");
 
 			char response[500];
-			int size = snprintf(response, sizeof(response), "d5:peers6:aaaaaa15:warning message5:test2e");
+			int size = std::snprintf(response, sizeof(response), "d5:peers6:aaaaaa15:warning message5:test2e");
 			return sim::send_response(200, "OK", size) + response;
 		}
 		, [](announce_entry const& ae)
@@ -513,7 +513,7 @@ TORRENT_TEST(test_scrape_data_in_announce)
 			TEST_EQUAL(method, "GET");
 
 			char response[500];
-			int size = snprintf(response, sizeof(response),
+			int size = std::snprintf(response, sizeof(response),
 				"d5:peers6:aaaaaa8:completei1e10:incompletei2e10:downloadedi3e11:downloadersi4ee");
 			return sim::send_response(200, "OK", size) + response;
 		}
@@ -539,7 +539,7 @@ TORRENT_TEST(test_scrape)
 			TEST_EQUAL(method, "GET");
 
 			char response[500];
-			int size = snprintf(response, sizeof(response),
+			int size = std::snprintf(response, sizeof(response),
 				"d5:filesd20:ababababababababababd8:completei1e10:downloadedi3e10:incompletei2eeee");
 			return sim::send_response(200, "OK", size) + response;
 		}
@@ -587,7 +587,7 @@ TORRENT_TEST(test_interval)
 		{
 			TEST_EQUAL(method, "GET");
 			char response[500];
-			int size = snprintf(response, sizeof(response)
+			int size = std::snprintf(response, sizeof(response)
 				, "d10:tracker id8:testteste");
 			return sim::send_response(200, "OK", size) + response;
 		}
@@ -611,7 +611,7 @@ TORRENT_TEST(test_invalid_bencoding)
 		{
 			TEST_EQUAL(method, "GET");
 			char response[500];
-			int size = snprintf(response, sizeof(response)
+			int size = std::snprintf(response, sizeof(response)
 				, "d10:tracer idteste");
 			return sim::send_response(200, "OK", size) + response;
 		}
@@ -650,7 +650,7 @@ TORRENT_TEST(try_next)
 
 			char response[500];
 			// respond with an empty peer list
-			int size = snprintf(response, sizeof(response), "d5:peers0:e");
+			int size = std::snprintf(response, sizeof(response), "d5:peers0:e");
 			return sim::send_response(200, "OK", size) + response;
 		}
 		, [](torrent_handle h) {}
@@ -665,7 +665,7 @@ TORRENT_TEST(try_next)
 
 			for (int i = 0; i < int(tr.size()); ++i)
 			{
-				fprintf(stderr, "tracker \"%s\"\n", tr[i].url.c_str());
+				std::fprintf(stderr, "tracker \"%s\"\n", tr[i].url.c_str());
 				if (tr[i].url == "http://tracker.com:8080/announce")
 				{
 					TEST_EQUAL(tr[i].fails, 0);

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -355,7 +355,7 @@ TORRENT_TEST(auto_disk_cache_size)
 			TEST_EQUAL(is_seed(*ses[0]), true);
 
 			int const cache_size = get_cache_size(*ses[0]);
-			printf("cache size: %d\n", cache_size);
+			std::printf("cache size: %d\n", cache_size);
 			// this assumes the test torrent is at least 4 blocks
 			TEST_CHECK(cache_size > 4);
 		}
@@ -372,7 +372,7 @@ TORRENT_TEST(disable_disk_cache)
 			TEST_EQUAL(is_seed(*ses[0]), true);
 
 			int const cache_size = get_cache_size(*ses[0]);
-			printf("cache size: %d\n", cache_size);
+			std::printf("cache size: %d\n", cache_size);
 			TEST_EQUAL(cache_size, 0);
 		}
 	);

--- a/simulation/utils.cpp
+++ b/simulation/utils.cpp
@@ -134,7 +134,7 @@ void print_alerts(lt::session& ses
 
 		for (lt::alert const* a : alerts)
 		{
-			printf("%-3d [0] %s\n", int(lt::duration_cast<lt::seconds>(a->timestamp()
+			std::printf("%-3d [0] %s\n", int(lt::duration_cast<lt::seconds>(a->timestamp()
 				- start_time).count()), a->message().c_str());
 			// call the user handler
 			on_alert(ses, a);

--- a/src/ConvertUTF.cpp
+++ b/src/ConvertUTF.cpp
@@ -155,7 +155,7 @@ ConversionResult ConvertUTF16toUTF32 (
 	*targetStart = target;
 #ifdef CVTUTF_DEBUG
 if (result == sourceIllegal) {
-	fprintf(stderr, "ConvertUTF16toUTF32 illegal seq 0x%04x,%04x\n", ch, ch2);
+	std::fprintf(stderr, "ConvertUTF16toUTF32 illegal seq 0x%04x,%04x\n", ch, ch2);
 	fflush(stderr);
 }
 #endif

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -31,6 +31,8 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <string>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/alert.hpp"
@@ -47,6 +49,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/piece_picker.hpp" // for piece_block
 
 #include "libtorrent/aux_/escape_string.hpp" // for convert_from_native
+#include "libtorrent/aux_/max_path.hpp" // for TORRENT_MAX_PATH
 
 #include <boost/bind.hpp>
 
@@ -162,13 +165,13 @@ namespace libtorrent {
 		char msg[200];
 		if (ec)
 		{
-			snprintf(msg, sizeof(msg), "%s: read_piece %u failed: %s"
+			std::snprintf(msg, sizeof(msg), "%s: read_piece %u failed: %s"
 				, torrent_alert::message().c_str() , piece
 				, convert_from_native(ec.message()).c_str());
 		}
 		else
 		{
-			snprintf(msg, sizeof(msg), "%s: read_piece %u successful"
+			std::snprintf(msg, sizeof(msg), "%s: read_piece %u successful"
 				, torrent_alert::message().c_str() , piece);
 		}
 		return msg;
@@ -184,7 +187,7 @@ namespace libtorrent {
 	std::string file_completed_alert::message() const
 	{
 		char msg[200 + TORRENT_MAX_PATH];
-		snprintf(msg, sizeof(msg), "%s: file %d finished downloading"
+		std::snprintf(msg, sizeof(msg), "%s: file %d finished downloading"
 			, torrent_alert::message().c_str(), index);
 		return msg;
 	}
@@ -213,7 +216,7 @@ namespace libtorrent {
 	std::string file_renamed_alert::message() const
 	{
 		char msg[200 + TORRENT_MAX_PATH * 2];
-		snprintf(msg, sizeof(msg), "%s: file %d renamed to %s"
+		std::snprintf(msg, sizeof(msg), "%s: file %d renamed to %s"
 			, torrent_alert::message().c_str(), index, new_name());
 		return msg;
 	}
@@ -230,7 +233,7 @@ namespace libtorrent {
 	std::string file_rename_failed_alert::message() const
 	{
 		char ret[200 + TORRENT_MAX_PATH * 2];
-		snprintf(ret, sizeof(ret), "%s: failed to rename file %d: %s"
+		std::snprintf(ret, sizeof(ret), "%s: failed to rename file %d: %s"
 			, torrent_alert::message().c_str(), index, convert_from_native(error.message()).c_str());
 		return ret;
 	}
@@ -314,7 +317,7 @@ namespace libtorrent {
 	std::string tracker_error_alert::message() const
 	{
 		char ret[400];
-		snprintf(ret, sizeof(ret), "%s (%d) %s \"%s\" (%d)"
+		std::snprintf(ret, sizeof(ret), "%s (%d) %s \"%s\" (%d)"
 			, tracker_alert::message().c_str(), status_code
 			, convert_from_native(error.message()).c_str(), error_message()
 			, times_in_row);
@@ -363,7 +366,7 @@ namespace libtorrent {
 	std::string scrape_reply_alert::message() const
 	{
 		char ret[400];
-		snprintf(ret, sizeof(ret), "%s scrape reply: %u %u"
+		std::snprintf(ret, sizeof(ret), "%s scrape reply: %u %u"
 			, tracker_alert::message().c_str(), incomplete, complete);
 		return ret;
 	}
@@ -424,7 +427,7 @@ namespace libtorrent {
 	std::string tracker_reply_alert::message() const
 	{
 		char ret[400];
-		snprintf(ret, sizeof(ret), "%s received peers: %u"
+		std::snprintf(ret, sizeof(ret), "%s received peers: %u"
 			, tracker_alert::message().c_str(), num_peers);
 		return ret;
 	}
@@ -439,7 +442,7 @@ namespace libtorrent {
 	std::string dht_reply_alert::message() const
 	{
 		char ret[400];
-		snprintf(ret, sizeof(ret), "%s received DHT peers: %u"
+		std::snprintf(ret, sizeof(ret), "%s received DHT peers: %u"
 			, tracker_alert::message().c_str(), num_peers);
 		return ret;
 	}
@@ -474,7 +477,7 @@ namespace libtorrent {
 	std::string hash_failed_alert::message() const
 	{
 		char ret[400];
-		snprintf(ret, sizeof(ret), "%s hash for piece %u failed"
+		std::snprintf(ret, sizeof(ret), "%s hash for piece %u failed"
 			, torrent_alert::message().c_str(), piece_index);
 		return ret;
 	}
@@ -526,7 +529,7 @@ namespace libtorrent {
 	std::string invalid_request_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s peer sent an invalid piece request "
+		std::snprintf(ret, sizeof(ret), "%s peer sent an invalid piece request "
 			"(piece: %u start: %u len: %u)%s"
 			, peer_alert::message().c_str(), request.piece, request.start
 			, request.length
@@ -558,7 +561,7 @@ namespace libtorrent {
 	std::string piece_finished_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s piece: %u finished downloading"
+		std::snprintf(ret, sizeof(ret), "%s piece: %u finished downloading"
 			, torrent_alert::message().c_str(), piece_index);
 		return ret;
 	}
@@ -576,7 +579,7 @@ namespace libtorrent {
 	std::string request_dropped_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s peer dropped block ( piece: %u block: %u)"
+		std::snprintf(ret, sizeof(ret), "%s peer dropped block ( piece: %u block: %u)"
 			, torrent_alert::message().c_str(), piece_index, block_index);
 		return ret;
 	}
@@ -594,7 +597,7 @@ namespace libtorrent {
 	std::string block_timeout_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s peer timed out request ( piece: %u block: %u)"
+		std::snprintf(ret, sizeof(ret), "%s peer timed out request ( piece: %u block: %u)"
 			, torrent_alert::message().c_str(), piece_index, block_index);
 		return ret;
 	}
@@ -612,7 +615,7 @@ namespace libtorrent {
 	std::string block_finished_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s block finished downloading (piece: %u block: %u)"
+		std::snprintf(ret, sizeof(ret), "%s block finished downloading (piece: %u block: %u)"
 			, torrent_alert::message().c_str(), piece_index, block_index);
 		return ret;
 	}
@@ -633,7 +636,7 @@ namespace libtorrent {
 	std::string block_downloading_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s requested block (piece: %u block: %u)"
+		std::snprintf(ret, sizeof(ret), "%s requested block (piece: %u block: %u)"
 			, torrent_alert::message().c_str(), piece_index, block_index);
 		return ret;
 	}
@@ -651,7 +654,7 @@ namespace libtorrent {
 	std::string unwanted_block_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "%s received block not in download queue (piece: %u block: %u)"
+		std::snprintf(ret, sizeof(ret), "%s received block not in download queue (piece: %u block: %u)"
 			, torrent_alert::message().c_str(), piece_index, block_index);
 		return ret;
 	}
@@ -856,7 +859,7 @@ namespace libtorrent {
 			"bind_to_device"
 		};
 		char ret[300];
-		snprintf(ret, sizeof(ret), "listening on %s (device: %s) failed: [%s] [%s] %s"
+		std::snprintf(ret, sizeof(ret), "listening on %s (device: %s) failed: [%s] [%s] %s"
 			, print_endpoint(endpoint).c_str()
 			, listen_interface()
 			, op_str[operation]
@@ -921,7 +924,7 @@ namespace libtorrent {
 	{
 		char const* type_str[] = { "TCP", "SSL/TCP", "UDP", "i2p", "socks5", "SSL/uTP" };
 		char ret[200];
-		snprintf(ret, sizeof(ret), "successfully listening on [%s] %s"
+		std::snprintf(ret, sizeof(ret), "successfully listening on [%s] %s"
 			, type_str[sock_type], print_endpoint(endpoint).c_str());
 		return ret;
 	}
@@ -949,7 +952,7 @@ namespace libtorrent {
 	std::string portmap_alert::message() const
 	{
 		char ret[200];
-		snprintf(ret, sizeof(ret), "successfully mapped port using %s. external port: %s/%u"
+		std::snprintf(ret, sizeof(ret), "successfully mapped port using %s. external port: %s/%u"
 			, nat_type_str[map_type], protocol_str[protocol], external_port);
 		return ret;
 	}
@@ -977,7 +980,7 @@ namespace libtorrent {
 	std::string portmap_log_alert::message() const
 	{
 		char ret[600];
-		snprintf(ret, sizeof(ret), "%s: %s", nat_type_str[map_type]
+		std::snprintf(ret, sizeof(ret), "%s: %s", nat_type_str[map_type]
 			, log_message());
 		return ret;
 	}
@@ -1042,7 +1045,7 @@ namespace libtorrent {
 			"invalid_local_interface"
 		};
 
-		snprintf(ret, sizeof(ret), "%s: blocked peer: %s [%s]"
+		std::snprintf(ret, sizeof(ret), "%s: blocked peer: %s [%s]"
 			, torrent_alert::message().c_str(), ip.to_string(ec).c_str()
 			, reason_str[reason]);
 		return ret;
@@ -1062,7 +1065,7 @@ namespace libtorrent {
 		char ih_hex[41];
 		to_hex(info_hash.data(), 20, ih_hex);
 		char msg[200];
-		snprintf(msg, sizeof(msg), "incoming dht announce: %s:%u (%s)"
+		std::snprintf(msg, sizeof(msg), "incoming dht announce: %s:%u (%s)"
 			, ip.to_string(ec).c_str(), port, ih_hex);
 		return msg;
 	}
@@ -1077,7 +1080,7 @@ namespace libtorrent {
 		char ih_hex[41];
 		to_hex(info_hash.data(), 20, ih_hex);
 		char msg[200];
-		snprintf(msg, sizeof(msg), "incoming dht get_peers: %s", ih_hex);
+		std::snprintf(msg, sizeof(msg), "incoming dht get_peers: %s", ih_hex);
 		return msg;
 	}
 
@@ -1109,7 +1112,7 @@ namespace libtorrent {
 	std::string stats_alert::message() const
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "%s: [%d] %d %d %d %d %d %d"
+		std::snprintf(msg, sizeof(msg), "%s: [%d] %d %d %d %d %d %d"
 #ifndef TORRENT_NO_DEPRECATE
 			" %d %d %d %d"
 #endif
@@ -1148,7 +1151,7 @@ namespace libtorrent {
 		char const* msgs[] = {
 			"tracker is not anonymous, set a proxy"
 		};
-		snprintf(msg, sizeof(msg), "%s: %s: %s"
+		std::snprintf(msg, sizeof(msg), "%s: %s: %s"
 			, torrent_alert::message().c_str()
 			, msgs[kind], str.c_str());
 		return msg;
@@ -1162,7 +1165,7 @@ namespace libtorrent {
 	std::string lsd_peer_alert::message() const
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "%s: received peer from local service discovery"
+		std::snprintf(msg, sizeof(msg), "%s: received peer from local service discovery"
 			, peer_alert::message().c_str());
 		return msg;
 	}
@@ -1216,7 +1219,7 @@ namespace libtorrent {
 	std::string torrent_error_alert::message() const
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), " ERROR: %s", convert_from_native(error.message()).c_str());
+		std::snprintf(msg, sizeof(msg), " ERROR: %s", convert_from_native(error.message()).c_str());
 		return torrent_alert::message() + msg;
 	}
 
@@ -1266,7 +1269,7 @@ namespace libtorrent {
 	{
 		char msg[600];
 		error_code ec;
-		snprintf(msg, sizeof(msg), "incoming connection from %s (%s)"
+		std::snprintf(msg, sizeof(msg), "incoming connection from %s (%s)"
 			, print_endpoint(ip).c_str(), socket_type_str[socket_type]);
 		return msg;
 	}
@@ -1281,7 +1284,7 @@ namespace libtorrent {
 	{
 		char msg[600];
 		error_code ec;
-		snprintf(msg, sizeof(msg), "%s connecting to peer (%s)"
+		std::snprintf(msg, sizeof(msg), "%s connecting to peer (%s)"
 			, peer_alert::message().c_str(), socket_type_str[socket_type]);
 		return msg;
 	}
@@ -1305,13 +1308,13 @@ namespace libtorrent {
 
 		if (error)
 		{
-			snprintf(msg, sizeof(msg), "failed to add torrent \"%s\": [%s] %s"
+			std::snprintf(msg, sizeof(msg), "failed to add torrent \"%s\": [%s] %s"
 				, torrent_name, error.category().name()
 				, convert_from_native(error.message()).c_str());
 		}
 		else
 		{
-			snprintf(msg, sizeof(msg), "added torrent: %s", torrent_name);
+			std::snprintf(msg, sizeof(msg), "added torrent: %s", torrent_name);
 		}
 		return msg;
 	}
@@ -1324,7 +1327,7 @@ namespace libtorrent {
 	std::string state_update_alert::message() const
 	{
 		char msg[600];
-		snprintf(msg, sizeof(msg), "state updates for %d torrents", int(status.size()));
+		std::snprintf(msg, sizeof(msg), "state updates for %d torrents", int(status.size()));
 		return msg;
 	}
 
@@ -1335,7 +1338,7 @@ namespace libtorrent {
 	std::string mmap_cache_alert::message() const
 	{
 		char msg[600];
-		snprintf(msg, sizeof(msg), "mmap cache failed: (%d) %s", error.value()
+		std::snprintf(msg, sizeof(msg), "mmap cache failed: (%d) %s", error.value()
 			, convert_from_native(error.message()).c_str());
 		return msg;
 	}
@@ -1355,7 +1358,7 @@ namespace libtorrent {
 	std::string peer_error_alert::message() const
 	{
 		char buf[200];
-		snprintf(buf, sizeof(buf), "%s peer error [%s] [%s]: %s"
+		std::snprintf(buf, sizeof(buf), "%s peer error [%s] [%s]: %s"
 			, peer_alert::message().c_str()
 			, operation_name(operation), error.category().name()
 			, convert_from_native(error.message()).c_str());
@@ -1402,7 +1405,7 @@ namespace libtorrent {
 	std::string torrent_update_alert::message() const
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), " torrent changed info-hash from: %s to %s"
+		std::snprintf(msg, sizeof(msg), " torrent changed info-hash from: %s to %s"
 			, to_hex(old_ih.to_string()).c_str()
 			, to_hex(new_ih.to_string()).c_str());
 		return torrent_alert::message() + msg;
@@ -1427,7 +1430,7 @@ namespace libtorrent {
 	std::string peer_disconnected_alert::message() const
 	{
 		char buf[600];
-		snprintf(buf, sizeof(buf), "%s disconnecting (%s) [%s] [%s]: %s (reason: %d)"
+		std::snprintf(buf, sizeof(buf), "%s disconnecting (%s) [%s] [%s]: %s (reason: %d)"
 			, peer_alert::message().c_str()
 			, socket_type_str[socket_type]
 			, operation_name(operation), error.category().name()
@@ -1454,7 +1457,7 @@ namespace libtorrent {
 			op = 0;
 
 		char msg[600];
-		snprintf(msg, sizeof(msg), "DHT error [%s] (%d) %s"
+		std::snprintf(msg, sizeof(msg), "DHT error [%s] (%d) %s"
 			, operation_names[op]
 			, error.value()
 			, convert_from_native(error.message()).c_str());
@@ -1469,7 +1472,7 @@ namespace libtorrent {
 	std::string dht_immutable_item_alert::message() const
 	{
 		char msg[1050];
-		snprintf(msg, sizeof(msg), "DHT immutable item %s [ %s ]"
+		std::snprintf(msg, sizeof(msg), "DHT immutable item %s [ %s ]"
 			, to_hex(target.to_string()).c_str()
 			, item.to_string().c_str());
 		return msg;
@@ -1490,7 +1493,7 @@ namespace libtorrent {
 	std::string dht_mutable_item_alert::message() const
 	{
 		char msg[1050];
-		snprintf(msg, sizeof(msg), "DHT mutable item (key=%s salt=%s seq=%" PRId64 " %s) [ %s ]"
+		std::snprintf(msg, sizeof(msg), "DHT mutable item (key=%s salt=%s seq=%" PRId64 " %s) [ %s ]"
 			, to_hex(std::string(&key[0], 32)).c_str()
 			, salt.c_str()
 			, seq
@@ -1524,7 +1527,7 @@ namespace libtorrent {
 		char msg[1050];
 		if (target.is_all_zeros())
 		{
-			snprintf(msg, sizeof(msg), "DHT put complete (success=%d key=%s sig=%s salt=%s seq=%" PRId64 ")"
+			std::snprintf(msg, sizeof(msg), "DHT put complete (success=%d key=%s sig=%s salt=%s seq=%" PRId64 ")"
 				, num_success
 				, to_hex(std::string(&public_key[0], 32)).c_str()
 				, to_hex(std::string(&signature[0], 64)).c_str()
@@ -1533,7 +1536,7 @@ namespace libtorrent {
 			return msg;
 		}
 
-		snprintf(msg, sizeof(msg), "DHT put commplete (success=%d hash=%s)"
+		std::snprintf(msg, sizeof(msg), "DHT put commplete (success=%d hash=%s)"
 			, num_success
 			, to_hex(target.to_string()).c_str());
 		return msg;
@@ -1546,7 +1549,7 @@ namespace libtorrent {
 	std::string i2p_alert::message() const
 	{
 		char msg[600];
-		snprintf(msg, sizeof(msg), "i2p_error: [%s] %s"
+		std::snprintf(msg, sizeof(msg), "i2p_error: [%s] %s"
 			, error.category().name(), convert_from_native(error.message()).c_str());
 		return msg;
 	}
@@ -1566,10 +1569,10 @@ namespace libtorrent {
 		obf[0] = '\0';
 		if (obfuscated_info_hash != info_hash)
 		{
-			snprintf(obf, sizeof(obf), " [obfuscated: %s]"
+			std::snprintf(obf, sizeof(obf), " [obfuscated: %s]"
 			, to_hex(obfuscated_info_hash.to_string()).c_str());
 		}
-		snprintf(msg, sizeof(msg), "outgoing dht get_peers : %s%s -> %s"
+		std::snprintf(msg, sizeof(msg), "outgoing dht get_peers : %s%s -> %s"
 			, to_hex(info_hash.to_string()).c_str()
 			, obf
 			, print_endpoint(ip).c_str());
@@ -1658,13 +1661,13 @@ namespace libtorrent {
 		// this specific output is parsed by tools/parse_session_stats.py
 		// if this is changed, that parser should also be changed
 		char msg[100];
-		snprintf(msg, sizeof(msg), "session stats (%d values): "
+		std::snprintf(msg, sizeof(msg), "session stats (%d values): "
 			, int(sizeof(values)/sizeof(values[0])));
 		std::string ret = msg;
 		bool first = true;
 		for (int i = 0; i < sizeof(values)/sizeof(values[0]); ++i)
 		{
-			snprintf(msg, sizeof(msg), first ? "%" PRIu64 : ", %" PRIu64, values[i]);
+			std::snprintf(msg, sizeof(msg), first ? "%" PRIu64 : ", %" PRIu64, values[i]);
 			first = false;
 			ret += msg;
 		}
@@ -1682,7 +1685,7 @@ namespace libtorrent {
 	std::string dht_stats_alert::message() const
 	{
 		char buf[2048];
-		snprintf(buf, sizeof(buf), "DHT stats: reqs: %d buckets: %d"
+		std::snprintf(buf, sizeof(buf), "DHT stats: reqs: %d buckets: %d"
 			, int(active_requests.size())
 			, int(routing_table.size()));
 		return buf;
@@ -1772,7 +1775,7 @@ namespace libtorrent {
 	std::string incoming_request_alert::message() const
 	{
 		char msg[1024];
-		snprintf(msg, sizeof(msg), "%s: incoming request [ piece: %d start: %d length: %d ]"
+		std::snprintf(msg, sizeof(msg), "%s: incoming request [ piece: %d start: %d length: %d ]"
 			, peer_alert::message().c_str(), req.piece, req.start, req.length);
 		return msg;
 	}
@@ -1801,7 +1804,7 @@ namespace libtorrent {
 		};
 
 		char ret[900];
-		snprintf(ret, sizeof(ret), "DHT %s: %s", dht_modules[module]
+		std::snprintf(ret, sizeof(ret), "DHT %s: %s", dht_modules[module]
 			, log_message());
 		return ret;
 	}
@@ -1838,7 +1841,7 @@ namespace libtorrent {
 
 		char const* prefix[2] = { "<==", "==>"};
 		char buf[1024];
-		snprintf(buf, sizeof(buf), "%s [%s] %s", prefix[dir]
+		std::snprintf(buf, sizeof(buf), "%s [%s] %s", prefix[dir]
 			, print_endpoint(node).c_str(), msg.c_str());
 
 		return buf;
@@ -1874,7 +1877,7 @@ namespace libtorrent {
 		char ih_hex[41];
 		to_hex(info_hash.data(), 20, ih_hex);
 		char msg[200];
-		snprintf(msg, sizeof(msg), "incoming dht get_peers reply: %s, peers %d", ih_hex, m_num_peers);
+		std::snprintf(msg, sizeof(msg), "incoming dht get_peers reply: %s, peers %d", ih_hex, m_num_peers);
 		return msg;
 	}
 
@@ -1922,7 +1925,7 @@ namespace libtorrent {
 	std::string dht_direct_response_alert::message() const
 	{
 		char msg[1050];
-		snprintf(msg, sizeof(msg), "DHT direct response (address=%s) [ %s ]"
+		std::snprintf(msg, sizeof(msg), "DHT direct response (address=%s) [ %s ]"
 			, addr.address().to_string().c_str()
 			, m_response_size ? std::string(m_alloc.get().ptr(m_response_idx), m_response_size).c_str() : "");
 		return msg;
@@ -2004,7 +2007,7 @@ namespace libtorrent {
 		for (int i = 0; i < int(b.size()); ++i)
 		{
 			char buf[50];
-			snprintf(buf, sizeof(buf), "(%d,%d) "
+			std::snprintf(buf, sizeof(buf), "(%d,%d) "
 				, b[i].piece_index, b[i].block_index);
 			ret += buf;
 		}

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -147,7 +147,7 @@ namespace libtorrent
 #undef mprotect
 #undef PROT_READ
 #endif
-//		fprintf(stderr, "malloc: %p head: %p tail: %p size: %d\n", ret + page, ret, ret + page + bytes, int(bytes));
+//		std::fprintf(stderr, "malloc: %p head: %p tail: %p size: %d\n", ret + page, ret, ret + page + bytes, int(bytes));
 
 		return static_cast<char*>(ret) + page;
 #else
@@ -173,7 +173,7 @@ namespace libtorrent
 		const int num_pages = (h->size + (page-1)) / page + 2;
 		TORRENT_ASSERT(h->magic == 0x1337);
 		mprotect(block + (num_pages-2) * page, page, PROT_READ | PROT_WRITE);
-//		fprintf(stderr, "free: %p head: %p tail: %p size: %d\n", block, block - page, block + h->size, int(h->size));
+//		std::fprintf(stderr, "free: %p head: %p tail: %p size: %d\n", block, block - page, block + h->size, int(h->size));
 		h->magic = 0;
 		block -= page;
 

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -52,7 +52,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstring>
 #include <stdlib.h>
-#include <stdarg.h>
+#include <cstdarg>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 #include <array>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
@@ -133,7 +135,7 @@ TORRENT_EXPORT void print_backtrace(char* out, int len, int max_depth, void*)
 
 	for (int i = 1; i < size && len > 0; ++i)
 	{
-		int ret = snprintf(out, len, "%d: %s\n", i, demangle(symbols[i]).c_str());
+		int ret = std::snprintf(out, len, "%d: %s\n", i, demangle(symbols[i]).c_str());
 		out += ret;
 		len -= ret;
 		if (i - 1 == max_depth && max_depth > 0) break;
@@ -225,25 +227,25 @@ TORRENT_EXPORT void print_backtrace(char* out, int len, int max_depth
 		BOOL const has_line = SymGetLineFromAddr64(GetCurrentProcess(), frame_ptr,
 			&line_displacement, &line);
 
-		int ret = snprintf(out, len, "%2d: %p", i, stack[i]);
+		int ret = std::snprintf(out, len, "%2d: %p", i, stack[i]);
 		out += ret; len -= ret; if (len <= 0) break;
 
 		if (has_symbol)
 		{
-			ret = snprintf(out, len, " %s +%-4" PRId64 " "
+			ret = std::snprintf(out, len, " %s +%-4" PRId64
 				, demangle(symbol.Name).c_str(), displacement);
 			out += ret; len -= ret; if (len <= 0) break;
 		}
 
 		if (has_line)
 		{
-			ret = snprintf(out, len, " %s:%d"
+			ret = std::snprintf(out, len, " %s:%d"
 				, line.FileName, line.LineNumber);
 			out += ret; len -= ret; if (len <= 0) break;
 		}
 
 
-		ret = snprintf(out, len, "\n");
+		ret = std::snprintf(out, len, "\n");
 		out += ret;
 		len -= ret;
 

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -50,7 +50,7 @@ namespace libtorrent
 		TORRENT_ASSERT(limit < INT_MAX);
 		m_limit = limit;
 	}
-	
+
 	int bandwidth_channel::quota_left() const
 	{
 		if (m_limit == 0) return inf;
@@ -63,9 +63,6 @@ namespace libtorrent
 		m_quota_left += (m_limit * dt_milliseconds + 500) / 1000;
 		if (m_quota_left > m_limit * 3) m_quota_left = m_limit * 3;
 		distribute_quota = int((std::max)(m_quota_left, boost::int64_t(0)));
-//		fprintf(stderr, "%p: [%d]: + %"PRId64" limit: %"PRId64" quota_left: %"PRId64"\n", this
-//			, dt_milliseconds, (m_limit * dt_milliseconds + 500) / 1000, m_limit
-//			, m_quota_left);
 	}
 
 	// this is used when connections disconnect with
@@ -85,8 +82,6 @@ namespace libtorrent
 		TORRENT_ASSERT(m_limit >= 0);
 		if (m_limit == 0) return;
 
-//		fprintf(stderr, "%p: - %"PRId64" limit: %"PRId64" quota_left: %"PRId64"\n", this
-//			, amount, m_limit, m_quota_left);
 		m_quota_left -= amount;
 	}
 

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -35,6 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/system/error_code.hpp>
 #include <limits>
 #include <cstring> // for memset
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
 #define BOOST_SYSTEM_NOEXCEPT throw()
@@ -974,7 +976,7 @@ done:
 			else
 			{
 				char tmp[5];
-				snprintf(tmp, sizeof(tmp), "\\x%02x", std::uint8_t(str[i]));
+				std::snprintf(tmp, sizeof(tmp), "\\x%02x", std::uint8_t(str[i]));
 				ret += tmp;
 			}
 		}
@@ -1036,7 +1038,7 @@ done:
 			case bdecode_node::int_t:
 			{
 				char str[100];
-				snprintf(str, sizeof(str), "%" PRId64, e.int_value());
+				std::snprintf(str, sizeof(str), "%" PRId64, e.int_value());
 				return str;
 			}
 			case bdecode_node::string_t:

--- a/src/block_cache.cpp
+++ b/src/block_cache.cpp
@@ -158,7 +158,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #if __cplusplus >= 201103L || defined __clang__
 
 #if DEBUG_CACHE
-#define DLOG(...) fprintf(__VA_ARGS__)
+#define DLOG(...) std::fprintf(__VA_ARGS__)
 #else
 #define DLOG(...) do {} while (false)
 #endif
@@ -181,10 +181,10 @@ void log_refcounts(cached_piece_entry const* pe)
 	char out[4096];
 	char* ptr = out;
 	char* end = ptr + sizeof(out);
-	ptr += snprintf(ptr, end - ptr, "piece: %d [ ", int(pe->piece));
+	ptr += std::snprintf(ptr, end - ptr, "piece: %d [ ", int(pe->piece));
 	for (int i = 0; i < pe->blocks_in_piece; ++i)
 	{
-		ptr += snprintf(ptr, end - ptr, "%d ", int(pe->blocks[i].refcount));
+		ptr += std::snprintf(ptr, end - ptr, "%d ", int(pe->blocks[i].refcount));
 	}
 	strncpy(ptr, "]\n", end - ptr);
 	DLOG(stderr, out);
@@ -252,11 +252,11 @@ static_assert(sizeof(job_action_name)/sizeof(job_action_name[0])
 		{
 			if (piece_log[i].block == -1)
 			{
-				printf("%d: %s\n", i, job_name(piece_log[i].job));
+				std::printf("%d: %s\n", i, job_name(piece_log[i].job));
 			}
 			else
 			{
-				printf("%d: %s %d\n", i, job_name(piece_log[i].job), piece_log[i].block);
+				std::printf("%d: %s %d\n", i, job_name(piece_log[i].job), piece_log[i].block);
 			}
 		}
 	}

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -210,7 +210,7 @@ namespace libtorrent
 #endif
 			open_multicast_socket(ios, i->interface_address, loopback, ec);
 #ifdef TORRENT_DEBUG
-			fprintf(stderr, "broadcast socket [ if: %s group: %s mask: %s ] %s\n"
+			std::fprintf(stderr, "broadcast socket [ if: %s group: %s mask: %s ] %s\n"
 				, i->interface_address.to_string().c_str()
 				, m_multicast_endpoint.address().to_string().c_str()
 				, i->netmask.to_string().c_str()

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -112,7 +112,7 @@ namespace libtorrent
 		va_end(v);
 		char buf[2300];
 		int t = total_milliseconds(clock_type::now() - start);
-		snprintf(buf, sizeof(buf), "%05d: [%p] %s", t, pthread_self(), usr);
+		std::snprintf(buf, sizeof(buf), "%05d: [%p] %s", t, pthread_self(), usr);
 		prepend_time = (usr[len-1] == '\n');
 		std::unique_lock<std::mutex> l(log_mutex);
 		fputs(buf, stderr);
@@ -1785,7 +1785,7 @@ namespace libtorrent
 
 		disk_io_job* j = allocate_job(disk_io_job::move_storage);
 		j->storage = storage->shared_from_this();
-		j->buffer.string = strdup(p.c_str());
+		j->buffer.string = allocate_string_copy(p.c_str());
 		j->callback = handler;
 		j->flags = flags;
 
@@ -1890,7 +1890,7 @@ namespace libtorrent
 		disk_io_job* j = allocate_job(disk_io_job::rename_file);
 		j->storage = storage->shared_from_this();
 		j->piece = index;
-		j->buffer.string = strdup(name.c_str());
+		j->buffer.string = allocate_string_copy(name.c_str());
 		j->callback = handler;
 		add_fence_job(storage, j);
 	}

--- a/src/escape_string.cpp
+++ b/src/escape_string.cpp
@@ -32,18 +32,12 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-
 #include <string>
 #include <cctype>
 #include <algorithm>
 #include <mutex>
-#include <boost/limits.hpp>
 #include <cstring>
-
-#include <boost/optional.hpp>
 #include <array>
-#include <boost/tuple/tuple.hpp>
 
 #ifdef TORRENT_WINDOWS
 #ifndef WIN32_LEAN_AND_MEAN
@@ -57,14 +51,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <locale.h>
 #endif
 
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #include "libtorrent/assert.hpp"
 #include "libtorrent/parse_url.hpp"
 #include "libtorrent/random.hpp"
 
 #include "libtorrent/utf8.hpp"
 #include "libtorrent/aux_/escape_string.hpp"
+#include "libtorrent/aux_/max_path.hpp" // for TORRENT_MAX_PATH
 #include "libtorrent/string_util.hpp" // for to_string
 
 namespace libtorrent
@@ -228,13 +221,13 @@ namespace libtorrent
 		error_code ec;
 		boost::tie(protocol, auth, host, port, path) = parse_url_components(url, ec);
 		if (ec) return url;
-		
+
 		// first figure out if this url contains unencoded characters
 		if (!need_encoding(path.c_str(), int(path.size())))
 			return url;
 
 		char msg[TORRENT_MAX_PATH*4];
-		snprintf(msg, sizeof(msg), "%s://%s%s%s%s%s%s", protocol.c_str(), auth.c_str()
+		std::snprintf(msg, sizeof(msg), "%s://%s%s%s%s%s%s", protocol.c_str(), auth.c_str()
 			, auth.empty()?"":"@", host.c_str()
 			, port == -1 ? "" : ":"
 			, port == -1 ? "" : to_string(port).data()

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -1065,7 +1065,7 @@ namespace libtorrent
 		e.size = size;
 		e.offset = offset;
 		char name[30];
-		snprintf(name, sizeof(name), ".____padding_file/%d", pad_file_counter);
+		std::snprintf(name, sizeof(name), ".____padding_file/%d", pad_file_counter);
 		std::string path = combine_path(m_name, name);
 		e.set_name(path.c_str());
 		e.pad_file = true;

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -169,9 +169,9 @@ void http_connection::get(std::string const& url, time_duration timeout, int pri
 	char* end = request + sizeof(request);
 	char* ptr = request;
 
-#define APPEND_FMT(fmt) ptr += snprintf(ptr, end - ptr, fmt)
-#define APPEND_FMT1(fmt, arg) ptr += snprintf(ptr, end - ptr, fmt, arg)
-#define APPEND_FMT2(fmt, arg1, arg2) ptr += snprintf(ptr, end - ptr, fmt, arg1, arg2)
+#define APPEND_FMT(fmt) ptr += std::snprintf(ptr, end - ptr, fmt)
+#define APPEND_FMT1(fmt, arg) ptr += std::snprintf(ptr, end - ptr, fmt, arg)
+#define APPEND_FMT2(fmt, arg1, arg2) ptr += std::snprintf(ptr, end - ptr, fmt, arg1, arg2)
 
 	// exclude ssl here, because SSL assumes CONNECT support in the
 	// proxy and is handled at the lower layer

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -259,7 +259,7 @@ restart_response:
 					// we're done once we reach the end of the headers
 //					if (!m_method.empty()) m_finished = true;
 					// the HTTP header should always be < 2 GB
-					TORRENT_ASSERT(m_recv_pos < INT_MAX);
+					TORRENT_ASSERT(m_recv_pos < (std::numeric_limits<int>::max)());
 					m_body_start_pos = int(m_recv_pos);
 					break;
 				}
@@ -337,7 +337,7 @@ restart_response:
 					boost::int64_t payload = m_cur_chunk_end - m_recv_pos;
 					if (payload > 0)
 					{
-						TORRENT_ASSERT(payload < INT_MAX);
+						TORRENT_ASSERT(payload < (std::numeric_limits<int>::max)());
 						m_recv_pos += payload;
 						boost::get<0>(ret) += int(payload);
 						incoming -= int(payload);
@@ -362,7 +362,7 @@ restart_response:
 						}
 						header_size -= m_partial_chunk_header;
 						m_partial_chunk_header = 0;
-//						fprintf(stderr, "parse_chunk_header(%d, -> %d, -> %d) -> %d\n"
+//						std::fprintf(stderr, "parse_chunk_header(%d, -> %d, -> %d) -> %d\n"
 //							"  incoming = %d\n  m_recv_pos = %d\n  m_cur_chunk_end = %d\n"
 //							"  content-length = %d\n"
 //							, buf.left(), int(chunk_size), header_size, 1, incoming, int(m_recv_pos)
@@ -373,7 +373,7 @@ restart_response:
 						m_partial_chunk_header += incoming;
 						header_size = incoming;
 						
-//						fprintf(stderr, "parse_chunk_header(%d, -> %d, -> %d) -> %d\n"
+//						std::fprintf(stderr, "parse_chunk_header(%d, -> %d, -> %d) -> %d\n"
 //							"  incoming = %d\n  m_recv_pos = %d\n  m_cur_chunk_end = %d\n"
 //							"  content-length = %d\n"
 //							, buf.left(), int(chunk_size), header_size, 0, incoming, int(m_recv_pos)
@@ -397,7 +397,8 @@ restart_response:
 				if (payload_received > m_content_length
 					&& m_content_length >= 0)
 				{
-					TORRENT_ASSERT(m_content_length - m_recv_pos + m_body_start_pos < INT_MAX);
+					TORRENT_ASSERT(m_content_length - m_recv_pos + m_body_start_pos
+						< (std::numeric_limits<int>::max)());
 					incoming = int(m_content_length - m_recv_pos + m_body_start_pos);
 				}
 
@@ -415,7 +416,7 @@ restart_response:
 		}
 		return ret;
 	}
-	
+
 	bool http_parser::parse_chunk_header(buffer::const_interval buf
 		, boost::int64_t* chunk_size, int* header_size)
 	{
@@ -494,7 +495,7 @@ restart_response:
 				++separator;
 			std::string value = line.substr(separator, std::string::npos);
 			tail_headers.insert(std::make_pair(name, value));
-//			fprintf(stderr, "tail_header: %s: %s\n", name.c_str(), value.c_str());
+//			std::fprintf(stderr, "tail_header: %s: %s\n", name.c_str(), value.c_str());
 
 			newline = std::find(pos, buf.end, '\n');
 		}
@@ -551,7 +552,7 @@ restart_response:
 		for (std::vector<std::pair<boost::int64_t, boost::int64_t> >::const_iterator i = c.begin()
 			, end(c.end()); i != end; ++i)
 		{
-			TORRENT_ASSERT(i->second - i->first < INT_MAX);
+			TORRENT_ASSERT(i->second - i->first < (std::numeric_limits<int>::max)());
 			TORRENT_ASSERT(i->second - offset <= size);
 			int len = int(i->second - i->first);
 			if (i->first - offset + len > size) len = size - int(i->first) + offset;

--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -34,11 +34,13 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include <vector>
-#include <boost/limits.hpp>
 #include <boost/bind.hpp>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
+
+#include <vector>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 #include "libtorrent/http_seed_connection.hpp"
 #include "libtorrent/session.hpp"

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -36,14 +36,16 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
+#include <boost/bind.hpp>
+
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+
 #include <vector>
 #include <list>
 #include <cctype>
 #include <algorithm>
-
-#include <boost/bind.hpp>
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 #include "libtorrent/tracker_manager.hpp"
 #include "libtorrent/http_tracker_connection.hpp"
@@ -119,7 +121,7 @@ namespace libtorrent
 
 			char str[1024];
 			const bool stats = tracker_req().send_stats;
-			snprintf(str, sizeof(str)
+			std::snprintf(str, sizeof(str)
 				, "&peer_id=%s"
 				"&port=%d"
 				"&uploaded=%" PRId64

--- a/src/i2p_stream.cpp
+++ b/src/i2p_stream.cpp
@@ -259,7 +259,7 @@ namespace libtorrent
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, sizeof(cmd) - 1)
 			, boost::bind(&i2p_stream::start_read_line, this, _1, h));
-//		fprintf(stderr, ">>> %s", cmd);
+//		std::fprintf(stderr, ">>> %s", cmd);
 	}
 
 	void i2p_stream::start_read_line(error_code const& e, boost::shared_ptr<handler_type> h)
@@ -336,7 +336,7 @@ namespace libtorrent
 				break;
 		}
 
-//		fprintf(stderr, "<<< %s\n", &m_buffer[0]);
+//		std::fprintf(stderr, "<<< %s\n", &m_buffer[0]);
 		ptr = string_tokenize(next, ' ', &next);
 		if (ptr == 0 || expect1 == 0 || strcmp(expect1, ptr)) { handle_error(invalid_response, h); return; }
 		ptr = string_tokenize(next, ' ', &next);
@@ -350,10 +350,10 @@ namespace libtorrent
 		{
 			char* name = string_tokenize(next, '=', &next);
 			if (name == 0) break;
-//			fprintf(stderr, "name=\"%s\"\n", name);
+//			std::fprintf(stderr, "name=\"%s\"\n", name);
 			char* ptr2 = string_tokenize(next, ' ', &next);
 			if (ptr2 == 0) { handle_error(invalid_response, h); return; }
-//			fprintf(stderr, "value=\"%s\"\n", ptr2);
+//			std::fprintf(stderr, "value=\"%s\"\n", ptr2);
 
 			if (strcmp("RESULT", name) == 0)
 			{
@@ -453,9 +453,9 @@ namespace libtorrent
 		TORRENT_ASSERT(m_magic == 0x1337);
 		m_state = read_connect_response;
 		char cmd[1024];
-		int size = snprintf(cmd, sizeof(cmd), "STREAM CONNECT ID=%s DESTINATION=%s\n"
+		int size = std::snprintf(cmd, sizeof(cmd), "STREAM CONNECT ID=%s DESTINATION=%s\n"
 			, m_id, m_dest.c_str());
-//		fprintf(stderr, ">>> %s", cmd);
+//		std::fprintf(stderr, ">>> %s", cmd);
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, size)
 			, boost::bind(&i2p_stream::start_read_line, this, _1, h));
@@ -466,8 +466,8 @@ namespace libtorrent
 		TORRENT_ASSERT(m_magic == 0x1337);
 		m_state = read_accept_response;
 		char cmd[400];
-		int size = snprintf(cmd, sizeof(cmd), "STREAM ACCEPT ID=%s\n", m_id);
-//		fprintf(stderr, ">>> %s", cmd);
+		int size = std::snprintf(cmd, sizeof(cmd), "STREAM ACCEPT ID=%s\n", m_id);
+//		std::fprintf(stderr, ">>> %s", cmd);
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, size)
 			, boost::bind(&i2p_stream::start_read_line, this, _1, h));
@@ -478,9 +478,9 @@ namespace libtorrent
 		TORRENT_ASSERT(m_magic == 0x1337);
 		m_state = read_session_create_response;
 		char cmd[400];
-		int size = snprintf(cmd, sizeof(cmd), "SESSION CREATE STYLE=STREAM ID=%s DESTINATION=TRANSIENT\n"
+		int size = std::snprintf(cmd, sizeof(cmd), "SESSION CREATE STYLE=STREAM ID=%s DESTINATION=TRANSIENT\n"
 			, m_id);
-//		fprintf(stderr, ">>> %s", cmd);
+//		std::fprintf(stderr, ">>> %s", cmd);
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, size)
 			, boost::bind(&i2p_stream::start_read_line, this, _1, h));
@@ -491,8 +491,8 @@ namespace libtorrent
 		TORRENT_ASSERT(m_magic == 0x1337);
 		m_state = read_name_lookup_response;
 		char cmd[1024];
-		int size = snprintf(cmd, sizeof(cmd), "NAMING LOOKUP NAME=%s\n", m_name_lookup.c_str());
-//		fprintf(stderr, ">>> %s", cmd);
+		int size = std::snprintf(cmd, sizeof(cmd), "NAMING LOOKUP NAME=%s\n", m_name_lookup.c_str());
+//		std::fprintf(stderr, ">>> %s", cmd);
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, size)
 			, boost::bind(&i2p_stream::start_read_line, this, _1, h));

--- a/src/identify_client.cpp
+++ b/src/identify_client.cpp
@@ -322,12 +322,12 @@ namespace
 			name = temp;
 		}
 
-		int num_chars = snprintf(identity, sizeof(identity), "%s %u.%u.%u", name
+		int num_chars = std::snprintf(identity, sizeof(identity), "%s %u.%u.%u", name
 			, f.major_version, f.minor_version, f.revision_version);
 
 		if (f.tag_version != 0)
 		{
-			snprintf(identity + num_chars, sizeof(identity) - num_chars
+			std::snprintf(identity + num_chars, sizeof(identity) - num_chars
 				, ".%u", f.tag_version);
 		}
 

--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -379,7 +379,7 @@ namespace
 				m_counters.immutable_data += 1;
 			}
 
-//			fprintf(stderr, "added immutable item (%d)\n", int(m_immutable_table.size()));
+//			std::fprintf(stderr, "added immutable item (%d)\n", int(m_immutable_table.size()));
 
 			touch_item(&i->second, addr);
 		}
@@ -462,7 +462,7 @@ namespace
 					std::make_pair(target, to_add));
 				m_counters.mutable_data += 1;
 
-//				fprintf(stderr, "added mutable item (%d)\n", int(m_mutable_table.size()));
+//				std::fprintf(stderr, "added mutable item (%d)\n", int(m_mutable_table.size()));
 			}
 			else
 			{

--- a/src/kademlia/item.cpp
+++ b/src/kademlia/item.cpp
@@ -35,6 +35,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/ed25519.hpp>
 
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
+
 #ifdef TORRENT_DEBUG
 #include "libtorrent/bdecode.hpp"
 #endif
@@ -63,13 +66,13 @@ namespace
 		int left = canonical_length - (ptr - out);
 		if (salt.second > 0)
 		{
-			ptr += snprintf(ptr, left, "4:salt%d:", salt.second);
+			ptr += std::snprintf(ptr, left, "4:salt%d:", salt.second);
 			left = canonical_length - (ptr - out);
 			memcpy(ptr, salt.first, (std::min)(salt.second, left));
 			ptr += (std::min)(salt.second, left);
 			left = canonical_length - (ptr - out);
 		}
-		ptr += snprintf(ptr, canonical_length - (ptr - out)
+		ptr += std::snprintf(ptr, canonical_length - (ptr - out)
 			, "3:seqi%" PRId64 "e1:v", seq);
 		left = canonical_length - (ptr - out);
 		memcpy(ptr, v.first, (std::min)(v.second, left));

--- a/src/kademlia/msg.cpp
+++ b/src/kademlia/msg.cpp
@@ -56,7 +56,7 @@ bool verify_message(bdecode_node const& message, key_desc_t const desc[]
 
 	if (msg.type() != bdecode_node::dict_t)
 	{
-		snprintf(error, error_size, "not a dictionary");
+		std::snprintf(error, error_size, "not a dictionary");
 		return false;
 	}
 	++stack_ptr;
@@ -65,7 +65,7 @@ bool verify_message(bdecode_node const& message, key_desc_t const desc[]
 	{
 		key_desc_t const& k = desc[i];
 
-		//		fprintf(stderr, "looking for %s in %s\n", k.name, print_entry(*msg).c_str());
+		//		std::fprintf(stderr, "looking for %s in %s\n", k.name, print_entry(*msg).c_str());
 
 		ret[i] = msg.dict_find(k.name);
 		// none_t means any type
@@ -74,7 +74,7 @@ bool verify_message(bdecode_node const& message, key_desc_t const desc[]
 		if (ret[i] == 0 && (k.flags & key_desc_t::optional) == 0)
 		{
 			// the key was not found, and it's not an optional key
-			snprintf(error, error_size, "missing '%s' key", k.name);
+			std::snprintf(error, error_size, "missing '%s' key", k.name);
 			return false;
 		}
 
@@ -94,7 +94,7 @@ bool verify_message(bdecode_node const& message, key_desc_t const desc[]
 				ret[i].clear();
 				if ((k.flags & key_desc_t::optional) == 0)
 				{
-					snprintf(error, error_size, "invalid value for '%s'", k.name);
+					std::snprintf(error, error_size, "invalid value for '%s'", k.name);
 					return false;
 				}
 			}

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
 #include <utility>
+#include <cinttypes> // for PRId64 et.al.
 #include <boost/bind.hpp>
 #include <boost/function/function1.hpp>
 
@@ -1030,7 +1031,7 @@ void node::incoming_request(msg const& m, entry& e)
 		else
 			target = item_target_id(buf);
 
-//		fprintf(stderr, "%s PUT target: %s salt: %s key: %s\n"
+//		std::fprintf(stderr, "%s PUT target: %s salt: %s key: %s\n"
 //			, mutable_put ? "mutable":"immutable"
 //			, to_hex(target.to_string()).c_str()
 //			, salt.second > 0 ? std::string(salt.first, salt.second).c_str() : ""
@@ -1141,7 +1142,7 @@ void node::incoming_request(msg const& m, entry& e)
 		m_counters.inc_stats_counter(counters::dht_get_in);
 		sha1_hash target(msg_keys[1].string_ptr());
 
-//		fprintf(stderr, "%s GET target: %s\n"
+//		std::fprintf(stderr, "%s GET target: %s\n"
 //			, msg_keys[1] ? "mutable":"immutable"
 //			, to_hex(target.to_string()).c_str());
 

--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -35,6 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm> // std::copy, std::remove_copy_if
 #include <functional>
 #include <numeric>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 #include "libtorrent/config.hpp"
 
@@ -256,7 +258,7 @@ void routing_table::print_state(std::ostream& os) const
 	std::vector<char> buf(2048);
 	int cursor = 0;
 
-	cursor += snprintf(&buf[cursor], buf.size() - cursor
+	cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 		, "kademlia routing table state\n"
 		"bucket_size: %d\n"
 		"global node count: %" PRId64 "\n"
@@ -272,27 +274,27 @@ void routing_table::print_state(std::ostream& os) const
 	for (table_t::const_iterator i = m_buckets.begin(), end(m_buckets.end());
 		i != end; ++i, ++idx)
 	{
-		cursor += snprintf(&buf[cursor], buf.size() - cursor
+		cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 			, "%2d: ", idx);
 		for (int k = 0; k < int(i->live_nodes.size()); ++k)
-			cursor += snprintf(&buf[cursor], buf.size() - cursor, "#");
+			cursor += std::snprintf(&buf[cursor], buf.size() - cursor, "#");
 		for (int k = 0; k < int(i->replacements.size()); ++k)
-			cursor += snprintf(&buf[cursor], buf.size() - cursor, "-");
-		cursor += snprintf(&buf[cursor], buf.size() - cursor, "\n");
+			cursor += std::snprintf(&buf[cursor], buf.size() - cursor, "-");
+		cursor += std::snprintf(&buf[cursor], buf.size() - cursor, "\n");
 
 		if (cursor > buf.size() - 500) buf.resize(buf.size() * 3 / 2);
 	}
 
 	time_point now = aux::time_now();
 
-	cursor += snprintf(&buf[cursor], buf.size() - cursor
+	cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 		, "\nnodes:");
 
 	int bucket_index = 0;
 	for (table_t::const_iterator i = m_buckets.begin(), end(m_buckets.end());
 		i != end; ++i, ++bucket_index)
 	{
-		cursor += snprintf(&buf[cursor], buf.size() - cursor
+		cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 			, "\n=== BUCKET == %d == %d|%d ==== \n"
 			, bucket_index, int(i->live_nodes.size())
 			, int(i->replacements.size()));
@@ -323,23 +325,23 @@ void routing_table::print_state(std::ostream& os) const
 			node_id id = j->id;
 			id <<= id_shift;
 
-			cursor += snprintf(&buf[cursor], buf.size() - cursor
+			cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 				, " prefix: %2x id: %s"
 				, ((id[0] & top_mask) >> mask_shift)
 				, to_hex(j->id.to_string()).c_str());
 
 			if (j->rtt == 0xffff)
 			{
-				cursor += snprintf(&buf[cursor], buf.size() - cursor
+				cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 					, " rtt:     ");
 			}
 			else
 			{
-				cursor += snprintf(&buf[cursor], buf.size() - cursor
+				cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 					, " rtt: %4d", j->rtt);
 			}
 
-			cursor += snprintf(&buf[cursor], buf.size() - cursor
+			cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 				, " fail: %4d ping: %d dist: %3d"
 				, j->fail_count()
 				, j->pinged()
@@ -347,22 +349,22 @@ void routing_table::print_state(std::ostream& os) const
 
 			if (j->last_queried == min_time())
 			{
-				cursor += snprintf(&buf[cursor], buf.size() - cursor
+				cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 					, " query:    ");
 			}
 			else
 			{
-				cursor += snprintf(&buf[cursor], buf.size() - cursor
+				cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 					, " query: %3d", int(total_seconds(now - j->last_queried)));
 			}
 
-			cursor += snprintf(&buf[cursor], buf.size() - cursor
+			cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 				, " ip: %s\n", print_endpoint(j->ep()).c_str());
 			if (cursor > buf.size() - 500) buf.resize(buf.size() * 3 / 2);
 		}
 	}
 
-	cursor += snprintf(&buf[cursor], buf.size() - cursor
+	cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 		, "\nnode spread per bucket:\n");
 	bucket_index = 0;
 	for (table_t::const_iterator i = m_buckets.begin(), end(m_buckets.end());
@@ -407,15 +409,15 @@ void routing_table::print_state(std::ostream& os) const
 			sub_buckets[b] = true;
 		}
 
-		cursor += snprintf(&buf[cursor], buf.size() - cursor
+		cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 			, "%2d mask: %2x: [", bucket_index, (top_mask >> mask_shift));
 
 		for (int j = 0; j < bucket_size_limit; ++j)
 		{
-			cursor += snprintf(&buf[cursor], buf.size() - cursor
+			cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 				, (sub_buckets[j] ? "X" : " "));
 		}
-		cursor += snprintf(&buf[cursor], buf.size() - cursor
+		cursor += std::snprintf(&buf[cursor], buf.size() - cursor
 			, "]\n");
 		if (cursor > buf.size() - 500) buf.resize(buf.size() * 3 / 2);
 	}

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -60,6 +60,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/time.hpp>
 #include <libtorrent/aux_/time.hpp> // for aux::time_now
 
+#ifndef TORRENT_DISABLE_LOGGING
+#include <cinttypes> // for PRId64 et.al.
+#endif
+
 namespace libtorrent { namespace dht
 {
 

--- a/src/lazy_bdecode.cpp
+++ b/src/lazy_bdecode.cpp
@@ -37,6 +37,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/bdecode.hpp" // for error codes
 #include <cstring>
 #include <limits> // for numeric_limits
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 namespace
 {
@@ -551,7 +553,7 @@ namespace libtorrent
 			else
 			{
 				char tmp[5];
-				snprintf(tmp, sizeof(tmp), "\\x%02x", boost::uint8_t(str[i]));
+				std::snprintf(tmp, sizeof(tmp), "\\x%02x", boost::uint8_t(str[i]));
 				ret += tmp;
 			}
 		}
@@ -610,7 +612,7 @@ namespace libtorrent
 			case lazy_entry::int_t:
 			{
 				char str[100];
-				snprintf(str, sizeof(str), "%" PRId64, e.int_value());
+				std::snprintf(str, sizeof(str), "%" PRId64, e.int_value());
 				return str;
 			}
 			case lazy_entry::string_t:

--- a/src/lsd.cpp
+++ b/src/lsd.cpp
@@ -58,7 +58,7 @@ int render_lsd_packet(char* dst, int len, int listen_port
 	, char const* info_hash_hex, int m_cookie, char const* host)
 {
 	TORRENT_ASSERT(len > 0);
-	return snprintf(dst, len,
+	return std::snprintf(dst, len,
 		"BT-SEARCH * HTTP/1.1\r\n"
 		"Host: %s:6771\r\n"
 		"Port: %d\r\n"

--- a/src/natpmp.cpp
+++ b/src/natpmp.cpp
@@ -43,6 +43,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
+#include <cstdio> // for snprintf
+
 #include "libtorrent/natpmp.hpp"
 #include "libtorrent/io.hpp"
 #include "libtorrent/assert.hpp"
@@ -90,7 +92,7 @@ void natpmp::start()
 	if (ec)
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "failed to find default route: %s"
+		std::snprintf(msg, sizeof(msg), "failed to find default route: %s"
 			, convert_from_native(ec.message()).c_str());
 		log(msg);
 		disable(ec);
@@ -104,7 +106,7 @@ void natpmp::start()
 	m_nat_endpoint = nat_endpoint;
 
 	char msg[200];
-	snprintf(msg, sizeof(msg), "found router at: %s"
+	std::snprintf(msg, sizeof(msg), "found router at: %s"
 		, print_address(m_nat_endpoint.address()).c_str());
 	log(msg);
 
@@ -351,7 +353,7 @@ void natpmp::send_map_request(int i)
 	write_uint32(ttl, out); // port mapping lifetime
 
 	char msg[200];
-	snprintf(msg, sizeof(msg), "==> port map [ mapping: %d action: %s"
+	std::snprintf(msg, sizeof(msg), "==> port map [ mapping: %d action: %s"
 		" proto: %s local: %u external: %u ttl: %u ]"
 		, i, m.action == mapping_t::action_add ? "add" : "delete"
 		, m.protocol == udp ? "udp" : "tcp"
@@ -413,7 +415,7 @@ void natpmp::on_reply(error_code const& e
 	if (e)
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "error on receiving reply: %s"
+		std::snprintf(msg, sizeof(msg), "error on receiving reply: %s"
 			, convert_from_native(e.message()).c_str());
 		log(msg);
 		return;
@@ -439,7 +441,7 @@ void natpmp::on_reply(error_code const& e
 	if (m_remote != m_nat_endpoint)
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "received packet from wrong IP: %s"
+		std::snprintf(msg, sizeof(msg), "received packet from wrong IP: %s"
 			, print_endpoint(m_remote).c_str());
 		log(msg);
 		return;
@@ -451,7 +453,7 @@ void natpmp::on_reply(error_code const& e
 	if (bytes_transferred < 12)
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "received packet of invalid size: %d", int(bytes_transferred));
+		std::snprintf(msg, sizeof(msg), "received packet of invalid size: %d", int(bytes_transferred));
 		log(msg);
 		return;
 	}
@@ -468,7 +470,7 @@ void natpmp::on_reply(error_code const& e
 		m_external_ip = read_v4_address(in);
 
 		char msg[200];
-		snprintf(msg, sizeof(msg), "<== public IP address [ %s ]", print_address(m_external_ip).c_str());
+		std::snprintf(msg, sizeof(msg), "<== public IP address [ %s ]", print_address(m_external_ip).c_str());
 		log(msg);
 		return;
 
@@ -477,7 +479,7 @@ void natpmp::on_reply(error_code const& e
 	if (bytes_transferred < 16)
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "received packet of invalid size: %d", int(bytes_transferred));
+		std::snprintf(msg, sizeof(msg), "received packet of invalid size: %d", int(bytes_transferred));
 		log(msg);
 		return;
 	}
@@ -491,14 +493,14 @@ void natpmp::on_reply(error_code const& e
 	int protocol = (cmd - 128 == 1)?udp:tcp;
 
 	char msg[200];
-	int num_chars = snprintf(msg, sizeof(msg), "<== port map ["
+	int num_chars = std::snprintf(msg, sizeof(msg), "<== port map ["
 		" protocol: %s local: %u external: %u ttl: %u ]"
 		, (cmd - 128 == 1 ? "udp" : "tcp")
 		, private_port, public_port, lifetime);
 
 	if (version != 0)
 	{
-		snprintf(msg + num_chars, sizeof(msg) - num_chars, "unexpected version: %u"
+		std::snprintf(msg + num_chars, sizeof(msg) - num_chars, "unexpected version: %u"
 			, version);
 		log(msg);
 	}
@@ -519,7 +521,7 @@ void natpmp::on_reply(error_code const& e
 
 	if (m == 0)
 	{
-		snprintf(msg + num_chars, sizeof(msg) - num_chars, " not found in map table");
+		std::snprintf(msg + num_chars, sizeof(msg) - num_chars, " not found in map table");
 		log(msg);
 		return;
 	}
@@ -604,7 +606,7 @@ void natpmp::update_expiration_timer()
 		if (i->expires < now)
 		{
 			char msg[200];
-			snprintf(msg, sizeof(msg), "mapping %u expired", index);
+			std::snprintf(msg, sizeof(msg), "mapping %u expired", index);
 			log(msg);
 			i->action = mapping_t::action_add;
 			if (m_next_refresh == index) m_next_refresh = -1;
@@ -644,7 +646,7 @@ void natpmp::mapping_expired(error_code const& e, int i)
 	COMPLETE_ASYNC("natpmp::mapping_expired");
 	if (e) return;
 	char msg[200];
-	snprintf(msg, sizeof(msg), "mapping %u expired", i);
+	std::snprintf(msg, sizeof(msg), "mapping %u expired", i);
 	log(msg);
 	m_mappings[i].action = mapping_t::action_add;
 	if (m_next_refresh == i) m_next_refresh = -1;

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2871,7 +2871,7 @@ namespace libtorrent
 		bool was_finished = picker.is_piece_finished(p.piece);
 		// did we request this block from any other peers?
 		bool multi = picker.num_peers(block_finished) > 1;
-//		fprintf(stderr, "peer_connection mark_as_writing peer: %p piece: %d block: %d\n"
+//		std::fprintf(stderr, "peer_connection mark_as_writing peer: %p piece: %d block: %d\n"
 //			, peer_info_struct(), block_finished.piece_index, block_finished.block_index);
 		picker.mark_as_writing(block_finished, peer_info_struct());
 
@@ -3037,7 +3037,7 @@ namespace libtorrent
 			picker.mark_as_canceled(block_finished, peer_info_struct());
 			return;
 		}
-//		fprintf(stderr, "peer_connection mark_as_finished peer: %p piece: %d block: %d\n"
+//		std::fprintf(stderr, "peer_connection mark_as_finished peer: %p piece: %d block: %d\n"
 //			, peer_info_struct(), block_finished.piece_index, block_finished.block_index);
 		picker.mark_as_finished(block_finished, peer_info_struct());
 
@@ -6562,7 +6562,7 @@ namespace libtorrent
 
 			if (m_outstanding_bytes != outstanding_bytes)
 			{
-				fprintf(stderr, "m_outstanding_bytes = %d\noutstanding_bytes = %d\n"
+				std::fprintf(stderr, "m_outstanding_bytes = %d\noutstanding_bytes = %d\n"
 					, m_outstanding_bytes, outstanding_bytes);
 			}
 

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -2470,10 +2470,10 @@ get_out:
 					, piece_block(i->index, j));
 				if (k != interesting_blocks.end()) continue;
 
-				fprintf(stderr, "interesting blocks:\n");
+				std::fprintf(stderr, "interesting blocks:\n");
 				for (k = interesting_blocks.begin(); k != interesting_blocks.end(); ++k)
-					fprintf(stderr, "(%d, %d)", k->piece_index, k->block_index);
-				fprintf(stderr, "\nnum_blocks: %d\n", num_blocks);
+					std::fprintf(stderr, "(%d, %d)", k->piece_index, k->block_index);
+				std::fprintf(stderr, "\nnum_blocks: %d\n", num_blocks);
 
 				for (std::vector<downloading_piece>::const_iterator l
 					= m_downloads[piece_pos::piece_downloading].begin()
@@ -2481,11 +2481,11 @@ get_out:
 					l != end2; ++l)
 				{
 					block_info const* binfo2 = blocks_for_piece(*l);
-					fprintf(stderr, "%d : ", l->index);
+					std::fprintf(stderr, "%d : ", l->index);
 					const int cnt = blocks_in_piece(l->index);
 					for (int m = 0; m < cnt; ++m)
-						fprintf(stderr, "%d", binfo2[m].state);
-					fprintf(stderr, "\n");
+						std::fprintf(stderr, "%d", binfo2[m].state);
+					std::fprintf(stderr, "\n");
 				}
 
 				TORRENT_ASSERT_FAIL();

--- a/src/puff.cpp
+++ b/src/puff.cpp
@@ -834,10 +834,10 @@ int main(int argc, char **argv)
     sourcelen = len;
     ret = puff(NIL, &destlen, source, &sourcelen);
     if (ret)
-        printf("puff() failed with return code %d\n", ret);
+        std::printf("puff() failed with return code %d\n", ret);
     else {
-        printf("puff() succeeded uncompressing %lu bytes\n", destlen);
-        if (sourcelen < len) printf("%lu compressed bytes unused\n",
+        std::printf("puff() succeeded uncompressing %lu bytes\n", destlen);
+        if (sourcelen < len) std::printf("%lu compressed bytes unused\n",
                                     len - sourcelen);
     }
     free(source);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -382,12 +382,12 @@ namespace libtorrent
 		{
 			sleep(1000);
 			++counter;
-			printf("\x1b[2J\x1b[0;0H\x1b[33m==== Waiting to shut down: %d ==== \x1b[0m\n\n"
+			std::printf("\x1b[2J\x1b[0;0H\x1b[33m==== Waiting to shut down: %d ==== \x1b[0m\n\n"
 				, counter);
 		}
 		async_dec_threads();
 
-		fprintf(stderr, "\n\nEXPECTS NO MORE ASYNC OPS\n\n\n");
+		std::fprintf(stderr, "\n\nEXPECTS NO MORE ASYNC OPS\n\n\n");
 #endif
 
 		if (m_thread && m_thread.unique())

--- a/src/session_call.cpp
+++ b/src/session_call.cpp
@@ -65,7 +65,7 @@ void dump_call_profile()
 	for (std::map<int, std::string>::const_reverse_iterator i = profile.rbegin()
 		, end(profile.rend()); i != end; ++i)
 	{
-		fprintf(out, "\n\n%d\n%s\n", i->first, i->second.c_str());
+		std::fprintf(out, "\n\n%d\n%s\n", i->first, i->second.c_str());
 	}
 	fclose(out);
 #endif

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -151,9 +151,9 @@ namespace
 		{
 			gcry_check_version(0);
 			gcry_error_t e = gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-			if (e != 0) fprintf(stderr, "libcrypt ERROR: %s\n", gcry_strerror(e));
+			if (e != 0) std::fprintf(stderr, "libcrypt ERROR: %s\n", gcry_strerror(e));
 			e = gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
-			if (e != 0) fprintf(stderr, "initialization finished error: %s\n", gcry_strerror(e));
+			if (e != 0) std::fprintf(stderr, "initialization finished error: %s\n", gcry_strerror(e));
 		}
 	} gcrypt_global_constructor;
 }
@@ -3073,7 +3073,7 @@ namespace aux {
 				return;
 			}
 #if defined TORRENT_ASIO_DEBUGGING
-			fprintf(stderr, "uTP sockets: %d ssl-uTP sockets: %d undead-peers left: %d\n"
+			std::fprintf(stderr, "uTP sockets: %d ssl-uTP sockets: %d undead-peers left: %d\n"
 				, m_utp_socket_manager.num_sockets()
 #ifdef TORRENT_USE_OPENSSL
 				, m_ssl_utp_socket_manager.num_sockets()
@@ -3245,7 +3245,7 @@ namespace aux {
 		// --------------------------------------------------------------
 
 #if TORRENT_DEBUG_STREAMING > 0
-		printf("\033[2J\033[0;0H");
+		std::printf("\033[2J\033[0;0H");
 #endif
 
 		std::vector<torrent*>& want_tick = m_torrent_lists[torrent_want_tick];
@@ -5857,12 +5857,12 @@ namespace aux {
 			time_point prev = m;
 			boost::uint64_t prev_csw = 0;
 			if (!_wakeups.empty()) prev_csw = _wakeups[0].context_switches;
-			fprintf(f, "abs. time\trel. time\tctx switch\tidle-wakeup\toperation\n");
+			std::fprintf(f, "abs. time\trel. time\tctx switch\tidle-wakeup\toperation\n");
 			for (int i = 0; i < _wakeups.size(); ++i)
 			{
 				wakeup_t const& w = _wakeups[i];
 				bool idle_wakeup = w.context_switches > prev_csw;
-				fprintf(f, "%" PRId64 "\t%" PRId64 "\t%" PRId64 "\t%c\t%s\n"
+				std::fprintf(f, "%" PRId64 "\t%" PRId64 "\t%" PRId64 "\t%c\t%s\n"
 					, total_microseconds(w.timestamp - m)
 					, total_microseconds(w.timestamp - prev)
 					, w.context_switches

--- a/src/sha1.cpp
+++ b/src/sha1.cpp
@@ -121,7 +121,7 @@ namespace
 	void SHAPrintContext(sha_ctx *context, char *msg)
 	{
 		using namespace std;
-		printf("%s (%d,%d) %x %x %x %x %x\n"
+		std::printf("%s (%d,%d) %x %x %x %x %x\n"
 			, msg, (unsigned int)context->count[0]
 			, (unsigned int)context->count[1]
 			, (unsigned int)context->state[0]

--- a/src/smart_ban.cpp
+++ b/src/smart_ban.cpp
@@ -79,7 +79,7 @@ void log_hash_block(FILE** f, libtorrent::torrent const& t, int piece, int block
 	if (*f == NULL)
 	{
 		char filename[1024];
-		snprintf(filename, sizeof(filename), "hash_failures/%s.log"
+		std::snprintf(filename, sizeof(filename), "hash_failures/%s.log"
 			, to_hex(t.info_hash().to_string()).c_str());
 		*f = fopen(filename, "w");
 	}
@@ -93,15 +93,15 @@ void log_hash_block(FILE** f, libtorrent::torrent const& t, int piece, int block
 	int offset = 0;
 	for (int i = 0; i < files.size(); ++i)
 	{
-		offset += snprintf(filename+offset, sizeof(filename)-offset
+		offset += std::snprintf(filename+offset, sizeof(filename)-offset
 			, "%s[%" PRId64 ",%d]", libtorrent::filename(fn).c_str(), files[i].offset, int(files[i].size));
 		if (offset >= sizeof(filename)) break;
 	}
 
-	fprintf(*f, "%s\t%04d\t%04d\t%s\t%s\t%s\n", to_hex(t.info_hash().to_string()).c_str(), piece
+	std::fprintf(*f, "%s\t%04d\t%04d\t%s\t%s\t%s\n", to_hex(t.info_hash().to_string()).c_str(), piece
 		, block, corrupt ? " bad" : "good", print_address(a).c_str(), filename);
 
-	snprintf(filename, sizeof(filename), "hash_failures/%s_%d_%d_%s.block"
+	std::snprintf(filename, sizeof(filename), "hash_failures/%s_%d_%d_%s.block"
 		, to_hex(t.info_hash().to_string()).c_str(), piece, block, corrupt ? "bad" : "good");
 	FILE* data = fopen(filename, "w+");
 	fwrite(bytes, 1, len, data);

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -71,10 +71,10 @@ namespace libtorrent
 		address const& addr = ep.address();
 #if TORRENT_USE_IPV6
 		if (addr.is_v6())
-			snprintf(buf, sizeof(buf), "[%s]:%d", addr.to_string(ec).c_str(), ep.port());
+			std::snprintf(buf, sizeof(buf), "[%s]:%d", addr.to_string(ec).c_str(), ep.port());
 		else
 #endif
-			snprintf(buf, sizeof(buf), "%s:%d", addr.to_string(ec).c_str(), ep.port());
+			std::snprintf(buf, sizeof(buf), "%s:%d", addr.to_string(ec).c_str(), ep.port());
 		return buf;
 	}
 

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -93,13 +93,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #if __cplusplus >= 201103L || defined __clang__
 
 #if DEBUG_STORAGE
-#define DLOG(...) fprintf(__VA_ARGS__)
+#define DLOG(...) std::fprintf(__VA_ARGS__)
 #else
 #define DLOG(...) do {} while (false)
 #endif
 
 #if DEBUG_DELETE_FILES
-#define DFLOG(...) fprintf(__VA_ARGS__)
+#define DFLOG(...) std::fprintf(__VA_ARGS__)
 #else
 #define DFLOG(...) do {} while (false)
 #endif
@@ -215,7 +215,7 @@ namespace libtorrent
 		l.unlock();
 		if (ret != sizeof(event))
 		{
-			fprintf(stderr, "ERROR writing to disk access log: (%d) %s\n"
+			std::fprintf(stderr, "ERROR writing to disk access log: (%d) %s\n"
 				, errno, strerror(errno));
 		}
 	}

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include <stdarg.h> // for va_list
+#include <cstdarg> // for va_list
 #include <ctime>
 #include <algorithm>
 #include <set>
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cctype>
 #include <numeric>
 #include <limits> // for numeric_limits
+#include <cstdio> // for snprintf
 
 #include <boost/bind.hpp>
 #include <boost/make_shared.hpp>
@@ -1340,7 +1341,7 @@ namespace libtorrent
 
 		schedule_storage_tick();
 
-//		fprintf(stderr, "torrent::on_disk_write_complete ret:%d piece:%d block:%d\n"
+//		std::fprintf(stderr, "torrent::on_disk_write_complete ret:%d piece:%d block:%d\n"
 //			, j->ret, j->piece, j->offset/0x4000);
 
 		INVARIANT_CHECK;
@@ -1651,7 +1652,7 @@ namespace libtorrent
 		SSL_CTX_set_cert_store(ssl_ctx, cert_store);
 #if 0
 		char filename[100];
-		snprintf(filename, sizeof(filename), "/tmp/%u.pem", random());
+		std::snprintf(filename, sizeof(filename), "/tmp/%u.pem", random());
 		FILE* f = fopen(filename, "w+");
 		fwrite(cert.c_str(), cert.size(), 1, f);
 		fclose(f);
@@ -3890,11 +3891,11 @@ namespace libtorrent
 		{
 			// Thist happens when a piece has been downloaded completely
 			// but not yet verified against the hash
-			fprintf(stderr, "num_have: %d\nunfinished:\n", num_have());
+			std::fprintf(stderr, "num_have: %d\nunfinished:\n", num_have());
 			for (std::vector<piece_picker::downloading_piece>::const_iterator i =
 				dl_queue.begin(); i != dl_queue.end(); ++i)
 			{
-				fprintf(stderr, "  %d ", i->index);
+				std::fprintf(stderr, "  %d ", i->index);
 				piece_picker::block_info* info = m_picker->blocks_for_piece(*i);
 				for (int j = 0; j < blocks_per_piece; ++j)
 				{
@@ -3910,7 +3911,7 @@ namespace libtorrent
 			for (std::map<piece_block, int>::iterator i = downloading_piece.begin();
 				i != downloading_piece.end(); ++i)
 			{
-				fprintf(stderr, "   %d:%d  %d\n", int(i->first.piece_index), int(i->first.block_index), i->second);
+				std::fprintf(stderr, "   %d:%d  %d\n", int(i->first.piece_index), int(i->first.block_index), i->second);
 			}
 
 		}
@@ -4140,7 +4141,7 @@ namespace libtorrent
 		debug_log("PIECE_PASSED (%d)", num_passed());
 #endif
 
-//		fprintf(stderr, "torrent::piece_passed piece:%d\n", index);
+//		std::fprintf(stderr, "torrent::piece_passed piece:%d\n", index);
 
 		TORRENT_ASSERT(index >= 0);
 		TORRENT_ASSERT(index < m_torrent_file->num_pieces());
@@ -8380,24 +8381,24 @@ namespace libtorrent
 				{
 					if (picker_count != count)
 					{
-						fprintf(stderr, "picker count discrepancy: "
+						std::fprintf(stderr, "picker count discrepancy: "
 							"picker: %d != peerlist: %d\n", picker_count, count);
 
 						for (const_peer_iterator j = this->begin(); j != this->end(); ++j)
 						{
 							peer_connection const& p = *(*j);
-							fprintf(stderr, "peer: %s\n", print_endpoint(p.remote()).c_str());
+							std::fprintf(stderr, "peer: %s\n", print_endpoint(p.remote()).c_str());
 							for (std::vector<pending_block>::const_iterator k = p.request_queue().begin()
 								, end2(p.request_queue().end()); k != end2; ++k)
 							{
-								fprintf(stderr, "  rq: (%d, %d) %s %s %s\n", k->block.piece_index
+								std::fprintf(stderr, "  rq: (%d, %d) %s %s %s\n", k->block.piece_index
 									, k->block.block_index, k->not_wanted ? "not-wanted" : ""
 									, k->timed_out ? "timed-out" : "", k->busy ? "busy": "");
 							}
 							for (std::vector<pending_block>::const_iterator k = p.download_queue().begin()
 								, end2(p.download_queue().end()); k != end2; ++k)
 							{
-								fprintf(stderr, "  dq: (%d, %d) %s %s %s\n", k->block.piece_index
+								std::fprintf(stderr, "  dq: (%d, %d) %s %s %s\n", k->block.piece_index
 									, k->block.block_index, k->not_wanted ? "not-wanted" : ""
 									, k->timed_out ? "timed-out" : "", k->busy ? "busy": "");
 							}
@@ -8713,7 +8714,7 @@ namespace libtorrent
 		if (ec)
 		{
 			char buf[1024];
-			snprintf(buf, sizeof(buf), "error %s: %s", ec.message().c_str()
+			std::snprintf(buf, sizeof(buf), "error %s: %s", ec.message().c_str()
 				, resolve_filename(error_file).c_str());
 			log_to_all_peers(buf);
 		}
@@ -9564,7 +9565,7 @@ namespace libtorrent
 		std::sort(queue.begin(), queue.end(), boost::bind(&partial_piece_info::piece_index, _1)
 			< boost::bind(&partial_piece_info::piece_index, _2));
 
-		printf("average piece download time: %.2f s (+/- %.2f s)\n"
+		std::printf("average piece download time: %.2f s (+/- %.2f s)\n"
 			, m_average_piece_time / 1000.f
 			, m_piece_time_deviation / 1000.f);
 		for (std::vector<partial_piece_info>::iterator i = queue.begin()
@@ -9949,7 +9950,7 @@ namespace libtorrent
 
 		int num_blocks = pp->blocks_in_piece;
 
-		printf("%5d: [", piece);
+		std::printf("%5d: [", piece);
 		for (int j = 0; j < num_blocks; ++j)
 		{
 			int index = pp ? peer_index(pp->blocks[j].peer(), peers) % 36 : -1;
@@ -9974,14 +9975,14 @@ namespace libtorrent
 			else if (pp->blocks[j].state == block_info::requested) color = esc("0");
 			else { color = esc("0"); chr = ' '; }
 
-			printf("%s%s%c%s", color, multi_req, chr, esc("0"));
+			std::printf("%s%s%c%s", color, multi_req, chr, esc("0"));
 		}
-		printf("%s]", esc("0"));
+		std::printf("%s]", esc("0"));
 		if (deadline != 0.f)
-			printf(" deadline: %f last-req: %f timed_out: %d\n"
+			std::printf(" deadline: %f last-req: %f timed_out: %d\n"
 				, deadline, last_request, timed_out);
 		else
-			printf("\n");
+			std::printf("\n");
 	}
 #endif // TORRENT_DEBUG_STREAMING
 
@@ -10033,11 +10034,11 @@ namespace libtorrent
 			++busy_count;
 
 #if TORRENT_DEBUG_STREAMING > 1
-			printf(" [%d (%d)]", b.block_index, info[k].num_peers);
+			std::printf(" [%d (%d)]", b.block_index, info[k].num_peers);
 #endif
 		}
 #if TORRENT_DEBUG_STREAMING > 1
-		printf("\n");
+		std::printf("\n");
 #endif
 
 		// then sort blocks by the number of peers with requests
@@ -10077,7 +10078,7 @@ namespace libtorrent
 			if (!peers.empty() && peers[0]->download_queue_time() > milliseconds(2000))
 			{
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("queue time: %d ms, done\n"
+				std::printf("queue time: %d ms, done\n"
 					, int(total_milliseconds(peers[0]->download_queue_time())));
 #endif
 				break;
@@ -10092,7 +10093,7 @@ namespace libtorrent
 			if (p == peers.end())
 			{
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("out of peers, done\n");
+				std::printf("out of peers, done\n");
 #endif
 				break;
 			}
@@ -10121,7 +10122,7 @@ namespace libtorrent
 				busy_mode = true;
 
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("interesting_blocks.empty()\n");
+				std::printf("interesting_blocks.empty()\n");
 #endif
 
 				// there aren't any free blocks to pick, and the piece isn't
@@ -10130,13 +10131,13 @@ namespace libtorrent
 				if (timed_out == 0)
 				{
 #if TORRENT_DEBUG_STREAMING > 1
-					printf("not timed out, moving on to next piece\n");
+					std::printf("not timed out, moving on to next piece\n");
 #endif
 					break;
 				}
 
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("pick busy blocks\n");
+				std::printf("pick busy blocks\n");
 #endif
 
 				pick_busy_blocks(picker, i->piece, blocks_in_piece, timed_out
@@ -10168,7 +10169,7 @@ namespace libtorrent
 				ignore_peers.push_back(*p);
 				peers.erase(p);
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("piece already requested by peer, try next peer\n");
+				std::printf("piece already requested by peer, try next peer\n");
 #endif
 				// try next peer
 				continue;
@@ -10184,7 +10185,7 @@ namespace libtorrent
 				if (!c.make_time_critical(b))
 				{
 #if TORRENT_DEBUG_STREAMING > 1
-					printf("piece already time-critical and in queue for peer, trying next peer\n");
+					std::printf("piece already time-critical and in queue for peer, trying next peer\n");
 #endif
 					ignore_peers.push_back(*p);
 					peers.erase(p);
@@ -10193,7 +10194,7 @@ namespace libtorrent
 				i->last_requested = now;
 
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("piece already in queue for peer, making time-critical\n");
+				std::printf("piece already in queue for peer, making time-critical\n");
 #endif
 
 				// we inserted a new block in the request queue, this
@@ -10206,7 +10207,7 @@ namespace libtorrent
 					| (busy_mode ? peer_connection::req_busy : 0)))
 				{
 #if TORRENT_DEBUG_STREAMING > 1
-					printf("failed to request block [%d, %d]\n"
+					std::printf("failed to request block [%d, %d]\n"
 						, b.piece_index, b.block_index);
 #endif
 					ignore_peers.push_back(*p);
@@ -10215,7 +10216,7 @@ namespace libtorrent
 				}
 
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("requested block [%d, %d]\n"
+				std::printf("requested block [%d, %d]\n"
 					, b.piece_index, b.block_index);
 #endif
 				peers_with_requests.insert(peers_with_requests.begin(), &c);
@@ -10228,7 +10229,7 @@ namespace libtorrent
 			if (!c.can_request_time_critical())
 			{
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("peer cannot pick time critical pieces\n");
+				std::printf("peer cannot pick time critical pieces\n");
 #endif
 				peers.erase(p);
 				// try next peer
@@ -10301,13 +10302,13 @@ namespace libtorrent
 			, end(m_time_critical_pieces.end()); i != end; ++i)
 		{
 #if TORRENT_DEBUG_STREAMING > 1
-			printf("considering %d\n", i->piece);
+			std::printf("considering %d\n", i->piece);
 #endif
 
 			if (peers.empty())
 			{
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("out of peers, done\n");
+				std::printf("out of peers, done\n");
 #endif
 				break;
 			}
@@ -10322,7 +10323,7 @@ namespace libtorrent
 				// this is one of the termination conditions. We don't want to
 				// send requests for all pieces in the torrent right away
 #if TORRENT_DEBUG_STREAMING > 0
-				printf("reached deadline horizon [%f + %f * 4 + 1]\n"
+				std::printf("reached deadline horizon [%f + %f * 4 + 1]\n"
 					, m_average_piece_time / 1000.f
 					, m_piece_time_deviation / 1000.f);
 #endif
@@ -10364,7 +10365,7 @@ namespace libtorrent
 				if (pi.requested == 0 || timed_out == 0)
 				{
 #if TORRENT_DEBUG_STREAMING > 1
-					printf("skipping %d (full) [req: %d timed_out: %d ]\n"
+					std::printf("skipping %d (full) [req: %d timed_out: %d ]\n"
 						, i->piece, pi.requested
 						, timed_out);
 #endif
@@ -10380,7 +10381,7 @@ namespace libtorrent
 				// it's been too long since we requested the last block from
 				// this piece. Allow re-requesting blocks from this piece
 #if TORRENT_DEBUG_STREAMING > 1
-				printf("timed out [average-piece-time: %d ms ]\n"
+				std::printf("timed out [average-piece-time: %d ms ]\n"
 					, m_average_piece_time);
 #endif
 			}

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -736,7 +736,7 @@ namespace libtorrent
 				{
 					++cnt;
 					char new_ext[50];
-					snprintf(new_ext, sizeof(new_ext), ".%d%s", cnt, ext.c_str());
+					std::snprintf(new_ext, sizeof(new_ext), ".%d%s", cnt, ext.c_str());
 					filename = base + new_ext;
 				}
 				while (!files.insert(filename).second);

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -258,7 +258,7 @@ namespace libtorrent
 					char const* tracker_address_type = target.address().is_v4() ? "IPv4" : "IPv6";
 					char const* bind_address_type = bind_interface().is_v4() ? "IPv4" : "IPv6";
 					char msg[200];
-					snprintf(msg, sizeof(msg)
+					std::snprintf(msg, sizeof(msg)
 						, "the tracker only resolves to an %s  address, and you're "
 						"listening on an %s socket. This may prevent you from receiving "
 						"incoming connections."

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -52,6 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include <cstdlib>
+#include <cstdio> // for snprintf
 
 namespace libtorrent {
 
@@ -141,7 +142,7 @@ void upnp::discover_device_impl()
 	if (ec)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "broadcast failed: %s. Aborting."
+		std::snprintf(msg, sizeof(msg), "broadcast failed: %s. Aborting."
 			, convert_from_native(ec.message()).c_str());
 		log(msg);
 		disable(ec);
@@ -165,7 +166,7 @@ int upnp::add_mapping(upnp::protocol_type p, int external_port, int local_port)
 	TORRENT_ASSERT(external_port != 0);
 
 	char msg[500];
-	snprintf(msg, sizeof(msg), "adding port map: [ protocol: %s ext_port: %u "
+	std::snprintf(msg, sizeof(msg), "adding port map: [ protocol: %s ext_port: %u "
 		"local_port: %u ] %s", (p == tcp?"tcp":"udp"), external_port
 		, local_port, m_disabled ? "DISABLED": "");
 	log(msg);
@@ -217,7 +218,7 @@ void upnp::delete_mapping(int mapping)
 	global_mapping_t& m = m_mappings[mapping];
 
 	char msg[500];
-	snprintf(msg, sizeof(msg), "deleting port map: [ protocol: %s ext_port: %u "
+	std::snprintf(msg, sizeof(msg), "deleting port map: [ protocol: %s ext_port: %u "
 		"local_port: %u ]", (m.protocol == tcp?"tcp":"udp"), m.external_port
 		, m.local_port);
 	log(msg);
@@ -285,7 +286,7 @@ void upnp::resend_request(error_code const& ec)
 			TORRENT_TRY
 			{
 				char msg[500];
-				snprintf(msg, sizeof(msg), "connecting to: %s", d.url.c_str());
+				std::snprintf(msg, sizeof(msg), "connecting to: %s", d.url.c_str());
 				log(msg);
 				if (d.upnp_connection) d.upnp_connection->close();
 				d.upnp_connection.reset(new http_connection(m_io_service
@@ -298,7 +299,7 @@ void upnp::resend_request(error_code const& ec)
 			{
 				TORRENT_DECLARE_DUMMY(std::exception, exc);
 				char msg[500];
-				snprintf(msg, sizeof(msg), "connection failed to: %s %s", d.url.c_str(), exc.what());
+				std::snprintf(msg, sizeof(msg), "connection failed to: %s %s", d.url.c_str(), exc.what());
 				log(msg);
 				d.disabled = true;
 			}
@@ -347,7 +348,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		if (ec)
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "when receiving response from: %s: %s"
+			std::snprintf(msg, sizeof(msg), "when receiving response from: %s: %s"
 				, print_endpoint(from).c_str(), convert_from_native(ec.message()).c_str());
 			log(msg);
 		}
@@ -357,7 +358,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 	if (!ec && !in_local_network(m_interfaces, from.address()))
 	{
 		char msg[400];
-		int num_chars = snprintf(msg, sizeof(msg)
+		int num_chars = std::snprintf(msg, sizeof(msg)
 			, "ignoring response from: %s. IP is not on local network. "
 			, print_endpoint(from).c_str());
 
@@ -365,7 +366,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		for (std::vector<ip_interface>::const_iterator i = net.begin()
 			, end(net.end()); i != end && num_chars < int(sizeof(msg)); ++i)
 		{
-			num_chars += snprintf(msg + num_chars, sizeof(msg) - num_chars, "(%s,%s) "
+			num_chars += std::snprintf(msg + num_chars, sizeof(msg) - num_chars, "(%s,%s) "
 				, print_address(i->interface_address).c_str(), print_address(i->netmask).c_str());
 		}
 		log(msg);
@@ -384,7 +385,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 			if (ec)
 			{
 				char msg[500];
-				snprintf(msg, sizeof(msg), "failed to enumerate routes when "
+				std::snprintf(msg, sizeof(msg), "failed to enumerate routes when "
 					"receiving response from: %s: %s"
 					, print_endpoint(from).c_str(), convert_from_native(ec.message()).c_str());
 				log(msg);
@@ -392,13 +393,13 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 			else
 			{
 				char msg[400];
-				int num_chars = snprintf(msg, sizeof(msg), "SSDP response from: "
+				int num_chars = std::snprintf(msg, sizeof(msg), "SSDP response from: "
 					"%s: IP is not a router. "
 					, print_endpoint(from).c_str());
 				for (std::vector<ip_route>::const_iterator i = routes.begin()
 					, end(routes.end()); i != end && num_chars < int(sizeof(msg)); ++i)
 				{
-					num_chars += snprintf(msg + num_chars, sizeof(msg) - num_chars, "(%s,%s) "
+					num_chars += std::snprintf(msg + num_chars, sizeof(msg) - num_chars, "(%s,%s) "
 						, print_address(i->gateway).c_str(), print_address(i->netmask).c_str());
 				}
 				log(msg);
@@ -414,7 +415,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 	if (error)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "received malformed HTTP from: %s"
+		std::snprintf(msg, sizeof(msg), "received malformed HTTP from: %s"
 			, print_endpoint(from).c_str());
 		log(msg);
 		return;
@@ -425,14 +426,14 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		if (p.method().empty())
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "HTTP status %u from %s"
+			std::snprintf(msg, sizeof(msg), "HTTP status %u from %s"
 				, p.status_code(), print_endpoint(from).c_str());
 			log(msg);
 		}
 		else
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "HTTP method %s from %s"
+			std::snprintf(msg, sizeof(msg), "HTTP method %s from %s"
 				, p.method().c_str(), print_endpoint(from).c_str());
 			log(msg);
 		}
@@ -442,7 +443,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 	if (!p.header_finished())
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "incomplete HTTP packet from %s"
+		std::snprintf(msg, sizeof(msg), "incomplete HTTP packet from %s"
 			, print_endpoint(from).c_str());
 		log(msg);
 		return;
@@ -452,7 +453,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 	if (url.empty())
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "missing location header from %s"
+		std::snprintf(msg, sizeof(msg), "missing location header from %s"
 			, print_endpoint(from).c_str());
 		log(msg);
 		return;
@@ -475,7 +476,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		if (ec)
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "invalid URL %s from %s: %s"
+			std::snprintf(msg, sizeof(msg), "invalid URL %s from %s: %s"
 				, d.url.c_str(), print_endpoint(from).c_str(), convert_from_native(ec.message()).c_str());
 			log(msg);
 			return;
@@ -487,7 +488,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		if (protocol != "http")
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "unsupported protocol %s from %s"
+			std::snprintf(msg, sizeof(msg), "unsupported protocol %s from %s"
 				, protocol.c_str(), print_endpoint(from).c_str());
 			log(msg);
 			return;
@@ -496,7 +497,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		if (d.port == 0)
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "URL with port 0 from %s"
+			std::snprintf(msg, sizeof(msg), "URL with port 0 from %s"
 				, print_endpoint(from).c_str());
 			log(msg);
 			return;
@@ -504,7 +505,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "found rootdevice: %s (%d)"
+			std::snprintf(msg, sizeof(msg), "found rootdevice: %s (%d)"
 				, d.url.c_str(), int(m_devices.size()));
 			log(msg);
 		}
@@ -512,7 +513,7 @@ void upnp::on_reply(udp::endpoint const& from, char* buffer
 		if (m_devices.size() >= 50)
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "too many rootdevices: (%d). Ignoring %s"
+			std::snprintf(msg, sizeof(msg), "too many rootdevices: (%d). Ignoring %s"
 				, int(m_devices.size()), d.url.c_str());
 			log(msg);
 			return;
@@ -576,7 +577,7 @@ void upnp::try_map_upnp(bool timer)
 		if (override_ignore_non_routers)
 		{
 			char msg[500];
-			snprintf(msg, sizeof(msg), "overriding ignore non-routers");
+			std::snprintf(msg, sizeof(msg), "overriding ignore non-routers");
 			log(msg);
 		}
 	}
@@ -601,7 +602,7 @@ void upnp::try_map_upnp(bool timer)
 			TORRENT_TRY
 			{
 				char msg[500];
-				snprintf(msg, sizeof(msg), "connecting to: %s"
+				std::snprintf(msg, sizeof(msg), "connecting to: %s"
 					, d.url.c_str());
 				log(msg);
 
@@ -616,7 +617,7 @@ void upnp::try_map_upnp(bool timer)
 			{
 				TORRENT_DECLARE_DUMMY(std::exception, exc);
 				char msg[500];
-				snprintf(msg, sizeof(msg), "connection failed to: %s %s"
+				std::snprintf(msg, sizeof(msg), "connection failed to: %s %s"
 					, d.url.c_str(), exc.what());
 				log(msg);
 				d.disabled = true;
@@ -633,7 +634,7 @@ void upnp::post(upnp::rootdevice const& d, char const* soap
 	TORRENT_ASSERT(d.upnp_connection);
 
 	char header[2048];
-	snprintf(header, sizeof(header), "POST %s HTTP/1.1\r\n"
+	std::snprintf(header, sizeof(header), "POST %s HTTP/1.1\r\n"
 		"Host: %s:%u\r\n"
 		"Content-Type: text/xml; charset=\"utf-8\"\r\n"
 		"Content-Length: %d\r\n"
@@ -646,7 +647,7 @@ void upnp::post(upnp::rootdevice const& d, char const* soap
 	d.upnp_connection->m_sendbuffer = header;
 
 	char msg[1024];
-	snprintf(msg, sizeof(msg), "sending: %s", header);
+	std::snprintf(msg, sizeof(msg), "sending: %s", header);
 	log(msg);
 }
 
@@ -660,7 +661,7 @@ void upnp::create_port_mapping(http_connection& c, rootdevice& d, int i)
 	{
 		TORRENT_ASSERT(d.disabled);
 		char msg[500];
-		snprintf(msg, sizeof(msg), "mapping %u aborted", i);
+		std::snprintf(msg, sizeof(msg), "mapping %u aborted", i);
 		log(msg);
 		return;
 	}
@@ -671,7 +672,7 @@ void upnp::create_port_mapping(http_connection& c, rootdevice& d, int i)
 	std::string local_endpoint = print_address(c.socket().local_endpoint(ec).address());
 
 	char soap[2048];
-	snprintf(soap, sizeof(soap), "<?xml version=\"1.0\"?>\n"
+	std::snprintf(soap, sizeof(soap), "<?xml version=\"1.0\"?>\n"
 		"<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" "
 		"s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
 		"<s:Body><u:%s xmlns:u=\"%s\">"
@@ -729,7 +730,7 @@ void upnp::update_map(rootdevice& d, int i)
 		|| m.protocol == none)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "mapping %u does not need updating, skipping", i);
+		std::snprintf(msg, sizeof(msg), "mapping %u does not need updating, skipping", i);
 		log(msg);
 		m.action = mapping_t::action_none;
 		next(d, i);
@@ -740,7 +741,7 @@ void upnp::update_map(rootdevice& d, int i)
 	TORRENT_ASSERT(d.service_namespace);
 
 	char msg[500];
-	snprintf(msg, sizeof(msg), "connecting to %s", d.hostname.c_str());
+	std::snprintf(msg, sizeof(msg), "connecting to %s", d.hostname.c_str());
 	log(msg);
 	if (m.action == mapping_t::action_add)
 	{
@@ -787,7 +788,7 @@ void upnp::delete_port_mapping(rootdevice& d, int i)
 	{
 		TORRENT_ASSERT(d.disabled);
 		char msg[500];
-		snprintf(msg, sizeof(msg), "unmapping %u aborted", i);
+		std::snprintf(msg, sizeof(msg), "unmapping %u aborted", i);
 		log(msg);
 		return;
 	}
@@ -796,7 +797,7 @@ void upnp::delete_port_mapping(rootdevice& d, int i)
 
 	char soap[2048];
 	error_code ec;
-	snprintf(soap, sizeof(soap), "<?xml version=\"1.0\"?>\n"
+	std::snprintf(soap, sizeof(soap), "<?xml version=\"1.0\"?>\n"
 		"<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" "
 		"s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
 		"<s:Body><u:%s xmlns:u=\"%s\">"
@@ -893,7 +894,7 @@ void upnp::on_upnp_xml(error_code const& e
 	if (e && e != boost::asio::error::eof)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while fetching control url from: %s: %s"
+		std::snprintf(msg, sizeof(msg), "error while fetching control url from: %s: %s"
 			, d.url.c_str(), convert_from_native(e.message()).c_str());
 		log(msg);
 		d.disabled = true;
@@ -903,7 +904,7 @@ void upnp::on_upnp_xml(error_code const& e
 	if (!p.header_finished())
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while fetching control url from: %s: incomplete HTTP message"
+		std::snprintf(msg, sizeof(msg), "error while fetching control url from: %s: incomplete HTTP message"
 			, d.url.c_str());
 		log(msg);
 		d.disabled = true;
@@ -913,7 +914,7 @@ void upnp::on_upnp_xml(error_code const& e
 	if (p.status_code() != 200)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while fetching control url from: %s: %s"
+		std::snprintf(msg, sizeof(msg), "error while fetching control url from: %s: %s"
 			, d.url.c_str(), convert_from_native(p.message()).c_str());
 		log(msg);
 		d.disabled = true;
@@ -926,7 +927,7 @@ void upnp::on_upnp_xml(error_code const& e
 	if (s.control_url.empty())
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "could not find a port mapping interface in response from: %s"
+		std::snprintf(msg, sizeof(msg), "could not find a port mapping interface in response from: %s"
 			, d.url.c_str());
 		log(msg);
 		d.disabled = true;
@@ -962,7 +963,7 @@ void upnp::on_upnp_xml(error_code const& e
 
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "found control URL: %s namespace %s "
+		std::snprintf(msg, sizeof(msg), "found control URL: %s namespace %s "
 			"urlbase: %s in response from %s"
 			, d.control_url.c_str(), d.service_namespace
 			, s.url_base.c_str(), d.url.c_str());
@@ -976,7 +977,7 @@ void upnp::on_upnp_xml(error_code const& e
 	if (ec)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "failed to parse URL '%s': %s"
+		std::snprintf(msg, sizeof(msg), "failed to parse URL '%s': %s"
 			, d.control_url.c_str(), convert_from_native(ec.message()).c_str());
 		log(msg);
 		d.disabled = true;
@@ -1002,7 +1003,7 @@ void upnp::get_ip_address(rootdevice& d)
 	{
 		TORRENT_ASSERT(d.disabled);
 		char msg[500];
-		snprintf(msg, sizeof(msg), "getting external IP address");
+		std::snprintf(msg, sizeof(msg), "getting external IP address");
 		log(msg);
 		return;
 	}
@@ -1011,7 +1012,7 @@ void upnp::get_ip_address(rootdevice& d)
 
 	char soap[2048];
 	error_code ec;
-	snprintf(soap, sizeof(soap), "<?xml version=\"1.0\"?>\n"
+	std::snprintf(soap, sizeof(soap), "<?xml version=\"1.0\"?>\n"
 		"<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" "
 		"s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
 		"<s:Body><u:%s xmlns:u=\"%s\">"
@@ -1140,7 +1141,7 @@ struct upnp_error_category : boost::system::error_category
 			return e->msg;
 		}
 		char msg[500];
-		snprintf(msg, sizeof(msg), "unknown UPnP error (%d)", ev);
+		std::snprintf(msg, sizeof(msg), "unknown UPnP error (%d)", ev);
 		return msg;
 	}
 
@@ -1176,7 +1177,7 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 	if (e && e != boost::asio::error::eof)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while getting external IP address: %s"
+		std::snprintf(msg, sizeof(msg), "error while getting external IP address: %s"
 			, convert_from_native(e.message()).c_str());
 		log(msg);
 		if (num_mappings() > 0) update_map(d, 0);
@@ -1193,7 +1194,7 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 	if (p.status_code() != 200)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while getting external IP address: %s"
+		std::snprintf(msg, sizeof(msg), "error while getting external IP address: %s"
 			, convert_from_native(p.message()).c_str());
 		log(msg);
 		if (num_mappings() > 0) update_map(d, 0);
@@ -1211,7 +1212,7 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "get external IP address response: %s"
+		std::snprintf(msg, sizeof(msg), "get external IP address response: %s"
 			, std::string(p.get_body().begin, p.get_body().end).c_str());
 		log(msg);
 	}
@@ -1222,14 +1223,14 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 	if (s.error_code != -1)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while getting external IP address, code: %u"
+		std::snprintf(msg, sizeof(msg), "error while getting external IP address, code: %u"
 			, s.error_code);
 		log(msg);
 	}
 
 	if (!s.ip_address.empty()) {
 		char msg[500];
-		snprintf(msg, sizeof(msg), "got router external IP address %s", s.ip_address.c_str());
+		std::snprintf(msg, sizeof(msg), "got router external IP address %s", s.ip_address.c_str());
 		log(msg);
 		d.external_ip = address::from_string(s.ip_address.c_str(), ignore_error);
 	} else {
@@ -1256,7 +1257,7 @@ void upnp::on_upnp_map_response(error_code const& e
 	if (e && e != boost::asio::error::eof)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while adding port map: %s"
+		std::snprintf(msg, sizeof(msg), "error while adding port map: %s"
 			, convert_from_native(e.message()).c_str());
 		log(msg);
 		d.disabled = true;
@@ -1298,7 +1299,7 @@ void upnp::on_upnp_map_response(error_code const& e
 		)
 	{
 		char msg[300];
-		snprintf(msg, sizeof(msg), "error while adding port map: invalid content-type, \"%s\". Expected text/xml or application/soap+xml"
+		std::snprintf(msg, sizeof(msg), "error while adding port map: invalid content-type, \"%s\". Expected text/xml or application/soap+xml"
 			, ct.c_str());
 		log(msg);
 		next(d, mapping);
@@ -1316,7 +1317,7 @@ void upnp::on_upnp_map_response(error_code const& e
 	if (s.error_code != -1)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while adding port map, code: %u"
+		std::snprintf(msg, sizeof(msg), "error while adding port map, code: %u"
 			, s.error_code);
 		log(msg);
 	}
@@ -1353,7 +1354,7 @@ void upnp::on_upnp_map_response(error_code const& e
 	}
 
 	char msg[500];
-	snprintf(msg, sizeof(msg), "map response: %s"
+	std::snprintf(msg, sizeof(msg), "map response: %s"
 		, std::string(p.get_body().begin, p.get_body().end).c_str());
 	log(msg);
 
@@ -1420,7 +1421,7 @@ void upnp::on_upnp_unmap_response(error_code const& e
 	if (e && e != boost::asio::error::eof)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while deleting portmap: %s"
+		std::snprintf(msg, sizeof(msg), "error while deleting portmap: %s"
 			, convert_from_native(e.message()).c_str());
 		log(msg);
 	}
@@ -1431,14 +1432,14 @@ void upnp::on_upnp_unmap_response(error_code const& e
 	else if (p.status_code() != 200)
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "error while deleting portmap: %s"
+		std::snprintf(msg, sizeof(msg), "error while deleting portmap: %s"
 			, convert_from_native(p.message()).c_str());
 		log(msg);
 	}
 	else
 	{
 		char msg[500];
-		snprintf(msg, sizeof(msg), "unmap response: %s"
+		std::snprintf(msg, sizeof(msg), "unmap response: %s"
 			, std::string(p.get_body().begin, p.get_body().end).c_str());
 		log(msg);
 	}

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -79,7 +79,7 @@ void utp_log(char const* fmt, ...)
 
 	std::lock_guard<std::mutex> lock(log_file_holder.utp_log_mutex);
 	static time_point start = clock_type::now();
-	fprintf(log_file_holder.utp_log_file, "[%012" PRId64 "] ", total_microseconds(clock_type::now() - start));
+	std::fprintf(log_file_holder.utp_log_file, "[%012" PRId64 "] ", total_microseconds(clock_type::now() - start));
 	va_list l;
 	va_start(l, fmt);
 	vfprintf(log_file_holder.utp_log_file, fmt, l);
@@ -3216,13 +3216,13 @@ bool utp_socket_impl::incoming_packet(aux::array_view<boost::uint8_t const> buf
 			{
 				char their_delay_base[20];
 				if (m_their_delay_hist.initialized())
-					snprintf(their_delay_base, sizeof(their_delay_base), "%u", m_their_delay_hist.base());
+					std::snprintf(their_delay_base, sizeof(their_delay_base), "%u", m_their_delay_hist.base());
 				else
 					strcpy(their_delay_base, "-");
 
 				char our_delay_base[20];
 				if (m_delay_hist.initialized())
-					snprintf(our_delay_base, sizeof(our_delay_base), "%u", m_delay_hist.base());
+					std::snprintf(our_delay_base, sizeof(our_delay_base), "%u", m_delay_hist.base());
 				else
 					strcpy(our_delay_base, "-");
 

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -34,12 +34,14 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include <vector>
-#include <boost/limits.hpp>
 #include <boost/bind.hpp>
-#include <stdlib.h>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
+
+#include <vector>
+#include <stdlib.h>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
 
 #include "libtorrent/web_peer_connection.hpp"
 #include "libtorrent/session.hpp"

--- a/test/bdecode_benchmark.cpp
+++ b/test/bdecode_benchmark.cpp
@@ -119,13 +119,13 @@ int main(int argc, char* argv[])
 	int ret = load_file(argv[1], buf, ec, 40 * 1000000);
 	if (ret == -1)
 	{
-		fprintf(stderr, "file too big, aborting\n");
+		std::fprintf(stderr, "file too big, aborting\n");
 		return 1;
 	}
 
 	if (ret != 0)
 	{
-		fprintf(stderr, "failed to load file: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "failed to load file: %s\n", ec.message().c_str());
 		return 1;
 	}
 
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
 	}
 	ptime stop(time_now_hires());
 
-	fprintf(stderr, "(slow) bdecode done in %5d ns per message\n"
+	std::fprintf(stderr, "(slow) bdecode done in %5d ns per message\n"
 		, int(total_microseconds(stop - start) / 1000));
 	}
 
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
 	}
 	time_point stop(clock_type::now());
 
-	fprintf(stderr, "lazy_bdecode done in   %5d ns per message\n"
+	std::fprintf(stderr, "lazy_bdecode done in   %5d ns per message\n"
 		, int(total_microseconds(stop - start) / 1000));
 	}
 
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
 	}
 	ptime stop(time_now_hires());
 
-	fprintf(stderr, "bdecode done in        %5d ns per message\n"
+	std::fprintf(stderr, "bdecode done in        %5d ns per message\n"
 		, int(total_microseconds(stop - start) / 1000));
 	}
 

--- a/test/bittorrent_peer.cpp
+++ b/test/bittorrent_peer.cpp
@@ -261,7 +261,7 @@ void peer_conn::close(char const* fmt, error_code const& ec)
 {
 	end_time = clock_type::now();
 	char tmp[1024];
-	snprintf(tmp, sizeof(tmp), fmt, ec.message().c_str());
+	std::snprintf(tmp, sizeof(tmp), fmt, ec.message().c_str());
 	int time = int(total_milliseconds(end_time - start_time));
 	if (time == 0) time = 1;
 	float up = (boost::int64_t(blocks_sent) * 0x4000) / time / 1000.f;
@@ -272,13 +272,13 @@ void peer_conn::close(char const* fmt, error_code const& ec)
 	address const& addr = s.local_endpoint(e).address();
 #if TORRENT_USE_IPV6
 	if (addr.is_v6())
-		snprintf(ep_str, sizeof(ep_str), "[%s]:%d", addr.to_string(e).c_str()
+		std::snprintf(ep_str, sizeof(ep_str), "[%s]:%d", addr.to_string(e).c_str()
 			, s.local_endpoint(e).port());
 	else
 #endif
-		snprintf(ep_str, sizeof(ep_str), "%s:%d", addr.to_string(e).c_str()
+		std::snprintf(ep_str, sizeof(ep_str), "%s:%d", addr.to_string(e).c_str()
 			, s.local_endpoint(e).port());
-	printf("%s ep: %s sent: %d received: %d duration: %d ms up: %.1fMB/s down: %.1fMB/s\n"
+	std::printf("%s ep: %s sent: %d received: %d duration: %d ms up: %.1fMB/s down: %.1fMB/s\n"
 		, tmp, ep_str, blocks_sent, blocks_received, time, up, down);
 }
 
@@ -325,7 +325,7 @@ void peer_conn::on_msg_length(error_code const& ec, size_t bytes_transferred)
 	unsigned int length = read_uint32(ptr);
 	if (length > sizeof(buffer))
 	{
-		fprintf(stderr, "len: %u\n", length);
+		std::fprintf(stderr, "len: %u\n", length);
 		close("ERROR RECEIVE MESSAGE PREFIX: packet too big", error_code());
 		return;
 	}
@@ -478,7 +478,7 @@ void peer_conn::on_message(error_code const& ec, size_t bytes_transferred)
 				}
 			}
 			--outstanding_requests;
-			fprintf(stderr, "REJECT: [ piece: %d start: %d length: %d ]\n", piece, start, length);
+			std::fprintf(stderr, "REJECT: [ piece: %d start: %d length: %d ]\n", piece, start, length);
 		}
 		else if (msg == 0) // choke
 		{
@@ -516,7 +516,7 @@ bool peer_conn::verify_piece(int piece, int start, char const* ptr, int size)
 	{
 		if (buf[i] != fill)
 		{
-			fprintf(stderr, "received invalid block. piece %d block %d\n", piece, start / 0x4000);
+			std::fprintf(stderr, "received invalid block. piece %d block %d\n", piece, start / 0x4000);
 			exit(1);
 			return false;
 		}

--- a/test/dht_server.cpp
+++ b/test/dht_server.cpp
@@ -72,24 +72,24 @@ struct dht_server
 		m_socket.open(udp::v4(), ec);
 		if (ec)
 		{
-			fprintf(stderr, "Error opening listen DHT socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "Error opening listen DHT socket: %s\n", ec.message().c_str());
 			return;
 		}
 
 		m_socket.bind(udp::endpoint(address_v4::any(), 0), ec);
 		if (ec)
 		{
-			fprintf(stderr, "Error binding DHT socket to port 0: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "Error binding DHT socket to port 0: %s\n", ec.message().c_str());
 			return;
 		}
 		m_port = m_socket.local_endpoint(ec).port();
 		if (ec)
 		{
-			fprintf(stderr, "Error getting local endpoint of DHT socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "Error getting local endpoint of DHT socket: %s\n", ec.message().c_str());
 			return;
 		}
 
-		fprintf(stderr, "%s: DHT initialized on port %d\n", time_now_string(), m_port);
+		std::fprintf(stderr, "%s: DHT initialized on port %d\n", time_now_string(), m_port);
 
 		m_thread = boost::make_shared<std::thread>(&dht_server::thread_fun, this);
 	}
@@ -136,7 +136,7 @@ struct dht_server
 
 			if (ec)
 			{
-				fprintf(stderr, "Error receiving on DHT socket: %s\n", ec.message().c_str());
+				std::fprintf(stderr, "Error receiving on DHT socket: %s\n", ec.message().c_str());
 				return;
 			}
 
@@ -151,7 +151,7 @@ struct dht_server
 			}
 			catch (std::exception& e)
 			{
-				fprintf(stderr, "failed to decode DHT message: %s\n", e.what());
+				std::fprintf(stderr, "failed to decode DHT message: %s\n", e.what());
 			}
 		}
 	}

--- a/test/enum_if.cpp
+++ b/test/enum_if.cpp
@@ -45,26 +45,26 @@ int main()
 	address def_gw = get_default_gateway(ios, ec);
 	if (ec)
 	{
-		fprintf(stderr, "%s\n", ec.message().c_str());
+		std::fprintf(stderr, "%s\n", ec.message().c_str());
 		return 1;
 	}
 
-	printf("Default gateway: %s\n", def_gw.to_string(ec).c_str());
+	std::printf("Default gateway: %s\n", def_gw.to_string(ec).c_str());
 
-	printf("=========== Routes ===========\n");
+	std::printf("=========== Routes ===========\n");
 	std::vector<ip_route> routes = enum_routes(ios, ec);
 	if (ec)
 	{
-		printf("%s\n", ec.message().c_str());
+		std::printf("%s\n", ec.message().c_str());
 		return 1;
 	}
 
-	printf("%-18s%-18s%-35s%-7sinterface\n", "destination", "network", "gateway", "mtu");
+	std::printf("%-18s%-18s%-35s%-7sinterface\n", "destination", "network", "gateway", "mtu");
 
 	for (std::vector<ip_route>::const_iterator i = routes.begin()
 		, end(routes.end()); i != end; ++i)
 	{
-		printf("%-18s%-18s%-35s%-7d%s\n"
+		std::printf("%-18s%-18s%-35s%-7d%s\n"
 			, i->destination.to_string(ec).c_str()
 			, i->netmask.to_string(ec).c_str()
 			, i->gateway.to_string(ec).c_str()
@@ -72,21 +72,21 @@ int main()
 			, i->name);
 	}
 
-	printf("========= Interfaces =========\n");
+	std::printf("========= Interfaces =========\n");
 
 	std::vector<ip_interface> const& net = enum_net_interfaces(ios, ec);
 	if (ec)
 	{
-		printf("%s\n", ec.message().c_str());
+		std::printf("%s\n", ec.message().c_str());
 		return 1;
 	}
 
-	printf("%-30s%-45s%-20s%-8sflags\n", "address", "netmask", "name", "mtu");
+	std::printf("%-30s%-45s%-20s%-8sflags\n", "address", "netmask", "name", "mtu");
 
 	for (std::vector<ip_interface>::const_iterator i = net.begin()
 		, end(net.end()); i != end; ++i)
 	{
-		printf("%-30s%-45s%-20s%-8d%s%s%s\n"
+		std::printf("%-30s%-45s%-20s%-8d%s%s%s\n"
 			, i->interface_address.to_string(ec).c_str()
 			, i->netmask.to_string(ec).c_str()
 			, i->name

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -88,7 +88,7 @@ void output_test_log_to_terminal()
 	dup2(old_stderr, fileno(stderr));
 
 	fseek(current_test->output, 0, SEEK_SET);
-	fprintf(stderr, "\x1b[1m[%s]\x1b[0m\n\n", current_test->name);
+	std::fprintf(stderr, "\x1b[1m[%s]\x1b[0m\n\n", current_test->name);
 	char buf[4096];
 	int size = 0;
 	do {
@@ -144,7 +144,7 @@ LONG WINAPI seh_exception_handler(LPEXCEPTION_POINTERS p)
 #undef EXC
 	};
 
-	fprintf(stderr, "exception: (0x%x) %s caught:\n%s\n"
+	std::fprintf(stderr, "exception: (0x%x) %s caught:\n%s\n"
 		, code, name, stack_text);
 
 	output_test_log_to_terminal();
@@ -189,7 +189,7 @@ void sig_handler(int sig)
 #endif
 #undef SIG
 	};
-	fprintf(stderr, "signal: (%d) %s caught:\n%s\n"
+	std::fprintf(stderr, "signal: (%d) %s caught:\n%s\n"
 		, sig, name, stack_text);
 
 	output_test_log_to_terminal();
@@ -201,7 +201,7 @@ void sig_handler(int sig)
 
 void print_usage(char const* executable)
 {
-	printf("%s [options] [tests...]\n"
+	std::printf("%s [options] [tests...]\n"
 		"\n"
 		"OPTIONS:\n"
 		"-h,--help           show this help\n"
@@ -234,10 +234,10 @@ EXPORT int main(int argc, char const* argv[])
 
 		if (strcmp(argv[0], "-l") == 0 || strcmp(argv[0], "--list") == 0)
 		{
-			printf("TESTS:\n");
+			std::printf("TESTS:\n");
 			for (int i = 0; i < _g_num_unit_tests; ++i)
 			{
-				printf(" - %s\n", _g_unit_tests[i].name);
+				std::printf(" - %s\n", _g_unit_tests[i].name);
 			}
 			return 0;
 		}
@@ -305,13 +305,13 @@ EXPORT int main(int argc, char const* argv[])
 	process_id = getpid();
 #endif
 	char dir[40];
-	snprintf(dir, sizeof(dir), "test_tmp_%u", process_id);
+	std::snprintf(dir, sizeof(dir), "test_tmp_%u", process_id);
 	std::string test_dir = complete(dir);
 	error_code ec;
 	create_directory(test_dir, ec);
 	if (ec)
 	{
-		fprintf(stderr, "Failed to create test directory: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "Failed to create test directory: %s\n", ec.message().c_str());
 		return 1;
 	}
 #ifdef TORRENT_WINDOWS
@@ -319,13 +319,13 @@ EXPORT int main(int argc, char const* argv[])
 #else
 	chdir(dir);
 #endif
-	fprintf(stderr, "cwd = \"%s\"\n", test_dir.c_str());
+	std::fprintf(stderr, "cwd = \"%s\"\n", test_dir.c_str());
 
 	int total_failures = 0;
 
 	if (_g_num_unit_tests == 0)
 	{
-		fprintf(stderr, "\x1b[31mERROR: no unit tests registered\x1b[0m\n");
+		std::fprintf(stderr, "\x1b[31mERROR: no unit tests registered\x1b[0m\n");
 		return 1;
 	}
 
@@ -360,13 +360,13 @@ EXPORT int main(int argc, char const* argv[])
 				}
 				else
 				{
-					fprintf(stderr, "failed to redirect output: (%d) %s\n"
+					std::fprintf(stderr, "failed to redirect output: (%d) %s\n"
 						, errno, strerror(errno));
 				}
 			}
 			else
 			{
-				fprintf(stderr, "failed to create temporary file for redirecting "
+				std::fprintf(stderr, "failed to create temporary file for redirecting "
 					"output: (%d) %s\n", errno, strerror(errno));
 			}
 		}
@@ -390,7 +390,7 @@ EXPORT int main(int argc, char const* argv[])
 		catch (boost::system::system_error const& e)
 		{
 			char buf[200];
-			snprintf(buf, sizeof(buf), "Terminated with system_error: (%d) [%s] \"%s\""
+			std::snprintf(buf, sizeof(buf), "Terminated with system_error: (%d) [%s] \"%s\""
 				, e.code().value()
 				, e.code().category().name()
 				, e.code().message().c_str());
@@ -399,7 +399,7 @@ EXPORT int main(int argc, char const* argv[])
 		catch (std::exception const& e)
 		{
 			char buf[200];
-			snprintf(buf, sizeof(buf), "Terminated with exception: \"%s\"", e.what());
+			std::snprintf(buf, sizeof(buf), "Terminated with exception: \"%s\"", e.what());
 			report_failure(buf, __FILE__, __LINE__);
 		}
 		catch (...)
@@ -434,17 +434,17 @@ EXPORT int main(int argc, char const* argv[])
 
 	if (!tests_to_run.empty())
 	{
-		fprintf(stderr, "\x1b[1mUNKONWN tests:\x1b[0m\n");
+		std::fprintf(stderr, "\x1b[1mUNKONWN tests:\x1b[0m\n");
 		for (std::set<std::string>::iterator i = tests_to_run.begin()
 			, end(tests_to_run.end()); i != end; ++i)
 		{
-			fprintf(stderr, "  %s\n", i->c_str());
+			std::fprintf(stderr, "  %s\n", i->c_str());
 		}
 	}
 
 	if (num_run == 0)
 	{
-		fprintf(stderr, "\x1b[31mERROR: no unit tests run\x1b[0m\n");
+		std::fprintf(stderr, "\x1b[31mERROR: no unit tests run\x1b[0m\n");
 		return 1;
 	}
 
@@ -468,7 +468,7 @@ EXPORT int main(int argc, char const* argv[])
 	{
 		remove_all(test_dir, ec);
 		if (ec)
-			fprintf(stderr, "failed to remove test dir: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "failed to remove test dir: %s\n", ec.message().c_str());
 	}
 #endif
 

--- a/test/make_torrent.cpp
+++ b/test/make_torrent.cpp
@@ -101,7 +101,7 @@ boost::shared_ptr<libtorrent::torrent_info> make_test_torrent(
 				file_entry["attr"].string() += "x";
 
 			char filename[100];
-			snprintf(filename, sizeof(filename), "test_file-%d", i);
+			std::snprintf(filename, sizeof(filename), "test_file-%d", i);
 
 			std::string name = filename;
 			if (ent.find("name=") != std::string::npos)
@@ -197,7 +197,7 @@ void generate_files(libtorrent::torrent_info const& ti, std::string const& path
 		int ret = st.writev(&b, 1, i, 0, 0, ec);
 		if (ret != piece_size || ec)
 		{
-			fprintf(stderr, "ERROR writing files: (%d expected %d) %s\n"
+			std::fprintf(stderr, "ERROR writing files: (%d expected %d) %s\n"
 				, ret, piece_size, ec.ec.message().c_str());
 		}
 	}

--- a/test/peer_server.cpp
+++ b/test/peer_server.cpp
@@ -70,30 +70,30 @@ struct peer_server
 		m_acceptor.open(tcp::v4(), ec);
 		if (ec)
 		{
-			fprintf(stderr, "PEER Error opening peer listen socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "PEER Error opening peer listen socket: %s\n", ec.message().c_str());
 			return;
 		}
 
 		m_acceptor.bind(tcp::endpoint(address_v4::any(), 0), ec);
 		if (ec)
 		{
-			fprintf(stderr, "PEER Error binding peer socket to port 0: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "PEER Error binding peer socket to port 0: %s\n", ec.message().c_str());
 			return;
 		}
 		m_port = m_acceptor.local_endpoint(ec).port();
 		if (ec)
 		{
-			fprintf(stderr, "PEER Error getting local endpoint of peer socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "PEER Error getting local endpoint of peer socket: %s\n", ec.message().c_str());
 			return;
 		}
 		m_acceptor.listen(10, ec);
 		if (ec)
 		{
-			fprintf(stderr, "PEER Error listening on peer socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "PEER Error listening on peer socket: %s\n", ec.message().c_str());
 			return;
 		}
 
-		fprintf(stderr, "%s: PEER peer initialized on port %d\n", time_now_string(), m_port);
+		std::fprintf(stderr, "%s: PEER peer initialized on port %d\n", time_now_string(), m_port);
 
 		m_thread = std::make_shared<std::thread>(&peer_server::thread_fun, this);
 	}
@@ -136,11 +136,11 @@ struct peer_server
 
 			if (ec)
 			{
-				fprintf(stderr, "PEER Error accepting connection on peer socket: %s\n", ec.message().c_str());
+				std::fprintf(stderr, "PEER Error accepting connection on peer socket: %s\n", ec.message().c_str());
 				return;
 			}
 
-			fprintf(stderr, "%s: PEER incoming peer connection\n", time_now_string());
+			std::fprintf(stderr, "%s: PEER incoming peer connection\n", time_now_string());
 			++m_peer_requests;
 			socket.close(ec);
 		}

--- a/test/print_alerts.cpp
+++ b/test/print_alerts.cpp
@@ -64,7 +64,7 @@ void print_alerts(libtorrent::session* ses, libtorrent::time_point start_time)
 #endif
 		lt::time_duration d = a->timestamp() - start_time;
 		boost::uint32_t millis = boost::uint32_t(lt::duration_cast<lt::milliseconds>(d).count());
-		printf("%4d.%03d: %-25s %s\n", millis / 1000, millis % 1000
+		std::printf("%4d.%03d: %-25s %s\n", millis / 1000, millis % 1000
 			, a->what()
 			, a->message().c_str());
 	}

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -165,7 +165,7 @@ alert const* wait_for_alert(lt::session& ses, int type, char const* name)
 		for (std::vector<alert*>::iterator i = alerts.begin()
 			, end(alerts.end()); i != end; ++i)
 		{
-			fprintf(stderr, "%s: %s: [%s] %s\n", time_now_string(), name
+			std::fprintf(stderr, "%s: %s: [%s] %s\n", time_now_string(), name
 				, (*i)->what(), (*i)->message().c_str());
 			if ((*i)->type() == type && !ret)
 			{
@@ -245,7 +245,7 @@ void save_file(char const* filename, char const* data, int size)
 	TEST_CHECK(!ec);
 	if (ec)
 	{
-		fprintf(stderr, "ERROR opening file '%s': %s\n", filename, ec.message().c_str());
+		std::fprintf(stderr, "ERROR opening file '%s': %s\n", filename, ec.message().c_str());
 		return;
 	}
 	file::iovec_t b = { (void*)data, size_t(size) };
@@ -253,7 +253,7 @@ void save_file(char const* filename, char const* data, int size)
 	TEST_CHECK(!ec);
 	if (ec)
 	{
-		fprintf(stderr, "ERROR writing file '%s': %s\n", filename, ec.message().c_str());
+		std::fprintf(stderr, "ERROR writing file '%s': %s\n", filename, ec.message().c_str());
 		return;
 	}
 
@@ -275,14 +275,14 @@ bool print_alerts(lt::session& ses, char const* name
 		if (predicate && predicate(*i)) ret = true;
 		if (peer_disconnected_alert const* p = alert_cast<peer_disconnected_alert>(*i))
 		{
-			fprintf(stderr, "%s: %s: [%s] (%s): %s\n", time_now_string(), name, (*i)->what(), print_endpoint(p->ip).c_str(), p->message().c_str());
+			std::fprintf(stderr, "%s: %s: [%s] (%s): %s\n", time_now_string(), name, (*i)->what(), print_endpoint(p->ip).c_str(), p->message().c_str());
 		}
 		else if ((*i)->message() != "block downloading"
 			&& (*i)->message() != "block finished"
 			&& (*i)->message() != "piece finished"
 			&& !no_output)
 		{
-			fprintf(stderr, "%s: %s: [%s] %s\n", time_now_string(), name, (*i)->what(), (*i)->message().c_str());
+			std::fprintf(stderr, "%s: %s: [%s] %s\n", time_now_string(), name, (*i)->what(), (*i)->message().c_str());
 		}
 
 		TEST_CHECK(alert_cast<fastresume_rejected_alert>(*i) == 0 || allow_failed_fastresume);
@@ -290,7 +290,7 @@ bool print_alerts(lt::session& ses, char const* name
 		peer_error_alert const* pea = alert_cast<peer_error_alert>(*i);
 		if (pea)
 		{
-			fprintf(stderr, "%s: peer error: %s\n", time_now_string(), pea->error.message().c_str());
+			std::fprintf(stderr, "%s: peer error: %s\n", time_now_string(), pea->error.message().c_str());
 			TEST_CHECK((!handles.empty() && h.status().is_seeding)
 				|| pea->error.message() == "connecting to peer"
 				|| pea->error.message() == "closing connection to ourself"
@@ -308,7 +308,7 @@ bool print_alerts(lt::session& ses, char const* name
 		invalid_request_alert const* ira = alert_cast<invalid_request_alert>(*i);
 		if (ira)
 		{
-			fprintf(stderr, "peer error: %s\n", ira->message().c_str());
+			std::fprintf(stderr, "peer error: %s\n", ira->message().c_str());
 			TEST_CHECK(false);
 		}
 	}
@@ -361,7 +361,7 @@ void wait_for_downloading(lt::session& ses, char const* name)
 	} while (a);
 	if (!downloading_done)
 	{
-		fprintf(stderr, "%s: did not receive a state_changed_alert indicating "
+		std::fprintf(stderr, "%s: did not receive a state_changed_alert indicating "
 			"the torrent is downloading. waited: %d ms\n"
 			, name, int(total_milliseconds(clock_type::now() - start)));
 	}
@@ -374,7 +374,7 @@ void print_ses_rate(float time
 {
 	if (st1)
 	{
-		fprintf(stderr, "%3.1fs | %dkB/s %dkB/s %d%% %d cc:%d%s", time
+		std::fprintf(stderr, "%3.1fs | %dkB/s %dkB/s %d%% %d cc:%d%s", time
 			, int(st1->download_payload_rate / 1000)
 			, int(st1->upload_payload_rate / 1000)
 			, int(st1->progress * 100)
@@ -383,7 +383,7 @@ void print_ses_rate(float time
 			, st1->errc ? (" [" + st1->errc.message() + "]").c_str() : "");
 	}
 	if (st2)
-		fprintf(stderr, " : %3.1fs | %dkB/s %dkB/s %d%% %d cc:%d%s", time
+		std::fprintf(stderr, " : %3.1fs | %dkB/s %dkB/s %d%% %d cc:%d%s", time
 			, int(st2->download_payload_rate / 1000)
 			, int(st2->upload_payload_rate / 1000)
 			, int(st2->progress * 100)
@@ -391,7 +391,7 @@ void print_ses_rate(float time
 			, st2->connect_candidates
 			, st2->errc ? (" [" + st1->errc.message() + "]").c_str() : "");
 	if (st3)
-		fprintf(stderr, " : %3.1fs | %dkB/s %dkB/s %d%% %d cc:%d%s", time
+		std::fprintf(stderr, " : %3.1fs | %dkB/s %dkB/s %d%% %d cc:%d%s", time
 			, int(st3->download_payload_rate / 1000)
 			, int(st3->upload_payload_rate / 1000)
 			, int(st3->progress * 100)
@@ -399,7 +399,7 @@ void print_ses_rate(float time
 			, st3->connect_candidates
 			, st3->errc ? (" [" + st1->errc.message() + "]").c_str() : "");
 
-	fprintf(stderr, "\n");
+	std::fprintf(stderr, "\n");
 }
 
 void test_sleep(int milliseconds)
@@ -430,7 +430,7 @@ static std::map<int, proxy_t> running_proxies;
 
 void stop_proxy(int port)
 {
-	fprintf(stderr, "stopping proxy on port %d\n", port);
+	std::fprintf(stderr, "stopping proxy on port %d\n", port);
 	// don't shut down proxies until the test is
 	// completely done. This saves a lot of time.
 	// they're closed at the end of main() by
@@ -442,7 +442,7 @@ pid_type async_run(char const* cmdline)
 {
 #ifdef _WIN32
 	char buf[2048];
-	snprintf(buf, sizeof(buf), "%s", cmdline);
+	std::snprintf(buf, sizeof(buf), "%s", cmdline);
 
 	PROCESS_INFORMATION pi;
 	STARTUPINFOA startup;
@@ -456,7 +456,7 @@ pid_type async_run(char const* cmdline)
 	if (ret == 0)
 	{
 		int error = GetLastError();
-		fprintf(stderr, "failed (%d) %s\n", error, error_code(error, system_category()).message().c_str());
+		std::fprintf(stderr, "failed (%d) %s\n", error, error_code(error, system_category()).message().c_str());
 		return 0;
 	}
 	return pi.dwProcessId;
@@ -482,7 +482,7 @@ pid_type async_run(char const* cmdline)
 	int ret = posix_spawnp(&p, argv[0], NULL, NULL, &argv[0], NULL);
 	if (ret != 0)
 	{
-		fprintf(stderr, "failed (%d) %s\n", errno, strerror(errno));
+		std::fprintf(stderr, "failed (%d) %s\n", errno, strerror(errno));
 		return 0;
 	}
 	return p;
@@ -496,7 +496,7 @@ void stop_process(pid_type p)
 	TerminateProcess(proc, 138);
 	CloseHandle(proc);
 #else
-	printf("killing pid: %d\n", p);
+	std::printf("killing pid: %d\n", p);
 	kill(p, SIGKILL);
 #endif
 }
@@ -568,15 +568,15 @@ int start_proxy(int proxy_type)
 			break;
 	}
 	char buf[512];
-	snprintf(buf, sizeof(buf), "%s --port %d%s", cmd, port, auth);
+	std::snprintf(buf, sizeof(buf), "%s --port %d%s", cmd, port, auth);
 
-	fprintf(stderr, "%s starting proxy on port %d (%s %s)...\n", time_now_string(), port, type, auth);
-	fprintf(stderr, "%s\n", buf);
+	std::fprintf(stderr, "%s starting proxy on port %d (%s %s)...\n", time_now_string(), port, type, auth);
+	std::fprintf(stderr, "%s\n", buf);
 	pid_type r = async_run(buf);
 	if (r == 0) abort();
 	proxy_t t = { r, proxy_type };
 	running_proxies.insert(std::make_pair(port, t));
-	fprintf(stderr, "%s launched\n", time_now_string());
+	std::fprintf(stderr, "%s launched\n", time_now_string());
 	test_sleep(500);
 	return port;
 }
@@ -600,9 +600,9 @@ void create_random_files(std::string const& path, const int file_sizes[], int nu
 	{
 		std::generate(random_data, random_data + 300000, random_byte);
 		char filename[200];
-		snprintf(filename, sizeof(filename), "test%d", i);
+		std::snprintf(filename, sizeof(filename), "test%d", i);
 		char dirname[200];
-		snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
+		std::snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
 
 		std::string full_path = combine_path(path, dirname);
 		error_code ec;
@@ -611,7 +611,7 @@ void create_random_files(std::string const& path, const int file_sizes[], int nu
 
 		int to_write = file_sizes[i];
 		file f(full_path, file::write_only, ec);
-		if (ec) fprintf(stderr, "failed to create file \"%s\": (%d) %s\n"
+		if (ec) std::fprintf(stderr, "failed to create file \"%s\": (%d) %s\n"
 			, full_path.c_str(), ec.value(), ec.message().c_str());
 		boost::int64_t offset = 0;
 		while (to_write > 0)
@@ -619,7 +619,7 @@ void create_random_files(std::string const& path, const int file_sizes[], int nu
 			int s = (std::min)(to_write, 300000);
 			file::iovec_t b = { random_data, size_t(s)};
 			f.writev(offset, &b, 1, ec);
-			if (ec) fprintf(stderr, "failed to write file \"%s\": (%d) %s\n"
+			if (ec) std::fprintf(stderr, "failed to write file \"%s\": (%d) %s\n"
 				, full_path.c_str(), ec.value(), ec.message().c_str());
 			offset += s;
 			to_write -= s;
@@ -653,7 +653,7 @@ boost::shared_ptr<torrent_info> create_torrent(std::ostream* file
 		int res = load_file(ssl_certificate, file_buf, ec);
 		if (ec || res < 0)
 		{
-			fprintf(stderr, "failed to load SSL certificate: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "failed to load SSL certificate: %s\n", ec.message().c_str());
 		}
 		else
 		{
@@ -767,7 +767,7 @@ setup_transfer(lt::session* ses1, lt::session* ses2, lt::session* ses3
 		}
 		char ih_hex[41];
 		to_hex((char const*)&t->info_hash()[0], 20, ih_hex);
-		fprintf(stderr, "generated torrent: %s tmp1%s/temporary\n", ih_hex, suffix.c_str());
+		std::fprintf(stderr, "generated torrent: %s tmp1%s/temporary\n", ih_hex, suffix.c_str());
 	}
 	else
 	{
@@ -788,7 +788,7 @@ setup_transfer(lt::session* ses1, lt::session* ses2, lt::session* ses3
 	torrent_handle tor1 = ses1->add_torrent(param, ec);
 	if (ec)
 	{
-		fprintf(stderr, "ses1.add_torrent: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "ses1.add_torrent: %s\n", ec.message().c_str());
 		return boost::make_tuple(torrent_handle(), torrent_handle(), torrent_handle());
 	}
 	tor1.super_seeding(super_seeding);
@@ -841,16 +841,16 @@ setup_transfer(lt::session* ses1, lt::session* ses2, lt::session* ses3
 		if (use_ssl_ports)
 		{
 			port = ses2->ssl_listen_port();
-			fprintf(stderr, "%s: ses2->ssl_listen_port(): %d\n", time_now_string(), port);
+			std::fprintf(stderr, "%s: ses2->ssl_listen_port(): %d\n", time_now_string(), port);
 		}
 
 		if (port == 0)
 		{
 			port = ses2->listen_port();
-			fprintf(stderr, "%s: ses2->listen_port(): %d\n", time_now_string(), port);
+			std::fprintf(stderr, "%s: ses2->listen_port(): %d\n", time_now_string(), port);
 		}
 
-		fprintf(stderr, "%s: ses1: connecting peer port: %d\n"
+		std::fprintf(stderr, "%s: ses1: connecting peer port: %d\n"
 			, time_now_string(), port);
 		tor1.connect_peer(tcp::endpoint(address::from_string("127.0.0.1", ec)
 			, port));
@@ -873,10 +873,10 @@ setup_transfer(lt::session* ses1, lt::session* ses2, lt::session* ses3
 			if (port == 0) port = ses2->listen_port();
 			if (port2 == 0) port2 = ses1->listen_port();
 
-			fprintf(stderr, "ses3: connecting peer port: %d\n", port);
+			std::fprintf(stderr, "ses3: connecting peer port: %d\n", port);
 			tor3.connect_peer(tcp::endpoint(
 					address::from_string("127.0.0.1", ec), port));
-			fprintf(stderr, "ses3: connecting peer port: %d\n", port2);
+			std::fprintf(stderr, "ses3: connecting peer port: %d\n", port2);
 				tor3.connect_peer(tcp::endpoint(
 					address::from_string("127.0.0.1", ec)
 					, port2));
@@ -904,16 +904,16 @@ int start_web_server(bool ssl, bool chunked_encoding, bool keepalive)
 	} while (ec);
 
 	char buf[200];
-	snprintf(buf, sizeof(buf), "python ../web_server.py %d %d %d %d"
+	std::snprintf(buf, sizeof(buf), "python ../web_server.py %d %d %d %d"
 		, port, chunked_encoding , ssl, keepalive);
 
-	fprintf(stderr, "%s starting web_server on port %d...\n", time_now_string(), port);
+	std::fprintf(stderr, "%s starting web_server on port %d...\n", time_now_string(), port);
 
-	fprintf(stderr, "%s\n", buf);
+	std::fprintf(stderr, "%s\n", buf);
 	pid_type r = async_run(buf);
 	if (r == 0) abort();
 	web_server_pid = r;
-	fprintf(stderr, "%s launched\n", time_now_string());
+	std::fprintf(stderr, "%s launched\n", time_now_string());
 	test_sleep(500);
 	return port;
 }
@@ -921,7 +921,7 @@ int start_web_server(bool ssl, bool chunked_encoding, bool keepalive)
 void stop_web_server()
 {
 	if (web_server_pid == 0) return;
-	fprintf(stderr, "stopping web server\n");
+	std::fprintf(stderr, "stopping web server\n");
 	stop_process(web_server_pid);
 	web_server_pid = 0;
 }

--- a/test/swarm_suite.cpp
+++ b/test/swarm_suite.cpp
@@ -47,7 +47,7 @@ void test_swarm(int flags)
 	using namespace libtorrent;
 	namespace lt = libtorrent;
 
-	fprintf(stderr, "\n\n ==== TEST SWARM === %s%s%s%s%s ===\n\n\n"
+	std::fprintf(stderr, "\n\n ==== TEST SWARM === %s%s%s%s%s ===\n\n\n"
 		, (flags & super_seeding) ? "super-seeding ": ""
 		, (flags & strict_super_seeding) ? "strict-super-seeding ": ""
 		, (flags & seed_mode) ? "seed-mode ": ""
@@ -94,7 +94,7 @@ void test_swarm(int flags)
 
 	int port = lt::random() % 100;
 	char iface[50];
-	snprintf(iface, sizeof(iface), "0.0.0.0:480%02d", port);
+	std::snprintf(iface, sizeof(iface), "0.0.0.0:480%02d", port);
 	pack.set_int(settings_pack::upload_rate_limit, int(rate_limit));
 	pack.set_str(settings_pack::listen_interfaces, iface);
 	pack.set_int(settings_pack::max_retry_port_bind, 1000);
@@ -104,13 +104,13 @@ void test_swarm(int flags)
 
 	lt::session ses1(pack);
 
-	snprintf(iface, sizeof(iface), "0.0.0.0:490%02d", port);
+	std::snprintf(iface, sizeof(iface), "0.0.0.0:490%02d", port);
 	pack.set_str(settings_pack::listen_interfaces, iface);
 	pack.set_int(settings_pack::download_rate_limit, int(rate_limit / 2));
 	pack.set_int(settings_pack::upload_rate_limit, int(rate_limit));
 	lt::session ses2(pack);
 
-	snprintf(iface, sizeof(iface), "0.0.0.0:500%02d", port);
+	std::snprintf(iface, sizeof(iface), "0.0.0.0:500%02d", port);
 	pack.set_str(settings_pack::listen_interfaces, iface);
 	lt::session ses3(pack);
 
@@ -200,19 +200,19 @@ void test_swarm(int flags)
 	alert const* ret;
 	while ((ret = ses1.wait_for_alert(seconds(2))))
 	{
-		fprintf(stderr, "wait returned: %d ms\n"
+		std::fprintf(stderr, "wait returned: %d ms\n"
 			, int(total_milliseconds(clock_type::now() - start)));
 		std::vector<alert*> alerts;
 		ses1.pop_alerts(&alerts);
 		for (std::vector<alert*>::iterator i = alerts.begin()
 			, end(alerts.end()); i != end; ++i)
 		{
-			fprintf(stderr, "%s\n", ret->message().c_str());
+			std::fprintf(stderr, "%s\n", ret->message().c_str());
 		}
 		start = clock_type::now();
 	}
 
-	fprintf(stderr, "loop returned: %d ms\n"
+	std::fprintf(stderr, "loop returned: %d ms\n"
 		, int(total_milliseconds(clock_type::now() - start)));
 
 	// this allows shutting down the sessions in parallel
@@ -222,7 +222,7 @@ void test_swarm(int flags)
 
 	time_point end = clock_type::now();
 
-	fprintf(stderr, "time: %d ms\n", int(total_milliseconds(end - start)));
+	std::fprintf(stderr, "time: %d ms\n", int(total_milliseconds(end - start)));
 	TEST_CHECK(end - start < milliseconds(3000));
 	TEST_CHECK(end - start > milliseconds(1900));
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <vector>
-#include <stdio.h> // for tmpfile()
+
 #include "test.hpp"
 
 unit_test_t _g_unit_tests[1024];
@@ -49,8 +49,8 @@ int test_counter()
 void report_failure(char const* err, char const* file, int line)
 {
 	char buf[500];
-	snprintf(buf, sizeof(buf), "\x1b[41m***** %s:%d \"%s\" *****\x1b[0m\n", file, line, err);
-	fprintf(stderr, "\n%s\n", buf);
+	std::snprintf(buf, sizeof(buf), "\x1b[41m***** %s:%d \"%s\" *****\x1b[0m\n", file, line, err);
+	std::fprintf(stderr, "\n%s\n", buf);
 	failure_strings.push_back(buf);
 	++_g_test_failures;
 }
@@ -64,7 +64,7 @@ int print_failures()
 		if (len > longest_name) longest_name = len;
 	}
 
-	fprintf(stderr, "\n\n");
+	std::fprintf(stderr, "\n\n");
 
 	for (int i = 0; i < _g_num_unit_tests; ++i)
 	{
@@ -72,22 +72,22 @@ int print_failures()
 
 		if (_g_unit_tests[i].num_failures == 0)
 		{
-			fprintf(stderr, "\x1b[32m[%-*s] ***PASS***\n"
+			std::fprintf(stderr, "\x1b[32m[%-*s] ***PASS***\n"
 				, longest_name, _g_unit_tests[i].name);
 		}
 		else
 		{
-			fprintf(stderr, "\x1b[31m[%-*s] %d FAILURES\n"
+			std::fprintf(stderr, "\x1b[31m[%-*s] %d FAILURES\n"
 				, longest_name
 				, _g_unit_tests[i].name
 				, _g_unit_tests[i].num_failures);
 		}
 	}
 
-	fprintf(stderr, "\x1b[0m");
+	std::fprintf(stderr, "\x1b[0m");
 
 	if (_g_test_failures > 0)
-		fprintf(stderr, "\n\n\x1b[41m   == %d TEST(S) FAILED ==\x1b[0m\n\n\n", _g_test_failures);
+		std::fprintf(stderr, "\n\n\x1b[41m   == %d TEST(S) FAILED ==\x1b[0m\n\n\n", _g_test_failures);
 	return _g_test_failures;
 }
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -40,6 +40,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <exception>
 #include <sstream>
 #include <vector>
+#include <cstdio> // for snprintf
+#include <cinttypes> // for PRId64 et.al.
+
 #include <boost/preprocessor/cat.hpp>
 
 #include "libtorrent/config.hpp"

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -207,7 +207,7 @@ TORRENT_TEST(wait_for_alert)
 
 	time_point end = clock_type::now();
 	TEST_EQUAL(a, static_cast<alert*>(0));
-	fprintf(stderr, "delay: %d ms (expected 1 second)\n"
+	std::fprintf(stderr, "delay: %d ms (expected 1 second)\n"
 		, int(total_milliseconds(end - start)));
 	TEST_CHECK(end - start > milliseconds(900));
 	TEST_CHECK(end - start < milliseconds(1100));
@@ -218,7 +218,7 @@ TORRENT_TEST(wait_for_alert)
 	a = mgr.wait_for_alert(seconds(1));
 	end = clock_type::now();
 
-	fprintf(stderr, "delay: %d ms\n", int(total_milliseconds(end - start)));
+	std::fprintf(stderr, "delay: %d ms\n", int(total_milliseconds(end - start)));
 	TEST_CHECK(end - start < milliseconds(1));
 	TEST_CHECK(a->type() == torrent_added_alert::alert_type);
 
@@ -231,7 +231,7 @@ TORRENT_TEST(wait_for_alert)
 	a = mgr.wait_for_alert(seconds(10));
 	end = clock_type::now();
 
-	fprintf(stderr, "delay: %d ms\n", int(total_milliseconds(end - start)));
+	std::fprintf(stderr, "delay: %d ms\n", int(total_milliseconds(end - start)));
 	TEST_CHECK(end - start < milliseconds(500));
 	TEST_CHECK(a->type() == torrent_added_alert::alert_type);
 

--- a/test/test_auto_unchoke.cpp
+++ b/test/test_auto_unchoke.cpp
@@ -99,7 +99,7 @@ void test_swarm()
 
 	std::map<std::string, boost::int64_t> cnt = get_counters(ses1);
 
-	fprintf(stderr, "allowed_upload_slots: %d\n", int(cnt["ses.num_unchoke_slots"]));
+	std::fprintf(stderr, "allowed_upload_slots: %d\n", int(cnt["ses.num_unchoke_slots"]));
 	TEST_EQUAL(cnt["ses.num_unchoke_slots"], 1);
 	for (int i = 0; i < 200; ++i)
 	{
@@ -108,7 +108,7 @@ void test_swarm()
 		print_alerts(ses3, "ses3");
 
 		cnt = get_counters(ses1);
-		fprintf(stderr, "allowed unchoked: %d\n", int(cnt["ses.num_unchoke_slots"]));
+		std::fprintf(stderr, "allowed unchoked: %d\n", int(cnt["ses.num_unchoke_slots"]));
 		if (cnt["ses.num_unchoke_slots"] >= 2) break;
 
 		torrent_status st1 = tor1.status();

--- a/test/test_bandwidth_limiter.cpp
+++ b/test/test_bandwidth_limiter.cpp
@@ -179,7 +179,7 @@ void spawn_connections(connections_t& v, bandwidth_manager& bwm
 	for (int i = 0; i < num; ++i)
 	{
 		char name[200];
-		snprintf(name, sizeof(name), "%s%d", prefix, i);
+		std::snprintf(name, sizeof(name), "%s%d", prefix, i);
 		v.push_back(boost::shared_ptr<peer_connection>(new peer_connection(bwm, bwc, 200, false, name)));
 	}
 }

--- a/test/test_bdecode.cpp
+++ b/test/test_bdecode.cpp
@@ -43,7 +43,7 @@ TORRENT_TEST(integer)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_CHECK(ret == 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	std::pair<const char*, int> section = e.data_section();
 	TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 	TEST_CHECK(section.second == sizeof(b) - 1);
@@ -59,7 +59,7 @@ TORRENT_TEST(string)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_CHECK(ret == 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	std::pair<const char*, int> section = e.data_section();
 	TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 	TEST_EQUAL(section.second, sizeof(b) - 1);
@@ -80,7 +80,7 @@ TORRENT_TEST(string_prefix1)
 	error_code ec;
 	int ret = bdecode(test.c_str(), test.c_str() + test.size(), e, ec);
 	TEST_CHECK(ret == 0);
-	printf("%d bytes string\n", e.string_length());
+	std::printf("%d bytes string\n", e.string_length());
 	std::pair<const char*, int> section = e.data_section();
 	TEST_CHECK(std::memcmp(test.c_str(), section.first, section.second) == 0);
 	TEST_EQUAL(section.second, int(test.size()));
@@ -97,7 +97,7 @@ TORRENT_TEST(list)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_CHECK(ret == 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	std::pair<const char*, int> section = e.data_section();
 	TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 	TEST_CHECK(section.second == sizeof(b) - 1);
@@ -121,7 +121,7 @@ TORRENT_TEST(dict)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	std::pair<const char*, int> section = e.data_section();
 	TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 	TEST_CHECK(section.second == sizeof(b) - 1);
@@ -149,7 +149,7 @@ TORRENT_TEST(dict_key_novalue)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 10);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_value));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test dictionary with a key that's not a string
@@ -163,7 +163,7 @@ TORRENT_TEST(dict_nonstring_key)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // dictionary key with \0
@@ -189,7 +189,7 @@ TORRENT_TEST(premature_e)
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test strings with negative length-prefix
@@ -203,7 +203,7 @@ TORRENT_TEST(negative_length_prefix)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 0);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_value));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test strings with overflow length-prefix
@@ -217,7 +217,7 @@ TORRENT_TEST(overflow_length_prefix)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 19);
 	TEST_EQUAL(ec,  error_code(bdecode_errors::overflow));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test strings with almost overflow (more than 8 digits)
@@ -231,7 +231,7 @@ TORRENT_TEST(close_overflow_length_prefix)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 8);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test strings with overflow (more than 8 digits)
@@ -246,7 +246,7 @@ TORRENT_TEST(overflow_length_prefix2)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 0);
 	TEST_EQUAL(ec, error_code(bdecode_errors::limit_exceeded));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test integer without any digits
@@ -260,7 +260,7 @@ TORRENT_TEST(nodigit_int)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test integer with just a minus
@@ -274,7 +274,7 @@ TORRENT_TEST(minus_int)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 2);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test integer with a minus inserted in it
@@ -288,7 +288,7 @@ TORRENT_TEST(interior_minus_int)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 6);
 	TEST_EQUAL(ec,  error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test integers that don't fit in 64 bits
@@ -299,7 +299,7 @@ TORRENT_TEST(int_overflow)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	// the lazy aspect makes this overflow when asking for
 	// the value. turning it to zero.
 	TEST_EQUAL(e.int_value(), 0);
@@ -316,7 +316,7 @@ TORRENT_TEST(int_overflow2)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 22);
 	TEST_EQUAL(ec,  error_code(bdecode_errors::overflow));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test truncated negative integer
@@ -330,7 +330,7 @@ TORRENT_TEST(int_truncated)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 2);
 	TEST_EQUAL(ec,  error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // bdecode_error
@@ -351,7 +351,7 @@ TORRENT_TEST(64bit_int)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_CHECK(ret == 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	TEST_CHECK(e.int_value() == 9223372036854775807LL);
 }
 
@@ -363,7 +363,7 @@ TORRENT_TEST(64bit_int_negative)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_CHECK(ret == 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	TEST_CHECK(e.int_value() == -9223372036854775807LL);
 }
 
@@ -378,7 +378,7 @@ TORRENT_TEST(int_invalid_digit)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 9);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test invalid encoding
@@ -399,7 +399,7 @@ TORRENT_TEST(invalid_encoding)
 		, 0xa1, 0x88, 0x7a, 0x8d, 0xc3, 0xd6, 0x31, 0x3a
 		, 0x79, 0x31, 0xae, 0x71, 0x65, 0};
 
-	printf("%s\n", buf);
+	std::printf("%s\n", buf);
 	bdecode_node e;
 	error_code ec;
 	int ret = bdecode((char*)buf, (char*)buf + sizeof(buf), e, ec);
@@ -456,7 +456,7 @@ TORRENT_TEST(unepected_eof)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 5);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test unexpected EOF (really expected terminator)
@@ -471,7 +471,7 @@ TORRENT_TEST(unepected_eof2)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 6);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_colon));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test expected string
@@ -487,7 +487,7 @@ TORRENT_TEST(expected_string)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test unexpected EOF while parsing dict key
@@ -502,7 +502,7 @@ TORRENT_TEST(unexpected_eof_dict_key)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 5);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test unexpected EOF while parsing dict key
@@ -517,7 +517,7 @@ TORRENT_TEST(unexpected_eof_dict_key2)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 5);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test expected string while parsing dict key
@@ -532,7 +532,7 @@ TORRENT_TEST(expected_string_dict_key2)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test unexpected EOF while parsing int
@@ -547,7 +547,7 @@ TORRENT_TEST(unexpected_eof_int)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test unexpected EOF while parsing int
@@ -562,7 +562,7 @@ TORRENT_TEST(unexpected_eof_int2)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 3);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 
@@ -578,7 +578,7 @@ TORRENT_TEST(expected_colon_dict)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 5);
 	TEST_EQUAL(ec, error_code(bdecode_errors::expected_colon));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test empty string
@@ -591,7 +591,7 @@ TORRENT_TEST(empty_string)
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test partial string
@@ -606,7 +606,7 @@ TORRENT_TEST(partial_string)
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(pos, 3);
 	TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 TORRENT_TEST(list_ints)
@@ -616,7 +616,7 @@ TORRENT_TEST(list_ints)
 	for (int i = 0; i < 1000; ++i)
 	{
 		char tmp[20];
-		snprintf(tmp, sizeof(tmp), "i%de", i);
+		std::snprintf(tmp, sizeof(tmp), "i%de", i);
 		buf += tmp;
 	}
 	buf += "e";
@@ -640,12 +640,12 @@ TORRENT_TEST(dict_ints)
 	for (int i = 0; i < 1000; ++i)
 	{
 		char tmp[30];
-		snprintf(tmp, sizeof(tmp), "4:%04di%de", i, i);
+		std::snprintf(tmp, sizeof(tmp), "4:%04di%de", i, i);
 		buf += tmp;
 	}
 	buf += "e";
 
-	printf("%s\n", buf.c_str());
+	std::printf("%s\n", buf.c_str());
 	bdecode_node e;
 	error_code ec;
 	int ret = bdecode((char*)&buf[0], (char*)&buf[0] + buf.size(), e, ec);
@@ -655,7 +655,7 @@ TORRENT_TEST(dict_ints)
 	for (int i = 0; i < 1000; ++i)
 	{
 		char tmp[30];
-		snprintf(tmp, sizeof(tmp), "%04d", i);
+		std::snprintf(tmp, sizeof(tmp), "%04d", i);
 		TEST_EQUAL(e.dict_find_int_value(tmp), i);
 	}
 }
@@ -707,7 +707,7 @@ TORRENT_TEST(exceed_buf_limit)
 	int ret = bdecode(b, b + 0x3fffffff, e, ec);
 	TEST_EQUAL(ret, -1);
 	TEST_EQUAL(ec, error_code(bdecode_errors::limit_exceeded));
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 }
 
 // test parse_int
@@ -786,7 +786,7 @@ TORRENT_TEST(dict_find_funs)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
@@ -855,7 +855,7 @@ TORRENT_TEST(list_at_funs)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(e.type(), bdecode_node::list_t);
 
@@ -893,7 +893,7 @@ TORRENT_TEST(list_at_reverse)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(e.type(), bdecode_node::list_t);
 
@@ -919,7 +919,7 @@ TORRENT_TEST(dict_find_funs2)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
@@ -937,7 +937,7 @@ TORRENT_TEST(print_entry)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(print_entry(e), "[ 1, 'foo', [ 1, 2 ], { 'x': 1 } ]");
 }
@@ -949,7 +949,7 @@ TORRENT_TEST(print_entry2)
 	error_code ec;
 	int ret = bdecode(b, b + sizeof(b)-1, e, ec);
 	TEST_EQUAL(ret, 0);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(print_entry(e), "{ 'a': 1, 'b': 'foo', 'c': [ 1, 2 ], 'd': { 'x': 1 } }");
 }
@@ -974,7 +974,7 @@ TORRENT_TEST(swap)
 	std::string str2 = print_entry(e2);
 	TEST_EQUAL(e1.type(), bdecode_node::dict_t);
 	TEST_EQUAL(e2.type(), bdecode_node::int_t);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 
 	e1.swap(e2);
 
@@ -982,7 +982,7 @@ TORRENT_TEST(swap)
 	TEST_EQUAL(e2.type(), bdecode_node::dict_t);
 	TEST_EQUAL(print_entry(e1), str2);
 	TEST_EQUAL(print_entry(e2), str1);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 
 	e1.swap(e2);
 
@@ -990,7 +990,7 @@ TORRENT_TEST(swap)
 	TEST_EQUAL(e2.type(), bdecode_node::int_t);
 	TEST_EQUAL(print_entry(e1), str1);
 	TEST_EQUAL(print_entry(e2), str2);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 }
 
 // test swap() (one node is the root of the other node)
@@ -1012,7 +1012,7 @@ TORRENT_TEST(swap_root)
 	std::string str2 = print_entry(e2);
 	TEST_EQUAL(e1.type(), bdecode_node::dict_t);
 	TEST_EQUAL(e2.type(), bdecode_node::int_t);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 
 	e1.swap(e2);
 
@@ -1020,7 +1020,7 @@ TORRENT_TEST(swap_root)
 	TEST_EQUAL(e2.type(), bdecode_node::dict_t);
 	TEST_EQUAL(print_entry(e1), str2);
 	TEST_EQUAL(print_entry(e2), str1);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 
 	// swap back
 	e1.swap(e2);
@@ -1029,7 +1029,7 @@ TORRENT_TEST(swap_root)
 	TEST_EQUAL(e2.type(), bdecode_node::int_t);
 	TEST_EQUAL(print_entry(e1), str1);
 	TEST_EQUAL(print_entry(e2), str2);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 }
 
 // test swap() (neither is a root and they don't share a root)
@@ -1120,14 +1120,14 @@ TORRENT_TEST(clear)
 	bdecode_node e;
 	error_code ec;
 	int ret = bdecode(b1, b1 + sizeof(b1)-1, e, ec);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	TEST_EQUAL(ret, 0);
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 	TEST_EQUAL(e.dict_size(), 4);
 	TEST_EQUAL(e.dict_at(1).first, "b");
 
 	ret = bdecode(b2, b2 + sizeof(b2)-1, e, ec);
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 	TEST_EQUAL(ret, 0);
 	TEST_EQUAL(e.type(), bdecode_node::list_t);
 	TEST_EQUAL(e.list_size(), 2);
@@ -1144,7 +1144,7 @@ TORRENT_TEST(copy_root)
 	int ret = bdecode(b1, b1 + sizeof(b1)-1, e1, ec);
 	TEST_EQUAL(ret, 0);
 	TEST_EQUAL(e1.type(), bdecode_node::dict_t);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 
 	bdecode_node e2(e1);
 	bdecode_node e3;
@@ -1172,7 +1172,7 @@ TORRENT_TEST(non_owning_refs)
 
 	TEST_EQUAL(ret, 0);
 	TEST_EQUAL(e1.type(), bdecode_node::dict_t);
-	printf("%s\n", print_entry(e1).c_str());
+	std::printf("%s\n", print_entry(e1).c_str());
 
 	bdecode_node e2 = e1.non_owning();
 
@@ -1197,7 +1197,7 @@ TORRENT_TEST(partial_parse)
 	TEST_EQUAL(pos, 35);
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(print_entry(e), "{ 'a': 1, 'b': 'foo', 'c': [ 1, 2 ], 'd': { 'x': {} } }");
 }
@@ -1214,7 +1214,7 @@ TORRENT_TEST(partial_parse2)
 	TEST_EQUAL(pos, 29);
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(print_entry(e), "{ 'a': 1, 'b': 'foo', 'c': [ 1, 2 ], 'd': {} }");
 }
@@ -1231,7 +1231,7 @@ TORRENT_TEST(partial_parse3)
 	TEST_EQUAL(pos, 26);
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(print_entry(e), "{ 'a': 1, 'b': 'foo', 'c': [ 1, 2 ] }");
 }
@@ -1248,7 +1248,7 @@ TORRENT_TEST(partial_parse4)
 	TEST_EQUAL(pos, 22);
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
-	printf("%s\n", print_entry(e).c_str());
+	std::printf("%s\n", print_entry(e).c_str());
 
 	TEST_EQUAL(print_entry(e), "{ 'a': 1, 'b': 'foo', 'c': [ 1 ] }");
 }
@@ -1268,12 +1268,12 @@ TORRENT_TEST(switch_buffer)
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 
 	std::string string1 = print_entry(e);
-	printf("%s\n", string1.c_str());
+	std::printf("%s\n", string1.c_str());
 
 	e.switch_underlying_buffer(b2);
 
 	std::string string2 = print_entry(e);
-	printf("%s\n", string2.c_str());
+	std::printf("%s\n", string2.c_str());
 
 	TEST_EQUAL(string1, string2);
 }

--- a/test/test_bencoding.cpp
+++ b/test/test_bencoding.cpp
@@ -130,7 +130,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		std::pair<const char*, int> section = e.data_section();
 		TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 		TEST_CHECK(section.second == sizeof(b) - 1);
@@ -144,7 +144,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		std::pair<const char*, int> section = e.data_section();
 		TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 		TEST_CHECK(section.second == sizeof(b) - 1);
@@ -159,7 +159,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		std::pair<const char*, int> section = e.data_section();
 		TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 		TEST_CHECK(section.second == sizeof(b) - 1);
@@ -181,7 +181,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		std::pair<const char*, int> section = e.data_section();
 		TEST_CHECK(std::memcmp(b, section.first, section.second) == 0);
 		TEST_CHECK(section.second == sizeof(b) - 1);
@@ -219,7 +219,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_CHECK(ec == error_code(bdecode_errors::expected_value
 			, get_bdecode_category()));
 	}
@@ -231,7 +231,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_CHECK(ec == error_code(bdecode_errors::overflow
 			, get_bdecode_category()));
 	}
@@ -243,7 +243,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		// the lazy aspect makes this overflow when asking for
 		// the value. turning it to zero.
 		TEST_CHECK(e.int_value() == 0);
@@ -256,7 +256,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_CHECK(e.int_value() == 9223372036854775807LL);
 	}
 
@@ -267,7 +267,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec);
 		TEST_CHECK(ret == 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_CHECK(e.int_value() == -9223372036854775807LL);
 	}
 
@@ -288,7 +288,7 @@ TORRENT_TEST(lazy_entry)
 			, 0xa1, 0x88, 0x7a, 0x8d, 0xc3, 0xd6, 0x31, 0x3a
 			, 0x79, 0x31, 0xae, 0x71, 0x65, 0};
 
-		printf("%s\n", buf);
+		std::printf("%s\n", buf);
 		lazy_entry e;
 		error_code ec;
 		int ret = lazy_bdecode((char*)buf, (char*)buf + sizeof(buf), e, ec);
@@ -339,7 +339,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -352,7 +352,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -366,7 +366,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit
 			, get_bdecode_category()));
 	}
@@ -379,7 +379,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -392,7 +392,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -405,7 +405,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::expected_digit
 			, get_bdecode_category()));
 	}
@@ -418,7 +418,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -431,7 +431,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -445,7 +445,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::expected_colon
 			, get_bdecode_category()));
 	}
@@ -460,7 +460,7 @@ TORRENT_TEST(lazy_entry)
 		TEST_EQUAL(ret, -1);
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 	}
 
 	// test partial string
@@ -471,7 +471,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_CHECK(ret != 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof
 			, get_bdecode_category()));
 	}
@@ -484,7 +484,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_EQUAL(ret, 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 
 		pascal_string ps = e.dict_find_pstr("foobar");
 		TEST_EQUAL(memcmp(ps.ptr, "barfoo", ps.len), 0);
@@ -503,7 +503,7 @@ TORRENT_TEST(lazy_entry)
 		error_code ec;
 		int ret = lazy_bdecode(b, b + sizeof(b)-1, e, ec, NULL);
 		TEST_EQUAL(ret, 0);
-		printf("%s\n", print_entry(e).c_str());
+		std::printf("%s\n", print_entry(e).c_str());
 
 		TEST_EQUAL(e.list_size(), 2);
 		pascal_string ps = e.list_pstr_at(0);
@@ -527,7 +527,7 @@ TORRENT_TEST(lazy_entry)
 		for (int i = 0; i < 1000; ++i)
 		{
 			char tmp[20];
-			snprintf(tmp, sizeof(tmp), "i%de", i);
+			std::snprintf(tmp, sizeof(tmp), "i%de", i);
 			buf += tmp;
 		}
 		buf += "e";
@@ -550,12 +550,12 @@ TORRENT_TEST(lazy_entry)
 		for (int i = 0; i < 1000; ++i)
 		{
 			char tmp[30];
-			snprintf(tmp, sizeof(tmp), "4:%04di%de", i, i);
+			std::snprintf(tmp, sizeof(tmp), "4:%04di%de", i, i);
 			buf += tmp;
 		}
 		buf += "e";
 
-		printf("%s\n", buf.c_str());
+		std::printf("%s\n", buf.c_str());
 		lazy_entry e;
 		error_code ec;
 		int ret = lazy_bdecode((char*)&buf[0], (char*)&buf[0] + buf.size(), e, ec);
@@ -565,7 +565,7 @@ TORRENT_TEST(lazy_entry)
 		for (int i = 0; i < 1000; ++i)
 		{
 			char tmp[30];
-			snprintf(tmp, sizeof(tmp), "%04d", i);
+			std::snprintf(tmp, sizeof(tmp), "%04d", i);
 			TEST_EQUAL(e.dict_find_int_value(tmp), i);
 		}
 	}
@@ -624,7 +624,7 @@ TORRENT_TEST(lazy_entry)
 			int ret = lazy_bdecode(b[i], b[i] + strlen(b[i]), e, ec, NULL);
 			TEST_EQUAL(ret, -1);
 			TEST_CHECK(ec == error_code(bdecode_errors::unexpected_eof));
-			printf("%s\n", print_entry(e).c_str());
+			std::printf("%s\n", print_entry(e).c_str());
 		}
 	}
 }

--- a/test/test_bitfield.cpp
+++ b/test/test_bitfield.cpp
@@ -43,7 +43,7 @@ void print_bitfield(bitfield const& b)
 	{
 		out += b.get_bit(i) ? "1" : "0";
 	}
-	printf("%s\n", out.c_str());
+	std::printf("%s\n", out.c_str());
 }
 
 void test_iterators(bitfield& test1)
@@ -51,14 +51,14 @@ void test_iterators(bitfield& test1)
 	test1.set_all();
 	int num = 0;
 
-	printf("expecting %d ones\n", test1.size());
+	std::printf("expecting %d ones\n", test1.size());
 	for (bitfield::const_iterator i = test1.begin(); i != test1.end(); ++i)
 	{
-		printf("%d", *i);
+		std::printf("%d", *i);
 		TEST_EQUAL(*i, true);
 		num += *i;
 	}
-	printf("\n");
+	std::printf("\n");
 	TEST_EQUAL(num, test1.size());
 	TEST_EQUAL(num, test1.count());
 }
@@ -82,7 +82,7 @@ TORRENT_TEST(bitfield)
 	test1.clear_bit(2);
 	TEST_EQUAL(test1.count(), 2);
 	int distance = int(std::distance(test1.begin(), test1.end()));
-	printf("distance: %d\n", distance);
+	std::printf("distance: %d\n", distance);
 	TEST_CHECK(distance == 10);
 
 	print_bitfield(test1);

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -61,7 +61,7 @@ void test_checking(int flags = read_only_files)
 	using namespace libtorrent;
 	namespace lt = libtorrent;
 
-	fprintf(stderr, "\n==== TEST CHECKING %s%s%s=====\n\n"
+	std::fprintf(stderr, "\n==== TEST CHECKING %s%s%s=====\n\n"
 		, (flags & read_only_files) ? "read-only-files ":""
 		, (flags & corrupt_files) ? "corrupt ":""
 		, (flags & incomplete_files) ? "incomplete ":"");
@@ -70,9 +70,9 @@ void test_checking(int flags = read_only_files)
 	for (int i = 0; i < num_files; ++i)
 	{
 		char name[1024];
-		snprintf(name, sizeof(name), "test%d", i);
+		std::snprintf(name, sizeof(name), "test%d", i);
 		char dirname[200];
-		snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
+		std::snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
 		std::string path = combine_path(combine_path("tmp1_checking", "test_torrent_dir"), dirname);
 		path = combine_path(path, name);
 #ifdef TORRENT_WINDOWS
@@ -85,14 +85,14 @@ void test_checking(int flags = read_only_files)
 	// in case the previous run was terminated
 	error_code ec;
 	remove_all("tmp1_checking", ec);
-	if (ec) fprintf(stderr, "ERROR: removing tmp1_checking: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: removing tmp1_checking: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	create_directory("tmp1_checking", ec);
-	if (ec) fprintf(stderr, "ERROR: creating directory tmp1_checking: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: creating directory tmp1_checking: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 	create_directory(combine_path("tmp1_checking", "test_torrent_dir"), ec);
-	if (ec) fprintf(stderr, "ERROR: creating directory test_torrent_dir: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: creating directory test_torrent_dir: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	file_storage fs;
@@ -108,14 +108,14 @@ void test_checking(int flags = read_only_files)
 
 	// calculate the hash for all pieces
 	set_piece_hashes(t, "tmp1_checking", ec);
-	if (ec) fprintf(stderr, "ERROR: set_piece_hashes: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: set_piece_hashes: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), t.generate());
 	boost::shared_ptr<torrent_info> ti(new torrent_info(&buf[0], int(buf.size()), ec));
 
-	fprintf(stderr, "generated torrent: %s tmp1_checking/test_torrent_dir\n"
+	std::fprintf(stderr, "generated torrent: %s tmp1_checking/test_torrent_dir\n"
 		, to_hex(ti->info_hash().to_string()).c_str());
 
 	// truncate every file in half
@@ -124,18 +124,18 @@ void test_checking(int flags = read_only_files)
 		for (int i = 0; i < num_files; ++i)
 		{
 			char name[1024];
-			snprintf(name, sizeof(name), "test%d", i);
+			std::snprintf(name, sizeof(name), "test%d", i);
 			char dirname[200];
-			snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
+			std::snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
 			std::string path = combine_path(combine_path("tmp1_checking", "test_torrent_dir"), dirname);
 			path = combine_path(path, name);
 
 			error_code ec;
 			file f(path, file::read_write, ec);
-			if (ec) fprintf(stderr, "ERROR: opening file \"%s\": (%d) %s\n"
+			if (ec) std::fprintf(stderr, "ERROR: opening file \"%s\": (%d) %s\n"
 				, path.c_str(), ec.value(), ec.message().c_str());
 			f.set_size(file_sizes[i] / 2, ec);
-			if (ec) fprintf(stderr, "ERROR: truncating file \"%s\": (%d) %s\n"
+			if (ec) std::fprintf(stderr, "ERROR: truncating file \"%s\": (%d) %s\n"
 				, path.c_str(), ec.value(), ec.message().c_str());
 		}
 	}
@@ -143,7 +143,7 @@ void test_checking(int flags = read_only_files)
 	// overwrite the files with new random data
 	if (flags & corrupt_files)
 	{
-		fprintf(stderr, "corrupt file test. overwriting files\n");
+		std::fprintf(stderr, "corrupt file test. overwriting files\n");
 		// increase the size of some files. When they're read only that forces
 		// the checker to open them in write-mode to truncate them
 		static const int file_sizes2[] =
@@ -155,17 +155,17 @@ void test_checking(int flags = read_only_files)
 	// make the files read only
 	if (flags & read_only_files)
 	{
-		fprintf(stderr, "making files read-only\n");
+		std::fprintf(stderr, "making files read-only\n");
 		for (int i = 0; i < num_files; ++i)
 		{
 			char name[1024];
-			snprintf(name, sizeof(name), "test%d", i);
+			std::snprintf(name, sizeof(name), "test%d", i);
 			char dirname[200];
-			snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
+			std::snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
 
 			std::string path = combine_path(combine_path("tmp1_checking", "test_torrent_dir"), dirname);
 			path = combine_path(path, name);
-			fprintf(stderr, "   %s\n", path.c_str());
+			std::fprintf(stderr, "   %s\n", path.c_str());
 
 #ifdef TORRENT_WINDOWS
 			SetFileAttributesA(path.c_str(), FILE_ATTRIBUTE_READONLY);
@@ -203,7 +203,7 @@ void test_checking(int flags = read_only_files)
 
 		st = tor1.status();
 
-		printf("%d %f %s\n", st.state, st.progress_ppm / 10000.f, st.errc.message().c_str());
+		std::printf("%d %f %s\n", st.state, st.progress_ppm / 10000.f, st.errc.message().c_str());
 
 		if (
 #ifndef TORRENT_NO_DEPRECATE
@@ -236,7 +236,7 @@ void test_checking(int flags = read_only_files)
 			// read-only here, we expect the checking to fail.
 			TEST_CHECK(st.errc);
 			if (st.errc)
-				fprintf(stderr, "error: %s\n", st.errc.message().c_str());
+				std::fprintf(stderr, "error: %s\n", st.errc.message().c_str());
 
 			// wait a while to make sure libtorrent survived the error
 			test_sleep(1000);
@@ -245,13 +245,13 @@ void test_checking(int flags = read_only_files)
 			TEST_CHECK(!st.is_seeding);
 			TEST_CHECK(st.errc);
 			if (st.errc)
-				fprintf(stderr, "error: %s\n", st.errc.message().c_str());
+				std::fprintf(stderr, "error: %s\n", st.errc.message().c_str());
 		}
 		else
 		{
 			TEST_CHECK(!st.errc);
 			if (st.errc)
-				fprintf(stderr, "error: %s\n", st.errc.message().c_str());
+				std::fprintf(stderr, "error: %s\n", st.errc.message().c_str());
 		}
 	}
 
@@ -259,7 +259,7 @@ void test_checking(int flags = read_only_files)
 	{
 		TEST_CHECK(st.is_seeding);
 		if (st.errc)
-			fprintf(stderr, "error: %s\n", st.errc.message().c_str());
+			std::fprintf(stderr, "error: %s\n", st.errc.message().c_str());
 	}
 
 	// make the files writable again
@@ -268,9 +268,9 @@ void test_checking(int flags = read_only_files)
 		for (int i = 0; i < num_files; ++i)
 		{
 			char name[1024];
-			snprintf(name, sizeof(name), "test%d", i);
+			std::snprintf(name, sizeof(name), "test%d", i);
 			char dirname[200];
-			snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
+			std::snprintf(dirname, sizeof(dirname), "test_dir%d", i / 5);
 
 			std::string path = combine_path(combine_path("tmp1_checking", "test_torrent_dir"), dirname);
 			path = combine_path(path, name);
@@ -283,7 +283,7 @@ void test_checking(int flags = read_only_files)
 	}
 
 	remove_all("tmp1_checking", ec);
-	if (ec) fprintf(stderr, "ERROR: removing tmp1_checking: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: removing tmp1_checking: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 }
 

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -239,7 +239,7 @@ void send_dht_request(node& node, char const* msg, udp::endpoint const& ep
 	bdecode_node decoded;
 	error_code ec;
 	bdecode(msg_buf, msg_buf + size, decoded, ec);
-	if (ec) fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, ep);
 	node.incoming(m);
@@ -288,7 +288,7 @@ void send_dht_response(node& node, bdecode_node const& request, udp::endpoint co
 	bdecode_node decoded;
 	error_code ec;
 	bdecode(msg_buf, msg_buf + size, decoded, ec);
-	if (ec) fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, ep);
 	node.incoming(m);
@@ -340,19 +340,19 @@ void announce_immutable_items(node& node, udp::endpoint const* eps
 			bdecode_node parsed[5];
 			char error_string[200];
 
-//			fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+//			std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 			int ret = verify_message(response, desc, parsed, error_string
 				, sizeof(error_string));
 			if (ret)
 			{
 				TEST_EQUAL(parsed[4].string_value(), "r");
 				token = parsed[2].string_value();
-//				fprintf(stderr, "got token: %s\n", token.c_str());
+//				std::fprintf(stderr, "got token: %s\n", token.c_str());
 			}
 			else
 			{
-				fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-				fprintf(stderr, "   invalid get response: %s\n", error_string);
+				std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid get response: %s\n", error_string);
 				TEST_ERROR(error_string);
 			}
 
@@ -381,14 +381,14 @@ void announce_immutable_items(node& node, udp::endpoint const* eps
 			if (ret)
 			{
 				if (parsed2[0].string_value() != "r")
-					fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+					std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 
 				TEST_EQUAL(parsed2[0].string_value(), "r");
 			}
 			else
 			{
-				fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-				fprintf(stderr, "   invalid put response: %s\n", error_string);
+				std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid put response: %s\n", error_string);
 				TEST_ERROR(error_string);
 			}
 		}
@@ -543,7 +543,7 @@ void do_test_dht(address(&rand_addr)())
 
 	bdecode_node pong_keys[4];
 
-	fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+	std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 	ret = dht::verify_message(response, pong_desc, pong_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(ret);
@@ -554,7 +554,7 @@ void do_test_dht(address(&rand_addr)())
 	}
 	else
 	{
-		fprintf(stderr, "   invalid ping response: %s\n", error_string);
+		std::fprintf(stderr, "   invalid ping response: %s\n", error_string);
 	}
 
 	// ====== invalid message ======
@@ -568,7 +568,7 @@ void do_test_dht(address(&rand_addr)())
 
 	bdecode_node err_keys[2];
 
-	fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+	std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 	ret = dht::verify_message(response, err_desc, err_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(ret);
@@ -587,7 +587,7 @@ void do_test_dht(address(&rand_addr)())
 	}
 	else
 	{
-		fprintf(stderr, "   invalid error response: %s\n", error_string);
+		std::fprintf(stderr, "   invalid error response: %s\n", error_string);
 	}
 
 	// ====== get_peers ======
@@ -605,7 +605,7 @@ void do_test_dht(address(&rand_addr)())
 	bdecode_node peer1_keys[4];
 
 	std::string token;
-	fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+	std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 	ret = dht::verify_message(response, peer1_desc, peer1_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(ret);
@@ -613,12 +613,12 @@ void do_test_dht(address(&rand_addr)())
 	{
 		TEST_CHECK(peer1_keys[0].string_value() == "r");
 		token = peer1_keys[2].string_value();
-//		fprintf(stderr, "got token: %s\n", token.c_str());
+//		std::fprintf(stderr, "got token: %s\n", token.c_str());
 	}
 	else
 	{
-		fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-		fprintf(stderr, "   invalid get_peers response: %s\n", error_string);
+		std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+		std::fprintf(stderr, "   invalid get_peers response: %s\n", error_string);
 	}
 
 	// ====== announce ======
@@ -639,7 +639,7 @@ void do_test_dht(address(&rand_addr)())
 
 	bdecode_node ann_keys[3];
 
-	fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+	std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 	ret = dht::verify_message(response, ann_desc, ann_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(ret);
@@ -649,7 +649,7 @@ void do_test_dht(address(&rand_addr)())
 	}
 	else
 	{
-		fprintf(stderr, "   invalid announce response: %s\n", error_string);
+		std::fprintf(stderr, "   invalid announce response: %s\n", error_string);
 	}
 
 	init_rand_address();
@@ -669,12 +669,12 @@ void do_test_dht(address(&rand_addr)())
 		{
 			TEST_CHECK(peer1_keys[0].string_value() == "r");
 			token = peer1_keys[2].string_value();
-//			fprintf(stderr, "got token: %s\n", token.c_str());
+//			std::fprintf(stderr, "got token: %s\n", token.c_str());
 		}
 		else
 		{
-			fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-			fprintf(stderr, "   invalid get_peers response: %s\n", error_string);
+			std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get_peers response: %s\n", error_string);
 		}
 		response.clear();
 		send_dht_request(node, "announce_peer", source, &response
@@ -703,7 +703,7 @@ void do_test_dht(address(&rand_addr)())
 
 	bdecode_node peer2_keys[5];
 
-	fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+	std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 	ret = dht::verify_message(response, peer2_desc, peer2_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(ret);
@@ -717,15 +717,15 @@ void do_test_dht(address(&rand_addr)())
 		downloaders.from_string(peer2_keys[2].string_ptr());
 		seeds.from_string(peer2_keys[3].string_ptr());
 
-		fprintf(stderr, "seeds: %f\n", seeds.size());
-		fprintf(stderr, "downloaders: %f\n", downloaders.size());
+		std::fprintf(stderr, "seeds: %f\n", seeds.size());
+		std::fprintf(stderr, "downloaders: %f\n", downloaders.size());
 
 		TEST_CHECK(fabs(seeds.size() - 50.f) <= 3.f);
 		TEST_CHECK(fabs(downloaders.size() - 50.f) <= 3.f);
 	}
 	else
 	{
-		fprintf(stderr, "   invalid get_peers response: %s\n", error_string);
+		std::fprintf(stderr, "   invalid get_peers response: %s\n", error_string);
 	}
 
 	// ====== test node ID testing =====
@@ -781,14 +781,14 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 			TEST_ERROR("invalid error response");
 		}
 	}
 	else
 	{
-		fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-		fprintf(stderr, "   invalid error response: %s\n", error_string);
+		std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+		std::fprintf(stderr, "   invalid error response: %s\n", error_string);
 	}
 
 	// a node with invalid node-id shouldn't be added to routing table.
@@ -810,7 +810,7 @@ void do_test_dht(address(&rand_addr)())
 
 	bdecode_node nodes_keys[3];
 
-	fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+	std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
 	ret = dht::verify_message(response, nodes_desc, nodes_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(ret);
@@ -820,8 +820,8 @@ void do_test_dht(address(&rand_addr)())
 	}
 	else
 	{
-		fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-		fprintf(stderr, "   invalid error response: %s\n", error_string);
+		std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+		std::fprintf(stderr, "   invalid error response: %s\n", error_string);
 	}
 	// node with valid node-id should be added to routing table.
 	TEST_EQUAL(node.size().get<0>(), nodes_num + 1);
@@ -834,7 +834,7 @@ void do_test_dht(address(&rand_addr)())
 	for (int i = 0; i < 256; ++i)
 	{
 		char adr[50];
-		snprintf(adr, 50, "192.0.2.%d", i);
+		std::snprintf(adr, 50, "192.0.2.%d", i);
 		address a = address::from_string(adr);
 		sha1_hash iphash;
 		hash_address(a, iphash);
@@ -846,7 +846,7 @@ void do_test_dht(address(&rand_addr)())
 		for (int i = 0; i < 0x3E8; ++i)
 		{
 			char adr[50];
-			snprintf(adr, 50, "2001:db8::%x", i);
+			std::snprintf(adr, 50, "2001:db8::%x", i);
 			address a = address::from_string(adr);
 			sha1_hash iphash;
 			hash_address(a, iphash);
@@ -856,8 +856,8 @@ void do_test_dht(address(&rand_addr)())
 
 	// these are test vectors from BEP 33
 	// http://www.bittorrent.org/beps/bep_0033.html
-	fprintf(stderr, "test.size: %f\n", test.size());
-	fprintf(stderr, "%s\n", to_hex(test.to_string()).c_str());
+	std::fprintf(stderr, "test.size: %f\n", test.size());
+	std::fprintf(stderr, "%s\n", to_hex(test.to_string()).c_str());
 	if (supports_ipv6())
 	{
 		TEST_CHECK(fabs(test.size() - 1224.93f) < 0.001);
@@ -927,13 +927,13 @@ void do_test_dht(address(&rand_addr)())
 	for (int with_salt = 0; with_salt < 2; ++with_salt)
 	{
 		seq = 4;
-		fprintf(stderr, "\nTEST GET/PUT%s \ngenerating ed25519 keys\n\n"
+		std::fprintf(stderr, "\nTEST GET/PUT%s \ngenerating ed25519 keys\n\n"
 			, with_salt ? " with-salt" : " no-salt");
 		unsigned char seed[32];
 		ed25519_create_seed(seed);
 
 		ed25519_create_keypair((unsigned char*)public_key, (unsigned char*)private_key, seed);
-		fprintf(stderr, "pub: %s priv: %s\n"
+		std::fprintf(stderr, "pub: %s priv: %s\n"
 			, to_hex(std::string(public_key, item_pk_len)).c_str()
 			, to_hex(std::string(private_key, item_sk_len)).c_str());
 
@@ -947,7 +947,7 @@ void do_test_dht(address(&rand_addr)())
 		if (with_salt) h.update(salt.first, salt.second);
 		sha1_hash target_id = h.final();
 
-		fprintf(stderr, "target_id: %s\n"
+		std::fprintf(stderr, "target_id: %s\n"
 			, to_hex(target_id.to_string()).c_str());
 
 		send_dht_request(node, "get", source, &response
@@ -970,14 +970,14 @@ void do_test_dht(address(&rand_addr)())
 		{
 			TEST_EQUAL(desc_keys[4].string_value(), "r");
 			token = desc_keys[2].string_value();
-			fprintf(stderr, "get response: %s\n"
+			std::fprintf(stderr, "get response: %s\n"
 				, print_entry(response).c_str());
-			fprintf(stderr, "got token: %s\n", to_hex(token).c_str());
+			std::fprintf(stderr, "got token: %s\n", to_hex(token).c_str());
 		}
 		else
 		{
-			fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-			fprintf(stderr, "   invalid get response: %s\n%s\n"
+			std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get response: %s\n%s\n"
 				, error_string, print_entry(response).c_str());
 			TEST_ERROR(error_string);
 		}
@@ -1002,13 +1002,13 @@ void do_test_dht(address(&rand_addr)())
 			, sizeof(error_string));
 		if (ret)
 		{
-			fprintf(stderr, "put response: %s\n"
+			std::fprintf(stderr, "put response: %s\n"
 				, print_entry(response).c_str());
 			TEST_EQUAL(desc2_keys[0].string_value(), "r");
 		}
 		else
 		{
-			fprintf(stderr, "   invalid put response: %s\n%s\n"
+			std::fprintf(stderr, "   invalid put response: %s\n%s\n"
 				, error_string, print_entry(response).c_str());
 			TEST_ERROR(error_string);
 		}
@@ -1016,7 +1016,7 @@ void do_test_dht(address(&rand_addr)())
 		send_dht_request(node, "get", source, &response
 			, msg_args().target((char*)&target_id[0]));
 
-		fprintf(stderr, "target_id: %s\n"
+		std::fprintf(stderr, "target_id: %s\n"
 			, to_hex(target_id.to_string()).c_str());
 
 		key_desc_t desc3[] =
@@ -1036,14 +1036,14 @@ void do_test_dht(address(&rand_addr)())
 			, sizeof(error_string));
 		if (ret == 0)
 		{
-			fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
-			fprintf(stderr, "   invalid get response: %s\n%s\n"
+			std::fprintf(stderr, "msg: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get response: %s\n%s\n"
 				, error_string, print_entry(response).c_str());
 			TEST_ERROR(error_string);
 		}
 		else
 		{
-			fprintf(stderr, "get response: %s\n"
+			std::fprintf(stderr, "get response: %s\n"
 				, print_entry(response).c_str());
 			char value[1020];
 			char* ptr = value;
@@ -1065,7 +1065,7 @@ void do_test_dht(address(&rand_addr)())
 		// break the signature
 		signature[2] ^= 0xaa;
 
-		fprintf(stderr, "PUT broken signature\n");
+		std::fprintf(stderr, "PUT broken signature\n");
 
 		TEST_CHECK(verify_mutable_item(itemv, salt, seq, public_key, signature) != 1);
 
@@ -1082,14 +1082,14 @@ void do_test_dht(address(&rand_addr)())
 			, sizeof(error_string));
 		if (ret)
 		{
-			fprintf(stderr, "put response: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "put response: %s\n", print_entry(response).c_str());
 			TEST_EQUAL(desc_error_keys[1].string_value(), "e");
 			// 206 is the code for invalid signature
 			TEST_EQUAL(desc_error_keys[0].list_int_value_at(0), 206);
 		}
 		else
 		{
-			fprintf(stderr, "   invalid put response: %s\n%s\n"
+			std::fprintf(stderr, "   invalid put response: %s\n%s\n"
 				, error_string, print_entry(response).c_str());
 			TEST_ERROR(error_string);
 		}
@@ -1133,7 +1133,7 @@ void do_test_dht(address(&rand_addr)())
 
 		TEST_CHECK(item_target_id(salt, public_key) == target_id);
 
-		fprintf(stderr, "PUT CAS 1\n");
+		std::fprintf(stderr, "PUT CAS 1\n");
 
 		send_dht_request(node, "put", source, &response
 			, msg_args()
@@ -1149,18 +1149,18 @@ void do_test_dht(address(&rand_addr)())
 			, sizeof(error_string));
 		if (ret)
 		{
-			fprintf(stderr, "put response: %s\n"
+			std::fprintf(stderr, "put response: %s\n"
 				, print_entry(response).c_str());
 			TEST_EQUAL(desc2_keys[0].string_value(), "r");
 		}
 		else
 		{
-			fprintf(stderr, "   invalid put response: %s\n%s\n"
+			std::fprintf(stderr, "   invalid put response: %s\n%s\n"
 				, error_string, print_entry(response).c_str());
 			TEST_ERROR(error_string);
 		}
 
-		fprintf(stderr, "PUT CAS 2\n");
+		std::fprintf(stderr, "PUT CAS 2\n");
 
 		// put the same message again. This should fail because the
 		// CAS hash is outdated, it's not the hash of the value that's
@@ -1179,7 +1179,7 @@ void do_test_dht(address(&rand_addr)())
 			, sizeof(error_string));
 		if (ret)
 		{
-			fprintf(stderr, "put response: %s\n"
+			std::fprintf(stderr, "put response: %s\n"
 				, print_entry(response).c_str());
 			TEST_EQUAL(desc_error_keys[1].string_value(), "e");
 			// 301 is the error code for CAS hash mismatch
@@ -1187,7 +1187,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid put response: %s\n%s\nExpected failure 301 (CAS hash mismatch)\n"
+			std::fprintf(stderr, "   invalid put response: %s\n%s\nExpected failure 301 (CAS hash mismatch)\n"
 				, error_string, print_entry(response).c_str());
 			TEST_ERROR(error_string);
 		}
@@ -1313,7 +1313,7 @@ void do_test_dht(address(&rand_addr)())
 			table.node_seen(tmp, udp::endpoint(rand_addr(), rand()), 20 + (tmp[19] & 0xff));
 			add_and_replace(tmp, diff);
 		}
-		printf("active buckets: %d\n", table.num_active_buckets());
+		std::printf("active buckets: %d\n", table.num_active_buckets());
 		TEST_EQUAL(table.num_active_buckets(), 10);
 		TEST_CHECK(table.size().get<0>() >= 10 * 10);
 		//#error test num_global_nodes
@@ -1325,13 +1325,13 @@ void do_test_dht(address(&rand_addr)())
 
 		table.for_each_node(node_push_back, nop, &nodes);
 
-		printf("nodes: %d\n", int(nodes.size()));
+		std::printf("nodes: %d\n", int(nodes.size()));
 
 		std::vector<node_entry> temp;
 
 		std::generate(tmp.begin(), tmp.end(), random_byte);
 		table.find_node(tmp, temp, 0, int(nodes.size()) * 2);
-		printf("returned-all: %d\n", int(temp.size()));
+		std::printf("returned-all: %d\n", int(temp.size()));
 		TEST_EQUAL(temp.size(), nodes.size());
 
 		// This makes sure enough of the nodes returned are actually
@@ -1348,7 +1348,7 @@ void do_test_dht(address(&rand_addr)())
 		{
 			std::generate(tmp.begin(), tmp.end(), random_byte);
 			table.find_node(tmp, temp, 0, bucket_size * 2);
-			printf("returned: %d\n", int(temp.size()));
+			std::printf("returned: %d\n", int(temp.size()));
 			TEST_EQUAL(int(temp.size()), (std::min)(bucket_size * 2, int(nodes.size())));
 
 			std::sort(nodes.begin(), nodes.end(), boost::bind(&compare_ref
@@ -1360,7 +1360,7 @@ void do_test_dht(address(&rand_addr)())
 			int sum_hits = std::accumulate(temp.begin(), temp.end()
 				, 0, boost::bind(&sum_distance_exp, _1, _2, tmp));
 			TEST_EQUAL(bucket_size * 2, int(temp.size()));
-			printf("expected: %d actual: %d\n", expected, sum_hits);
+			std::printf("expected: %d actual: %d\n", expected, sum_hits);
 			TEST_EQUAL(expected, sum_hits);
 
 			duplicates.clear();
@@ -1404,7 +1404,7 @@ void do_test_dht(address(&rand_addr)())
 			TEST_CHECK((id[2] & 0xf8) == (prefixes[i][2] & 0xf8));
 
 			TEST_CHECK(id[19] == rs[i]);
-			fprintf(stderr, "IP address: %s r: %d node ID: %s\n", ips[i]
+			std::fprintf(stderr, "IP address: %s r: %d node ID: %s\n", ips[i]
 				, rs[i], to_hex(id.to_string()).c_str());
 		}
 	}
@@ -1477,7 +1477,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid find_node request: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid find_node request: %s\n", print_entry(response).c_str());
 			TEST_ERROR(error_string);
 			break;
 		}
@@ -1505,7 +1505,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid find_node request: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid find_node request: %s\n", print_entry(response).c_str());
 			TEST_ERROR(error_string);
 			break;
 		}
@@ -1546,7 +1546,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid get_peers request: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get_peers request: %s\n", print_entry(response).c_str());
 			TEST_ERROR(error_string);
 			break;
 		}
@@ -1580,7 +1580,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid get_peers request: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get_peers request: %s\n", print_entry(response).c_str());
 			TEST_ERROR(error_string);
 			break;
 		}
@@ -1596,7 +1596,7 @@ void do_test_dht(address(&rand_addr)())
 		for (std::list<std::pair<udp::endpoint, entry> >::iterator i = g_sent_packets.begin()
 			, end(g_sent_packets.end()); i != end; ++i)
 		{
-//			fprintf(stderr, " %s:%d: %s\n", i->first.address().to_string(ec).c_str()
+//			std::fprintf(stderr, " %s:%d: %s\n", i->first.address().to_string(ec).c_str()
 //				, i->first.port(), i->second.to_string().c_str());
 			TEST_EQUAL(i->second["q"].string(), "announce_peer");
 		}
@@ -1641,7 +1641,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
 			TEST_ERROR(error_string);
 			break;
 		}
@@ -1686,7 +1686,7 @@ void do_test_dht(address(&rand_addr)())
 		}
 		else
 		{
-			fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
+			std::fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
 			TEST_ERROR(error_string);
 			break;
 		}
@@ -1789,12 +1789,12 @@ void do_test_dht(address(&rand_addr)())
 				, sizeof(error_string));
 			if (!ret)
 			{
-				fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
 				TEST_ERROR(error_string);
 				continue;
 			}
 			char t[10];
-			snprintf(t, sizeof(t), "%02d", i);
+			std::snprintf(t, sizeof(t), "%02d", i);
 
 			msg_args args;
 			args.token(t).port(1234).nid(nodes[i].id).nodes(nodes_t(1, nodes[i]));
@@ -1823,7 +1823,7 @@ void do_test_dht(address(&rand_addr)())
 				std::pair<const char*, int>v = put_immutable_item_keys[6].data_section();
 				TEST_EQUAL(std::string(v.first, v.second), flat_data);
 				char t[10];
-				snprintf(t, sizeof(t), "%02d", i);
+				std::snprintf(t, sizeof(t), "%02d", i);
 				TEST_EQUAL(put_immutable_item_keys[5].string_value(), t);
 				if (put_immutable_item_keys[0].string_value() != "q"
 					|| put_immutable_item_keys[2].string_value() != "put") continue;
@@ -1832,7 +1832,7 @@ void do_test_dht(address(&rand_addr)())
 			}
 			else
 			{
-				fprintf(stderr, "   invalid immutable put request: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid immutable put request: %s\n", print_entry(response).c_str());
 				TEST_ERROR(error_string);
 				continue;
 			}
@@ -1886,12 +1886,12 @@ void do_test_dht(address(&rand_addr)())
 				, sizeof(error_string));
 			if (!ret)
 			{
-				fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
 				TEST_ERROR(error_string);
 				continue;
 			}
 			char t[10];
-			snprintf(t, sizeof(t), "%02d", i);
+			std::snprintf(t, sizeof(t), "%02d", i);
 
 			msg_args args;
 			args.token(t).port(1234).nid(nodes[i].id).nodes(nodes_t(1, nodes[i]));
@@ -1925,7 +1925,7 @@ void do_test_dht(address(&rand_addr)())
 				TEST_EQUAL(v.second, itemv.second);
 				TEST_CHECK(memcmp(v.first, itemv.first, itemv.second) == 0);
 				char t[10];
-				snprintf(t, sizeof(t), "%02d", i);
+				std::snprintf(t, sizeof(t), "%02d", i);
 				TEST_EQUAL(put_mutable_item_keys[9].string_value(), t);
 				if (put_mutable_item_keys[0].string_value() != "q"
 					|| put_mutable_item_keys[2].string_value() != "put") continue;
@@ -1934,7 +1934,7 @@ void do_test_dht(address(&rand_addr)())
 			}
 			else
 			{
-				fprintf(stderr, "   invalid put request: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid put request: %s\n", print_entry(response).c_str());
 				TEST_ERROR(error_string);
 				continue;
 			}
@@ -2001,12 +2001,12 @@ void do_test_dht(address(&rand_addr)())
 				, sizeof(error_string));
 			if (!ret)
 			{
-				fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
+				std::fprintf(stderr, "   invalid get request: %s\n", print_entry(response).c_str());
 				TEST_ERROR(error_string);
 				continue;
 			}
 			char t[10];
-			snprintf(t, sizeof(t), "%02d", i);
+			std::snprintf(t, sizeof(t), "%02d", i);
 
 			msg_args args;
 			args.token(t).port(1234).nid(nodes[i].id);
@@ -2092,7 +2092,7 @@ TORRENT_TEST(dht_dual_stack)
 	}
 	else
 	{
-		fprintf(stderr, "find_node response: %s\n", print_entry(response).c_str());
+		std::fprintf(stderr, "find_node response: %s\n", print_entry(response).c_str());
 		TEST_ERROR(error_string);
 	}
 
@@ -2125,7 +2125,7 @@ TORRENT_TEST(dht_dual_stack)
 	}
 	else
 	{
-		fprintf(stderr, "find_node response: %s\n", print_entry(response).c_str());
+		std::fprintf(stderr, "find_node response: %s\n", print_entry(response).c_str());
 		TEST_ERROR(error_string);
 	}
 
@@ -2165,7 +2165,7 @@ TORRENT_TEST(dht_dual_stack)
 	}
 	else
 	{
-		fprintf(stderr, "find_node response: %s\n", print_entry(response).c_str());
+		std::fprintf(stderr, "find_node response: %s\n", print_entry(response).c_str());
 		TEST_ERROR(error_string);
 	}
 }
@@ -2264,7 +2264,7 @@ TORRENT_TEST(verify_message)
 	error_code ec;
 	char const test_msg[] = "d1:A4:test1:Bd2:B15:test22:B25:test3ee";
 	bdecode(test_msg, test_msg + sizeof(test_msg)-1, ent, ec);
-	fprintf(stderr, "%s\n", print_entry(ent).c_str());
+	std::fprintf(stderr, "%s\n", print_entry(ent).c_str());
 
 	bool ret = verify_message(ent, msg_desc, msg_keys, error_string
 		, sizeof(error_string));
@@ -2282,7 +2282,7 @@ TORRENT_TEST(verify_message)
 
 	char const test_msg2[] = "d1:A4:test1:Cd2:C15:test22:C25:test3ee";
 	bdecode(test_msg2, test_msg2 + sizeof(test_msg2)-1, ent, ec);
-	fprintf(stderr, "%s\n", print_entry(ent).c_str());
+	std::fprintf(stderr, "%s\n", print_entry(ent).c_str());
 
 	ret = verify_message(ent, msg_desc, msg_keys, error_string
 		, sizeof(error_string));
@@ -2301,38 +2301,38 @@ TORRENT_TEST(verify_message)
 
 	char const test_msg3[] = "d1:Cd2:C15:test22:C25:test3ee";
 	bdecode(test_msg3, test_msg3 + sizeof(test_msg3)-1, ent, ec);
-	fprintf(stderr, "%s\n", print_entry(ent).c_str());
+	std::fprintf(stderr, "%s\n", print_entry(ent).c_str());
 
 	ret = verify_message(ent, msg_desc, msg_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(!ret);
-	fprintf(stderr, "%s\n", error_string);
+	std::fprintf(stderr, "%s\n", error_string);
 	TEST_EQUAL(error_string, std::string("missing 'A' key"));
 
 	char const test_msg4[] = "d1:A6:foobare";
 	bdecode(test_msg4, test_msg4 + sizeof(test_msg4)-1, ent, ec);
-	fprintf(stderr, "%s\n", print_entry(ent).c_str());
+	std::fprintf(stderr, "%s\n", print_entry(ent).c_str());
 
 	ret = verify_message(ent, msg_desc, msg_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(!ret);
-	fprintf(stderr, "%s\n", error_string);
+	std::fprintf(stderr, "%s\n", error_string);
 	TEST_EQUAL(error_string, std::string("invalid value for 'A'"));
 
 	char const test_msg5[] = "d1:A4:test1:Cd2:C15:test2ee";
 	bdecode(test_msg5, test_msg5 + sizeof(test_msg5)-1, ent, ec);
-	fprintf(stderr, "%s\n", print_entry(ent).c_str());
+	std::fprintf(stderr, "%s\n", print_entry(ent).c_str());
 
 	ret = verify_message(ent, msg_desc, msg_keys, error_string
 		, sizeof(error_string));
 	TEST_CHECK(!ret);
-	fprintf(stderr, "%s\n", error_string);
+	std::fprintf(stderr, "%s\n", error_string);
 	TEST_EQUAL(error_string, std::string("missing 'C2' key"));
 
 	// test empty strings [ { "":1 }, "" ]
 	char const test_msg6[] = "ld0:i1ee0:e";
 	bdecode(test_msg6, test_msg6 + sizeof(test_msg6)-1, ent, ec);
-	fprintf(stderr, "%s\n", print_entry(ent).c_str());
+	std::fprintf(stderr, "%s\n", print_entry(ent).c_str());
 	TEST_CHECK(ent.type() == bdecode_node::list_t);
 	if (ent.type() == bdecode_node::list_t)
 	{
@@ -2374,7 +2374,7 @@ TORRENT_TEST(routing_table_uniform)
 		// restore the first byte of the node ID
 		id[0] ^= i;
 	}
-	printf("num_active_buckets: %d\n", tbl.num_active_buckets());
+	std::printf("num_active_buckets: %d\n", tbl.num_active_buckets());
 	// number of nodes per tree level (when adding 256 evenly distributed
 	// nodes):
 	// 0: 128
@@ -2407,7 +2407,7 @@ TORRENT_TEST(routing_table_balance)
 		id[4] = i;
 		tbl.node_seen(id, rand_udp_ep(), 20 + (id[19] & 0xff));
 	}
-	printf("num_active_buckets: %d\n", tbl.num_active_buckets());
+	std::printf("num_active_buckets: %d\n", tbl.num_active_buckets());
 	TEST_EQUAL(tbl.num_active_buckets(), 2);
 
 #if defined TORRENT_DEBUG
@@ -2609,7 +2609,7 @@ TORRENT_TEST(invalid_error_msg)
 	bdecode_node decoded;
 	error_code ec;
 	bdecode(msg_buf, msg_buf + size, decoded, ec);
-	if (ec) fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, source);
 	node.incoming(m);
@@ -2621,7 +2621,7 @@ TORRENT_TEST(invalid_error_msg)
 			&& observer.m_log[i].find("(malformed)") != std::string::npos)
 			found = true;
 
-		printf("%s\n", observer.m_log[i].c_str());
+		std::printf("%s\n", observer.m_log[i].c_str());
 	}
 
 	TEST_EQUAL(found, true);
@@ -2669,7 +2669,7 @@ TORRENT_TEST(rpc_invalid_error_msg)
 	bdecode_node decoded;
 	error_code ec;
 	bdecode(msg_buf, msg_buf + size, decoded, ec);
-	if (ec) fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, source);
 	node_id nid;
@@ -2683,7 +2683,7 @@ TORRENT_TEST(rpc_invalid_error_msg)
 			&& observer.m_log[i].find("error") != std::string::npos)
 			found = true;
 
-		printf("%s\n", observer.m_log[i].c_str());
+		std::printf("%s\n", observer.m_log[i].c_str());
 	}
 
 	TEST_EQUAL(found, true);
@@ -2704,9 +2704,9 @@ TORRENT_TEST(node_id_bucket_distribution)
 
 	for (int i = 0; i < 25; ++i)
 	{
-		printf("%3d ", nodes_per_bucket[i]);
+		std::printf("%3d ", nodes_per_bucket[i]);
 	}
-	printf("\n");
+	std::printf("\n");
 
 	int expected = num_samples / 2;
 	for (int i = 0; i < 25; ++i)
@@ -2816,7 +2816,7 @@ TORRENT_TEST(distance_exp)
 
 	for (auto const& t : distance_tests)
 	{
-		fprintf(stderr, "%s %s: %d\n"
+		std::fprintf(stderr, "%s %s: %d\n"
 			, std::get<0>(t), std::get<1>(t), std::get<2>(t));
 
 		TEST_EQUAL(distance_exp(
@@ -2842,7 +2842,7 @@ TORRENT_TEST(compare_ip_cidr)
 
 	for (auto const& t : v4tests)
 	{
-		fprintf(stderr, "%s %s\n", std::get<0>(t), std::get<1>(t));
+		std::fprintf(stderr, "%s %s\n", std::get<0>(t), std::get<1>(t));
 		TEST_EQUAL(compare_ip_cidr(
 			address_v4::from_string(std::get<0>(t))
 			, address_v4::from_string(std::get<1>(t)))

--- a/test/test_dos_blocker.cpp
+++ b/test/test_dos_blocker.cpp
@@ -62,10 +62,10 @@ struct log_t : libtorrent::dht::dht_logger
 		TEST_EQUAL(ret, 0);
 
 		std::string msg = print_entry(print, true);
-		printf("%s", msg.c_str());
+		std::printf("%s", msg.c_str());
 
 		char const* prefix[2] = { "<==", "==>"};
-		printf("%s [%s] %s", prefix[dir], print_endpoint(node).c_str()
+		std::printf("%s [%s] %s", prefix[dir], print_endpoint(node).c_str()
 			, msg.c_str());
 	}
 };

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -65,7 +65,7 @@ void log(char const* fmt, ...)
 	vsnprintf(buf, sizeof(buf), fmt, v);
 	va_end(v);
 
-	fprintf(stderr, "\x1b[1m\x1b[36m%s: %s\x1b[0m\n"
+	std::fprintf(stderr, "\x1b[1m\x1b[36m%s: %s\x1b[0m\n"
 		, time_now_string(), buf);
 }
 
@@ -123,9 +123,9 @@ void print_message(char const* buffer, int len)
 		if (msg >= 0 && msg < int(sizeof(message_name)/sizeof(message_name[0])))
 			strcpy(message, message_name[msg]);
 		else if (msg == 20)
-			snprintf(message, sizeof(message), "extension msg [%d]", buffer[1]);
+			std::snprintf(message, sizeof(message), "extension msg [%d]", buffer[1]);
 		else
-			snprintf(message, sizeof(message), "unknown[%d]", msg);
+			std::snprintf(message, sizeof(message), "unknown[%d]", msg);
 
 		if (msg == 0x6 && len == 13)
 		{
@@ -134,17 +134,17 @@ void print_message(char const* buffer, int len)
 			r.piece = detail::read_int32(ptr);
 			r.start = detail::read_int32(ptr);
 			r.length = detail::read_int32(ptr);
-			snprintf(extra, sizeof(extra), "p: %d s: %d l: %d", r.piece, r.start, r.length);
+			std::snprintf(extra, sizeof(extra), "p: %d s: %d l: %d", r.piece, r.start, r.length);
 		}
 		else if (msg == 0x11 && len == 5)
 		{
 			const char* ptr = buffer + 1;
 			int index = detail::read_int32(ptr);
-			snprintf(extra, sizeof(extra), "p: %d", index);
+			std::snprintf(extra, sizeof(extra), "p: %d", index);
 		}
 		else if (msg == 20 && len > 4 && buffer[1] == 0 )
 		{
-			snprintf(extra, sizeof(extra), "%s"
+			std::snprintf(extra, sizeof(extra), "%s"
 				, bdecode(buffer + 2, buffer + len).to_string().c_str());
 		}
 	}
@@ -432,7 +432,7 @@ boost::shared_ptr<torrent_info> setup_peer(tcp::socket& s, sha1_hash& ih
 	wait_for_downloading(*ses, "ses");
 
 	int const port = ses->listen_port();
-	fprintf(stderr, "listen port: %d\n", port);
+	std::fprintf(stderr, "listen port: %d\n", port);
 	s.connect(tcp::endpoint(address::from_string("127.0.0.1", ec), port), ec);
 	if (ec) TEST_ERROR(ec.message());
 

--- a/test/test_fence.cpp
+++ b/test/test_fence.cpp
@@ -153,7 +153,7 @@ TORRENT_TEST(double_fence)
 	// since we have outstanding jobs, no need
 	// to post anything
 	TEST_CHECK(ret_int == disk_job_fence::fence_post_none);
-	fprintf(stderr, "ret: %d\n", ret_int);
+	std::fprintf(stderr, "ret: %d\n", ret_int);
 
 	ret = fence.is_blocked(&test_job[9]);
 	TEST_CHECK(ret == true);

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -97,7 +97,7 @@ TORRENT_TEST(file_status)
 	TEST_CHECK(!ec);
 
 	int diff = int(st2.mtime - st1.mtime);
-	fprintf(stderr, "timestamp difference: %d seconds. expected approx. 3 seconds\n"
+	std::fprintf(stderr, "timestamp difference: %d seconds. expected approx. 3 seconds\n"
 		, diff);
 
 	TEST_CHECK(diff >= 2 && diff <= 4);
@@ -108,7 +108,7 @@ TORRENT_TEST(directory)
 	error_code ec;
 
 	create_directory("file_test_dir", ec);
-	if (ec) fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
 	TEST_CHECK(!ec);
 
 	std::string cwd = current_working_directory();
@@ -123,7 +123,7 @@ TORRENT_TEST(directory)
 		std::string f = i.file();
 		TEST_CHECK(files.count(f) == 0);
 		files.insert(f);
-		fprintf(stderr, " %s\n", f.c_str());
+		std::fprintf(stderr, " %s\n", f.c_str());
 	}
 
 	TEST_CHECK(files.count("abc") == 1);
@@ -140,13 +140,13 @@ TORRENT_TEST(directory)
 		std::string f = i.file();
 		TEST_CHECK(files.count(f) == 0);
 		files.insert(f);
-		fprintf(stderr, " %s\n", f.c_str());
+		std::fprintf(stderr, " %s\n", f.c_str());
 	}
 
 	remove_all("file_test_dir", ec);
-	if (ec) fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
 	remove_all("file_test_dir2", ec);
-	if (ec) fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
 }
 
 // test path functions
@@ -289,20 +289,20 @@ TORRENT_TEST(file)
 	TEST_CHECK(f.open("test_file", file::read_write, ec));
 #endif
 	if (ec)
-		fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 	file::iovec_t b = {(void*)"test", 4};
 	TEST_EQUAL(f.writev(0, &b, 1, ec), 4);
 	if (ec)
-		fprintf(stderr, "writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_CHECK(!ec);
 	char test_buf[5] = {0};
 	b.iov_base = test_buf;
 	b.iov_len = 4;
 	TEST_EQUAL(f.readv(0, &b, 1, ec), 4);
 	if (ec)
-		fprintf(stderr, "readv failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "readv failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 	TEST_CHECK(strcmp(test_buf, "test") == 0);
 	f.close();
@@ -319,26 +319,26 @@ TORRENT_TEST(hard_link)
 	file f;
 	TEST_CHECK(f.open("original_file", file::read_write, ec));
 	if (ec)
-		fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 
 	file::iovec_t b = {(void*)"abcdefghijklmnopqrstuvwxyz", 26};
 	TEST_EQUAL(f.writev(0, &b, 1, ec), 26);
 	if (ec)
-		fprintf(stderr, "writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 	f.close();
 
 	hard_link("original_file", "second_link", ec);
 
 	if (ec)
-		fprintf(stderr, "hard_link failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "hard_link failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 
 
 	TEST_CHECK(f.open("second_link", file::read_write, ec));
 	if (ec)
-		fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 
 	char test_buf[27] = {0};
@@ -346,18 +346,18 @@ TORRENT_TEST(hard_link)
 	b.iov_len = 27;
 	TEST_EQUAL(f.readv(0, &b, 1, ec), 26);
 	if (ec)
-		fprintf(stderr, "readv failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "readv failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 	TEST_CHECK(strcmp(test_buf, "abcdefghijklmnopqrstuvwxyz") == 0);
 	f.close();
 
 	remove("original_file", ec);
 	if (ec)
-		fprintf(stderr, "remove failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "remove failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 
 	remove("second_link", ec);
 	if (ec)
-		fprintf(stderr, "remove failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "remove failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 }
 
 TORRENT_TEST(coalesce_buffer)
@@ -366,13 +366,13 @@ TORRENT_TEST(coalesce_buffer)
 	file f;
 	TEST_CHECK(f.open("test_file", file::read_write, ec));
 	if (ec)
-		fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 	file::iovec_t b[2] = {{(void*)"test", 4}, {(void*)"foobar", 6}};
 	TEST_EQUAL(f.writev(0, b, 2, ec, file::coalesce_buffers), 4 + 6);
 	if (ec)
-		fprintf(stderr, "writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+		std::fprintf(stderr, "writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_CHECK(!ec);
 	char test_buf1[5] = {0};
 	char test_buf2[7] = {0};
@@ -383,7 +383,7 @@ TORRENT_TEST(coalesce_buffer)
 	TEST_EQUAL(f.readv(0, b, 2, ec), 4 + 6);
 	if (ec)
 	{
-		fprintf(stderr, "readv failed: [%s] %s\n"
+		std::fprintf(stderr, "readv failed: [%s] %s\n"
 			, ec.category().name(), ec.message().c_str());
 	}
 	TEST_EQUAL(ec, error_code());

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -71,7 +71,7 @@ void setup_test_storage(file_storage& st)
 
 	TEST_EQUAL(st.total_size(), 100000);
 	TEST_EQUAL(st.piece_length(), 0x4000);
-	printf("%d\n", st.num_pieces());
+	std::printf("%d\n", st.num_pieces());
 	TEST_EQUAL(st.num_pieces(), (100000 + 0x3fff) / 0x4000);
 }
 
@@ -204,8 +204,8 @@ TORRENT_TEST(file_path_hash)
 	fs.add_file(combine_path("temp_storage", "Foo"), 17);
 	fs.add_file(combine_path("temp_storage", "foo"), 612);
 
-	fprintf(stderr, "path: %s\n", fs.file_path(0).c_str());
-	fprintf(stderr, "file: %s\n", fs.file_path(1).c_str());
+	std::fprintf(stderr, "path: %s\n", fs.file_path(0).c_str());
+	std::fprintf(stderr, "file: %s\n", fs.file_path(1).c_str());
 	boost::uint32_t file_hash0 = fs.file_path_hash(0, "a");
 	boost::uint32_t file_hash1 = fs.file_path_hash(1, "a");
 	TEST_EQUAL(file_hash0, file_hash1);

--- a/test/test_gzip.cpp
+++ b/test/test_gzip.cpp
@@ -43,7 +43,7 @@ TORRENT_TEST(gzip)
 	std::vector<char> zipped;
 	error_code ec;
 	load_file(combine_path("..", "zeroes.gz"), zipped, ec, 1000000);
-	if (ec) fprintf(stderr, "failed to open file: (%d) %s\n", ec.value()
+	if (ec) std::fprintf(stderr, "failed to open file: (%d) %s\n", ec.value()
 		, ec.message().c_str());
 	TEST_CHECK(!ec);
 
@@ -51,7 +51,7 @@ TORRENT_TEST(gzip)
 	inflate_gzip(&zipped[0], int(zipped.size()), inflated, 1000000, ec);
 
 	if (ec) {
-		fprintf(stderr, "failed to unzip: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "failed to unzip: %s\n", ec.message().c_str());
 	}
 	TEST_CHECK(!ec);
 	TEST_CHECK(inflated.size() > 0);

--- a/test/test_http_connection.cpp
+++ b/test/test_http_connection.cpp
@@ -148,11 +148,11 @@ void write_test_file()
 	error_code ec;
 	file test_file("test_file", file::write_only, ec);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "file error: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "file error: %s\n", ec.message().c_str());
 	file::iovec_t b = { data_buffer, 3216};
 	test_file.writev(0, &b, 1, ec);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "file error: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "file error: %s\n", ec.message().c_str());
 	test_file.close();
 }
 
@@ -186,7 +186,7 @@ void run_suite(std::string const& protocol
 	typedef boost::optional<error_code> err;
 
 	char url[256];
-	snprintf(url, sizeof(url), "%s://127.0.0.1:%d/", protocol.c_str(), port);
+	std::snprintf(url, sizeof(url), "%s://127.0.0.1:%d/", protocol.c_str(), port);
 	std::string url_base(url);
 
 	run_test(url_base + "relative/redirect", 3216, 200, 2, error_code(), ps);
@@ -204,7 +204,7 @@ void run_suite(std::string const& protocol
 	// only run the tests to handle NX_DOMAIN if we have a proper internet
 	// connection that doesn't inject false DNS responses (like Comcast does)
 	hostent* h = gethostbyname("non-existent-domain.se");
-	printf("gethostbyname(\"non-existent-domain.se\") = %p. h_errno = %d\n", h, h_errno);
+	std::printf("gethostbyname(\"non-existent-domain.se\") = %p. h_errno = %d\n", h, h_errno);
 	if (h == 0 && h_errno == HOST_NOT_FOUND)
 	{
 		run_test(protocol + "://non-existent-domain.se/non-existing-file", -1, -1, 0, err(), ps);

--- a/test/test_http_parser.cpp
+++ b/test/test_http_parser.cpp
@@ -226,7 +226,7 @@ TORRENT_TEST(http_parser)
 
 	received = feed_bytes(parser, chunked_test);
 
-	printf("payload: %d protocol: %d\n", received.get<0>(), received.get<1>());
+	std::printf("payload: %d protocol: %d\n", received.get<0>(), received.get<1>());
 	TEST_CHECK(received == make_tuple(20, int(strlen(chunked_test)) - 20, false));
 	TEST_CHECK(parser.finished());
 	TEST_CHECK(std::equal(parser.get_body().begin, parser.get_body().end

--- a/test/test_ip_voter.cpp
+++ b/test/test_ip_voter.cpp
@@ -45,12 +45,12 @@ using namespace libtorrent;
 bool cast_vote(ip_voter& ipv, address ext_ip, address voter)
 {
 	bool new_ip = ipv.cast_vote(ext_ip, 1, voter);
-	fprintf(stderr, "%15s -> %-15s\n"
+	std::fprintf(stderr, "%15s -> %-15s\n"
 		, print_address(voter).c_str()
 		, print_address(ext_ip).c_str());
 	if (new_ip)
 	{
-		fprintf(stderr, "   \x1b[1mnew external IP: %s\x1b[0m\n"
+		std::fprintf(stderr, "   \x1b[1mnew external IP: %s\x1b[0m\n"
 			, print_address(ipv.external_address()).c_str());
 	}
 	return new_ip;

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -119,7 +119,7 @@ TORRENT_TEST(magnet)
 		"&dht=127.0.0.1:43";
 	torrent_handle t = s->add_torrent(p, ec);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 
 	std::vector<announce_entry> trackers = t.trackers();
 	TEST_EQUAL(trackers.size(), 3);
@@ -140,7 +140,7 @@ TORRENT_TEST(magnet)
 		"&xt=urn:btih:c352cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
 	torrent_handle t2 = s->add_torrent(p, ec);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 
 	trackers = t2.trackers();
 	TEST_EQUAL(trackers.size(), 2);
@@ -153,24 +153,24 @@ TORRENT_TEST(magnet)
 		"&dn=Ubuntu+11.04+%28Final%29";
 	torrent_handle t3 = s->add_torrent(p, ec);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 
 	trackers = t3.trackers();
 	TEST_EQUAL(trackers.size(), 3);
 	if (trackers.size() > 0)
 	{
 		TEST_EQUAL(trackers[0].url, "udp://tracker.openbittorrent.com:80");
-		fprintf(stderr, "1: %s\n", trackers[0].url.c_str());
+		std::fprintf(stderr, "1: %s\n", trackers[0].url.c_str());
 	}
 	if (trackers.size() > 1)
 	{
 		TEST_EQUAL(trackers[1].url, "udp://tracker.publicbt.com:80");
-		fprintf(stderr, "2: %s\n", trackers[1].url.c_str());
+		std::fprintf(stderr, "2: %s\n", trackers[1].url.c_str());
 	}
 	if (trackers.size() > 2)
 	{
 		TEST_EQUAL(trackers[2].url, "udp://tracker.ccc.de:80");
-		fprintf(stderr, "3: %s\n", trackers[2].url.c_str());
+		std::fprintf(stderr, "3: %s\n", trackers[2].url.c_str());
 	}
 
 	TEST_EQUAL(to_hex(t.info_hash().to_string()), "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");
@@ -184,7 +184,7 @@ TORRENT_TEST(magnet)
 	int ret = bdecode(&buf[0], &buf[0] + buf.size(), session_state2, ec);
 	TEST_CHECK(ret == 0);
 
-	fprintf(stderr, "session_state\n%s\n", print_entry(session_state2).c_str());
+	std::fprintf(stderr, "session_state\n%s\n", print_entry(session_state2).c_str());
 
 	// make sure settings that haven't been changed from their defaults are not saved
 	TEST_CHECK(session_state2.dict_find("settings")
@@ -192,7 +192,7 @@ TORRENT_TEST(magnet)
 
 	s->load_state(session_state2);
 
-#define CMP_SET(x) fprintf(stderr, #x ": %d %d\n"\
+#define CMP_SET(x) std::fprintf(stderr, #x ": %d %d\n"\
 	, s->get_settings().get_int(settings_pack:: x)\
 	, pack.get_int(settings_pack:: x)); \
 	TEST_EQUAL(s->get_settings().get_int(settings_pack:: x), pack.get_int(settings_pack:: x))
@@ -283,7 +283,7 @@ TORRENT_TEST(parse_dht_node)
 	add_torrent_params p;
 	parse_magnet_uri("magnet:?xt=urn:btih:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd&dn=foo&dht=127.0.0.1:43", p, ec);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 	ec.clear();
 
 	TEST_EQUAL(p.dht_nodes.size(), 1);
@@ -338,14 +338,14 @@ TORRENT_TEST(make_magnet_uri)
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), torrent);
 	buf.push_back('\0');
-	printf("%s\n", &buf[0]);
+	std::printf("%s\n", &buf[0]);
 	error_code ec;
 	torrent_info ti(&buf[0], int(buf.size()), ec);
 
 	TEST_EQUAL(al.size(), ti.trackers().size());
 
 	std::string magnet = make_magnet_uri(ti);
-	printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
+	std::printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
 }
 
 TORRENT_TEST(make_magnet_uri2)
@@ -365,12 +365,12 @@ TORRENT_TEST(make_magnet_uri2)
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), torrent);
 	buf.push_back('\0');
-	printf("%s\n", &buf[0]);
+	std::printf("%s\n", &buf[0]);
 	error_code ec;
 	torrent_info ti(&buf[0], int(buf.size()), ec);
 
 	std::string magnet = make_magnet_uri(ti);
-	printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
+	std::printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
 	TEST_CHECK(magnet.find("&ws=http%3a%2f%2ffoo.com%2fbar") != std::string::npos);
 }
 

--- a/test/test_packet_buffer.cpp
+++ b/test/test_packet_buffer.cpp
@@ -92,12 +92,12 @@ TORRENT_TEST(insert)
 	{
 		int index = (i + 0xfff0) & 0xffff;
 		pb.insert(index, reinterpret_cast<int*>(size_t(index) + 1));
-		fprintf(stderr, "insert: %u (mask: %x)\n", index, int(pb.capacity() - 1));
+		std::fprintf(stderr, "insert: %u (mask: %x)\n", index, int(pb.capacity() - 1));
 		TEST_EQUAL(pb.capacity(), 512);
 		if (i >= 14)
 		{
 			index = (index - 14) & 0xffff;
-			fprintf(stderr, "remove: %u\n", index);
+			std::fprintf(stderr, "remove: %u\n", index);
 			TEST_CHECK(pb.remove(index) == reinterpret_cast<int*>(size_t(index) + 1));
 			TEST_EQUAL(pb.size(), 14);
 		}

--- a/test/test_part_file.cpp
+++ b/test/test_part_file.cpp
@@ -44,22 +44,22 @@ TORRENT_TEST(part_file)
 	std::string cwd = complete(".");
 
 	remove_all(combine_path(cwd, "partfile_test_dir"), ec);
-	if (ec) fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
 	remove_all(combine_path(cwd, "partfile_test_dir2"), ec);
-	if (ec) fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "remove_all: %s\n", ec.message().c_str());
 
 	int piece_size = 16 * 0x4000;
 	char buf[1024];
 
 	{
 		create_directory(combine_path(cwd, "partfile_test_dir"), ec);
-		if (ec) fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
 		create_directory(combine_path(cwd, "partfile_test_dir2"), ec);
-		if (ec) fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
 
 		part_file pf(combine_path(cwd, "partfile_test_dir"), "partfile.parts", 100, piece_size);
 		pf.flush_metadata(ec);
-		if (ec) fprintf(stderr, "flush_metadata: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "flush_metadata: %s\n", ec.message().c_str());
 
 		// since we don't have anything in the part file, it will have
 		// not have been created yet
@@ -71,17 +71,17 @@ TORRENT_TEST(part_file)
 
 		file::iovec_t v = {&buf, 1024};
 		pf.writev(&v, 1, 10, 0, ec);
-		if (ec) fprintf(stderr, "part_file::writev: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "part_file::writev: %s\n", ec.message().c_str());
 
 		pf.flush_metadata(ec);
-		if (ec) fprintf(stderr, "flush_metadata: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "flush_metadata: %s\n", ec.message().c_str());
 
 		// now wwe should have created the partfile
 		TEST_CHECK(exists(combine_path(combine_path(cwd, "partfile_test_dir"), "partfile.parts")));
 
 		pf.move_partfile(combine_path(cwd, "partfile_test_dir2"), ec);
 		TEST_CHECK(!ec);
-		if (ec) fprintf(stderr, "move_partfile: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "move_partfile: %s\n", ec.message().c_str());
 
 		TEST_CHECK(!exists(combine_path(combine_path(cwd, "partfile_test_dir"), "partfile.parts")));
 		TEST_CHECK(exists(combine_path(combine_path(cwd, "partfile_test_dir2"), "partfile.parts")));
@@ -89,7 +89,7 @@ TORRENT_TEST(part_file)
 		memset(buf, 0, sizeof(buf));
 
 		pf.readv(&v, 1, 10, 0, ec);
-		if (ec) fprintf(stderr, "part_file::readv: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "part_file::readv: %s\n", ec.message().c_str());
 
 		for (int i = 0; i < 1024; ++i)
 			TEST_CHECK(buf[i] == char(i));
@@ -103,7 +103,7 @@ TORRENT_TEST(part_file)
 
 		file::iovec_t v = {&buf, 1024};
 		pf.readv(&v, 1, 10, 0, ec);
-		if (ec) fprintf(stderr, "part_file::readv: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "part_file::readv: %s\n", ec.message().c_str());
 
 		for (int i = 0; i < 1024; ++i)
 			TEST_CHECK(buf[i] == char(i));
@@ -113,32 +113,32 @@ TORRENT_TEST(part_file)
 		std::string output_filename = combine_path(combine_path(cwd, "partfile_test_dir")
 			, "part_file_test_export");
 		file output(output_filename, file::read_write, ec);
-		if (ec) fprintf(stderr, "export open file: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "export open file: %s\n", ec.message().c_str());
 
 		pf.export_file(output, 10 * piece_size, 1024, ec);
-		if (ec) fprintf(stderr, "export_file: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "export_file: %s\n", ec.message().c_str());
 
 		pf.free_piece(10);
 
 		pf.flush_metadata(ec);
-		if (ec) fprintf(stderr, "flush_metadata: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "flush_metadata: %s\n", ec.message().c_str());
 
 		// we just removed the last piece. The partfile does not
 		// contain anything anymore, it should have deleted itself
 		TEST_CHECK(!exists(combine_path(combine_path(cwd, "partfile_test_dir2"), "partfile.parts"), ec));
 		TEST_CHECK(!ec);
-		if (ec) fprintf(stderr, "exists: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "exists: %s\n", ec.message().c_str());
 
 		output.close();
 
 		// verify that the exported file is what we expect it to be
 		output.open(output_filename, file::read_only, ec);
-		if (ec) fprintf(stderr, "exported file open: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "exported file open: %s\n", ec.message().c_str());
 
 		memset(buf, 0, sizeof(buf));
 
 		output.readv(0, &v, 1, ec);
-		if (ec) fprintf(stderr, "exported file read: %s\n", ec.message().c_str());
+		if (ec) std::fprintf(stderr, "exported file read: %s\n", ec.message().c_str());
 
 		for (int i = 0; i < 1024; ++i)
 			TEST_CHECK(buf[i] == char(i));

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -97,9 +97,9 @@ void print_key(char const* key)
 {
 	for (int i = 0;i < 96; ++i)
 	{
-		printf("%02x ", unsigned(key[i]));
+		std::printf("%02x ", unsigned(key[i]));
 	}
-	printf("\n");
+	std::printf("\n");
 }
 
 TORRENT_TEST(diffie_hellman)
@@ -122,16 +122,16 @@ TORRENT_TEST(diffie_hellman)
 		TEST_CHECK(std::equal(DH1.get_secret(), DH1.get_secret() + 96, DH2.get_secret()));
 		if (!std::equal(DH1.get_secret(), DH1.get_secret() + 96, DH2.get_secret()))
 		{
-			printf("DH1 local: ");
+			std::printf("DH1 local: ");
 			print_key(DH1.get_local_key());
 
-			printf("DH2 local: ");
+			std::printf("DH2 local: ");
 			print_key(DH2.get_local_key());
 
-			printf("DH1 shared_secret: ");
+			std::printf("DH1 shared_secret: ");
 			print_key(DH1.get_secret());
 
-			printf("DH2 shared_secret: ");
+			std::printf("DH2 shared_secret: ");
 			print_key(DH2.get_secret());
 		}
 	}
@@ -144,7 +144,7 @@ TORRENT_TEST(rc4)
 	sha1_hash test1_key = hasher("test1_key",8).final();
 	sha1_hash test2_key = hasher("test2_key",8).final();
 
-	fprintf(stderr, "testing RC4 handler\n");
+	std::fprintf(stderr, "testing RC4 handler\n");
 	rc4_handler rc41;
 	rc41.set_incoming_key(&test2_key[0], 20);
 	rc41.set_outgoing_key(&test1_key[0], 20);
@@ -157,7 +157,7 @@ TORRENT_TEST(rc4)
 #else
 TORRENT_TEST(disabled)
 {
-	fprintf(stderr, "PE test not run because it's disabled\n");
+	std::fprintf(stderr, "PE test not run because it's disabled\n");
 }
 #endif
 

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -514,7 +514,7 @@ TORRENT_TEST(erase_peers)
 		TEST_CHECK(peer);
 		if (peer == NULL || st.erased.size() > 0)
 		{
-			fprintf(stderr, "unexpected rejection of peer: %s | %d in list. "
+			std::fprintf(stderr, "unexpected rejection of peer: %s | %d in list. "
 				"added peer %p, erased %d peers\n"
 				, print_endpoint(ep).c_str(), p.num_peers(), peer
 				, int(st.erased.size()));

--- a/test/test_piece_picker.cpp
+++ b/test/test_piece_picker.cpp
@@ -215,13 +215,13 @@ void print_availability(boost::shared_ptr<piece_picker> const& p)
 {
 	std::vector<int> avail;
 	p->get_availability(avail);
-	printf("[ ");
+	std::printf("[ ");
 	for (std::vector<int>::iterator i = avail.begin()
 		, end(avail.end()); i != end; ++i)
 	{
-		printf("%d ", *i);
+		std::printf("%d ", *i);
 	}
-	printf("]\n");
+	std::printf("]\n");
 }
 
 bool verify_availability(boost::shared_ptr<piece_picker> const& p, char const* a)
@@ -453,12 +453,12 @@ TORRENT_TEST(piece_picker)
 
 	p->mark_as_downloading(piece_block(0, 0), &tmp2);
 
-	fprintf(stderr, "num_peers: %d\n", p->num_peers(piece_block(0, 0)));
+	std::fprintf(stderr, "num_peers: %d\n", p->num_peers(piece_block(0, 0)));
 	TEST_EQUAL(p->num_peers(piece_block(0, 0)), 2);
 
 	p->abort_download(piece_block(0, 0), &tmp1);
 
-	fprintf(stderr, "num_peers: %d\n", p->num_peers(piece_block(0, 0)));
+	std::fprintf(stderr, "num_peers: %d\n", p->num_peers(piece_block(0, 0)));
 	TEST_EQUAL(p->num_peers(piece_block(0, 0)), 1);
 
 // ========================================================

--- a/test/test_primitives.cpp
+++ b/test/test_primitives.cpp
@@ -78,9 +78,9 @@ TORRENT_TEST(primitives)
 		int delay = ae.next_announce_in();
 		TEST_CHECK(delay > last);
 		last = delay;
-		fprintf(stderr, "%d, ", delay);
+		std::fprintf(stderr, "%d, ", delay);
 	}
-	fprintf(stderr, "\n");
+	std::fprintf(stderr, "\n");
 
 	// test error codes
 	TEST_CHECK(error_code(errors::http_error).message() == "HTTP error");
@@ -96,7 +96,7 @@ TORRENT_TEST(primitives)
 	// test snprintf
 
 	char msg[10];
-	snprintf(msg, sizeof(msg), "too %s format string", "long");
+	std::snprintf(msg, sizeof(msg), "too %s format string", "long");
 	TEST_CHECK(strcmp(msg, "too long ") == 0);
 
 	if (supports_ipv6())

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -236,7 +236,7 @@ void test_transfer(settings_pack const& sett, bool test_deprecated = false)
 	tor2.pause();
 	wait_for_alert(ses2, torrent_paused_alert::alert_type, "ses2");
 
-	fprintf(stderr, "save resume data\n");
+	std::fprintf(stderr, "save resume data\n");
 	tor2.save_resume_data();
 
 	std::vector<char> resume_data;
@@ -257,12 +257,12 @@ void test_transfer(settings_pack const& sett, bool test_deprecated = false)
 			{
 				bencode(std::back_inserter(resume_data)
 					, *alert_cast<save_resume_data_alert>(a)->resume_data);
-				fprintf(stderr, "saved resume data\n");
+				std::fprintf(stderr, "saved resume data\n");
 				goto done;
 			}
 			else if (alert_cast<save_resume_data_failed_alert>(a))
 			{
-				fprintf(stderr, "save resume failed\n");
+				std::fprintf(stderr, "save resume failed\n");
 				goto done;
 			}
 			if (total_seconds(clock_type::now() - start) > 10)
@@ -275,7 +275,7 @@ done:
 	if (resume_data.empty())
 		return;
 
-	fprintf(stderr, "%s\n", &resume_data[0]);
+	std::fprintf(stderr, "%s\n", &resume_data[0]);
 
 	ses2.remove_torrent(tor2);
 
@@ -367,7 +367,7 @@ done:
 
 		if (peer_disconnects >= 2)
 		{
-			fprintf(stderr, "too many disconnects (%d), exiting\n", peer_disconnects);
+			std::fprintf(stderr, "too many disconnects (%d), exiting\n", peer_disconnects);
 			break;
 		}
 
@@ -376,7 +376,7 @@ done:
 
 	st2 = tor2.status();
 	if (!st2.is_seeding)
-		fprintf(stderr, "ses2 failed to reconnect to ses1!\n");
+		std::fprintf(stderr, "ses2 failed to reconnect to ses1!\n");
 	TEST_CHECK(st2.is_seeding);
 
 	sp.push_back(ses1.abort());

--- a/test/test_privacy.cpp
+++ b/test/test_privacy.cpp
@@ -89,7 +89,7 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, int flags)
 	// if DHT is disabled, we won't get any requests to it
 	flags &= ~expect_dht_msg;
 #endif
-	fprintf(stderr, "\n=== TEST == proxy: %s anonymous-mode: %s\n\n", proxy_name[proxy_type], (flags & force_proxy_mode) ? "yes" : "no");
+	std::fprintf(stderr, "\n=== TEST == proxy: %s anonymous-mode: %s\n\n", proxy_name[proxy_type], (flags & force_proxy_mode) ? "yes" : "no");
 	int http_port = start_web_server();
 	int udp_port = start_udp_tracker();
 	int dht_port = start_dht();
@@ -118,7 +118,7 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, int flags)
 	// pipelining of the tests) they actually need to use different ports
 	static int listen_port = 10000 + libtorrent::random() % 50000;
 	char iface[200];
-	snprintf(iface, sizeof(iface), "127.0.0.1:%d", listen_port);
+	std::snprintf(iface, sizeof(iface), "127.0.0.1:%d", listen_port);
 	listen_port += (libtorrent::random() % 10) + 1;
 	sett.set_str(settings_pack::listen_interfaces, iface);
 
@@ -143,11 +143,11 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, int flags)
 	file.close();
 
 	char http_tracker_url[200];
-	snprintf(http_tracker_url, sizeof(http_tracker_url), "http://127.0.0.1:%d/announce", http_port);
+	std::snprintf(http_tracker_url, sizeof(http_tracker_url), "http://127.0.0.1:%d/announce", http_port);
 	t->add_tracker(http_tracker_url, 0);
 
 	char udp_tracker_url[200];
-	snprintf(udp_tracker_url, sizeof(udp_tracker_url), "udp://127.0.0.1:%d/announce", udp_port);
+	std::snprintf(udp_tracker_url, sizeof(udp_tracker_url), "udp://127.0.0.1:%d/announce", udp_port);
 	t->add_tracker(udp_tracker_url, 1);
 
 	add_torrent_params addp;
@@ -163,7 +163,7 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, int flags)
 	addp.dht_nodes.push_back(std::pair<std::string, int>("127.0.0.1", dht_port));
 	torrent_handle h = s->add_torrent(addp);
 
-	printf("connect_peer: 127.0.0.1:%d\n", peer_port);
+	std::printf("connect_peer: 127.0.0.1:%d\n", peer_port);
 	h.connect_peer(tcp::endpoint(address_v4::from_string("127.0.0.1"), peer_port));
 
 	rejected_trackers.clear();
@@ -230,7 +230,7 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, int flags)
 	if (flags & expect_http_reject)
 		TEST_CHECK(std::find(rejected_trackers.begin(), rejected_trackers.end(), http_tracker_url) != rejected_trackers.end());
 
-	fprintf(stderr, "%s: ~session\n", time_now_string());
+	std::fprintf(stderr, "%s: ~session\n", time_now_string());
 	session_proxy pr = s->abort();
 	delete s;
 

--- a/test/test_random.cpp
+++ b/test/test_random.cpp
@@ -57,7 +57,7 @@ TORRENT_TEST(random)
 		{
 			const int expected = repetitions / 256;
 			// expect each bucket to be within 15% of the expected value
-			fprintf(stderr, "%d: %f\n", i, float(buckets[i] - expected) * 100.f / expected);
+			std::fprintf(stderr, "%d: %f\n", i, float(buckets[i] - expected) * 100.f / expected);
 			TEST_CHECK(abs(buckets[i] - expected) < expected / 6);
 		}
 	}

--- a/test/test_read_piece.cpp
+++ b/test/test_read_piece.cpp
@@ -48,20 +48,20 @@ void test_read_piece(int flags)
 	using namespace libtorrent;
 	namespace lt = libtorrent;
 
-	fprintf(stderr, "==== TEST READ PIECE =====\n");
+	std::fprintf(stderr, "==== TEST READ PIECE =====\n");
 
 	// in case the previous run was terminated
 	error_code ec;
 	remove_all("tmp1_read_piece", ec);
-	if (ec) fprintf(stderr, "ERROR: removing tmp1_read_piece: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: removing tmp1_read_piece: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	create_directory("tmp1_read_piece", ec);
-	if (ec) fprintf(stderr, "ERROR: creating directory tmp1_read_piece: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: creating directory tmp1_read_piece: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	create_directory(combine_path("tmp1_read_piece", "test_torrent"), ec);
-	if (ec) fprintf(stderr, "ERROR: creating directory test_torrent: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: creating directory test_torrent: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	file_storage fs;
@@ -78,14 +78,14 @@ void test_read_piece(int flags)
 
 	// calculate the hash for all pieces
 	set_piece_hashes(t, "tmp1_read_piece", ec);
-	if (ec) fprintf(stderr, "ERROR: set_piece_hashes: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: set_piece_hashes: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), t.generate());
 	boost::shared_ptr<torrent_info> ti(new torrent_info(&buf[0], int(buf.size()), ec));
 
-	fprintf(stderr, "generated torrent: %s tmp1_read_piece/test_torrent\n"
+	std::fprintf(stderr, "generated torrent: %s tmp1_read_piece/test_torrent\n"
 		, to_hex(ti->info_hash().to_string()).c_str());
 
 	const int mask = alert::all_categories
@@ -142,7 +142,7 @@ void test_read_piece(int flags)
 	}
 
 	remove_all("tmp1_read_piece", ec);
-	if (ec) fprintf(stderr, "ERROR: removing tmp1_read_piece: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: removing tmp1_read_piece: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 }
 

--- a/test/test_recheck.cpp
+++ b/test/test_recheck.cpp
@@ -60,7 +60,7 @@ void wait_for_complete(lt::session& ses, torrent_handle h)
 	{
 		print_alerts(ses, "ses1");
 		torrent_status st = h.status();
-		fprintf(stderr, "%f %%\n", st.progress_ppm / 10000.f);
+		std::fprintf(stderr, "%f %%\n", st.progress_ppm / 10000.f);
 		if (st.progress_ppm == 1000000) return;
 		if (st.progress_ppm != last_progress)
 		{
@@ -85,7 +85,7 @@ TORRENT_TEST(recheck)
 	sett.set_bool(settings_pack::enable_dht, false);
 	lt::session ses1(sett);
 	create_directory("tmp1_recheck", ec);
-	if (ec) fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "create_directory: %s\n", ec.message().c_str());
 	std::ofstream file("tmp1_recheck/temporary");
 	boost::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 4 * 1024 * 1024
 		, 7, false);
@@ -98,7 +98,7 @@ TORRENT_TEST(recheck)
 	param.save_path = "tmp1_recheck";
 	param.flags |= add_torrent_params::flag_seed_mode;
 	torrent_handle tor1 = ses1.add_torrent(param, ec);
-	if (ec) fprintf(stderr, "add_torrent: %s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "add_torrent: %s\n", ec.message().c_str());
 
 	wait_for_listen(ses1, "ses1");
 

--- a/test/test_remap_files.cpp
+++ b/test/test_remap_files.cpp
@@ -96,7 +96,7 @@ void test_remap_files_gather(storage_mode_t storage_mode = storage_mode_sparse)
 	create_directory(combine_path("tmp1_remap", "test_torrent_dir"), ec);
 	if (ec)
 	{
-		fprintf(stderr, "error creating directory: %s\n"
+		std::fprintf(stderr, "error creating directory: %s\n"
 			, ec.message().c_str());
 		TEST_CHECK(false);
 		return;
@@ -117,7 +117,7 @@ void test_remap_files_gather(storage_mode_t storage_mode = storage_mode_sparse)
 	set_piece_hashes(ct, "tmp1_remap", ec);
 	if (ec)
 	{
-		fprintf(stderr, "error creating hashes for test torrent: %s\n"
+		std::fprintf(stderr, "error creating hashes for test torrent: %s\n"
 			, ec.message().c_str());
 		TEST_CHECK(false);
 		return;
@@ -147,7 +147,7 @@ void test_remap_files_gather(storage_mode_t storage_mode = storage_mode_sparse)
 		, true, false, true, "_remap", 8 * 1024, &t, false, &params
 		, true, false, &t2);
 
-	fprintf(stderr, "\ntesting remap gather\n\n");
+	std::fprintf(stderr, "\ntesting remap gather\n\n");
 
 	for (int i = 0; i < 50; ++i)
 	{
@@ -187,7 +187,7 @@ void test_remap_files_gather(storage_mode_t storage_mode = storage_mode_sparse)
 
 	if (!st2.is_seeding) return;
 
-	fprintf(stderr, "\ntesting force recheck\n\n");
+	std::fprintf(stderr, "\ntesting force recheck\n\n");
 
 	// test force rechecking a seeding torrent with remapped files
 	tor2.force_recheck();
@@ -263,11 +263,11 @@ void test_remap_files_scatter(storage_mode_t storage_mode = storage_mode_sparse)
 	for (int i = 0; i < num_files-1; ++i)
 	{
 		char name[100];
-		snprintf(name, sizeof(name), "multifile/file%d.txt", i);
+		std::snprintf(name, sizeof(name), "multifile/file%d.txt", i);
 		fs.add_file(name, t->total_size() / 10);
 	}
 	char name[100];
-	snprintf(name, sizeof(name), "multifile/file%d.txt", num_files);
+	std::snprintf(name, sizeof(name), "multifile/file%d.txt", num_files);
 	// the last file has to be a special case to make the size
 	// add up exactly (in case the total size is not divisible by 10).
 	fs.add_file(name, t->total_size() - fs.total_size());
@@ -291,7 +291,7 @@ void test_remap_files_scatter(storage_mode_t storage_mode = storage_mode_sparse)
 		, true, false, true, "_remap2", 8 * 1024, &t, false, &params
 		, true, false, &t2);
 
-	fprintf(stderr, "\ntesting remap scatter\n\n");
+	std::fprintf(stderr, "\ntesting remap scatter\n\n");
 
 	for (int i = 0; i < 50; ++i)
 	{
@@ -331,7 +331,7 @@ void test_remap_files_scatter(storage_mode_t storage_mode = storage_mode_sparse)
 
 	if (!st2.is_seeding) return;
 
-	fprintf(stderr, "\ntesting force recheck\n\n");
+	std::fprintf(stderr, "\ntesting force recheck\n\n");
 
 	// test force rechecking a seeding torrent with remapped files
 	tor2.force_recheck();
@@ -414,7 +414,7 @@ void test_remap_files_prio(storage_mode_t storage_mode = storage_mode_sparse)
 
 	// calculate the hash for all pieces
 	set_piece_hashes(ct, "tmp1_remap3", ec);
-	if (ec) fprintf(stderr, "ERROR: set_piece_hashes: (%d) %s\n"
+	if (ec) std::fprintf(stderr, "ERROR: set_piece_hashes: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
 	std::vector<char> buf;
@@ -427,11 +427,11 @@ void test_remap_files_prio(storage_mode_t storage_mode = storage_mode_sparse)
 	for (int i = 0; i < num_new_files-1; ++i)
 	{
 		char name[100];
-		snprintf(name, sizeof(name), "multifile/file%d.txt", i);
+		std::snprintf(name, sizeof(name), "multifile/file%d.txt", i);
 		fs.add_file(name, t->total_size() / 10);
 	}
 	char name[100];
-	snprintf(name, sizeof(name), "multifile/file%d.txt", num_new_files);
+	std::snprintf(name, sizeof(name), "multifile/file%d.txt", num_new_files);
 	// the last file has to be a special case to make the size
 	// add up exactly (in case the total size is not divisible by 10).
 	fs.add_file(name, t->total_size() - fs.total_size());
@@ -465,7 +465,7 @@ void test_remap_files_prio(storage_mode_t storage_mode = storage_mode_sparse)
 	test_sleep(500);
 	tor1.resume();
 
-	fprintf(stderr, "\ntesting remap scatter prio\n\n");
+	std::fprintf(stderr, "\ntesting remap scatter prio\n\n");
 
 	for (int i = 0; i < 50; ++i)
 	{

--- a/test/test_resolve_links.cpp
+++ b/test/test_resolve_links.cpp
@@ -95,14 +95,14 @@ TORRENT_TEST(resolve_links)
 		test_torrent_t const& e = test_torrents[i];
 
 		std::string p = combine_path(path, e.filename1) + ".torrent";
-		fprintf(stderr, "loading %s\n", p.c_str());
+		std::fprintf(stderr, "loading %s\n", p.c_str());
 		boost::shared_ptr<torrent_info> ti1 = boost::make_shared<torrent_info>(p);
 
 		p = combine_path(path, e.filename2) + ".torrent";
-		fprintf(stderr, "loading %s\n", p.c_str());
+		std::fprintf(stderr, "loading %s\n", p.c_str());
 		boost::shared_ptr<torrent_info> ti2 = boost::make_shared<torrent_info>(p);
 
-		fprintf(stderr, "resolving\n");
+		std::fprintf(stderr, "resolving\n");
 		resolve_links l(ti1);
 		l.match(ti2, ".");
 
@@ -118,7 +118,7 @@ TORRENT_TEST(resolve_links)
 			for (int i = 0; i < int(links.size()); ++i)
 			{
 				TORRENT_ASSERT(i < fs.num_files());
-				fprintf(stderr, "%s --> %s : %d\n", fs.file_name(i).c_str()
+				std::fprintf(stderr, "%s --> %s : %d\n", fs.file_name(i).c_str()
 					, links[i].ti ? to_hex(links[i].ti->info_hash()
 						.to_string()).c_str() : "", links[i].file_idx);
 			}

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -127,7 +127,7 @@ std::vector<char> generate_resume_data(torrent_info* ti
 	std::vector<char> ret;
 	bencode(back_inserter(ret), rd);
 
-	fprintf(stderr, "%s\n", rd.to_string().c_str());
+	std::fprintf(stderr, "%s\n", rd.to_string().c_str());
 
 	return ret;
 }
@@ -218,7 +218,7 @@ void test_piece_priorities(bool test_deprecated = false)
 	TEST_CHECK(a);
 	if (save_resume_data_alert const* ra = alert_cast<save_resume_data_alert>(a))
 	{
-		fprintf(stderr, "%s\n", ra->resume_data->to_string().c_str());
+		std::fprintf(stderr, "%s\n", ra->resume_data->to_string().c_str());
 		entry::string_type prios = (*ra->resume_data)["piece_priority"].string();
 		TEST_EQUAL(int(prios.size()), ti->num_pieces());
 		TEST_EQUAL(prios[0], '\0');
@@ -633,7 +633,7 @@ TORRENT_TEST(paused_deprecated)
 TORRENT_TEST(url_seed_resume_data_deprecated)
 {
 	// merge url seeds with resume data
-	fprintf(stderr, "flags: merge_resume_http_seeds\n");
+	std::fprintf(stderr, "flags: merge_resume_http_seeds\n");
 	settings_pack sett = settings();
 	lt::session ses(sett);
 	torrent_handle h = test_resume_flags(ses,
@@ -657,7 +657,7 @@ TORRENT_TEST(url_seed_resume_data_deprecated)
 TORRENT_TEST(resume_override_torrent_deprecated)
 {
 	// resume data overrides the .torrent_file
-	fprintf(stderr, "flags: no merge_resume_http_seed\n");
+	std::fprintf(stderr, "flags: no merge_resume_http_seed\n");
 	settings_pack sett = settings();
 	lt::session ses(sett);
 	torrent_handle h = test_resume_flags(ses,
@@ -714,7 +714,7 @@ TORRENT_TEST(file_priorities_seed_mode)
 
 void test_zero_file_prio(bool test_deprecated = false)
 {
-	fprintf(stderr, "test_file_prio\n");
+	std::fprintf(stderr, "test_file_prio\n");
 
 	lt::session ses;
 	boost::shared_ptr<torrent_info> ti = generate_torrent();
@@ -780,7 +780,7 @@ TORRENT_TEST(zero_file_prio)
 void test_seed_mode(bool const file_prio, bool const pieces_have, bool const piece_prio
 	, bool const all_files_zero = false, bool const test_deprecated = false)
 {
-	fprintf(stderr, "test_seed_mode file_prio: %d pieces_have: %d piece_prio: %d\n"
+	std::fprintf(stderr, "test_seed_mode file_prio: %d pieces_have: %d piece_prio: %d\n"
 		, file_prio, pieces_have, piece_prio);
 
 	settings_pack sett = settings();
@@ -947,7 +947,7 @@ TORRENT_TEST(resume_save_load_resume)
 	entry::list_type& l = e["file_priority"].list();
 	entry::list_type::iterator i = l.begin();
 
-	fprintf(stderr, "%s\n", e.to_string().c_str());
+	std::fprintf(stderr, "%s\n", e.to_string().c_str());
 
 	TEST_EQUAL(l.size(), 3);
 	TEST_EQUAL(*i++, 1);

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -192,7 +192,7 @@ void test_save_restore(Set setup, Save s, Default d, Load l)
 		lt::session ses(p);
 		// the loading function takes a bdecode_node, so we have to transform the
 		// entry
-		printf("%s\n", st.to_string().c_str());
+		std::printf("%s\n", st.to_string().c_str());
 		std::vector<char> buf;
 		bencode(std::back_inserter(buf), st);
 		bdecode_node state;
@@ -202,8 +202,8 @@ void test_save_restore(Set setup, Save s, Default d, Load l)
 		TEST_EQUAL(ret, 0);
 		if (ec)
 		{
-			printf("bdecode: %s\n", ec.message().c_str());
-			printf("%s\n", std::string(buf.data(), buf.size()).c_str());
+			std::printf("bdecode: %s\n", ec.message().c_str());
+			std::printf("%s\n", std::string(buf.data(), buf.size()).c_str());
 		}
 		TEST_CHECK(!ec);
 		l(ses, state);

--- a/test/test_sha1_hash.cpp
+++ b/test/test_sha1_hash.cpp
@@ -139,7 +139,7 @@ TORRENT_TEST(count_leading_zeroes)
 
 	for (auto const& t : tests)
 	{
-		fprintf(stderr, "%s\n", t.first);
+		std::fprintf(stderr, "%s\n", t.first);
 		TEST_EQUAL(to_hash(t.first).count_leading_zeroes(), t.second);
 	}
 }

--- a/test/test_sliding_average.cpp
+++ b/test/test_sliding_average.cpp
@@ -107,7 +107,7 @@ TORRENT_TEST(sliding_average)
 	TEST_EQUAL(avg.avg_deviation(), 1);
 	avg.add_sample(0);
 	avg.add_sample(0);
-	printf("avg: %d dev: %d\n", avg.mean(), avg.avg_deviation());
+	std::printf("avg: %d dev: %d\n", avg.mean(), avg.avg_deviation());
 	TEST_CHECK(abs(avg.mean() - 250) < 50);
 	TEST_CHECK(abs(avg.avg_deviation() - 250) < 80);
 }

--- a/test/test_ssl.cpp
+++ b/test/test_ssl.cpp
@@ -102,7 +102,7 @@ bool on_alert(alert const* a)
 		if (strcmp(e->error.category().name(), boost::asio::error::get_ssl_category().name()) == 0)
 			++ssl_peer_disconnects;
 
-		fprintf(stderr, "--- peer_errors: %d ssl_disconnects: %d\n"
+		std::fprintf(stderr, "--- peer_errors: %d ssl_disconnects: %d\n"
 			, peer_errors, ssl_peer_disconnects);
 	}
 
@@ -114,7 +114,7 @@ bool on_alert(alert const* a)
 		if (strcmp(e->error.category().name(), boost::asio::error::get_ssl_category().name()) == 0)
 			++ssl_peer_disconnects;
 
-		fprintf(stderr, "--- peer_errors: %d ssl_disconnects: %d\n"
+		std::fprintf(stderr, "--- peer_errors: %d ssl_disconnects: %d\n"
 			, peer_errors, ssl_peer_disconnects);
 	}
 	return false;
@@ -130,7 +130,7 @@ void test_ssl(int test_idx, bool use_utp)
 
 	test_config_t const& test = test_config[test_idx];
 
-	fprintf(stderr, "\n%s TEST: %s Protocol: %s\n\n", time_now_string(), test.name, use_utp ? "uTP": "TCP");
+	std::fprintf(stderr, "\n%s TEST: %s Protocol: %s\n\n", time_now_string(), test.name, use_utp ? "uTP": "TCP");
 
 	// in case the previous run was terminated
 	error_code ec;
@@ -143,7 +143,7 @@ void test_ssl(int test_idx, bool use_utp)
 	sett.set_int(settings_pack::max_retry_port_bind, 100);
 
 	char listen_iface[100];
-	snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%ds", port);
+	std::snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%ds", port);
 	sett.set_str(settings_pack::listen_interfaces, listen_iface);
 	sett.set_bool(settings_pack::enable_incoming_utp, use_utp);
 	sett.set_bool(settings_pack::enable_outgoing_utp, use_utp);
@@ -163,9 +163,9 @@ void test_ssl(int test_idx, bool use_utp)
 
 	// the +20 below is the port we use for non-SSL connections
 	if (test.downloader_has_ssl_listen_port)
-		snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%d,0.0.0.0:%ds", port + 20, port);
+		std::snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%d,0.0.0.0:%ds", port + 20, port);
 	else
-		snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%d", port + 20);
+		std::snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%d", port + 20);
 
 	sett.set_str(settings_pack::listen_interfaces, listen_iface);
 
@@ -227,7 +227,7 @@ void test_ssl(int test_idx, bool use_utp)
 
 	// connect the peers after setting the certificates
 	if (test.use_ssl_ports == false) port += 20;
-	fprintf(stderr, "\n\n%s: ses1: connecting peer port: %d\n\n\n"
+	std::fprintf(stderr, "\n\n%s: ses1: connecting peer port: %d\n\n\n"
 		, time_now_string(), port);
 	tor1.connect_peer(tcp::endpoint(address::from_string("127.0.0.1", ec)
 		, port));
@@ -263,7 +263,7 @@ void test_ssl(int test_idx, bool use_utp)
 
 		if (peer_disconnects >= 2)
 		{
-			fprintf(stderr, "too many disconnects (%d), breaking\n", peer_disconnects);
+			std::fprintf(stderr, "too many disconnects (%d), breaking\n", peer_disconnects);
 			break;
 		}
 
@@ -285,15 +285,15 @@ void test_ssl(int test_idx, bool use_utp)
 		test_sleep(100);
 	}
 
-	fprintf(stderr, "peer_errors: %d expected_errors: %d\n"
+	std::fprintf(stderr, "peer_errors: %d expected_errors: %d\n"
 		, peer_errors, test.peer_errors);
 	TEST_EQUAL(peer_errors > 0, test.peer_errors > 0);
 
-	fprintf(stderr, "ssl_disconnects: %d  expected: %d\n", ssl_peer_disconnects, test.ssl_disconnects);
+	std::fprintf(stderr, "ssl_disconnects: %d  expected: %d\n", ssl_peer_disconnects, test.ssl_disconnects);
 	TEST_EQUAL(ssl_peer_disconnects > 0, test.ssl_disconnects > 0);
 
-	fprintf(stderr, "%s: EXPECT: %s\n", time_now_string(), test.expected_to_complete ? "SUCCEESS" : "FAILURE");
-	fprintf(stderr, "%s: RESULT: %s\n", time_now_string(), tor2.status().is_seeding ? "SUCCEESS" : "FAILURE");
+	std::fprintf(stderr, "%s: EXPECT: %s\n", time_now_string(), test.expected_to_complete ? "SUCCEESS" : "FAILURE");
+	std::fprintf(stderr, "%s: RESULT: %s\n", time_now_string(), tor2.status().is_seeding ? "SUCCEESS" : "FAILURE");
 	TEST_EQUAL(tor2.status().is_seeding, test.expected_to_complete);
 
 	// this allows shutting down the sessions in parallel
@@ -349,19 +349,19 @@ bool try_connect(libtorrent::session& ses1, int port
 {
 	using boost::asio::ssl::context;
 
-	fprintf(stderr, "\nMALICIOUS PEER TEST: ");
-	if (flags & invalid_certificate) fprintf(stderr, "invalid-certificate ");
-	else if (flags & valid_certificate) fprintf(stderr, "valid-certificate ");
-	else fprintf(stderr, "no-certificate ");
+	std::fprintf(stderr, "\nMALICIOUS PEER TEST: ");
+	if (flags & invalid_certificate) std::fprintf(stderr, "invalid-certificate ");
+	else if (flags & valid_certificate) std::fprintf(stderr, "valid-certificate ");
+	else std::fprintf(stderr, "no-certificate ");
 
-	if (flags & invalid_sni_hash) fprintf(stderr, "invalid-SNI-hash ");
-	else if (flags & valid_sni_hash) fprintf(stderr, "valid-SNI-hash ");
-	else fprintf(stderr, "no-SNI-hash ");
+	if (flags & invalid_sni_hash) std::fprintf(stderr, "invalid-SNI-hash ");
+	else if (flags & valid_sni_hash) std::fprintf(stderr, "valid-SNI-hash ");
+	else std::fprintf(stderr, "no-SNI-hash ");
 
-	if (flags & valid_bittorrent_hash) fprintf(stderr, "valid-bittorrent-hash ");
-	else fprintf(stderr, "invalid-bittorrent-hash ");
+	if (flags & valid_bittorrent_hash) std::fprintf(stderr, "valid-bittorrent-hash ");
+	else std::fprintf(stderr, "invalid-bittorrent-hash ");
 
-	fprintf(stderr, " port: %d\n", port);
+	std::fprintf(stderr, " port: %d\n", port);
 
 	error_code ec;
 	boost::asio::io_service ios;
@@ -380,7 +380,7 @@ bool try_connect(libtorrent::session& ses1, int port
 	ctx.set_verify_mode(context::verify_none, ec);
 	if (ec)
 	{
-		fprintf(stderr, "Failed to set SSL verify mode: %s\n"
+		std::fprintf(stderr, "Failed to set SSL verify mode: %s\n"
 			, ec.message().c_str());
 		TEST_CHECK(!ec);
 		return false;
@@ -400,38 +400,38 @@ bool try_connect(libtorrent::session& ses1, int port
 
 	if (flags & (valid_certificate | invalid_certificate))
 	{
-		fprintf(stderr, "set_password_callback\n");
+		std::fprintf(stderr, "set_password_callback\n");
 		ctx.set_password_callback(boost::bind(&password_callback, _1, _2, "test"), ec);
 		if (ec)
 		{
-			fprintf(stderr, "Failed to set certificate password callback: %s\n"
+			std::fprintf(stderr, "Failed to set certificate password callback: %s\n"
 				, ec.message().c_str());
 			TEST_CHECK(!ec);
 			return false;
 		}
-		fprintf(stderr, "use_certificate_file \"%s\"\n", certificate.c_str());
+		std::fprintf(stderr, "use_certificate_file \"%s\"\n", certificate.c_str());
 		ctx.use_certificate_file(certificate, context::pem, ec);
 		if (ec)
 		{
-			fprintf(stderr, "Failed to set certificate file: %s\n"
+			std::fprintf(stderr, "Failed to set certificate file: %s\n"
 				, ec.message().c_str());
 			TEST_CHECK(!ec);
 			return false;
 		}
-		fprintf(stderr, "use_private_key_file \"%s\"\n", private_key.c_str());
+		std::fprintf(stderr, "use_private_key_file \"%s\"\n", private_key.c_str());
 		ctx.use_private_key_file(private_key, context::pem, ec);
 		if (ec)
 		{
-			fprintf(stderr, "Failed to set private key: %s\n"
+			std::fprintf(stderr, "Failed to set private key: %s\n"
 				, ec.message().c_str());
 			TEST_CHECK(!ec);
 			return false;
 		}
-		fprintf(stderr, "use_tmp_dh_file \"%s\"\n", dh_params.c_str());
+		std::fprintf(stderr, "use_tmp_dh_file \"%s\"\n", dh_params.c_str());
 		ctx.use_tmp_dh_file(dh_params, ec);
 		if (ec)
 		{
-			fprintf(stderr, "Failed to set DH params: %s\n"
+			std::fprintf(stderr, "Failed to set DH params: %s\n"
 				, ec.message().c_str());
 			TEST_CHECK(!ec);
 			return false;
@@ -440,14 +440,14 @@ bool try_connect(libtorrent::session& ses1, int port
 
 	boost::asio::ssl::stream<tcp::socket> ssl_sock(ios, ctx);
 
-	fprintf(stderr, "connecting 127.0.0.1:%d\n", port);
+	std::fprintf(stderr, "connecting 127.0.0.1:%d\n", port);
 	ssl_sock.lowest_layer().connect(tcp::endpoint(
 		address_v4::from_string("127.0.0.1"), port), ec);
 	print_alerts(ses1, "ses1", true, true, true, &on_alert);
 
 	if (ec)
 	{
-		fprintf(stderr, "Failed to connect: %s\n"
+		std::fprintf(stderr, "Failed to connect: %s\n"
 			, ec.message().c_str());
 		TEST_CHECK(!ec);
 		return false;
@@ -456,7 +456,7 @@ bool try_connect(libtorrent::session& ses1, int port
 	if (flags & valid_sni_hash)
 	{
 		std::string name = to_hex(t->info_hash().to_string());
-		fprintf(stderr, "SNI: %s\n", name.c_str());
+		std::fprintf(stderr, "SNI: %s\n", name.c_str());
 		SSL_set_tlsext_host_name(ssl_sock.native_handle(), name.c_str());
 	}
 	else if (flags & invalid_sni_hash)
@@ -467,17 +467,17 @@ bool try_connect(libtorrent::session& ses1, int port
 		for (int i = 0; i < 40; ++i)
 			name += hex_alphabet[rand() % 16];
 
-		fprintf(stderr, "SNI: %s\n", name.c_str());
+		std::fprintf(stderr, "SNI: %s\n", name.c_str());
 		SSL_set_tlsext_host_name(ssl_sock.native_handle(), name.c_str());
 	}
 
-	fprintf(stderr, "SSL handshake\n");
+	std::fprintf(stderr, "SSL handshake\n");
 	ssl_sock.handshake(boost::asio::ssl::stream_base::client, ec);
 
 	print_alerts(ses1, "ses1", true, true, true, &on_alert);
 	if (ec)
 	{
-		fprintf(stderr, "Failed SSL handshake: %s\n"
+		std::fprintf(stderr, "Failed SSL handshake: %s\n"
 			, ec.message().c_str());
 		return false;
 	}
@@ -502,40 +502,40 @@ bool try_connect(libtorrent::session& ses1, int port
 	// fill in the peer-id
 	std::generate(handshake + 48, handshake + 68, &rand);
 
-	fprintf(stderr, "bittorrent handshake\n");
+	std::fprintf(stderr, "bittorrent handshake\n");
 	boost::asio::write(ssl_sock, boost::asio::buffer(handshake, (sizeof(handshake) - 1)), ec);
 	print_alerts(ses1, "ses1", true, true, true, &on_alert);
 	if (ec)
 	{
-		fprintf(stderr, "failed to write bittorrent handshake: %s\n"
+		std::fprintf(stderr, "failed to write bittorrent handshake: %s\n"
 			, ec.message().c_str());
 		return false;
 	}
 
 	char buf[68];
-	fprintf(stderr, "read bittorrent handshake\n");
+	std::fprintf(stderr, "read bittorrent handshake\n");
 	boost::asio::read(ssl_sock, boost::asio::buffer(buf, sizeof(buf)), ec);
 	print_alerts(ses1, "ses1", true, true, true, &on_alert);
 	if (ec)
 	{
-		fprintf(stderr, "failed to read bittorrent handshake: %s\n"
+		std::fprintf(stderr, "failed to read bittorrent handshake: %s\n"
 			, ec.message().c_str());
 		return false;
 	}
 
 	if (memcmp(buf, "\x13" "BitTorrent protocol", 20) != 0)
 	{
-		fprintf(stderr, "invalid bittorrent handshake\n");
+		std::fprintf(stderr, "invalid bittorrent handshake\n");
 		return false;
 	}
 
 	if (memcmp(buf + 28, &t->info_hash()[0], 20) != 0)
 	{
-		fprintf(stderr, "invalid info-hash in bittorrent handshake\n");
+		std::fprintf(stderr, "invalid info-hash in bittorrent handshake\n");
 		return false;
 	}
 
-	fprintf(stderr, "successfully connected over SSL and shook hand over bittorrent\n");
+	std::fprintf(stderr, "successfully connected over SSL and shook hand over bittorrent\n");
 
 	return true;
 }
@@ -552,7 +552,7 @@ void test_malicious_peer()
 	sett.set_int(settings_pack::max_retry_port_bind, 100);
 
 	char listen_iface[100];
-	snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%ds", port);
+	std::snprintf(listen_iface, sizeof(listen_iface), "0.0.0.0:%ds", port);
 	sett.set_str(settings_pack::listen_interfaces, listen_iface);
 	sett.set_bool(settings_pack::enable_dht, false);
 	sett.set_bool(settings_pack::enable_lsd, false);

--- a/test/test_stat_cache.cpp
+++ b/test/test_stat_cache.cpp
@@ -46,7 +46,7 @@ TORRENT_TEST(stat_cache)
 	for (int i = 0; i < 20; ++i)
 	{
 		char buf[50];
-		snprintf(buf, sizeof(buf), "test_torrent/test-%d", i);
+		std::snprintf(buf, sizeof(buf), "test_torrent/test-%d", i);
 		fs.add_file(buf, (i + 1) * 10);
 	}
 

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -95,7 +95,7 @@ void on_check_resume_data(disk_io_job const* j, bool* done)
 
 void print_error(char const* call, int ret, storage_error const& ec)
 {
-	fprintf(stderr, "%s: %s() returned: %d error: \"%s\" in file: %d operation: %d\n"
+	std::fprintf(stderr, "%s: %s() returned: %d error: \"%s\" in file: %d operation: %d\n"
 		, time_now_string(), call, ret, ec.ec.message().c_str(), ec.file, ec.operation);
 }
 
@@ -142,7 +142,7 @@ boost::shared_ptr<default_storage> setup_torrent(file_storage& fs
 
 	if (ec)
 	{
-		fprintf(stderr, "torrent_info constructor failed: %s\n"
+		std::fprintf(stderr, "torrent_info constructor failed: %s\n"
 			, ec.message().c_str());
 	}
 
@@ -160,7 +160,7 @@ boost::shared_ptr<default_storage> setup_torrent(file_storage& fs
 	if (se)
 	{
 		TEST_ERROR(se.ec.message().c_str());
-		fprintf(stderr, "default_storage::initialize %s: %d\n", se.ec.message().c_str(), int(se.file));
+		std::fprintf(stderr, "default_storage::initialize %s: %d\n", se.ec.message().c_str(), int(se.file));
 	}
 
 	return s;
@@ -361,7 +361,7 @@ void test_remove(std::string const& test_path, bool unbuffered)
 	if (se)
 	{
 		TEST_ERROR(se.ec.message().c_str());
-		fprintf(stderr, "default_storage::delete_files %s: %d\n", se.ec.message().c_str(), int(se.file));
+		std::fprintf(stderr, "default_storage::delete_files %s: %d\n", se.ec.message().c_str(), int(se.file));
 	}
 
 	TEST_CHECK(!exists(combine_path(test_path, "temp_storage")));
@@ -399,7 +399,7 @@ void test_rename(std::string const& test_path)
 	s->rename_file(0, "new_filename", se);
 	if (se.ec)
 	{
-		fprintf(stderr, "default_storage::rename_file failed: %s\n"
+		std::fprintf(stderr, "default_storage::rename_file failed: %s\n"
 			, se.ec.message().c_str());
 	}
 	TEST_CHECK(!se.ec);
@@ -532,7 +532,7 @@ void run_test(bool unbuffered)
 
 	// make sure the files have the correct size
 	std::string base = combine_path(test_path, "temp_storage");
-	fprintf(stderr, "base = \"%s\"\n", base.c_str());
+	std::fprintf(stderr, "base = \"%s\"\n", base.c_str());
 	TEST_EQUAL(file_size(combine_path(base, "test1.tmp")), 17);
 	TEST_EQUAL(file_size(combine_path(base, "test2.tmp")), 612);
 
@@ -544,7 +544,7 @@ void run_test(bool unbuffered)
 
 	TEST_EQUAL(file_size(combine_path(base, "test5.tmp")), 3253);
 	TEST_EQUAL(file_size(combine_path(base, "test6.tmp")), 841);
-	printf("file: %d expected: %d last_file_size: %d, piece_size: %d\n"
+	std::printf("file: %d expected: %d last_file_size: %d, piece_size: %d\n"
 		, int(file_size(combine_path(base, "test7.tmp")))
 		, int(last_file_size - piece_size), last_file_size, piece_size);
 	TEST_EQUAL(file_size(combine_path(base, "test7.tmp")), last_file_size - piece_size);
@@ -1236,7 +1236,7 @@ TORRENT_TEST(readwritev_error)
 	TEST_EQUAL(ec.file, 2);
 	TEST_EQUAL(ec.operation, storage_error::read);
 	TEST_EQUAL(ec.ec, boost::system::errc::permission_denied);
-	printf("error: %s\n", ec.ec.message().c_str());
+	std::printf("error: %s\n", ec.ec.message().c_str());
 }
 
 TORRENT_TEST(readwritev_zero_size_files)
@@ -1269,7 +1269,7 @@ void delete_dirs(std::string path)
 	remove_all(path, ec);
 	if (ec && ec != boost::system::errc::no_such_file_or_directory)
 	{
-		fprintf(stderr, "remove_all \"%s\": %s\n"
+		std::fprintf(stderr, "remove_all \"%s\": %s\n"
 			, path.c_str(), ec.message().c_str());
 	}
 	TEST_CHECK(!exists(path));

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -157,7 +157,7 @@ TORRENT_TEST(string)
 	error_code ec;
 	TEST_CHECK(unescape_string(escape_path(test_string, int(strlen(test_string))), ec) == test_string);
 	TEST_CHECK(!ec);
-	if (ec) fprintf(stderr, "%s\n", ec.message().c_str());
+	if (ec) std::fprintf(stderr, "%s\n", ec.message().c_str());
 
 	// need_encoding
 	char const* test_string2 = "!@$&()-_/,.%?";

--- a/test/test_threads.cpp
+++ b/test/test_threads.cpp
@@ -45,11 +45,11 @@ using namespace libtorrent;
 
 void fun(std::condition_variable* s, std::mutex* m, int* waiting, int i)
 {
-	fprintf(stderr, "thread %d waiting\n", i);
+	std::fprintf(stderr, "thread %d waiting\n", i);
 	std::unique_lock<std::mutex> l(*m);
 	*waiting += 1;
 	s->wait(l);
-	fprintf(stderr, "thread %d done\n", i);
+	std::fprintf(stderr, "thread %d done\n", i);
 }
 
 void increment(std::condition_variable* s, std::mutex* m, int* waiting, std::atomic<int>* c)

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -71,7 +71,7 @@ void test_running_torrent(boost::shared_ptr<torrent_info> info, boost::int64_t f
 	torrent_handle h = ses.add_torrent(p, ec);
 	if (ec)
 	{
-		fprintf(stderr, "add_torrent: %s\n", ec.message().c_str());
+		std::fprintf(stderr, "add_torrent: %s\n", ec.message().c_str());
 		return;
 	}
 

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -494,70 +494,70 @@ TORRENT_TEST(verify_encoding)
 	// valid 2-byte sequence
 	test = "filename\xc2\xa1";
 	TEST_CHECK(verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename\xc2\xa1");
 
 	// truncated 2-byte sequence
 	test = "filename\xc2";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename_");
 
 	// valid 3-byte sequence
 	test = "filename\xe2\x9f\xb9";
 	TEST_CHECK(verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename\xe2\x9f\xb9");
 
 	// truncated 3-byte sequence
 	test = "filename\xe2\x9f";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename_");
 
 	// truncated 3-byte sequence
 	test = "filename\xe2";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename_");
 
 	// valid 4-byte sequence
 	test = "filename\xf0\x9f\x92\x88";
 	TEST_CHECK(verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename\xf0\x9f\x92\x88");
 
 	// truncated 4-byte sequence
 	test = "filename\xf0\x9f\x92";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename_");
 
 	// 5-byte utf-8 sequence (not allowed)
 	test = "filename\xf8\x9f\x9f\x9f\x9f""foobar";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename_____foobar");
 
 	// redundant (overlong) 2-byte sequence
 	// ascii code 0x2e encoded with a leading 0
 	test = "filename\xc0\xae";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename__");
 
 	// redundant (overlong) 3-byte sequence
 	// ascii code 0x2e encoded with two leading 0s
 	test = "filename\xe0\x80\xae";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename___");
 
 	// redundant (overlong) 4-byte sequence
 	// ascii code 0x2e encoded with three leading 0s
 	test = "filename\xf0\x80\x80\xae";
 	TEST_CHECK(!verify_encoding(test));
-	fprintf(stderr, "%s\n", test.c_str());
+	std::fprintf(stderr, "%s\n", test.c_str());
 	TEST_CHECK(test == "filename____");
 }
 
@@ -609,12 +609,12 @@ TORRENT_TEST(parse_torrents)
 	std::string root_dir = parent_path(current_working_directory());
 	for (int i = 0; i < int(sizeof(test_torrents)/sizeof(test_torrents[0])); ++i)
 	{
-		fprintf(stderr, "loading %s\n", test_torrents[i].file);
+		std::fprintf(stderr, "loading %s\n", test_torrents[i].file);
 		std::string filename = combine_path(combine_path(root_dir, "test_torrents")
 			, test_torrents[i].file);
 		auto ti = boost::make_shared<torrent_info>(filename, ec);
 		TEST_CHECK(!ec);
-		if (ec) fprintf(stderr, " loading(\"%s\") -> failed %s\n", filename.c_str()
+		if (ec) std::fprintf(stderr, " loading(\"%s\") -> failed %s\n", filename.c_str()
 			, ec.message().c_str());
 
 		if (std::string(test_torrents[i].file) == "whitespace_url.torrent")
@@ -718,7 +718,7 @@ TORRENT_TEST(parse_torrents)
 			int first = ti->map_file(i, 0, 0).piece;
 			int last = ti->map_file(i, (std::max)(fs.file_size(i)-1, boost::int64_t(0)), 0).piece;
 			int flags = fs.file_flags(i);
-			fprintf(stderr, "  %11" PRId64 " %c%c%c%c [ %4d, %4d ] %7u %s %s %s%s\n"
+			std::fprintf(stderr, "  %11" PRId64 " %c%c%c%c [ %4d, %4d ] %7u %s %s %s%s\n"
 				, fs.file_size(i)
 				, (flags & file_storage::flag_pad_file)?'p':'-'
 				, (flags & file_storage::flag_executable)?'x':'-'
@@ -750,10 +750,10 @@ TORRENT_TEST(parse_torrents)
 	for (int i = 0; i < int(sizeof(test_error_torrents)/sizeof(test_error_torrents[0])); ++i)
 	{
 		error_code ec;
-		fprintf(stderr, "loading %s\n", test_error_torrents[i].file);
+		std::fprintf(stderr, "loading %s\n", test_error_torrents[i].file);
 		auto ti = boost::make_shared<torrent_info>(combine_path(
 			combine_path(root_dir, "test_torrents"), test_error_torrents[i].file), ec);
-		fprintf(stderr, "E:        \"%s\"\nexpected: \"%s\"\n", ec.message().c_str()
+		std::fprintf(stderr, "E:        \"%s\"\nexpected: \"%s\"\n", ec.message().c_str()
 			, test_error_torrents[i].error.message().c_str());
 		TEST_CHECK(ec.message() == test_error_torrents[i].error.message());
 	}
@@ -842,7 +842,7 @@ void test_resolve_duplicates(int test_case)
 	{
 		std::string p = ti.files().file_path(i);
 		convert_path_to_posix(p);
-		fprintf(stderr, "%s == %s\n", p.c_str(), filenames[test_case][i]);
+		std::fprintf(stderr, "%s == %s\n", p.c_str(), filenames[test_case][i]);
 
 		TEST_EQUAL(p, filenames[test_case][i]);
 	}
@@ -870,7 +870,7 @@ TORRENT_TEST(empty_file2)
 	}
 	catch (system_error& e)
 	{
-		printf("Expected error: %s\n", e.code().message().c_str());
+		std::printf("Expected error: %s\n", e.code().message().c_str());
 	}
 }
 
@@ -901,7 +901,7 @@ TORRENT_TEST(copy)
 		std::string p = a->files().file_path(i);
 		convert_path_to_posix(p);
 		TEST_EQUAL(p, expected_files[i]);
-		fprintf(stderr, "%s\n", p.c_str());
+		std::fprintf(stderr, "%s\n", p.c_str());
 
 		TEST_EQUAL(a->files().hash(i), file_hashes[i]);
 	}
@@ -923,7 +923,7 @@ TORRENT_TEST(copy)
 		std::string p = b->files().file_path(i);
 		convert_path_to_posix(p);
 		TEST_EQUAL(p, expected_files[i]);
-		fprintf(stderr, "%s\n", p.c_str());
+		std::fprintf(stderr, "%s\n", p.c_str());
 
 		TEST_EQUAL(b->files().hash(i), file_hashes[i]);
 	}

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -334,10 +334,10 @@ TORRENT_TEST(udp_tracker)
 	file.close();
 
 	char tracker_url[200];
-	snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce", http_port);
+	std::snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce", http_port);
 	t->add_tracker(tracker_url, 0);
 
-	snprintf(tracker_url, sizeof(tracker_url), "udp://127.0.0.1:%d/announce", udp_port);
+	std::snprintf(tracker_url, sizeof(tracker_url), "udp://127.0.0.1:%d/announce", udp_port);
 	t->add_tracker(tracker_url, 1);
 
 	add_torrent_params addp;
@@ -355,7 +355,7 @@ TORRENT_TEST(udp_tracker)
 			break;
 
 		test_sleep(100);
-		fprintf(stderr, "UDP: %d / %d\n", int(num_udp_announces())
+		std::fprintf(stderr, "UDP: %d / %d\n", int(num_udp_announces())
 			, int(prev_udp_announces) + 1);
 	}
 
@@ -375,13 +375,13 @@ TORRENT_TEST(udp_tracker)
 			break;
 
 		test_sleep(100);
-		fprintf(stderr, "UDP: %d / %d\n", int(num_udp_announces())
+		std::fprintf(stderr, "UDP: %d / %d\n", int(num_udp_announces())
 			, int(prev_udp_announces) + 1);
 	}
 
-	fprintf(stderr, "destructing session\n");
+	std::fprintf(stderr, "destructing session\n");
 	s.reset();
-	fprintf(stderr, "done\n");
+	std::fprintf(stderr, "done\n");
 
 	// we should have announced the stopped event now
 	TEST_EQUAL(num_udp_announces(), prev_udp_announces + 2);
@@ -409,7 +409,7 @@ TORRENT_TEST(http_peers)
 
 	char tracker_url[200];
 	// and this should not be announced to (since the one before it succeeded)
-	snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
+	std::snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
 		, http_port);
 	t->add_tracker(tracker_url, 0);
 
@@ -446,13 +446,13 @@ TORRENT_TEST(http_peers)
 		TEST_EQUAL(expected_peers.count(i->ip), 1);
 	}
 
-	fprintf(stderr, "destructing session\n");
+	std::fprintf(stderr, "destructing session\n");
 	s.reset();
-	fprintf(stderr, "done\n");
+	std::fprintf(stderr, "done\n");
 
-	fprintf(stderr, "stop_web_server\n");
+	std::fprintf(stderr, "stop_web_server\n");
 	stop_web_server();
-	fprintf(stderr, "done\n");
+	std::fprintf(stderr, "done\n");
 }
 
 void test_proxy(bool proxy_trackers)
@@ -483,7 +483,7 @@ void test_proxy(bool proxy_trackers)
 
 	char tracker_url[200];
 	// and this should not be announced to (since the one before it succeeded)
-	snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
+	std::snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
 		, http_port);
 	t->add_tracker(tracker_url, 0);
 
@@ -506,21 +506,21 @@ void test_proxy(bool proxy_trackers)
 		TEST_CHECK(a != NULL);
 	}
 
-	fprintf(stderr, "destructing session\n");
+	std::fprintf(stderr, "destructing session\n");
 	s.reset();
-	fprintf(stderr, "done\n");
+	std::fprintf(stderr, "done\n");
 
-	fprintf(stderr, "stop_web_server\n");
+	std::fprintf(stderr, "stop_web_server\n");
 	stop_web_server();
-	fprintf(stderr, "done\n");
+	std::fprintf(stderr, "done\n");
 }
 
 TORRENT_TEST(tracker_proxy)
 {
-	fprintf(stderr, "\n\nnot proxying tracker connections (expect to reach the tracker)\n\n");
+	std::fprintf(stderr, "\n\nnot proxying tracker connections (expect to reach the tracker)\n\n");
 	test_proxy(false);
 
-	fprintf(stderr, "\n\nproxying tracker connections through non-existent proxy (do not expect to reach the tracker)\n\n");
+	std::fprintf(stderr, "\n\nproxying tracker connections through non-existent proxy (do not expect to reach the tracker)\n\n");
 	test_proxy(true);
 }
 

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -128,7 +128,7 @@ void test_transfer(int proxy_type, settings_pack const& sett
 {
 	char const* test_name[] = {"no", "SOCKS4", "SOCKS5", "SOCKS5 password", "HTTP", "HTTP password"};
 
-	fprintf(stderr, "\n\n  ==== TESTING %s proxy ==== disk-full: %s\n\n\n"
+	std::fprintf(stderr, "\n\n  ==== TESTING %s proxy ==== disk-full: %s\n\n\n"
 		, test_name[proxy_type], test_disk_full ? "true": "false");
 
 	// in case the previous run was terminated
@@ -304,21 +304,21 @@ void test_transfer(int proxy_type, settings_pack const& sett
 			print_alerts(ses2, "ses2", true, true, true, &on_alert);
 
 			lt::error_code err = tor2.status().errc;
-			fprintf(stderr, "error: \"%s\"\n", err.message().c_str());
+			std::fprintf(stderr, "error: \"%s\"\n", err.message().c_str());
 			TEST_CHECK(!err);
 			tor2.set_upload_mode(false);
 
 			// at this point we probably disconnected the seed
 			// so we need to reconnect as well
-			fprintf(stderr, "%s: reconnecting peer\n", time_now_string());
+			std::fprintf(stderr, "%s: reconnecting peer\n", time_now_string());
 			error_code ec;
 			tor2.connect_peer(tcp::endpoint(address::from_string("127.0.0.1", ec)
 				, ses1.listen_port()));
 
 			TEST_CHECK(tor2.status().is_finished == false);
-			fprintf(stderr, "disconnects: %d\n", peer_disconnects);
+			std::fprintf(stderr, "disconnects: %d\n", peer_disconnects);
 			TEST_CHECK(peer_disconnects >= 2);
-			fprintf(stderr, "%s: discovered disk full mode. Raise limit and disable upload-mode\n", time_now_string());
+			std::fprintf(stderr, "%s: discovered disk full mode. Raise limit and disable upload-mode\n", time_now_string());
 			peer_disconnects = 0;
 			continue;
 		}
@@ -448,7 +448,7 @@ TORRENT_TEST(allocate)
 {
 	using namespace libtorrent;
 	// test storage_mode_allocate
-	fprintf(stderr, "full allocation mode\n");
+	std::fprintf(stderr, "full allocation mode\n");
 	test_transfer(0, settings_pack(), false, storage_mode_allocate);
 
 	cleanup();

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -94,7 +94,7 @@ void incoming_msearch(udp::endpoint const& from, char* buffer
 
 	TORRENT_ASSERT(g_port != 0);
 	char buf[sizeof(msg) + 30];
-	int len = snprintf(buf, sizeof(buf), msg, g_port);
+	int len = std::snprintf(buf, sizeof(buf), msg, g_port);
 
 	error_code ec;
 	sock->send(buf, len, ec);
@@ -141,11 +141,11 @@ void run_upnp_test(char const* root_filename, char const* router_model, char con
 	FILE* xml_file = fopen("upnp.xml", "w+");
 	if (xml_file == NULL)
 	{
-		fprintf(stderr, "failed to open file 'upnp.xml': %s\n", strerror(errno));
+		std::fprintf(stderr, "failed to open file 'upnp.xml': %s\n", strerror(errno));
 		TEST_CHECK(false);
 		return;
 	}
-	fprintf(xml_file, &buf[0], g_port);
+	std::fprintf(xml_file, &buf[0], g_port);
 	fclose(xml_file);
 
 	std::ofstream xml(control_name, std::ios::trunc);
@@ -170,7 +170,7 @@ void run_upnp_test(char const* root_filename, char const* router_model, char con
 		ios.poll(ec);
 		if (ec)
 		{
-			fprintf(stderr, "io_service::run(): %s\n", ec.message().c_str());
+			std::fprintf(stderr, "io_service::run(): %s\n", ec.message().c_str());
 			ec.clear();
 			break;
 		}
@@ -190,7 +190,7 @@ void run_upnp_test(char const* root_filename, char const* router_model, char con
 		ios.poll(ec);
 		if (ec)
 		{
-			fprintf(stderr, "io_service::run(): %s\n", ec.message().c_str());
+			std::fprintf(stderr, "io_service::run(): %s\n", ec.message().c_str());
 			ec.clear();
 			break;
 		}
@@ -216,7 +216,7 @@ void run_upnp_test(char const* root_filename, char const* router_model, char con
 		ios.poll(ec);
 		if (ec)
 		{
-			fprintf(stderr, "io_service::run(): %s\n", ec.message().c_str());
+			std::fprintf(stderr, "io_service::run(): %s\n", ec.message().c_str());
 			ec.clear();
 			break;
 		}

--- a/test/test_utf8.cpp
+++ b/test/test_utf8.cpp
@@ -57,7 +57,7 @@ void verify_transforms(char const* utf8_source, int utf8_source_len = -1)
 		if (ret != conversionOK && utf8_source_len < 10)
 		{
 			for (char const* i = utf8_source; *i != 0; ++i)
-				fprintf(stderr, "%x ", UTF8(*i));
+				std::fprintf(stderr, "%x ", UTF8(*i));
 		}
 
 		std::vector<UTF32> utf32(utf8_source_len);
@@ -70,7 +70,7 @@ void verify_transforms(char const* utf8_source, int utf8_source_len = -1)
 		if (ret != conversionOK && utf8_source_len < 10)
 		{
 			for (char const* i = utf8_source; *i != 0; ++i)
-				fprintf(stderr, "%x ", UTF8(*i));
+				std::fprintf(stderr, "%x ", UTF8(*i));
 		}
 
 		std::vector<UTF8> utf8(utf8_source_len);
@@ -83,7 +83,7 @@ void verify_transforms(char const* utf8_source, int utf8_source_len = -1)
 		if (ret != conversionOK && utf8_source_len < 10)
 		{
 			for (char const* i = utf8_source; *i != 0; ++i)
-				fprintf(stderr, "%x ", UTF8(*i));
+				std::fprintf(stderr, "%x ", UTF8(*i));
 		}
 
 		TEST_EQUAL(out8 - &utf8[0], utf8_source_len);
@@ -102,7 +102,7 @@ void verify_transforms(char const* utf8_source, int utf8_source_len = -1)
 		if (ret != conversionOK && utf8_source_len < 10)
 		{
 			for (char const* i = utf8_source; *i != 0; ++i)
-				fprintf(stderr, "%x ", UTF8(*i));
+				std::fprintf(stderr, "%x ", UTF8(*i));
 		}
 
 		std::vector<UTF16> utf16(utf8_source_len);
@@ -115,7 +115,7 @@ void verify_transforms(char const* utf8_source, int utf8_source_len = -1)
 		if (ret != conversionOK && utf8_source_len < 10)
 		{
 			for (char const* i = utf8_source; *i != 0; ++i)
-				fprintf(stderr, "%x ", UTF8(*i));
+				std::fprintf(stderr, "%x ", UTF8(*i));
 		}
 
 		std::vector<UTF8> utf8(utf8_source_len);
@@ -128,7 +128,7 @@ void verify_transforms(char const* utf8_source, int utf8_source_len = -1)
 		if (ret != conversionOK && utf8_source_len < 10)
 		{
 			for (char const* i = utf8_source; *i != 0; ++i)
-				fprintf(stderr, "%x ", UTF8(*i));
+				std::fprintf(stderr, "%x ", UTF8(*i));
 		}
 
 		TEST_EQUAL(out8 - &utf8[0], utf8_source_len);
@@ -147,9 +147,9 @@ void expect_error(char const* utf8, ConversionResult expect)
 	TEST_EQUAL(ret, expect);
 	if (ret != expect)
 	{
-		fprintf(stderr, "%d expected %d\n", ret, expect);
+		std::fprintf(stderr, "%d expected %d\n", ret, expect);
 		for (char const* i = utf8; *i != 0; ++i)
-			fprintf(stderr, "%x ", UTF8(*i));
+			std::fprintf(stderr, "%x ", UTF8(*i));
 	}
 
 	in8 = (UTF8 const*)utf8;
@@ -161,9 +161,9 @@ void expect_error(char const* utf8, ConversionResult expect)
 	TEST_EQUAL(ret, expect);
 	if (ret != expect)
 	{
-		fprintf(stderr, "%d expected %d\n", ret, expect);
+		std::fprintf(stderr, "%d expected %d\n", ret, expect);
 		for (char const* i = utf8; *i != 0; ++i)
-			fprintf(stderr, "%x ", UTF8(*i));
+			std::fprintf(stderr, "%x ", UTF8(*i));
 	}
 }
 
@@ -172,7 +172,7 @@ TORRENT_TEST(utf8)
 	std::vector<char> utf8_source;
 	error_code ec;
 	load_file(combine_path("..", "utf8_test.txt"), utf8_source, ec, 1000000);
-	if (ec) fprintf(stderr, "failed to open file: (%d) %s\n", ec.value()
+	if (ec) std::fprintf(stderr, "failed to open file: (%d) %s\n", ec.value()
 		, ec.message().c_str());
 	TEST_CHECK(!ec);
 

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -47,7 +47,7 @@ namespace libtorrent
 		int s = t / 1000;
 		t -= s * 1000;
 		int ms = t;
-		snprintf(ret, sizeof(ret), "%02d:%02d:%02d.%03d", h, m, s, ms);
+		std::snprintf(ret, sizeof(ret), "%02d:%02d:%02d.%03d", h, m, s, ms);
 		return ret;
 	}
 }

--- a/test/test_web_seed_redirect.cpp
+++ b/test/test_web_seed_redirect.cpp
@@ -52,7 +52,7 @@ TORRENT_TEST(web_seed_redirect)
 	file f("test_file", file::write_only, ec);
 	if (ec)
 	{
-		fprintf(stderr, "failed to create file \"test_file\": (%d) %s\n"
+		std::fprintf(stderr, "failed to create file \"test_file\": (%d) %s\n"
 			, ec.value(), ec.message().c_str());
 		TEST_ERROR("failed to create file");
 		return;
@@ -68,7 +68,7 @@ TORRENT_TEST(web_seed_redirect)
 	libtorrent::create_torrent t(fs, piece_size, 0x4000);
 
 	char tmp[512];
-	snprintf(tmp, sizeof(tmp), "http://127.0.0.1:%d/redirect", port);
+	std::snprintf(tmp, sizeof(tmp), "http://127.0.0.1:%d/redirect", port);
 	t.add_url_seed(tmp);
 
 	// calculate the hash for all pieces
@@ -76,7 +76,7 @@ TORRENT_TEST(web_seed_redirect)
 
 	if (ec)
 	{
-		fprintf(stderr, "error creating hashes for test torrent: %s\n"
+		std::fprintf(stderr, "error creating hashes for test torrent: %s\n"
 			, ec.message().c_str());
 		TEST_ERROR("failed to create hashes");
 		return;

--- a/test/test_xml.cpp
+++ b/test/test_xml.cpp
@@ -269,7 +269,7 @@ void test_parse(char const* in, char const* expected)
 	std::string out;
 	xml_parse(in, in + strlen(in), boost::bind(&parser_callback
 		, boost::ref(out), _1, _2, _3, _4, _5));
-	fprintf(stderr, "in: %s\n     out: %s\nexpected: %s\n"
+	std::fprintf(stderr, "in: %s\n     out: %s\nexpected: %s\n"
 		, in, out.c_str(), expected);
 	TEST_EQUAL(out, expected);
 }

--- a/test/udp_tracker.cpp
+++ b/test/udp_tracker.cpp
@@ -70,13 +70,13 @@ struct udp_tracker
 	{
 		if (ec)
 		{
-			fprintf(stderr, "%s: UDP tracker, read failed: %s\n", time_now_string(), ec.message().c_str());
+			std::fprintf(stderr, "%s: UDP tracker, read failed: %s\n", time_now_string(), ec.message().c_str());
 			return;
 		}
 
 		if (bytes_transferred < 16)
 		{
-			fprintf(stderr, "%s: UDP message too short (from: %s)\n", time_now_string(), print_endpoint(*from).c_str());
+			std::fprintf(stderr, "%s: UDP message too short (from: %s)\n", time_now_string(), print_endpoint(*from).c_str());
 			return;
 		}
 
@@ -85,7 +85,7 @@ struct udp_tracker
 			return;
 		}
 
-		fprintf(stderr, "%s: UDP message %d bytes\n", time_now_string(), int(bytes_transferred));
+		std::fprintf(stderr, "%s: UDP message %d bytes\n", time_now_string(), int(bytes_transferred));
 
 		char* ptr = buffer;
 		detail::read_uint64(ptr);
@@ -98,23 +98,23 @@ struct udp_tracker
 		{
 			case 0: // connect
 
-				fprintf(stderr, "%s: UDP connect from %s\n", time_now_string()
+				std::fprintf(stderr, "%s: UDP connect from %s\n", time_now_string()
 					, print_endpoint(*from).c_str());
 				ptr = buffer;
 				detail::write_uint32(0, ptr); // action = connect
 				detail::write_uint32(transaction_id, ptr); // transaction_id
 				detail::write_uint64(10, ptr); // connection_id
 				m_socket.send_to(boost::asio::buffer(buffer, 16), *from, 0, e);
-				if (e) fprintf(stderr, "%s: UDP send_to failed. ERROR: %s\n"
+				if (e) std::fprintf(stderr, "%s: UDP send_to failed. ERROR: %s\n"
 					, time_now_string(), e.message().c_str());
-				else fprintf(stderr, "%s: UDP sent response to: %s\n"
+				else std::fprintf(stderr, "%s: UDP sent response to: %s\n"
 					, time_now_string(), print_endpoint(*from).c_str());
 				break;
 
 			case 1: // announce
 
 				++m_udp_announces;
-				fprintf(stderr, "%s: UDP announce [%d]\n", time_now_string()
+				std::fprintf(stderr, "%s: UDP announce [%d]\n", time_now_string()
 					, int(m_udp_announces));
 				ptr = buffer;
 				detail::write_uint32(1, ptr); // action = announce
@@ -124,17 +124,17 @@ struct udp_tracker
 				detail::write_uint32(1, ptr); // complete
 				// 0 peers
 				m_socket.send_to(boost::asio::buffer(buffer, 20), *from, 0, e);
-				if (e) fprintf(stderr, "%s: UDP send_to failed. ERROR: %s\n"
+				if (e) std::fprintf(stderr, "%s: UDP send_to failed. ERROR: %s\n"
 					, time_now_string(), e.message().c_str());
-				else fprintf(stderr, "%s: UDP sent response to: %s\n"
+				else std::fprintf(stderr, "%s: UDP sent response to: %s\n"
 					, time_now_string(), print_endpoint(*from).c_str());
 				break;
 			case 2:
 				// ignore scrapes
-				fprintf(stderr, "%s: UDP scrape (ignored)\n", time_now_string());
+				std::fprintf(stderr, "%s: UDP scrape (ignored)\n", time_now_string());
 				break;
 			default:
-				fprintf(stderr, "%s: UDP unknown message: %d\n", time_now_string()
+				std::fprintf(stderr, "%s: UDP unknown message: %d\n", time_now_string()
 					, action);
 				break;
 		}
@@ -154,24 +154,24 @@ struct udp_tracker
 		m_socket.open(udp::v4(), ec);
 		if (ec)
 		{
-			fprintf(stderr, "UDP Error opening listen UDP tracker socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "UDP Error opening listen UDP tracker socket: %s\n", ec.message().c_str());
 			return;
 		}
 
 		m_socket.bind(udp::endpoint(address_v4::any(), 0), ec);
 		if (ec)
 		{
-			fprintf(stderr, "UDP Error binding UDP tracker socket to port 0: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "UDP Error binding UDP tracker socket to port 0: %s\n", ec.message().c_str());
 			return;
 		}
 		m_port = m_socket.local_endpoint(ec).port();
 		if (ec)
 		{
-			fprintf(stderr, "UDP Error getting local endpoint of UDP tracker socket: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "UDP Error getting local endpoint of UDP tracker socket: %s\n", ec.message().c_str());
 			return;
 		}
 
-		fprintf(stderr, "%s: UDP tracker initialized on port %d\n", time_now_string(), m_port);
+		std::fprintf(stderr, "%s: UDP tracker initialized on port %d\n", time_now_string(), m_port);
 
 		m_thread = boost::make_shared<std::thread>(&udp_tracker::thread_fun, this);
 	}
@@ -214,11 +214,11 @@ struct udp_tracker
 
 		if (ec)
 		{
-			fprintf(stderr, "UDP Error running UDP tracker service: %s\n", ec.message().c_str());
+			std::fprintf(stderr, "UDP Error running UDP tracker service: %s\n", ec.message().c_str());
 			return;
 		}
 
-		fprintf(stderr, "UDP exiting UDP tracker thread\n");
+		std::fprintf(stderr, "UDP exiting UDP tracker thread\n");
 	}
 };
 

--- a/test/web_seed_suite.cpp
+++ b/test/web_seed_suite.cpp
@@ -91,7 +91,7 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 
 	static char const* test_name[] = {"no", "SOCKS4", "SOCKS5", "SOCKS5 password", "HTTP", "HTTP password"};
 
-	fprintf(stderr, "\n\n  ==== TESTING === proxy: %s ==== protocol: %s "
+	std::fprintf(stderr, "\n\n  ==== TESTING === proxy: %s ==== protocol: %s "
 		"==== seed: %s === transfer-encoding: %s === corruption: %s "
 		"==== keepalive: %s\n\n\n"
 		, test_name[proxy], protocol, url_seed ? "URL seed" : "HTTP seed"
@@ -104,7 +104,7 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 		proxy_port = start_proxy(proxy);
 		if (proxy_port < 0)
 		{
-			fprintf(stderr, "failed to start proxy");
+			std::fprintf(stderr, "failed to start proxy");
 			return;
 		}
 		settings_pack pack;
@@ -139,7 +139,7 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 	p.ti = torrent_file;
 	p.save_path = save_path;
 	torrent_handle th = ses.add_torrent(p, ec);
-	printf("adding torrent, save_path = \"%s\" cwd = \"%s\" torrent = \"%s\"\n"
+	std::printf("adding torrent, save_path = \"%s\" cwd = \"%s\" torrent = \"%s\"\n"
 		, save_path.c_str(), current_working_directory().c_str()
 		, torrent_file->name().c_str());
 
@@ -170,17 +170,17 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 
 		if (test_ban && th.url_seeds().empty() && th.http_seeds().empty())
 		{
-			fprintf(stderr, "testing ban: URL seed removed\n");
+			std::fprintf(stderr, "testing ban: URL seed removed\n");
 			// when we don't have any web seeds left, we know we successfully banned it
 			break;
 		}
 
 		if (s.is_seeding)
 		{
-			fprintf(stderr, "SEEDING\n");
-			fprintf(stderr, "session.payload: %d session.redundant: %d\n"
+			std::fprintf(stderr, "SEEDING\n");
+			std::fprintf(stderr, "session.payload: %d session.redundant: %d\n"
 				, int(cnt["net.recv_payload_bytes"]), int(cnt["net.recv_redundant_bytes"]));
-			fprintf(stderr, "torrent.payload: %d torrent.redundant: %d\n"
+			std::fprintf(stderr, "torrent.payload: %d torrent.redundant: %d\n"
 				, int(s.total_payload_download), int(s.total_redundant_bytes));
 
 			TEST_EQUAL(s.total_payload_download - s.total_redundant_bytes, total_size - pad_file_size);
@@ -227,7 +227,7 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 					&& cnt["disk.disk_blocks_in_use"]
 						== (torrent_file->total_size() + 0x3fff) / 0x4000)
 					break;
-				fprintf(stderr, "cache_size: %d/%d\n", int(cnt["disk.read_cache_blocks"])
+				std::fprintf(stderr, "cache_size: %d/%d\n", int(cnt["disk.read_cache_blocks"])
 					, int(cnt["disk.disk_blocks_in_use"]));
 				test_sleep(100);
 			}
@@ -264,7 +264,7 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 		{
 			bool const expect = !fs.pad_file_at(i);
 			std::string file_path = combine_path(save_path, fs.file_path(i));
-			fprintf(stderr, "checking file: %s\n", file_path.c_str());
+			std::fprintf(stderr, "checking file: %s\n", file_path.c_str());
 			TEST_EQUAL(exists(file_path), expect);
 		}
 	}
@@ -292,8 +292,8 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 	if (test_url_seed)
 	{
 		char url[512];
-		snprintf(url, sizeof(url), ("%s://127.0.0.1:%d/" + save_path).c_str(), protocol, port);
-		fprintf(stderr, "testing: %s\n", url);
+		std::snprintf(url, sizeof(url), ("%s://127.0.0.1:%d/" + save_path).c_str(), protocol, port);
+		std::fprintf(stderr, "testing: %s\n", url);
 
 		create_directories(combine_path(save_path, "torrent_dir"), ec);
 
@@ -355,7 +355,7 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 			.name("torrent_dir")
 			.url_seed(url));
 
-		snprintf(url, sizeof(url), ("%s://127.0.0.1:%d/" + save_path + "/test-single-file").c_str(), protocol, port);
+		std::snprintf(url, sizeof(url), ("%s://127.0.0.1:%d/" + save_path + "/test-single-file").c_str(), protocol, port);
 
 		// test case 6 (single file torrent)
 		test_cases.push_back(torrent_args()
@@ -366,8 +366,8 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 	else
 	{
 		char url[512];
-		snprintf(url, sizeof(url), "%s://127.0.0.1:%d/%s/seed", protocol, port, save_path.c_str());
-		fprintf(stderr, "testing: %s\n", url);
+		std::snprintf(url, sizeof(url), "%s://127.0.0.1:%d/%s/seed", protocol, port, save_path.c_str());
+		std::fprintf(stderr, "testing: %s\n", url);
 
 		// there's really just one test case for http seeds
 		test_cases.push_back(torrent_args().file("589824,name=seed")
@@ -376,7 +376,7 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 
 	for (int a = 0; a < int(test_cases.size()); ++a)
 	{
-		fprintf(stderr, "\n\n ====  test case %d ====\n\n\n", a);
+		std::fprintf(stderr, "\n\n ====  test case %d ====\n\n\n", a);
 
 		boost::shared_ptr<torrent_info> torrent_file = make_test_torrent(test_cases[a]);
 
@@ -386,7 +386,7 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 
 		if (ec)
 		{
-			fprintf(stderr, "error creating hashes for test torrent: %s\n"
+			std::fprintf(stderr, "error creating hashes for test torrent: %s\n"
 				, ec.message().c_str());
 			TEST_CHECK(false);
 			return 0;

--- a/tools/dht_put.cpp
+++ b/tools/dht_put.cpp
@@ -49,7 +49,7 @@ namespace lt = libtorrent;
 
 int main(int argc, char* argv[])
 {
-	fprintf(stderr, "not built with DHT support\n");
+	std::fprintf(stderr, "not built with DHT support\n");
 	return 1;
 }
 
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
 
 void usage()
 {
-	fprintf(stderr,
+	std::fprintf(stderr,
 		"USAGE:\ndht <command> <arg>\n\nCOMMANDS:\n"
 		"get <hash>                - retrieves and prints out the immutable\n"
 		"                            item stored under hash.\n"
@@ -92,7 +92,7 @@ alert* wait_for_alert(lt::session& s, int alert_type)
 			{
 				static int spinner = 0;
 				static const char anim[] = {'-', '\\', '|', '/'};
-				printf("\r%c", anim[spinner]);
+				std::printf("\r%c", anim[spinner]);
 				fflush(stdout);
 				spinner = (spinner + 1) & 3;
 				//print some alerts?
@@ -102,7 +102,7 @@ alert* wait_for_alert(lt::session& s, int alert_type)
 			found = true;
 		}
 	}
-	printf("\n");
+	std::printf("\n");
 	return ret;
 }
 
@@ -126,9 +126,9 @@ void put_string(entry& e, std::array<char, 64>& sig, boost::uint64_t& seq
 
 void bootstrap(lt::session& s)
 {
-	printf("bootstrapping\n");
+	std::printf("bootstrapping\n");
 	wait_for_alert(s, dht_bootstrap_alert::alert_type);
-	printf("bootstrap done.\n");
+	std::printf("bootstrap done.\n");
 }
 
 int dump_key(char *filename)
@@ -136,7 +136,7 @@ int dump_key(char *filename)
 	FILE* f = fopen(filename, "rb+");
 	if (f == NULL)
 	{
-		fprintf(stderr, "failed to open file \"%s\": (%d) %s\n"
+		std::fprintf(stderr, "failed to open file \"%s\": (%d) %s\n"
 			, filename, errno, strerror(errno));
 		return 1;
 	}
@@ -145,7 +145,7 @@ int dump_key(char *filename)
 	int size = int(fread(seed, 1, 32, f));
 	if (size != 32)
 	{
-		fprintf(stderr, "invalid key file.\n");
+		std::fprintf(stderr, "invalid key file.\n");
 		return 1;
 	}
 	fclose(f);
@@ -155,7 +155,7 @@ int dump_key(char *filename)
 	ed25519_create_keypair((unsigned char*)public_key.data()
 		, (unsigned char*)private_key.data(), seed);
 
-	printf("public key: %s\nprivate key: %s\n",
+	std::printf("public key: %s\nprivate key: %s\n",
 		to_hex(std::string(public_key.data(), public_key.size())).c_str(),
 		to_hex(std::string(private_key.data(), private_key.size())).c_str());
 
@@ -170,7 +170,7 @@ int generate_key(char* filename)
 	FILE* f = fopen(filename, "wb+");
 	if (f == NULL)
 	{
-		fprintf(stderr, "failed to open file for writing \"%s\": (%d) %s\n"
+		std::fprintf(stderr, "failed to open file for writing \"%s\": (%d) %s\n"
 			, filename, errno, strerror(errno));
 		return 1;
 	}
@@ -178,7 +178,7 @@ int generate_key(char* filename)
 	int size = int(fwrite(seed, 1, 32, f));
 	if (size != 32)
 	{
-		fprintf(stderr, "failed to write key file.\n");
+		std::fprintf(stderr, "failed to write key file.\n");
 		return 1;
 	}
 	fclose(f);
@@ -205,11 +205,11 @@ void load_dht_state(lt::session& s)
 		error_code ec;
 		bdecode(&state[0], &state[0] + state.size(), e, ec);
 		if (ec)
-			fprintf(stderr, "failed to parse .dht file: (%d) %s\n"
+			std::fprintf(stderr, "failed to parse .dht file: (%d) %s\n"
 				, ec.value(), ec.message().c_str());
 		else
 		{
-			printf("load dht state from .dht\n");
+			std::printf("load dht state from .dht\n");
 			s.load_state(e);
 		}
 	}
@@ -226,7 +226,7 @@ int save_dht_state(lt::session& s)
 	FILE* f = fopen(".dht", "wb+");
 	if (f == NULL)
 	{
-		fprintf(stderr, "failed to open file .dht for writing");
+		std::fprintf(stderr, "failed to open file .dht for writing");
 		return 1;
 	}
 	fwrite(&state[0], 1, state.size(), f);
@@ -281,21 +281,21 @@ int main(int argc, char* argv[])
 
 		if (strlen(argv[0]) != 40)
 		{
-			fprintf(stderr, "the hash is expected to be 40 hex characters\n");
+			std::fprintf(stderr, "the hash is expected to be 40 hex characters\n");
 			usage();
 		}
 		sha1_hash target;
 		bool ret = from_hex(argv[0], 40, (char*)&target[0]);
 		if (!ret)
 		{
-			fprintf(stderr, "invalid hex encoding of target hash\n");
+			std::fprintf(stderr, "invalid hex encoding of target hash\n");
 			return 1;
 		}
 
 		bootstrap(s);
 		s.dht_get_item(target);
 
-		printf("GET %s\n", to_hex(target.to_string()).c_str());
+		std::printf("GET %s\n", to_hex(target.to_string()).c_str());
 
 		alert* a = wait_for_alert(s, dht_immutable_item_alert::alert_type);
 
@@ -304,7 +304,7 @@ int main(int argc, char* argv[])
 		if (item)
 			data.swap(item->item);
 
-		printf("%s", data.to_string().c_str());
+		std::printf("%s", data.to_string().c_str());
 	}
 	else if (strcmp(argv[0], "put") == 0)
 	{
@@ -318,11 +318,11 @@ int main(int argc, char* argv[])
 		bootstrap(s);
 		sha1_hash target = s.dht_put_item(data);
 		
-		printf("PUT %s\n", to_hex(target.to_string()).c_str());
+		std::printf("PUT %s\n", to_hex(target.to_string()).c_str());
 
 		alert* a = wait_for_alert(s, dht_put_alert::alert_type);
 		dht_put_alert* pa = alert_cast<dht_put_alert>(a);
-		printf("%s\n", pa->message().c_str());
+		std::printf("%s\n", pa->message().c_str());
 	}
 	else if (strcmp(argv[0], "mput") == 0)
 	{
@@ -333,7 +333,7 @@ int main(int argc, char* argv[])
 		FILE* f = fopen(argv[0], "rb+");
 		if (f == NULL)
 		{
-			fprintf(stderr, "failed to open file \"%s\": (%d) %s\n"
+			std::fprintf(stderr, "failed to open file \"%s\": (%d) %s\n"
 				, argv[0], errno, strerror(errno));
 			return 1;
 		}
@@ -355,12 +355,12 @@ int main(int argc, char* argv[])
 		s.dht_put_item(public_key, boost::bind(&put_string, _1, _2, _3, _4
 			, public_key.data(), private_key.data(), argv[0]));
 
-		printf("MPUT publick key: %s\n", to_hex(std::string(public_key.data()
+		std::printf("MPUT publick key: %s\n", to_hex(std::string(public_key.data()
 			, public_key.size())).c_str());
 
 		alert* a = wait_for_alert(s, dht_put_alert::alert_type);
 		dht_put_alert* pa = alert_cast<dht_put_alert>(a);
-		printf("%s\n", pa->message().c_str());
+		std::printf("%s\n", pa->message().c_str());
 	}
 	else if (strcmp(argv[0], "mget") == 0)
 	{
@@ -371,20 +371,20 @@ int main(int argc, char* argv[])
 		int len = int(strlen(argv[0]));
 		if (len != 64)
 		{
-			fprintf(stderr, "public key is expected to be 64 hex digits\n");
+			std::fprintf(stderr, "public key is expected to be 64 hex digits\n");
 			return 1;
 		}
 		std::array<char, 32> public_key;
 		bool ret = from_hex(argv[0], len, &public_key[0]);
 		if (!ret)
 		{
-			fprintf(stderr, "invalid hex encoding of public key\n");
+			std::fprintf(stderr, "invalid hex encoding of public key\n");
 			return 1;
 		}
 
 		bootstrap(s);
 		s.dht_get_item(public_key);
-		printf("MGET %s\n", argv[0]);
+		std::printf("MGET %s\n", argv[0]);
 
 		bool authoritative = false;
 
@@ -398,7 +398,7 @@ int main(int argc, char* argv[])
 				data.swap(item->item);
 
 			authoritative = item->authoritative;
-			printf("%s: %s", authoritative ? "auth" : "non-auth", data.to_string().c_str());
+			std::printf("%s: %s", authoritative ? "auth" : "non-auth", data.to_string().c_str());
 		}
 	}
 	else

--- a/tools/fuzz_torrent.cpp
+++ b/tools/fuzz_torrent.cpp
@@ -113,7 +113,7 @@ void print_ascii_number(std::string& output, boost::int64_t val)
 		if (negative) output += '-';
 		else if (double_negative) output += "--";
 		char buf[50];
-		snprintf(buf, sizeof(buf), "%" PRId64 "", val);
+		std::snprintf(buf, sizeof(buf), "%" PRId64 "", val);
 		output += buf;
 	}
 }
@@ -355,7 +355,7 @@ int main(int argc, char const* argv[])
 
 	if (argc < 2)
 	{
-		fprintf(stderr, "usage: fuzz_torrent torrent-file [torrent-file ...]\n");
+		std::fprintf(stderr, "usage: fuzz_torrent torrent-file [torrent-file ...]\n");
 		return 1;
 	}
 
@@ -366,7 +366,7 @@ int main(int argc, char const* argv[])
 		int ret = load_file(*argv, buf, ec);
 		if (ret < 0)
 		{
-			fprintf(stderr, "ERROR loading file: %s\n%s\n"
+			std::fprintf(stderr, "ERROR loading file: %s\n%s\n"
 				, *argv, ec.message().c_str());
 			continue;
 		}
@@ -374,7 +374,7 @@ int main(int argc, char const* argv[])
 		bdecode_node e;
 		if (buf.size() == 0 || bdecode(&buf[0], &buf[0] + buf.size(), e, ec) != 0)
 		{
-			fprintf(stderr, "ERROR parsing file: %s\n%s\n"
+			std::fprintf(stderr, "ERROR parsing file: %s\n%s\n"
 				, *argv, ec.message().c_str());
 			continue;
 		}
@@ -393,13 +393,13 @@ int main(int argc, char const* argv[])
 			// TODO: add option to save to file unconditionally (to test other clients)
 			/*
 				{
-				fprintf(stderr, "saving %d\n", i);
+				std::fprintf(stderr, "saving %d\n", i);
 				char filename[100];
-				snprintf(filename, sizeof(filename), "torrents/fuzz-%d.torrent", i);
+				std::snprintf(filename, sizeof(filename), "torrents/fuzz-%d.torrent", i);
 				FILE* f = fopen(filename, "wb+");
 				if (f == 0)
 				{
-				fprintf(stderr, "ERROR saving file: (%d) %s\n", errno, strerror(errno));
+				std::fprintf(stderr, "ERROR saving file: (%d) %s\n", errno, strerror(errno));
 				return 1;
 				}
 				fwrite(test_buffer.c_str(), test_buffer.size(), 1, f);
@@ -408,7 +408,7 @@ int main(int argc, char const* argv[])
 			 */
 			if (g_seed > 0) break;
 		}
-		fprintf(stderr, "tested %d variants of %s\n", i, *argv);
+		std::fprintf(stderr, "tested %d variants of %s\n", i, *argv);
 	}
 	return 0;
 }

--- a/tools/parse_access_log.cpp
+++ b/tools/parse_access_log.cpp
@@ -45,7 +45,7 @@ using namespace libtorrent::detail; // for write_* and read_*
 
 void print_usage()
 {
-	fprintf(stderr, "usage: parse_access_log log-file\n\n"
+	std::fprintf(stderr, "usage: parse_access_log log-file\n\n"
 		"prints a gnuplot readable data file to stdout\n");
 	exit(1);
 }
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
 	FILE* log_file = fopen(argv[1], "r");
 	if (log_file == 0)
 	{
-		fprintf(stderr, "failed to open logfile: %s\n%d: %s\n"
+		std::fprintf(stderr, "failed to open logfile: %s\n%d: %s\n"
 			, argv[1], errno, strerror(errno));
 		return 1;
 	}
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 			{
 				if (i->second.timestamp > op.timestamp)
 				{
-					fprintf(stderr, "end-event stamped before "
+					std::fprintf(stderr, "end-event stamped before "
 						"start-event: %" PRId64 " started at: %f\n"
 						, op.offset, double(i->second.timestamp) / 1000000.f);
 					i->second.timestamp = op.timestamp;
@@ -116,17 +116,17 @@ int main(int argc, char* argv[])
 				double start_time = double(i->second.timestamp - first_timestamp) / 1000000.0;
 				double end_time = double(op.timestamp - first_timestamp) / 1000000.0;
 				double duration_time = double(op.timestamp - i->second.timestamp) / 1000000.0;
-				fprintf(out_file, "%f\t%" PRId64 "\t%f\n"
+				std::fprintf(out_file, "%f\t%" PRId64 "\t%f\n"
 					, start_time, op.offset, duration_time);
 
 				out_file = write ? writes_elev_file : reads_elev_file;
-				fprintf(out_file, "%f\t%" PRId64 "\n", end_time, op.offset);
+				std::fprintf(out_file, "%f\t%" PRId64 "\n", end_time, op.offset);
 
 				outstanding_ops.erase(i);
 			}
 			else
 			{
-				fprintf(stderr, "no start event for (%u): %" PRId64 " ended at: %f\n"
+				std::fprintf(stderr, "no start event for (%u): %" PRId64 " ended at: %f\n"
 					, event_id, op.offset, double(op.timestamp) / 1000000.f);
 			}
 		}
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
 			op_map::iterator i = outstanding_ops.find(event_id);
 			if (i != outstanding_ops.end())
 			{
-				fprintf(stderr, "duplicate start event for (%u): %" PRId64 " at: %f"
+				std::fprintf(stderr, "duplicate start event for (%u): %" PRId64 " at: %f"
 					"(current start is at: %f)\n"
 					, event_id, op.offset, double(i->second.timestamp - first_timestamp) / 1000000.f
 					, double(op.timestamp - first_timestamp) / 1000000.f);


### PR DESCRIPTION
primarily, printf family of functions, since C++11 version is used now. This removes the need for an snprintf-wrapper on windows