### PR TITLE
simplify peer_connection's read handlers and the receive buffer.

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -389,7 +389,7 @@ int print_peer_info(std::string& out
 	if (print_ip) out += "IP                             ";
 	out += "progress        down     (total | peak   )  up      (total | peak   ) sent-req tmo bsy rcv flags         dn  up  source  ";
 	if (print_fails) out += "fail hshf ";
-	if (print_send_bufs) out += "rq sndb rcvb   q-bytes ";
+	if (print_send_bufs) out += "rq sndb (recvb |alloc ) q-bytes ";
 	if (print_timers) out += "inactive wait timeout q-time ";
 	out += "  v disk ^    rtt  ";
 	if (print_block) out += "block-progress ";
@@ -471,9 +471,10 @@ int print_peer_info(std::string& out
 		}
 		if (print_send_bufs)
 		{
-			std::snprintf(str, sizeof(str), "%2d %6d %6d%5dkB "
+			std::snprintf(str, sizeof(str), "%2d %6d %6d|%6d%5dkB "
 				, i->requests_in_buffer, i->used_send_buffer
 				, i->used_receive_buffer
+				, i->receive_buffer_size
 				, i->queue_bytes / 1000);
 			out += str;
 		}

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -389,7 +389,7 @@ int print_peer_info(std::string& out
 	if (print_ip) out += "IP                             ";
 	out += "progress        down     (total | peak   )  up      (total | peak   ) sent-req tmo bsy rcv flags         dn  up  source  ";
 	if (print_fails) out += "fail hshf ";
-	if (print_send_bufs) out += "rq sndb (recvb |alloc ) q-bytes ";
+	if (print_send_bufs) out += "rq sndb (recvb |alloc | wmrk ) q-bytes ";
 	if (print_timers) out += "inactive wait timeout q-time ";
 	out += "  v disk ^    rtt  ";
 	if (print_block) out += "block-progress ";
@@ -471,10 +471,11 @@ int print_peer_info(std::string& out
 		}
 		if (print_send_bufs)
 		{
-			std::snprintf(str, sizeof(str), "%2d %6d %6d|%6d%5dkB "
+			std::snprintf(str, sizeof(str), "%2d %6d %6d|%6d|%6d%5dkB "
 				, i->requests_in_buffer, i->used_send_buffer
 				, i->used_receive_buffer
 				, i->receive_buffer_size
+				, i->receive_buffer_watermark
 				, i->queue_bytes / 1000);
 			out += str;
 		}

--- a/include/libtorrent/aux_/array_view.hpp
+++ b/include/libtorrent/aux_/array_view.hpp
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_ARRAY_VIEW_HPP_INCLUDED
 
 #include <vector>
+#include <array>
 #include <type_traits> // for std::is_convertible
 #include "libtorrent/assert.hpp"
 

--- a/include/libtorrent/aux_/suggest_piece.hpp
+++ b/include/libtorrent/aux_/suggest_piece.hpp
@@ -107,10 +107,6 @@ struct suggest_piece
 		}
 
 		m_priority_pieces.push_back(index);
-
-		std::printf("SUGGEST: ");
-		for (int p : m_priority_pieces) std::printf(" %d", p);
-		std::printf("\n");
 	}
 
 private:

--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -52,6 +52,13 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
+	namespace {
+		std::size_t round_up8(std::size_t const v)
+		{
+			return (v + 7) & (~0x7);
+		}
+	}
+
 // the buffer is allocated once and cannot be resized. The size() may be
 // larger than requested, in case the underlying allocator over allocated. In
 // order to "grow" an allocation, create a new buffer and initialize it by
@@ -126,11 +133,13 @@ public:
 	};
 
 	// allocate an uninitialized buffer of the specified size
-	buffer(std::size_t const size = 0)
+	buffer(std::size_t size = 0)
 	{
-		TORRENT_ASSERT(size < std::numeric_limits<std::int32_t>::max());
+		TORRENT_ASSERT(size < std::size_t(std::numeric_limits<std::int32_t>::max()));
 
 		if (size == 0) return;
+
+		size = round_up8(size);
 
 		m_begin = static_cast<char*>(std::malloc(size));
 		if (m_begin == nullptr)
@@ -202,9 +211,9 @@ public:
 	{ return interval(m_begin, m_begin + m_size); }
 
 	operator aux::array_view<char>()
-	{ return aux::array_view<char>(m_begin, m_size); }
+	{ return aux::array_view<char>(m_begin, int(m_size)); }
 	operator aux::array_view<char const>() const
-	{ return aux::array_view<char const>(m_begin, m_size); }
+	{ return aux::array_view<char const>(m_begin, int(m_size)); }
 
 	std::size_t size() const { return m_size; }
 

--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -53,9 +53,9 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 
 	namespace {
-		std::size_t round_up8(std::size_t const v)
+		inline std::size_t round_up8(std::size_t const v)
 		{
-			return (v + 7) & (~0x7);
+			return (v + 7) & (~std::size_t(0x7));
 		}
 	}
 

--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -111,17 +111,11 @@ public:
 	};
 
 	buffer(std::size_t n = 0)
-		: m_begin(0)
-		, m_size(0)
-		, m_capacity(0)
 	{
 		if (n) resize(n);
 	}
 
 	buffer(buffer const& b)
-		: m_begin(0)
-		, m_size(0)
-		, m_capacity(0)
 	{
 		if (b.size() == 0) return;
 		resize(b.size());
@@ -221,6 +215,8 @@ public:
 		if (tmp == nullptr) throw std::bad_alloc();
 #endif
 		m_begin = tmp;
+		// TODO: 4 on linux, ask about the actual number of bytes in the
+		// allocation here
 		m_capacity = std::uint32_t(n);
 	}
 
@@ -241,9 +237,9 @@ public:
 		swap(m_capacity, b.m_capacity);
 	}
 private:
