### PR TITLE
Don't force the compiler to search in /usr/include

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -524,7 +524,7 @@ lib libiconv : : <name>iconv <link>shared <search>/usr/local/lib ;
 # openssl on linux/bsd/macos etc.
 lib gcrypt : : <name>gcrypt <link>shared <search>/opt/local/lib <search>/usr/local/lib : : <include>/opt/local/include <include>/usr/local/include ;
 lib z : : <link>shared <name>z <search>/usr/lib ;
-lib crypto : : <name>crypto <link>shared <search>/usr/lib <use>z : : <include>/usr/include <include>/opt/local/include ;
+lib crypto : : <name>crypto <link>shared <search>/usr/lib <use>z : : <include>/opt/local/include <include>/usr/local/include ;
 lib ssl : : <name>ssl <link>shared <use>crypto <search>/opt/local/lib <search>/usr/local/lib : : <include>/opt/local/include <include>/usr/local/include ;
 lib dl : : <link>shared <name>dl ;
 


### PR DESCRIPTION
This was causing problems with android and the clang toolchain and probably other hidden issues.