### PR TITLE
keep debug-iterators consistent between the tests and library

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -75,7 +75,6 @@ lib libtorrent_test
 	<toolset>darwin:<cflags>-Wno-unused-command-line-argument
 # disable warning C4275: non DLL-interface classkey 'identifier' used as base for DLL-interface classkey 'identifier'
 	<toolset>msvc:<cflags>/wd4275
-	<debug-iterators>on
 
 	: # default build
 	<link>shared


### PR DESCRIPTION
With GCC 5 debug-iterators changes the type of STL containers so the build fails
due to undefined symbols if the setting is not consistent