### PR TITLE
deprecate functions in torrent_handle

### DIFF
--- a/include/libtorrent/peer_info.hpp
+++ b/include/libtorrent/peer_info.hpp
@@ -162,7 +162,7 @@ namespace libtorrent
 			// connect via the NAT holepunch mechanism.
 			holepunched = 0x8000,
 
-			// indicates that this socket is runnin on top of the
+			// indicates that this socket is running on top of the
 			// I2P transport.
 			i2p_socket = 0x10000,
 
@@ -416,7 +416,7 @@ namespace libtorrent
 	};
 
 	// internal
-	struct TORRENT_EXPORT peer_list_entry
+	struct TORRENT_EXTRA_EXPORT peer_list_entry
 	{
 		// internal
 		enum flags_t

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -43,7 +43,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/weak_ptr.hpp>
-#include <boost/cstdint.hpp>
 
 #ifndef TORRENT_NO_DEPRECATE
 // for deprecated force_reannounce
@@ -242,12 +241,8 @@ namespace libtorrent
 		// add_torrent_params. Perhaps those flags should have a more generic
 		// name.
 
-		// TODO: 4 remove some of these friends
-		friend class invariant_access;
 		friend struct aux::session_impl;
-		friend class session;
 		friend struct session_handle;
-		friend struct feed;
 		friend class torrent;
 		friend std::size_t hash_value(torrent_handle const& th);
 
@@ -298,8 +293,11 @@ namespace libtorrent
 		// otherwise.
 		bool have_piece(int piece) const;
 
+#ifndef TORRENT_NO_DEPRECATE
 		// internal
+		TORRENT_DEPRECATED
 		void get_full_peer_list(std::vector<peer_list_entry>& v) const;
+#endif
 
 		// takes a reference to a vector that will be cleared and filled with one
 		// entry for each peer connected to this torrent, given the handle is
@@ -873,9 +871,12 @@ namespace libtorrent
 			, std::string const& private_key
 			, std::string const& dh_params);
 
+#ifndef TORRENT_NO_DEPRECATE
 		// Returns the storage implementation for this torrent. This depends on the
 		// storage constructor function that was passed to add_torrent.
+		TORRENT_DEPRECATED
 		storage_interface* get_storage_impl() const;
+#endif
 
 		// Returns a pointer to the torrent_info object associated with this
 		// torrent. The torrent_info object may be a copy of the internal object.

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -871,12 +871,9 @@ namespace libtorrent
 			, std::string const& private_key
 			, std::string const& dh_params);
 
-#ifndef TORRENT_NO_DEPRECATE
 		// Returns the storage implementation for this torrent. This depends on the
 		// storage constructor function that was passed to add_torrent.
-		TORRENT_DEPRECATED
 		storage_interface* get_storage_impl() const;
-#endif
 
 		// Returns a pointer to the torrent_info object associated with this
 		// torrent. The torrent_info object may be a copy of the internal object.

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -582,12 +582,10 @@ namespace libtorrent
 		return sync_call_ret<bool>(false, &torrent::have_piece, piece);
 	}
 
-#ifndef TORRENT_NO_DEPRECATE
 	storage_interface* torrent_handle::get_storage_impl() const
 	{
 		return sync_call_ret<storage_interface*>(nullptr, &torrent::get_storage);
 	}
-#endif
 
 	bool torrent_handle::is_valid() const
 	{

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -582,10 +582,12 @@ namespace libtorrent
 		return sync_call_ret<bool>(false, &torrent::have_piece, piece);
 	}
 
+#ifndef TORRENT_NO_DEPRECATE
 	storage_interface* torrent_handle::get_storage_impl() const
 	{
 		return sync_call_ret<storage_interface*>(nullptr, &torrent::get_storage);
 	}
+#endif
 
 	bool torrent_handle::is_valid() const
 	{
@@ -682,11 +684,13 @@ namespace libtorrent
 		async_call(&torrent::set_super_seeding, on);
 	}
 
+#ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::get_full_peer_list(std::vector<peer_list_entry>& v) const
 	{
 		auto vp = &v;
 		sync_call(&torrent::get_full_peer_list, vp);
 	}
+#endif
 
 	void torrent_handle::get_peer_info(std::vector<peer_info>& v) const
 	{

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -238,7 +238,7 @@ TORRENT_TEST(added_peers)
 	torrent_handle h = ses.add_torrent(p);
 
 	std::vector<peer_list_entry> v;
-	h.get_full_peer_list(v);
+	h.native_handle()->get_full_peer_list(&v);
 	TEST_EQUAL(v.size(), 2);
 }
 

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/http_tracker_connection.hpp" // for parse_tracker_response
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/announce_entry.hpp"
+#include "libtorrent/torrent.hpp"
 
 #include <fstream>
 
@@ -427,7 +428,7 @@ TORRENT_TEST(http_peers)
 	// we expect to have certain peers in our peer list now
 	// these peers are hard coded in web_server.py
 	std::vector<peer_list_entry> peers;
-	h.get_full_peer_list(peers);
+	h.native_handle()->get_full_peer_list(&peers);
 
 	std::set<tcp::endpoint> expected_peers;
 	expected_peers.insert(tcp::endpoint(address_v4::from_string("65.65.65.65"), 16962));


### PR DESCRIPTION
feel free to discard/close this PR if you don't agree with the API change.

I think `get_storage_impl` is very dangerous and `get_full_peer_list` is too internal.