-	char* m_begin;
-	std::uint32_t m_size;
-	std::uint32_t m_capacity;
+	char* m_begin = nullptr;
+	std::uint32_t m_size = 0;
+	std::uint32_t m_capacity = 0;
 };
 
 

--- a/include/libtorrent/peer_info.hpp
+++ b/include/libtorrent/peer_info.hpp
@@ -246,6 +246,7 @@ namespace libtorrent
 		// allocated and used as receive buffer, respectively.
 		int receive_buffer_size;
 		int used_receive_buffer;
+		int receive_buffer_watermark;
 
 		// the number of pieces this peer has participated in sending us that
 		// turned out to fail the hash check.

--- a/include/libtorrent/receive_buffer.hpp
+++ b/include/libtorrent/receive_buffer.hpp
@@ -60,7 +60,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 	int watermark() const { return m_watermark.mean(); }
 
 	boost::asio::mutable_buffer reserve(int size);
-	void grow(int limit = 2 * 1024 * 1024);
+	void grow(int limit);
 
 	// tell the buffer we just received more bytes at the end of it. This will
 	// advance the end cursor
@@ -77,9 +77,6 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 
 	// has the read cursor reached the end cursor?
 	bool pos_at_end() { return m_recv_pos == m_recv_end; }
-
-	// make the buffer size divisible by 8 bytes (RC4 block size)
-	void clamp_size();
 
 	// size = the packet size to remove from the receive buffer
 	// packet_size = the next packet size to receive in the buffer
@@ -100,7 +97,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 
 	// the purpose of this function is to free up and cut off all messages
 	// in the receive buffer that have been parsed and processed.
-	void normalize();
+	void normalize(int force_shrink = 0);
 	bool normalized() const { return m_recv_start == 0; }
 
 	void reset(int packet_size);

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1098,13 +1098,16 @@ namespace libtorrent
 			// and is disconnected.
 			max_rejects,
 
-			// ``recv_socket_buffer_size`` and ``send_socket_buffer_size``
 			// specifies the buffer sizes set on peer sockets. 0 (which is the
 			// default) means the OS default (i.e. don't change the buffer sizes).
 			// The socket buffer sizes are changed using setsockopt() with
 			// SOL_SOCKET/SO_RCVBUF and SO_SNDBUFFER.
 			recv_socket_buffer_size,
 			send_socket_buffer_size,
+
+			// the max number of bytes a single peer connection's receive buffer is
+			// allowed to grow to.
+			max_peer_recv_buffer_size,
 
 			// ``file_checks_delay_per_block`` is the number of milliseconds to
 			// sleep in between disk read operations when checking torrents. This

