### PR TITLE
using bsr even with no popcnt present

### DIFF
--- a/src/sha1_hash.cpp
+++ b/src/sha1_hash.cpp
@@ -76,16 +76,13 @@ namespace libtorrent
 			}
 
 #if TORRENT_HAS_SSE
-			if (aux::mmx_support)
-			{
 #ifdef __GNUC__
-				return ret + __builtin_clz(v);
+			return ret + __builtin_clz(v);
 #else
-				DWORD pos;
-				_BitScanReverse(&pos, v);
-				return ret + 31 - pos;
+			DWORD pos;
+			_BitScanReverse(&pos, v);
+			return ret + 31 - pos;
 #endif
-			}
 #else
 			// http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
 			static const int MultiplyDeBruijnBitPosition[32] =


### PR DESCRIPTION
For context, this is part of an ongoing research to include support for arm crc32c, clz and popcnt.

I don't see why `bsrl` needs to by tied to the presence of `popcnt`, any reason for that?