### PR TITLE
Ported support for magnet x.pe parameter from master

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 1.1.1 release
 
 	* fixed parsing of IPv6 endpoint with invalid port character separator
+	* added limited support for new x.pe parameter from BEP 9
 	* fixed dht stats counters that weren't being updated
 	* make sure add_torrent_alert is always posted before other alerts for
 	  the torrent

--- a/include/libtorrent/magnet_uri.hpp
+++ b/include/libtorrent/magnet_uri.hpp
@@ -78,6 +78,9 @@ namespace libtorrent
 	// This function parses out information from the magnet link and populates the
 	// add_torrent_params object.
 	TORRENT_EXPORT void parse_magnet_uri(std::string const& uri, add_torrent_params& p, error_code& ec);
+
+	// internal, delete when merge in master
+	TORRENT_EXTRA_EXPORT void parse_magnet_uri_peers(std::string const& uri, std::vector<tcp::endpoint>& peers);
 }
 
 #endif

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -40,6 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/announce_entry.hpp"
 
 #include <string>
+#include "libtorrent/socket_io.hpp"
 
 namespace libtorrent
 {
@@ -269,6 +270,24 @@ namespace libtorrent
 
 		p.info_hash = info_hash;
 		if (!name.empty()) p.name = name;
+	}
+
+	void parse_magnet_uri_peers(std::string const& uri, std::vector<tcp::endpoint>& peers)
+	{
+		std::string::size_type peer_pos = std::string::npos;
+		std::string peer = url_has_argument(uri, "x.pe", &peer_pos);
+		while (!peer.empty())
+		{
+			error_code e;
+			tcp::endpoint endp = parse_endpoint(peer, e);
+			if (!e)
+				peers.push_back(endp);
+
+			peer_pos = uri.find("&x.pe=", peer_pos);
+			if (peer_pos == std::string::npos) break;
+			peer_pos += 6;
+			peer = uri.substr(peer_pos, uri.find('&', peer_pos) - peer_pos);
+		}
 	}
 }
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4785,6 +4785,19 @@ retry:
 		add_torrent_params params = p;
 		boost::shared_ptr<torrent> const torrent_ptr = add_torrent_impl(params, ec);
 
+		// --- PEERS --- (delete when merged to master)
+		std::vector<tcp::endpoint> peers;
+		parse_magnet_uri_peers(p.url, peers);
+
+		for (std::vector<tcp::endpoint>::const_iterator i = peers.begin()
+			, end(peers.end()); i != end; ++i)
+		{
+			torrent_ptr->add_peer(*i , peer_info::resume_data);
+		}
+
+		if (!peers.empty())
+			torrent_ptr->update_want_peers();
+
 		torrent_handle const handle(torrent_ptr);
 		m_alerts.emplace_alert<add_torrent_alert>(handle, params, ec);
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -11579,6 +11579,7 @@ namespace libtorrent
 	{
 		if (!m_apply_ip_filter) return;
 		if (!m_peer_list) return;
+		if (!m_ip_filter) return;
 
 		torrent_state st = get_peer_list_state();
 		std::vector<address> banned;

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -31,6 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "test.hpp"
+#include "setup_transfer.hpp"
 #include "libtorrent/magnet_uri.hpp"
 #include "libtorrent/session.hpp"
 #include "libtorrent/torrent_handle.hpp"
@@ -274,6 +275,20 @@ TORRENT_TEST(parse_space_hash)
 	parse_magnet_uri("magnet:?xt=urn:btih: abababababababababab", p, ec);
 	TEST_EQUAL(ec, error_code(errors::invalid_info_hash));
 	ec.clear();
+}
+
+TORRENT_TEST(parse_peer)
+{
+	std::vector<tcp::endpoint> peers;
+	parse_magnet_uri_peers("magnet:?xt=urn:btih:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd&dn=foo&x.pe=127.0.0.1:43&x.pe=<invalid1>&x.pe=<invalid2>:100&x.pe=[::1]:45", peers);
+#if TORRENT_USE_IPV6
+	TEST_EQUAL(peers.size(), 2);
+	TEST_EQUAL(peers[0], ep("127.0.0.1", 43));
+	TEST_EQUAL(peers[1], ep("::1", 45));
+#else
+	TEST_EQUAL(peers.size(), 1);
+	TEST_EQUAL(peers[0], ep("127.0.0.1", 43));
+#endif
 }
 
 #ifndef TORRENT_DISABLE_DHT


### PR DESCRIPTION
I tried to do this with the minimal potential conflicts when merged to master, but the actual logic of adding the peers was impossible to add inside the torrent constructor due to the alerts using get_handle()