### PR TITLE
use array_view instead of std::vector in crypto_plugin interface

### DIFF
--- a/include/libtorrent/aux_/array_view.hpp
+++ b/include/libtorrent/aux_/array_view.hpp
@@ -46,11 +46,12 @@ namespace libtorrent { namespace aux {
 
 		// T -> const T conversion constructor
 		template <typename U, typename
-			= std::enable_if<std::is_convertible<U, T>::value>
+			= std::enable_if<std::is_convertible<U*, T*>::value>
 			>
 		array_view(array_view<U> const& v)
 			: m_ptr(v.data()), m_len(v.size()) {}
 
+		array_view(T& p) : m_ptr(&p), m_len(1) {}
 		array_view(T* p, int l) : m_ptr(p), m_len(l)
 		{
 			TORRENT_ASSERT(l >= 0);

--- a/include/libtorrent/aux_/array_view.hpp
+++ b/include/libtorrent/aux_/array_view.hpp
@@ -70,8 +70,14 @@ namespace libtorrent { namespace aux {
 
 		size_t size() const { return m_len; }
 		T* data() const { return m_ptr; }
+
+		using iterator = T*;
+		using reverse_iterator = std::reverse_iterator<T*>;
+
 		T* begin() const { return m_ptr; }
 		T* end() const { return m_ptr + m_len; }
+		reverse_iterator rbegin() const { return reverse_iterator(end()); }
+		reverse_iterator rend() const { return reverse_iterator(begin()); }
 
 		T& front() const { TORRENT_ASSERT(m_len > 0); return m_ptr[0]; }
 		T& back() const { TORRENT_ASSERT(m_len > 0); return m_ptr[m_len-1]; }

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -159,9 +159,9 @@ namespace libtorrent
 		void on_receive_impl(std::size_t bytes_transferred);
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
-		// next_barrier
+		// next_barrier, buffers-to-prepend
 		virtual
-		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 		hit_send_barrier(aux::array_view<boost::asio::mutable_buffer> iovec) override;
 #endif
 

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -159,7 +159,10 @@ namespace libtorrent
 		void on_receive_impl(std::size_t bytes_transferred);
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
-		virtual int hit_send_barrier(std::vector<boost::asio::mutable_buffer>& iovec) override;
+		// next_barrier
+		virtual
+		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		hit_send_barrier(aux::array_view<boost::asio::mutable_buffer> iovec) override;
 #endif
 
 		virtual void get_specific_peer_info(peer_info& p) const override;

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -49,6 +49,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
+	// TODO: 2 this type should probably be renamed to send_buffer
 	struct TORRENT_EXTRA_EXPORT chained_buffer : private single_threaded
 	{
 		chained_buffer(): m_bytes(0), m_capacity(0)
@@ -67,6 +68,9 @@ namespace libtorrent
 		{
 			free_buffer_fun free_fun;
 			void* userdata;
+			// TODO: 2 the pointers here should probably be const, since
+			// they're not supposed to be mutated once inserted into the send
+			// buffer
 			char* buf; // the first byte of the buffer
 			char* start; // the first byte to send/receive in the buffer
 			int size; // the total size of the buffer

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -188,14 +188,6 @@ namespace libtorrent
 	struct peer_connection_handle;
 	struct torrent_handle;
 
-	// Functions of this type are called to handle incoming DHT requests
-	using dht_extension_handler_t = boost::function<bool(udp::endpoint const& source
-		, bdecode_node const& request, entry& response)>;
-
-	// Map of query strings to handlers. Note that query strings are limited to 15 bytes.
-	// see max_dht_query_length
-	using dht_extensions_t = std::vector<std::pair<std::string, dht_extension_handler_t> >;
-
 	// this is the base class for a session plugin. One primary feature
 	// is that it is notified of all torrents that are added to the session,
 	// and can add its own torrent_plugins.
@@ -511,8 +503,12 @@ namespace libtorrent
 		// are now ready to be sent to the lower layer. This must be at least
 		// as large as the number of bytes passed in and may be larger if there
 		// is additional data to be inserted at the head of the send buffer.
-		// The additional data is returned as the second tupled value
-		virtual std::tuple<int, std::vector<boost::asio::const_buffer>>
+		// The additional data is returned as the second tupled value. Any
+		// returned buffer as well as the iovec itself, to be prepended to the
+		// send buffer, must be owned by the crypto plugin and guaranteed to stay
+		// alive until the crypto_plugin is destructed or this function is called
+		// again.
+		virtual std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 		encrypt(aux::array_view<boost::asio::mutable_buffer> /*send_vec*/) = 0;
 
 		// decrypt the provided buffers.

--- a/include/libtorrent/pe_crypto.hpp
+++ b/include/libtorrent/pe_crypto.hpp
@@ -99,7 +99,7 @@ namespace libtorrent
 
 	struct encryption_handler
 	{
-		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 		encrypt(aux::array_view<boost::asio::mutable_buffer> iovec);
 
 		int decrypt(crypto_receive_buffer& recv_buffer
@@ -144,7 +144,7 @@ namespace libtorrent
 		void set_incoming_key(unsigned char const* key, int len) override;
 		void set_outgoing_key(unsigned char const* key, int len) override;
 
-		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 		encrypt(aux::array_view<boost::asio::mutable_buffer> buf) override;
 
 		void decrypt(aux::array_view<boost::asio::mutable_buffer> buf

--- a/include/libtorrent/pe_crypto.hpp
+++ b/include/libtorrent/pe_crypto.hpp
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/sha1_hash.hpp"
 #include "libtorrent/extensions.hpp"
 #include "libtorrent/assert.hpp"
+#include "libtorrent/aux_/array_view.hpp"
 
 #include <list>
 #include <array>
@@ -98,8 +99,11 @@ namespace libtorrent
 
 	struct encryption_handler
 	{
-		int encrypt(std::vector<boost::asio::mutable_buffer>& iovec);
-		int decrypt(crypto_receive_buffer& recv_buffer, std::size_t& bytes_transferred);
+		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		encrypt(aux::array_view<boost::asio::mutable_buffer> iovec);
+
+		int decrypt(crypto_receive_buffer& recv_buffer
+			, std::size_t& bytes_transferred);
 
 		bool switch_send_crypto(boost::shared_ptr<crypto_plugin> crypto
 			, int pending_encryption);
@@ -140,8 +144,10 @@ namespace libtorrent
 		void set_incoming_key(unsigned char const* key, int len) override;
 		void set_outgoing_key(unsigned char const* key, int len) override;
 
-		int encrypt(std::vector<boost::asio::mutable_buffer>& buf) override;
-		void decrypt(std::vector<boost::asio::mutable_buffer>& buf
+		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		encrypt(aux::array_view<boost::asio::mutable_buffer> buf) override;
+
+		void decrypt(aux::array_view<boost::asio::mutable_buffer> buf
 			, int& consume
 			, int& produce
 			, int& packet_size) override;

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -61,19 +61,21 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/receive_buffer.hpp"
 #include "libtorrent/aux_/allocating_handler.hpp"
 #include "libtorrent/debug.hpp"
-
-#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include "libtorrent/aux_/array_view.hpp"
 
 #include <ctime>
 #include <algorithm>
 #include <vector>
 #include <string>
 #include <utility> // for std::forward
+#include <tuple> // for make_tuple
+#include <array>
+
+#include "libtorrent/aux_/disable_warnings_push.hpp"
 
 #include <boost/smart_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/noncopyable.hpp>
-#include <array>
 #include <boost/optional.hpp>
 #include <cstdint>
 
@@ -747,8 +749,10 @@ namespace libtorrent
 
 		void send_piece_suggestions(int num);
 
-		virtual int hit_send_barrier(std::vector<boost::asio::mutable_buffer>&)
-		{ return INT_MAX; }
+		virtual
+		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		hit_send_barrier(aux::array_view<boost::asio::mutable_buffer> /* iovec */)
+		{ return std::make_tuple(INT_MAX, std::vector<boost::asio::const_buffer>()); }
 
 		void attach_to_torrent(sha1_hash const& ih);
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -750,9 +750,9 @@ namespace libtorrent
 		void send_piece_suggestions(int num);
 
 		virtual
-		std::tuple<int, std::vector<boost::asio::const_buffer>>
+		std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 		hit_send_barrier(aux::array_view<boost::asio::mutable_buffer> /* iovec */)
-		{ return std::make_tuple(INT_MAX, std::vector<boost::asio::const_buffer>()); }
+		{ return std::make_tuple(INT_MAX, aux::array_view<boost::asio::const_buffer>()); }
 
 		void attach_to_torrent(sha1_hash const& ih);
 

--- a/include/libtorrent/receive_buffer.hpp
+++ b/include/libtorrent/receive_buffer.hpp
@@ -36,7 +36,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/buffer.hpp>
 #include <libtorrent/disk_buffer_holder.hpp>
 #include <boost/asio/buffer.hpp>
-#include <vector>
 
 namespace libtorrent {
 
@@ -110,7 +109,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 	buffer::interval mutable_buffer();
 
 	// returns the last 'bytes' from the receive buffer
-	boost::asio::mutable_buffer mutable_buffers(int bytes);
+	boost::asio::mutable_buffer mutable_buffer(int bytes);
 #endif
 
 	// the purpose of this function is to free up and cut off all messages
@@ -226,7 +225,7 @@ struct crypto_receive_buffer
 
 	buffer::const_interval get() const;
 
-	boost::asio::mutable_buffer mutable_buffers(std::size_t bytes);
+	boost::asio::mutable_buffer mutable_buffer(std::size_t bytes);
 
 private:
 	// explicitly disallow assignment, to silence msvc warning

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -3520,19 +3520,19 @@ namespace libtorrent
 	}
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
-	std::tuple<int, std::vector<boost::asio::const_buffer>>
+	std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 	bt_peer_connection::hit_send_barrier(
 		aux::array_view<boost::asio::mutable_buffer> iovec)
 	{
 		int next_barrier;
-		std::vector<boost::asio::const_buffer> out_iovec;
+		aux::array_view<boost::asio::const_buffer> out_iovec;
 		std::tie(next_barrier, out_iovec) = m_enc_handler.encrypt(iovec);
 #ifndef TORRENT_DISABLE_LOGGING
 		if (next_barrier != 0)
 			peer_log(peer_log_alert::outgoing, "SEND_BARRIER"
 				, "encrypted block s = %d", next_barrier);
 #endif
-		return std::make_tuple(next_barrier, std::move(out_iovec));
+		return std::make_tuple(next_barrier, out_iovec);
 	}
 #endif
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -3532,7 +3532,7 @@ namespace libtorrent
 			peer_log(peer_log_alert::outgoing, "SEND_BARRIER"
 				, "encrypted block s = %d", next_barrier);
 #endif
-		return { next_barrier, out_iovec };
+		return std::make_tuple(next_barrier, std::move(out_iovec));
 	}
 #endif
 

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -103,7 +103,7 @@ namespace libtorrent
 		m_xor_mask = h.final();
 	}
 
-	std::tuple<int, std::vector<boost::asio::const_buffer>>
+	std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 	encryption_handler::encrypt(
 		aux::array_view<boost::asio::mutable_buffer> iovec)
 	{
@@ -146,8 +146,8 @@ namespace libtorrent
 		}
 
 		int next_barrier = 0;
-		std::vector<const_buffer> out_iovec;
-		bool process_barrier = iovec.size() == 0;
+		aux::array_view<const_buffer> out_iovec;
+		bool process_barrier = num_bufs == 0;
 		if (!process_barrier)
 		{
 			std::tie(next_barrier, out_iovec)
@@ -185,7 +185,7 @@ namespace libtorrent
 			for (int i = 0; i < num_bufs; ++i)
 				bufs[i].~mutable_buffer();
 		}
-		return std::make_tuple(next_barrier, std::move(out_iovec));
+		return std::make_tuple(next_barrier, out_iovec);
 	}
 
 	int encryption_handler::decrypt(crypto_receive_buffer& recv_buffer
@@ -283,11 +283,11 @@ namespace libtorrent
 		encrypt(vec);
 	}
 
-	std::tuple<int, std::vector<boost::asio::const_buffer>>
+	std::tuple<int, aux::array_view<boost::asio::const_buffer>>
 	rc4_handler::encrypt(aux::array_view<boost::asio::mutable_buffer> bufs)
 	{
 		using namespace boost::asio;
-		std::vector<boost::asio::const_buffer> empty;
+		aux::array_view<boost::asio::const_buffer> empty;
 		if (!m_encrypt) return std::make_tuple(0, empty);
 		if (bufs.size() == 0) return std::make_tuple(0, empty);
 

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -185,7 +185,7 @@ namespace libtorrent
 			for (int i = 0; i < num_bufs; ++i)
 				bufs[i].~mutable_buffer();
 		}
-		return { next_barrier, out_iovec };
+		return std::make_tuple(next_barrier, std::move(out_iovec));
 	}
 
 	int encryption_handler::decrypt(crypto_receive_buffer& recv_buffer
@@ -288,8 +288,8 @@ namespace libtorrent
 	{
 		using namespace boost::asio;
 		std::vector<boost::asio::const_buffer> empty;
-		if (!m_encrypt) return { 0, empty};
-		if (bufs.size() == 0) return  { 0, empty};
+		if (!m_encrypt) return std::make_tuple(0, empty);
+		if (bufs.size() == 0) return std::make_tuple(0, empty);
 
 		int bytes_processed = 0;
 		for (auto& buf : bufs)
@@ -303,7 +303,7 @@ namespace libtorrent
 			bytes_processed += len;
 			rc4_encrypt(pos, len, &m_rc4_outgoing);
 		}
-		return { bytes_processed, empty};
+		return std::make_tuple(bytes_processed, empty);
 	}
 
 	void rc4_handler::decrypt(aux::array_view<boost::asio::mutable_buffer> bufs

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -50,9 +50,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <random>
 
 #include "libtorrent/random.hpp"
+#include "libtorrent/alloca.hpp"
 #include "libtorrent/pe_crypto.hpp"
 #include "libtorrent/hasher.hpp"
 #include "libtorrent/assert.hpp"
+#include "libtorrent/aux_/array_view.hpp"
 
 namespace libtorrent
 {
@@ -101,47 +103,55 @@ namespace libtorrent
 		m_xor_mask = h.final();
 	}
 
-	int encryption_handler::encrypt(std::vector<boost::asio::mutable_buffer>& iovec)
+	std::tuple<int, std::vector<boost::asio::const_buffer>>
+	encryption_handler::encrypt(
+		aux::array_view<boost::asio::mutable_buffer> iovec)
 	{
+		using namespace boost::asio;
+
 		TORRENT_ASSERT(!m_send_barriers.empty());
 		TORRENT_ASSERT(m_send_barriers.front().enc_handler);
 
 		int to_process = m_send_barriers.front().next;
 
+		boost::asio::mutable_buffer* bufs;
+		int num_bufs;
+		bool need_destruct = false;
 		if (to_process != INT_MAX)
 		{
-			for (std::vector<boost::asio::mutable_buffer>::iterator i = iovec.begin();
-				to_process >= 0; ++i)
+			bufs = TORRENT_ALLOCA(mutable_buffer, iovec.size());
+			need_destruct = true;
+			num_bufs = 0;
+			for (int i = 0; to_process > 0; ++i)
 			{
-				if (to_process == 0)
+				++num_bufs;
+				int const size = buffer_size(iovec[i]);
+				if (to_process < size)
 				{
-					iovec.erase(i, iovec.end());
-					break;
-				}
-				else if (to_process < boost::asio::buffer_size(*i))
-				{
-					*i = boost::asio::mutable_buffer(boost::asio::buffer_cast<void*>(*i), to_process);
-					iovec.erase(++i, iovec.end());
+					new (&bufs[i]) mutable_buffer(
+						buffer_cast<void*>(iovec[i]), to_process);
 					to_process = 0;
-					break;
 				}
-				to_process -= int(boost::asio::buffer_size(*i));
+				else
+				{
+					new (&bufs[i]) mutable_buffer(iovec[i]);
+					to_process -= size;
+				}
 			}
-			TORRENT_ASSERT(to_process == 0);
+		}
+		else
+		{
+			bufs = iovec.data();
+			num_bufs = iovec.size();
 		}
 
-#if TORRENT_USE_ASSERTS
-		to_process = 0;
-		for (std::vector<boost::asio::mutable_buffer>::iterator i = iovec.begin();
-			i != iovec.end(); ++i)
-			to_process += int(boost::asio::buffer_size(*i));
-#endif
-
 		int next_barrier = 0;
-		bool process_barrier = iovec.empty();
+		std::vector<const_buffer> out_iovec;
+		bool process_barrier = iovec.size() == 0;
 		if (!process_barrier)
 		{
-			next_barrier = m_send_barriers.front().enc_handler->encrypt(iovec);
+			std::tie(next_barrier, out_iovec)
+				= m_send_barriers.front().enc_handler->encrypt({bufs, num_bufs});
 			process_barrier = (next_barrier != 0);
 		}
 		if (process_barrier)
@@ -149,37 +159,43 @@ namespace libtorrent
 			if (m_send_barriers.front().next != INT_MAX)
 			{
 				if (m_send_barriers.size() == 1)
+				{
 					// transitioning back to plaintext
 					next_barrier = INT_MAX;
+				}
 				m_send_barriers.pop_front();
 			}
 
 #if TORRENT_USE_ASSERTS
 			if (next_barrier != INT_MAX)
 			{
+				int payload = 0;
+				for (int i = 0; i < num_bufs; ++i)
+					payload += int(buffer_size(bufs[i]));
+
 				int overhead = 0;
-				for (std::vector<boost::asio::mutable_buffer>::iterator i = iovec.begin();
-					i != iovec.end(); ++i)
-					overhead += int(boost::asio::buffer_size(*i));
-				TORRENT_ASSERT(overhead + to_process == next_barrier);
+				for (auto buf : out_iovec)
+					overhead += int(buffer_size(buf));
+				TORRENT_ASSERT(overhead + payload == next_barrier);
 			}
 #endif
 		}
-		else
+		if (need_destruct)
 		{
-			iovec.clear();
+			for (int i = 0; i < num_bufs; ++i)
+				bufs[i].~mutable_buffer();
 		}
-		return next_barrier;
+		return { next_barrier, out_iovec };
 	}
 
-	int encryption_handler::decrypt(crypto_receive_buffer& recv_buffer, std::size_t& bytes_transferred)
+	int encryption_handler::decrypt(crypto_receive_buffer& recv_buffer
+		, std::size_t& bytes_transferred)
 	{
 		TORRENT_ASSERT(!is_recv_plaintext());
 		int consume = 0;
 		if (recv_buffer.crypto_packet_finished())
 		{
-			std::vector<boost::asio::mutable_buffer> wr_buf;
-			wr_buf.push_back(recv_buffer.mutable_buffers(bytes_transferred));
+			boost::asio::mutable_buffer wr_buf = recv_buffer.mutable_buffer(bytes_transferred);
 			int packet_size = 0;
 			int produce = int(bytes_transferred);
 			m_dec_handler->decrypt(wr_buf, consume, produce, packet_size);
@@ -249,11 +265,11 @@ namespace libtorrent
 		m_decrypt = true;
 		rc4_init(key, len, &m_rc4_incoming);
 		// Discard first 1024 bytes
-		char buf[1024];
-		std::vector<boost::asio::mutable_buffer> vec(1, boost::asio::mutable_buffer(buf, 1024));
 		int consume = 0;
 		int produce = 0;
 		int packet_size = 0;
+		char buf[1024];
+		boost::asio::mutable_buffer vec(buf, sizeof(buf));
 		decrypt(vec, consume, produce, packet_size);
 	}
 
@@ -263,21 +279,23 @@ namespace libtorrent
 		rc4_init(key, len, &m_rc4_outgoing);
 		// Discard first 1024 bytes
 		char buf[1024];
-		std::vector<boost::asio::mutable_buffer> vec(1, boost::asio::mutable_buffer(buf, 1024));
+		boost::asio::mutable_buffer vec(buf, sizeof(buf));
 		encrypt(vec);
 	}
 
-	int rc4_handler::encrypt(std::vector<boost::asio::mutable_buffer>& buf)
+	std::tuple<int, std::vector<boost::asio::const_buffer>>
+	rc4_handler::encrypt(aux::array_view<boost::asio::mutable_buffer> bufs)
 	{
-		if (!m_encrypt) return 0;
-		if (buf.empty()) return 0;
+		using namespace boost::asio;
+		std::vector<boost::asio::const_buffer> empty;
+		if (!m_encrypt) return { 0, empty};
+		if (bufs.size() == 0) return  { 0, empty};
 
 		int bytes_processed = 0;
-		for (std::vector<boost::asio::mutable_buffer>::iterator i = buf.begin();
-			i != buf.end(); ++i)
+		for (auto& buf : bufs)
 		{
-			unsigned char* pos = boost::asio::buffer_cast<unsigned char*>(*i);
-			int len = int(boost::asio::buffer_size(*i));
+			unsigned char* const pos = buffer_cast<unsigned char*>(buf);
+			int const len = int(buffer_size(buf));
 
 			TORRENT_ASSERT(len >= 0);
 			TORRENT_ASSERT(pos);
@@ -285,11 +303,10 @@ namespace libtorrent
 			bytes_processed += len;
 			rc4_encrypt(pos, len, &m_rc4_outgoing);
 		}
-		buf.clear();
-		return bytes_processed;
+		return { bytes_processed, empty};
 	}
 
-	void rc4_handler::decrypt(std::vector<boost::asio::mutable_buffer>& buf
+	void rc4_handler::decrypt(aux::array_view<boost::asio::mutable_buffer> bufs
 		, int& consume
 		, int& produce
 		, int& packet_size)
@@ -301,11 +318,10 @@ namespace libtorrent
 		if (!m_decrypt) return;
 
 		int bytes_processed = 0;
-		for (std::vector<boost::asio::mutable_buffer>::iterator i = buf.begin();
-			i != buf.end(); ++i)
+		for (auto& buf : bufs)
 		{
-			unsigned char* pos = boost::asio::buffer_cast<unsigned char*>(*i);
-			int len = int(boost::asio::buffer_size(*i));
+			unsigned char* const pos = boost::asio::buffer_cast<unsigned char*>(buf);
+			int const len = int(boost::asio::buffer_size(buf));
 
 			TORRENT_ASSERT(len >= 0);
 			TORRENT_ASSERT(pos);
@@ -313,7 +329,6 @@ namespace libtorrent
 			bytes_processed += len;
 			rc4_encrypt(pos, len, &m_rc4_incoming);
 		}
-		buf.clear();
 		produce = bytes_processed;
 	}
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5511,7 +5511,7 @@ namespace libtorrent
 			std::vector<boost::asio::mutable_buffer> vec;
 			m_send_buffer.build_mutable_iovec(m_send_buffer.size(), vec);
 			int next_barrier;
-			std::vector<boost::asio::const_buffer> inject_vec;
+			aux::array_view<boost::asio::const_buffer> inject_vec;
 			std::tie(next_barrier, inject_vec) = hit_send_barrier(vec);
 			for (auto i = inject_vec.rbegin(); i != inject_vec.rend(); ++i)
 			{

--- a/src/receive_buffer.cpp
+++ b/src/receive_buffer.cpp
@@ -151,7 +151,7 @@ buffer::interval receive_buffer::mutable_buffer()
 		, &m_recv_buffer[0] + m_recv_start + rcv_pos);
 }
 
-boost::asio::mutable_buffer receive_buffer::mutable_buffers(int const bytes)
+boost::asio::mutable_buffer receive_buffer::mutable_buffer(int const bytes)
 {
 	namespace asio = boost::asio;
 
@@ -305,13 +305,13 @@ buffer::const_interval crypto_receive_buffer::get() const
 	return recv_buffer;
 }
 
-boost::asio::mutable_buffer crypto_receive_buffer::mutable_buffers(
+boost::asio::mutable_buffer crypto_receive_buffer::mutable_buffer(
 	std::size_t const bytes)
 {
 	int const pending_decryption = (m_recv_pos != INT_MAX)
 		? m_connection_buffer.packet_size() - m_recv_pos
 		: int(bytes);
-	return m_connection_buffer.mutable_buffers(pending_decryption);
+	return m_connection_buffer.mutable_buffer(pending_decryption);
 }
 #endif // TORRENT_DISABLE_ENCRYPTION
 

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -37,11 +37,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/pe_crypto.hpp"
 #include "libtorrent/session.hpp"
 #include "libtorrent/random.hpp"
+#include "libtorrent/aux_/array_view.hpp"
 
 #include "setup_transfer.hpp"
 #include "test.hpp"
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
+
+namespace lt = libtorrent;
 
 void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b)
 {
@@ -60,10 +63,10 @@ void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b
 		{
 			mutable_buffer iovec(&buf[0], buf_len);
 			int next_barrier;
-			std::vector<const_buffer> iovec_out;
+			lt::aux::array_view<const_buffer> iovec_out;
 			std::tie(next_barrier, iovec_out) = a.encrypt(iovec);
 			TEST_CHECK(buf != cmp_buf);
-			TEST_CHECK(iovec_out.empty());
+			TEST_EQUAL(iovec_out.size(), 0);
 			TEST_EQUAL(next_barrier, buf_len);
 		}
 
@@ -82,8 +85,9 @@ void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b
 		{
 			mutable_buffer iovec(&buf[0], buf_len);
 			int next_barrier;
-			std::vector<const_buffer> iovec_out;
+			lt::aux::array_view<const_buffer> iovec_out;
 			std::tie(next_barrier, iovec_out) = b.encrypt(iovec);
+			TEST_EQUAL(iovec_out.size(), 0);
 			TEST_CHECK(buf != cmp_buf);
 			TEST_EQUAL(next_barrier, buf_len);
 

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -43,9 +43,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 
-void test_enc_handler(libtorrent::crypto_plugin* a, libtorrent::crypto_plugin* b)
+void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b)
 {
-	const int repcount = 128;
+	int const repcount = 128;
 	for (int rep = 0; rep < repcount; ++rep)
 	{
 		int const buf_len = rand() % (512 * 1024);
@@ -56,36 +56,47 @@ void test_enc_handler(libtorrent::crypto_plugin* a, libtorrent::crypto_plugin* b
 		std::copy(buf.begin(), buf.end(), cmp_buf.begin());
 
 		using namespace boost::asio;
-		std::vector<mutable_buffer> iovec;
-		iovec.push_back(mutable_buffer(&buf[0], buf_len));
-		a->encrypt(iovec);
-		TEST_CHECK(!std::equal(buf.begin(), buf.end(), cmp_buf.begin()));
-		TEST_CHECK(iovec.empty());
-		int consume = 0;
-		int produce = buf_len;
-		int packet_size = 0;
-		iovec.push_back(mutable_buffer(&buf[0], buf_len));
-		b->decrypt(iovec, consume, produce, packet_size);
-		TEST_CHECK(std::equal(buf.begin(), buf.end(), cmp_buf.begin()));
-		TEST_CHECK(iovec.empty());
-		TEST_EQUAL(consume, 0);
-		TEST_EQUAL(produce, buf_len);
-		TEST_EQUAL(packet_size, 0);
 
-		iovec.push_back(mutable_buffer(&buf[0], buf_len));
-		b->encrypt(iovec);
-		TEST_CHECK(!std::equal(buf.begin(), buf.end(), cmp_buf.begin()));
-		TEST_CHECK(iovec.empty());
-		consume = 0;
-		produce = buf_len;
-		packet_size = 0;
-		iovec.push_back(mutable_buffer(&buf[0], buf_len));
-		a->decrypt(iovec, consume, produce, packet_size);
-		TEST_CHECK(std::equal(buf.begin(), buf.end(), cmp_buf.begin()));
-		TEST_CHECK(iovec.empty());
-		TEST_EQUAL(consume, 0);
-		TEST_EQUAL(produce, buf_len);
-		TEST_EQUAL(packet_size, 0);
+		{
+			mutable_buffer iovec(&buf[0], buf_len);
+			int next_barrier;
+			std::vector<const_buffer> iovec_out;
+			std::tie(next_barrier, iovec_out) = a.encrypt(iovec);
+			TEST_CHECK(buf != cmp_buf);
+			TEST_CHECK(iovec_out.empty());
+			TEST_EQUAL(next_barrier, buf_len);
+		}
+
+		{
+			int consume = 0;
+			int produce = buf_len;
+			int packet_size = 0;
+			mutable_buffer iovec(&buf[0], buf_len);
+			b.decrypt(iovec, consume, produce, packet_size);
+			TEST_CHECK(buf == cmp_buf);
+			TEST_EQUAL(consume, 0);
+			TEST_EQUAL(produce, buf_len);
+			TEST_EQUAL(packet_size, 0);
+		}
+
+		{
+			mutable_buffer iovec(&buf[0], buf_len);
+			int next_barrier;
+			std::vector<const_buffer> iovec_out;
+			std::tie(next_barrier, iovec_out) = b.encrypt(iovec);
+			TEST_CHECK(buf != cmp_buf);
+			TEST_EQUAL(next_barrier, buf_len);
+
+			int consume = 0;
+			int produce = buf_len;
+			int packet_size = 0;
+			mutable_buffer iovec2(&buf[0], buf_len);
+			a.decrypt(iovec2, consume, produce, packet_size);
+			TEST_CHECK(buf == cmp_buf);
+			TEST_EQUAL(consume, 0);
+			TEST_EQUAL(produce, buf_len);
+			TEST_EQUAL(packet_size, 0);
+		}
 	}
 }
 
@@ -134,7 +145,7 @@ TORRENT_TEST(rc4)
 	rc4_handler rc42;
 	rc42.set_incoming_key(&test1_key[0], 20);
 	rc42.set_outgoing_key(&test2_key[0], 20);
-	test_enc_handler(&rc41, &rc42);
+	test_enc_handler(rc41, rc42);
 }
 
 #else

--- a/test/test_receive_buffer.cpp
+++ b/test/test_receive_buffer.cpp
@@ -107,7 +107,7 @@ TORRENT_TEST(recv_buffer_mutable_buffers)
 	b.cut(100, 1000); // packet size = 1000
 	packet_transferred = b.advance_pos(999);
 	TEST_EQUAL(packet_transferred, 999);
-	boost::asio::mutable_buffer vec = b.mutable_buffers(999);
+	boost::asio::mutable_buffer vec = b.mutable_buffer(999);
 
 	// previous packet
 	//   |


### PR DESCRIPTION
return a vector of const_buffers for prepending new buffers. use stack allocated (single buffer) iovecs for receives. general cleanup