--- a/include/libtorrent/sliding_average.hpp
+++ b/include/libtorrent/sliding_average.hpp
@@ -45,6 +45,8 @@ template <int inverted_gain>
 struct sliding_average
 {
 	sliding_average(): m_mean(0), m_average_deviation(0), m_num_samples(0) {}
+	sliding_average(sliding_average const&) = default;
+	sliding_average& operator=(sliding_average const&) = default;
 
 	void add_sample(int s)
 	{
@@ -75,19 +77,16 @@ struct sliding_average
 
 private:
 	// both of these are fixed point values (* 64)
-	int m_mean;
-	int m_average_deviation;
+	int m_mean = 0;
+	int m_average_deviation = 0;
 	// the number of samples we have received, but no more than inverted_gain
 	// this is the effective inverted_gain
-	int m_num_samples;
+	int m_num_samples = 0;
 };
 
 struct average_accumulator
 {
-	average_accumulator()
-		: m_num_samples(0)
-		, m_sample_sum(0)
-	{}
+	average_accumulator() {}
 
 	void add_sample(int s)
 	{
@@ -108,8 +107,10 @@ struct average_accumulator
 		return ret;
 	}
 
-	int m_num_samples;
-	std::uint64_t m_sample_sum;
+private:
+
+	int m_num_samples = 0;
+	std::uint64_t m_sample_sum = 0;
 };
 
 }

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -42,6 +42,10 @@ namespace libtorrent { namespace aux
 	{
 		stack_allocator() {}
 
+		// non-copyable
+		stack_allocator(stack_allocator const&) = delete;
+		stack_allocator& operator=(stack_allocator const&) = delete;
+
 		int copy_string(std::string const& str)
 		{
 			int ret = int(m_storage.size());
@@ -100,11 +104,7 @@ namespace libtorrent { namespace aux
 
 	private:
 
-		// non-copyable
-		stack_allocator(stack_allocator const&);
-		stack_allocator& operator=(stack_allocator const&);
-
-		buffer m_storage;
+		std::vector<char> m_storage;
 	};
 
 } }

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -1105,12 +1105,11 @@ namespace libtorrent
 
 		boost::shared_ptr<torrent> t = associated_torrent().lock();
 		TORRENT_ASSERT(t);
-		bool merkle = static_cast<std::uint8_t>(recv_buffer.begin[0]) == 250;
+		bool const merkle = static_cast<std::uint8_t>(recv_buffer.begin[0]) == 250;
 		if (merkle)
 		{
 			if (recv_pos == 1)
 			{
-				m_recv_buffer.set_soft_packet_size(13);
 				received_bytes(0, received);
 				return;
 			}
@@ -1119,13 +1118,10 @@ namespace libtorrent
 				received_bytes(0, received);
 				return;
 			}
-			if (recv_pos == 13)
+			if (recv_pos >= 13)
 			{
-				const char* ptr = recv_buffer.begin + 9;
-				int list_size = detail::read_int32(ptr);
-				// now we know how long the bencoded hash list is
-				// and we can allocate the disk buffer and receive
-				// into it
+				char const* ptr = recv_buffer.begin + 9;
+				int const list_size = detail::read_int32(ptr);
 
 				if (list_size > m_recv_buffer.packet_size() - 13)
 				{

--- a/src/file_progress.cpp
+++ b/src/file_progress.cpp
@@ -91,12 +91,13 @@ namespace libtorrent { namespace aux
 			m_have_pieces.set_bit(piece);
 #endif
 
-			int size = (std::min)(std::uint64_t(piece_size), total_size - off);
+			TORRENT_ASSERT(total_size >= off);
+			std::int64_t size = (std::min)(std::uint64_t(piece_size), total_size - off);
 			TORRENT_ASSERT(size >= 0);
 
 			while (size)
 			{
-				int add = (std::min)(std::int64_t(size), fs.file_size(file_index) - file_offset);
+				std::int64_t add = (std::min)(size, fs.file_size(file_index) - file_offset);
 				TORRENT_ASSERT(add >= 0);
 				m_file_progress[file_index] += add;
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -299,8 +299,6 @@ namespace libtorrent
 
 		if (!m_outgoing)
 		{
-			m_recv_buffer.reserve(300);
-
 			tcp::socket::non_blocking_io ioc(true);
 			error_code ec;
 			m_socket->io_control(ioc, ec);
@@ -5655,6 +5653,12 @@ namespace libtorrent
 
 		if (m_disconnecting) return;
 
+		if (m_recv_buffer.capacity() < 100
+			&& m_recv_buffer.max_receive() == 0)
+		{
+			m_recv_buffer.reserve(100);
+		}
+
 		// we may want to request more quota at this point
 		int const buffer_size = m_recv_buffer.max_receive();
 		request_bandwidth(download_channel, buffer_size);
@@ -5686,8 +5690,6 @@ namespace libtorrent
 		}
 		TORRENT_ASSERT(m_connected);
 		if (m_quota[download_channel] == 0) return;
-
-		if (!can_read()) return;
 
 		int const quota_left = m_quota[download_channel];
 		int const max_receive = (std::min)(buffer_size, quota_left);
@@ -6032,8 +6034,6 @@ namespace libtorrent
 #endif
 
 		INVARIANT_CHECK;
-
-		m_recv_buffer.reserve(300);
 
 #ifndef TORRENT_DISABLE_LOGGING
 		{

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4485,6 +4485,7 @@ namespace libtorrent
 		p.used_send_buffer = m_send_buffer.size();
 		p.receive_buffer_size = m_recv_buffer.capacity();
 		p.used_receive_buffer = m_recv_buffer.pos();
+		p.receive_buffer_watermark = m_recv_buffer.watermark();
 		p.write_state = m_channel_state[upload_channel];
 		p.read_state = m_channel_state[download_channel];
 
@@ -5960,6 +5961,7 @@ namespace libtorrent
 		{
 			// the message we're receiving is larger than our buffer receive
 			// buffer, we must grow.
+			// TODO: 4 make the size limit configurable and passed in here
 			m_recv_buffer.grow();
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::incoming, "GROW_BUFFER", "%d bytes"

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -84,6 +84,8 @@ namespace libtorrent
 		set.set_bool(settings_pack::contiguous_recv_buffer, false);
 #endif
 
+		set.set_int(settings_pack::max_peer_recv_buffer_size, 32 * 1024 + 200);
+
 		set.set_int(settings_pack::disk_io_write_mode, settings_pack::disable_os_cache);
 		set.set_int(settings_pack::disk_io_read_mode, settings_pack::disable_os_cache);
 
@@ -170,6 +172,8 @@ namespace libtorrent
 
 		set.set_int(settings_pack::max_out_request_queue, 1500);
 		set.set_int(settings_pack::max_allowed_in_request_queue, 2000);
+
+		set.set_int(settings_pack::max_peer_recv_buffer_size, 5 * 1024 * 1024);
 
 		// we will probably see a high rate of alerts, make it less
 		// likely to loose alerts

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -279,6 +279,7 @@ namespace libtorrent
 		SET(max_rejects, 50, 0),
 		SET(recv_socket_buffer_size, 0, &session_impl::update_socket_buffer_size),
 		SET(send_socket_buffer_size, 0, &session_impl::update_socket_buffer_size),
+		SET_NOPREV(max_peer_recv_buffer_size, 2 * 1024 * 1024, 0),
 		SET(file_checks_delay_per_block, 0, 0),
 		SET(read_cache_line_size, 32, 0),
 		SET(write_cache_line_size, 16, 0),

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -73,7 +73,7 @@ TORRENT_TEST(buffer_swap)
 	buffer b1;
 	TEST_CHECK(b1.size() == 0);
 	buffer b2(10, data);
-	int const b2_size = b2.size();
+	std::size_t const b2_size = b2.size();
 	TEST_CHECK(b2_size >= 10);
 
 	b1.swap(b2);
@@ -89,7 +89,7 @@ TORRENT_TEST(buffer_subscript)
 	TEST_CHECK(std::memcmp(b.ptr(), data, 10) == 0);
 	TEST_CHECK(b.size() >= 50);
 
-	for (int i = 0; i < sizeof(data)/sizeof(data[0]); ++i)
+	for (int i = 0; i < int(sizeof(data)/sizeof(data[0])); ++i)
 		TEST_CHECK(b[i] == data[i]);
 }
 
@@ -98,10 +98,10 @@ TORRENT_TEST(buffer_subscript2)
 	buffer b(1);
 	TEST_CHECK(b.size() >= 1);
 
-	for (int i = 0; i < b.size(); ++i)
+	for (int i = 0; i < int(b.size()); ++i)
 		b[i] = i & 0xff;
 
-	for (int i = 0; i < b.size(); ++i)
+	for (int i = 0; i < int(b.size()); ++i)
 		TEST_CHECK(b[i] == (i & 0xff));
 }
 

--- a/test/test_receive_buffer.cpp
+++ b/test/test_receive_buffer.cpp
@@ -92,6 +92,10 @@ TORRENT_TEST(recv_buffer_packet_finished)
 	TEST_EQUAL(b.packet_finished(), true);
 }
 
+// TODO: 4 test grow()
+// TODO: 4 test normalize(), specifically buffer shrinking + edge cases
+// TODO: 4 test max_receive()
+
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 
 TORRENT_TEST(recv_buffer_mutable_buffers)


### PR DESCRIPTION
removed the concept of soft-packet-size. removed the secondary null-buffer receive path. removed try_read