### PR TITLE
Fix abort_jobs being called multiple times

### DIFF
--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -556,7 +556,8 @@ namespace libtorrent
 		// this is a counter of how many threads are currently running.
 		// it's used to identify the last thread still running while
 		// shutting down. This last thread is responsible for cleanup
-		std::atomic<int> m_num_running_threads;
+		// must hold the job mutex to access
+		int m_num_running_threads;
 
 		// std::mutex to protect the m_generic_io_jobs and m_hash_io_jobs lists
 		mutable std::mutex m_job_mutex;

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -639,6 +639,7 @@ namespace libtorrent
 		bool m_outstanding_reclaim_message;
 #if TORRENT_USE_ASSERTS
 		int m_magic;
+		std::atomic<bool> m_jobs_aborted;
 #endif
 	};
 }

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -174,7 +174,7 @@ namespace libtorrent
 			{
 				// on error
 				*ec = j->error.ec;
-				iothread->set_num_threads(0);
+				iothread->abort(true);
 				return;
 			}
 			t->set_hash(j->piece, sha1_hash(j->d.piece_hash));


### PR DESCRIPTION
disk_io_thread::abort_jobs must only be called once, but it was possible for
concurrent calls to be made from abort() and thread_fun() if the max threads
had been set to zero but there were still disk I/O threads running.