### PR TITLE
fix msvc-8.0 build

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -697,7 +697,7 @@ int snprintf(char* buf, int len, char const* fmt, ...)
 #if (defined _M_AMD64 || defined _M_IX86 || defined _M_X64 \
 	|| defined __amd64__ || defined __i386 || defined __i386__ \
 	|| defined __x86_64__ || defined __x86_64) \
-	&& (defined __GNUC__ || defined _MSC_VER)
+	&& (defined __GNUC__ || (defined _MSC_VER && _MSC_VER >= 1600))
 #define TORRENT_HAS_SSE 1
 #else
 #define TORRENT_HAS_SSE 0

--- a/src/crc32c.cpp
+++ b/src/crc32c.cpp
@@ -36,7 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
 #include <boost/crc.hpp>
-#ifdef _MSC_VER
+#if (defined _MSC_VER && _MSC_VER >= 1600)
 #include <nmmintrin.h>
 #endif
 

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -230,9 +230,7 @@ namespace libtorrent
 			, m_flags(flags)
 		{}
 
-		int file_op(int const file_index
-			, boost::int64_t const file_offset
-			, int const size
+		int file_op(int file_index, boost::int64_t file_offset, int size
 			, file::iovec_t const* bufs, storage_error& ec)
 			TORRENT_OVERRIDE TORRENT_FINAL
 		{
@@ -321,9 +319,7 @@ namespace libtorrent
 			, m_flags(flags)
 		{}
 
-		int file_op(int const file_index
-			, boost::int64_t const file_offset
-			, int const size
+		int file_op(int file_index, boost::int64_t file_offset, int size
 			, file::iovec_t const* bufs, storage_error& ec)
 			TORRENT_OVERRIDE TORRENT_FINAL
 		{

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -105,7 +105,7 @@ namespace libtorrent
 	condition_variable::condition_variable()
 		: m_num_waiters(0)
 	{
-#if _WIN32_WINNT == 0x0501
+#if _WIN32_WINNT <= 0x0501
 		m_sem = CreateSemaphore(0, 0, INT_MAX, 0);
 #else
 		m_sem = CreateSemaphoreEx(0, 0, INT_MAX, 0, 0, SEMAPHORE_ALL_ACCESS);


### PR DESCRIPTION
1、fixed #850
2、fixed SSE42 compile error。
3、fixed CreateSemaphoreEx not defined for _WIN32_WINNT  < 0x0501