### PR TITLE
don't risk use of invalid data during fast resume check

### DIFF
--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -50,6 +50,12 @@ namespace libtorrent
 	struct add_torrent_params;
 	struct cache_status;
 
+	struct TORRENT_EXTRA_EXPORT resume_data_t
+	{
+		std::vector<char> buf;
+		bdecode_node node;
+	};
+
 	struct TORRENT_EXTRA_EXPORT disk_interface
 	{
 		virtual void async_read(piece_manager* storage, peer_request const& r
@@ -67,7 +73,7 @@ namespace libtorrent
 			, boost::function<void(disk_io_job const*)> const& handler
 			= boost::function<void(disk_io_job const*)>()) = 0;
 		virtual void async_check_fastresume(piece_manager* storage
-			, bdecode_node const* resume_data
+			, resume_data_t const* resume_data
 			, std::vector<std::string>& links
 			, boost::function<void(disk_io_job const*)> const& handler) = 0;
 #ifndef TORRENT_NO_DEPRECATE

--- a/include/libtorrent/disk_io_job.hpp
+++ b/include/libtorrent/disk_io_job.hpp
@@ -54,6 +54,7 @@ namespace libtorrent
 	struct cached_piece_entry;
 	struct bdecode_node;
 	class torrent_info;
+	struct resume_data_t;
 
 	struct block_cache_reference
 	{
@@ -157,7 +158,7 @@ namespace libtorrent
 			char* disk_block;
 			char* string;
 			entry* resume_data;
-			bdecode_node const* check_resume_data;
+			resume_data_t const* check_resume_data;
 			std::vector<boost::uint8_t>* priorities;
 			torrent_info* torrent_file;
 			int delete_options;

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -314,7 +314,7 @@ namespace libtorrent
 		void async_delete_files(piece_manager* storage, int options
 			, boost::function<void(disk_io_job const*)> const& handler) TORRENT_OVERRIDE;
 		void async_check_fastresume(piece_manager* storage
-			, bdecode_node const* resume_data
+			, resume_data_t const* resume_data
 			, std::vector<std::string>& links
 			, boost::function<void(disk_io_job const*)> const& handler) TORRENT_OVERRIDE;
 		void async_save_resume_data(piece_manager* storage

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1318,6 +1318,7 @@ namespace libtorrent
 
 		// used if there is any resume data
 		boost::scoped_ptr<resume_data_t> m_resume_data;
+		bool m_check_fastresume_queued;
 
 		// if the torrent is started without metadata, it may
 		// still be given a name until the metadata is received

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -105,12 +105,6 @@ namespace libtorrent
 		struct piece_checker_data;
 	}
 
-	struct resume_data_t
-	{
-		std::vector<char> buf;
-		bdecode_node node;
-	};
-
 	struct time_critical_piece
 	{
 		// when this piece was first requested
@@ -1317,8 +1311,7 @@ namespace libtorrent
 		error_code m_error;
 
 		// used if there is any resume data
-		boost::scoped_ptr<resume_data_t> m_resume_data;
-		bool m_check_fastresume_queued;
+		std::unique_ptr<resume_data_t> m_resume_data;
 
 		// if the torrent is started without metadata, it may
 		// still be given a name until the metadata is received

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -1865,7 +1865,7 @@ namespace libtorrent
 	}
 
 	void disk_io_thread::async_check_fastresume(piece_manager* storage
-		, bdecode_node const* resume_data
+		, resume_data_t const* resume_data
 		, std::vector<std::string>& links
 		, boost::function<void(disk_io_job const*)> const& handler)
 	{
@@ -2573,12 +2573,12 @@ namespace libtorrent
 		// if this assert fails, something's wrong with the fence logic
 		TORRENT_ASSERT(j->storage->num_outstanding_jobs() == 1);
 
-		bdecode_node const* rd = j->buffer.check_resume_data;
+		resume_data_t const* rd = j->buffer.check_resume_data;
 		bdecode_node tmp;
-		if (rd == NULL) rd = &tmp;
 
 		boost::scoped_ptr<std::vector<std::string> > links(j->d.links);
-		return j->storage->check_fastresume(*rd, links.get(), j->error);
+		return j->storage->check_fastresume(rd != NULL ? rd->node : tmp
+			, links.get(), j->error);
 	}
 
 	int disk_io_thread::do_save_resume_data(disk_io_job* j, jobqueue_t& completed_jobs)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -201,6 +201,7 @@ namespace libtorrent
 		, m_uuid(p.uuid)
 		, m_source_feed_url(p.source_feed_url)
 		, m_stats_counters(ses.stats_counters())
+		, m_check_fastresume_queued(false)
 		, m_storage_constructor(p.storage)
 		, m_added_time(time(0))
 		, m_completed_time(0)
@@ -2100,9 +2101,10 @@ namespace libtorrent
 		inc_refcount("check_fastresume");
 		// async_check_fastresume will gut links
 		m_ses.disk_thread().async_check_fastresume(
-			m_storage.get(), m_resume_data ? &m_resume_data->node : NULL
+			m_storage.get(), m_resume_data && !m_check_fastresume_queued ? &m_resume_data->node : NULL
 			, links, boost::bind(&torrent::on_resume_data_checked
 			, shared_from_this(), _1));
+		m_check_fastresume_queued = true;
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("init, async_check_fastresume");
 #endif

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -467,7 +467,7 @@ void test_check_files(std::string const& test_path
 	libtorrent::mutex lock;
 
 	bool done = false;
-	bdecode_node frd;
+	resume_data_t frd;
 	std::vector<std::string> links;
 	io.async_check_fastresume(pm.get(), &frd, links
 		, boost::bind(&on_check_resume_data, _1, &done));


### PR DESCRIPTION
This is another attempt to fix https://github.com/arvidn/libtorrent/issues/781

The explanation of this change is: When you don't use `flag_duplicate_is_error` it seems to me that is possible that two successively and rapidly `add_torrent` calls with the same parameters result in calling `async_check_fastresume` twice, since the first one still has not finished the async task, the `m_resume_data` is still not cleared at the time of the second call. The second job will eventually reference an invalid pointer.

(I personally don't like the adding of another flag, can't see other option)