### PR TITLE
Added support for x.pe parameter in parse_magnet_uri

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* added support for parsing new x.pe parameter from BEP 9
 	* peer_blocked_alert now derives from peer_alert
 	* transitioned exception types to system_error
 	* made alerts move-only

--- a/include/libtorrent/receive_buffer.hpp
+++ b/include/libtorrent/receive_buffer.hpp
@@ -79,7 +79,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 	// with possible disk buffer usage
 	int reserve(std::array<boost::asio::mutable_buffer, 2>& vec, int size);
 
-	// tell the buffer we just receved more bytes at the end of it. This will
+	// tell the buffer we just received more bytes at the end of it. This will
 	// advance the end cursor
 	void received(int bytes_transferred)
 	{
@@ -96,7 +96,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 	// has the read cursor reached the end cursor?
 	bool pos_at_end() { return m_recv_pos == m_recv_end; }
 
-	// make the buffer size dividible by 8 bytes (RC4 block size)
+	// make the buffer size divisible by 8 bytes (RC4 block size)
 	void clamp_size();
 
 	void set_soft_packet_size(int size) { m_soft_packet_size = size; }

--- a/include/libtorrent/string_util.hpp
+++ b/include/libtorrent/string_util.hpp
@@ -74,7 +74,7 @@ namespace libtorrent
 		bool ssl;
 	};
 
-	// this parses the string that's used as the liste_interfaces setting.
+	// this parses the string that's used as the listen_interfaces setting.
 	// it is a comma-separated list of IP or device names with ports. For
 	// example: "eth0:6881,eth1:6881" or "127.0.0.1:6881"
 	TORRENT_EXTRA_EXPORT void parse_listen_interfaces(

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -112,11 +112,11 @@ const rlim_t rlim_infinity = RLIM_INFINITY;
 #include "libtorrent/error.hpp"
 #include "libtorrent/platform_util.hpp"
 #include "libtorrent/aux_/bind_to_device.hpp"
+#include "libtorrent/hex.hpp" // to_hex, from_hex
 
 #ifndef TORRENT_DISABLE_LOGGING
 
 #include "libtorrent/socket_io.hpp"
-#include "libtorrent/hex.hpp" // to_hex, from_hex
 
 // for logging stat layout
 #include "libtorrent/stat.hpp"

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -205,7 +205,7 @@ namespace libtorrent
 		return ret;
 	}
 
-	// this parses the string that's used as the liste_interfaces setting.
+	// this parses the string that's used as the listen_interfaces setting.
 	// it is a comma-separated list of IP or device names with ports. For
 	// example: "eth0:6881,eth1:6881" or "127.0.0.1:6881"
 	void parse_listen_interfaces(std::string const& in

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -31,6 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "test.hpp"
+#include "setup_transfer.hpp"
 #include "libtorrent/magnet_uri.hpp"
 #include "libtorrent/session.hpp"
 #include "libtorrent/torrent_handle.hpp"
@@ -276,6 +277,23 @@ TORRENT_TEST(parse_space_hash)
 	add_torrent_params p;
 	parse_magnet_uri("magnet:?xt=urn:btih: abababababababababab", p, ec);
 	TEST_EQUAL(ec, error_code(errors::invalid_info_hash));
+	ec.clear();
+}
+
+TORRENT_TEST(parse_peer)
+{
+	error_code ec;
+	add_torrent_params p;
+	parse_magnet_uri("magnet:?xt=urn:btih:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd&dn=foo&x.pe=127.0.0.1:43&x.pe=<invalid1>&x.pe=<invalid2>:100&x.pe=[::1]:45", p, ec);
+	TEST_CHECK(!ec);
+#if TORRENT_USE_IPV6
+	TEST_EQUAL(p.peers.size(), 2);
+	TEST_EQUAL(p.peers[0], ep("127.0.0.1", 43));
+	TEST_EQUAL(p.peers[1], ep("::1", 45));
+#else
+	TEST_EQUAL(p.peers.size(), 1);
+	TEST_EQUAL(p.peers[0], ep("127.0.0.1", 43));
+#endif
 	ec.clear();
 }
 


### PR DESCRIPTION
`BEP 9: 16-May-2016: added peer source parameter to magnets`