### PR TITLE
removed buffer::interval

### DIFF
--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -286,7 +286,7 @@ namespace libtorrent
 			, char const* target, int target_size) const;
 
 		// helper to cut down on boilerplate
-		void rc4_decrypt(char* pos, int len);
+		void rc4_decrypt(boost::asio::mutable_buffer vec);
 #endif
 
 public:

--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -46,42 +46,8 @@ namespace libtorrent {
 class buffer
 {
 public:
-	struct interval
-	{
-	interval()
-		: begin(0)
-		, end(0)
-		{}
-
-	interval(char* b, char* e)
-		: begin(b)
-		, end(e)
-		{}
-
-		char operator[](int index) const
-		{
-			TORRENT_ASSERT(begin + index < end);
-			return begin[index];
-		}
-
-		int left() const
-		{
-			TORRENT_ASSERT(end >= begin);
-			TORRENT_ASSERT(end - begin < (std::numeric_limits<int>::max)());
-			return int(end - begin);
-		}
-
-		char* begin;
-		char* end;
-	};
-
 	struct const_interval
 	{
-	const_interval(interval const& i)
-		: begin(i.begin)
-		, end(i.end)
-		{}
-
 	const_interval(char const* b, char const* e)
 		: begin(b)
 		, end(e)
@@ -163,8 +129,6 @@ public:
 		std::free(m_begin);
 	}
 
-	buffer::interval data()
-	{ return interval(m_begin, m_begin + m_size); }
 	buffer::const_interval data() const
 	{ return const_interval(m_begin, m_begin + m_size); }
 

--- a/include/libtorrent/receive_buffer.hpp
+++ b/include/libtorrent/receive_buffer.hpp
@@ -106,7 +106,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 	// returns the entire regular buffer
 	// should only be used during the handshake
-	buffer::interval mutable_buffer();
+	boost::asio::mutable_buffer mutable_buffer();
 
 	// returns the last 'bytes' from the receive buffer
 	boost::asio::mutable_buffer mutable_buffer(int bytes);
@@ -178,7 +178,7 @@ private:
 // Wraps a receive_buffer to provide the ability to inject
 // possibly authenticated crypto beneath the bittorrent protocol.
 // When authenticated crypto is in use the wrapped receive_buffer
-// holds the receive state of the crpyto layer while this class
+// holds the receive state of the crypto layer while this class
 // tracks the state of the bittorrent protocol.
 struct crypto_receive_buffer
 {
@@ -189,7 +189,10 @@ struct crypto_receive_buffer
 		, m_connection_buffer(next)
 	{}
 
-	buffer::interval mutable_buffer() { return m_connection_buffer.mutable_buffer(); }
+	boost::asio::mutable_buffer mutable_buffer()
+	{
+		return m_connection_buffer.mutable_buffer();
+	}
 
 	bool packet_finished() const;
 

--- a/src/receive_buffer.cpp
+++ b/src/receive_buffer.cpp
@@ -130,7 +130,7 @@ buffer::const_interval receive_buffer::get() const
 	if (m_recv_buffer.empty())
 	{
 		TORRENT_ASSERT(m_recv_pos == 0);
-		return buffer::interval(0,0);
+		return buffer::const_interval(0,0);
 	}
 
 	int rcv_pos = (std::min)(m_recv_pos, int(m_recv_buffer.size()) - m_recv_start);
@@ -139,16 +139,17 @@ buffer::const_interval receive_buffer::get() const
 }
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
-buffer::interval receive_buffer::mutable_buffer()
+boost::asio::mutable_buffer receive_buffer::mutable_buffer()
 {
+	namespace asio = boost::asio;
+
 	if (m_recv_buffer.empty())
 	{
 		TORRENT_ASSERT(m_recv_pos == 0);
-		return buffer::interval(0,0);
+		return asio::mutable_buffer();
 	}
 	int const rcv_pos = (std::min)(m_recv_pos, int(m_recv_buffer.size()));
-	return buffer::interval(&m_recv_buffer[0] + m_recv_start
-		, &m_recv_buffer[0] + m_recv_start + rcv_pos);
+	return asio::mutable_buffer(&m_recv_buffer[0] + m_recv_start, rcv_pos);
 }
 
 boost::asio::mutable_buffer receive_buffer::mutable_buffer(int const bytes)


### PR DESCRIPTION
This is soft PR, it's just a refactor to eliminate what I think is a redundant type. If you have something else in mind, feel free to discard/close it.