### PR TITLE
keep debug-iterators consistent between the tests and library

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -73,7 +73,6 @@ lib libtorrent_test
 	<target-os>windows:<library>advapi32
 	<conditional>@link_libtorrent
 	<toolset>darwin:<cflags>-Wno-unused-command-line-argument
-	<debug-iterators>on
 
 	: # default build
 	<link>shared


### PR DESCRIPTION
With GCC 5 debug-iterators changes the type of STL containers so the build fails
due to undefined symbols if the setting is not consistent