### PR TITLE
avoid double inspection of bdecode_node in piece_manager::check_fastresume

### DIFF
--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -689,6 +689,8 @@ namespace libtorrent
 		// the piece_manager destructs. This is because
 		// the torrent_info object is owned by the torrent.
 		boost::shared_ptr<void> m_torrent;
+
+		bool checked_fastresume;
 	};
 
 	// this identifies a read or write operation so that readwritev() knows

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1616,6 +1616,7 @@ namespace libtorrent
 		: m_files(*files)
 		, m_storage(storage_impl)
 		, m_torrent(torrent)
+		, checked_fastresume(false)
 	{
 	}
 
@@ -1691,6 +1692,9 @@ namespace libtorrent
 		, storage_error& ec)
 	{
 		TORRENT_ASSERT(m_files.piece_length() > 0);
+
+		if (checked_fastresume) return check_no_fastresume(ec);
+		checked_fastresume = true;
 
 		// if we don't have any resume data, return
 		if (rd.type() == bdecode_node::none_t) return check_no_fastresume(ec);

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -92,6 +92,32 @@ void on_check_resume_data(disk_io_job const* j, bool* done)
 	*done = true;
 }
 
+void on_checked_resume_data(disk_io_job const* j, int n, bool* done)
+{
+	TEST_CHECK(n == 1 || n == 2 || n == 3)
+
+	std::cerr << time_now_string() << " on_checked_resume_data ret: " << j->ret;
+
+	if (n == 1)
+	{
+		TEST_EQUAL(j->ret, piece_manager::no_error);
+		TEST_EQUAL(j->error.ec.value(), errors::not_a_dictionary);
+	}
+	if (n == 2)
+	{
+		TEST_EQUAL(j->ret, piece_manager::no_error);
+		TEST_EQUAL(j->error.ec.value(), 0);
+	}
+	if (n == 3)
+	{
+		TEST_EQUAL(j->ret, piece_manager::no_error);
+		TEST_EQUAL(j->error.ec.value(), 0);
+		*done = true;
+	}
+
+	std::cerr << std::endl;
+}
+
 void print_error(char const* call, int ret, storage_error const& ec)
 {
 	fprintf(stderr, "%s: %s() returned: %d error: \"%s\" in file: %d operation: %d\n"
@@ -1277,3 +1303,51 @@ TORRENT_TEST(move_storage_into_self)
 #endif
 }
 
+TORRENT_TEST(double_call_to_check_fastresume)
+{
+	file_storage fs;
+	aux::session_settings set;
+	file_pool fp;
+	boost::asio::io_service ios;
+	counters cnt;
+	disk_io_thread io(ios, cnt, NULL);
+	io.set_num_threads(1);
+	disk_buffer_pool dp(16 * 1024, ios, boost::bind(&nop));
+	storage_params p;
+	p.files = &fs;
+	p.pool = &fp;
+	boost::shared_ptr<void> dummy;
+
+	boost::shared_ptr<piece_manager> pm = boost::make_shared<piece_manager>(new default_storage(p), dummy, &fs);
+
+	bool done = false;
+
+	char b[] = "li12453e3:aaae";
+	bdecode_node e;
+	error_code ec;
+	bdecode(b, b + sizeof(b) - 1, e, ec);
+	boost::scoped_ptr<bdecode_node> rd(new bdecode_node());
+	bdecode_node* rd1 = rd.get();
+	bdecode_node* rd2 = rd.get();
+	bdecode_node* rd3 = rd.get();
+	std::vector<std::string> links;
+
+	*rd1 = e;
+
+	io.async_check_fastresume(pm.get(), rd1, links
+		, boost::bind(&on_checked_resume_data, _1, 1, &done));
+
+	// no error since it was already checked out
+	io.async_check_fastresume(pm.get(), rd2, links
+		, boost::bind(&on_checked_resume_data, _1, 2, &done));
+
+	// no error here either
+	io.async_check_fastresume(pm.get(), rd3, links
+		, boost::bind(&on_checked_resume_data, _1, 3, &done));
+
+	io.submit_jobs();
+	ios.reset();
+	run_until(ios, done);
+
+	io.set_num_threads(0);
+}


### PR DESCRIPTION
@arvidn this is to tackle #781

I can see that torrent::init could be called on multiple occasions, potentially putting multiple fast resume jobs. I'm not a fan of mutable states, but in this case I couldn't see any other quick alternative.

If this is not acceptable or break some other assumption, let me know another path. Thanks.