### PR TITLE
making disk_buffer_holder internal and include cleanup

### DIFF
--- a/include/libtorrent/disk_buffer_holder.hpp
+++ b/include/libtorrent/disk_buffer_holder.hpp
@@ -36,12 +36,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/assert.hpp"
 #include "libtorrent/disk_io_job.hpp" // for block_cache_reference
-#include <algorithm>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
 #include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
@@ -69,7 +67,7 @@ namespace libtorrent
 	// 
 	// ``get()`` returns the pointer without transferring ownership. If
 	// this buffer has been released, ``get()`` will return nullptr.
-	struct TORRENT_EXPORT disk_buffer_holder
+	struct TORRENT_EXTRA_EXPORT disk_buffer_holder
 	{
 		// internal
 		disk_buffer_holder(buffer_allocator_interface& alloc, char* buf);
@@ -126,4 +124,3 @@ namespace libtorrent
 }
 
 #endif
-

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -425,7 +425,7 @@ namespace libtorrent
 		virtual bool on_allowed_fast(int /*index*/) { return false; }
 		virtual bool on_request(peer_request const&) { return false; }
 		virtual bool on_piece(peer_request const& /*piece*/
-			, char* /*buf*/, int /*piece*/, int /*block*/) { return false; }
+			, char* /*buf*/) { return false; }
 		virtual bool on_cancel(peer_request const&) { return false; }
 		virtual bool on_reject(peer_request const&) { return false; }
 		virtual bool on_suggest(int /*index*/) { return false; }

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -180,7 +180,6 @@ namespace libtorrent
 	struct peer_request;
 	class entry;
 	struct bdecode_node;
-	struct disk_buffer_holder;
 	struct bitfield;
 	class alert;
 	struct torrent_plugin;

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -424,8 +424,16 @@ namespace libtorrent
 		virtual bool on_have_none() { return false; }
 		virtual bool on_allowed_fast(int /*index*/) { return false; }
 		virtual bool on_request(peer_request const&) { return false; }
+
+		// This function is called when the peer connection is receiving
+		// a piece. ``buf`` points (non-owning pointer) to the data in an
+		// internal immutable disk buffer. The length of the data is specified
+		// in the ``length`` member of the ``piece`` parameter.
+		// returns true to indicate that the piece is handled and the
+		// rest of the logic should be ignored.
 		virtual bool on_piece(peer_request const& /*piece*/
-			, char* /*buf*/) { return false; }
+			, char const* /*buf*/) { return false; }
+
 		virtual bool on_cancel(peer_request const&) { return false; }
 		virtual bool on_reject(peer_request const&) { return false; }
 		virtual bool on_suggest(int /*index*/) { return false; }

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -426,7 +426,7 @@ namespace libtorrent
 		virtual bool on_allowed_fast(int /*index*/) { return false; }
 		virtual bool on_request(peer_request const&) { return false; }
 		virtual bool on_piece(peer_request const& /*piece*/
-			, disk_buffer_holder& /*data*/) { return false; }
+			, char* /*buf*/, int /*piece*/, int /*block*/) { return false; }
 		virtual bool on_cancel(peer_request const&) { return false; }
 		virtual bool on_reject(peer_request const&) { return false; }
 		virtual bool on_suggest(int /*index*/) { return false; }

--- a/include/libtorrent/web_connection_base.hpp
+++ b/include/libtorrent/web_connection_base.hpp
@@ -79,7 +79,7 @@ namespace libtorrent
 	public:
 
 		// this is the constructor where the we are the active part.
-		// The peer_conenction should handshake and verify that the
+		// The peer_connection should handshake and verify that the
 		// other end has the correct id
 		web_connection_base(peer_connection_args const& pack
 			, web_seed_t& web);

--- a/src/disk_buffer_holder.cpp
+++ b/src/disk_buffer_holder.cpp
@@ -31,8 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/disk_buffer_holder.hpp"
-#include "libtorrent/aux_/session_impl.hpp"
-#include "libtorrent/disk_io_thread.hpp"
+#include "libtorrent/storage.hpp" // for piece_manager
 
 namespace libtorrent
 {
@@ -105,4 +104,3 @@ namespace libtorrent
 
 	disk_buffer_holder::~disk_buffer_holder() { reset(); }
 }
-

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2675,8 +2675,7 @@ namespace libtorrent
 		for (extension_list_t::iterator i = m_extensions.begin()
 			, end(m_extensions.end()); i != end; ++i)
 		{
-			block_cache_reference ref = data.ref();
-			if ((*i)->on_piece(p, data.get(), ref.piece, ref.block))
+			if ((*i)->on_piece(p, data.get()))
 			{
 #if TORRENT_USE_ASSERTS
 				TORRENT_ASSERT(m_received_in_piece == p.length);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2675,7 +2675,8 @@ namespace libtorrent
 		for (extension_list_t::iterator i = m_extensions.begin()
 			, end(m_extensions.end()); i != end; ++i)
 		{
-			if ((*i)->on_piece(p, data))
+			block_cache_reference ref = data.ref();
+			if ((*i)->on_piece(p, data.get(), ref.piece, ref.block))
 			{
 #if TORRENT_USE_ASSERTS
 				TORRENT_ASSERT(m_received_in_piece == p.length);


### PR DESCRIPTION
`disk_buffer_holder` was exposing a pointer to a private structure (`piece_manager`) via `ref()`. I expect some comment about the new `on_piece` signature.