### PR TITLE
modernize: remove redundant smart ptr get()

### DIFF
--- a/include/libtorrent/ConvertUTF.h
+++ b/include/libtorrent/ConvertUTF.h
@@ -79,39 +79,14 @@
 
 ------------------------------------------------------------------------ */
 
-/* ---------------------------------------------------------------------
-    The following 4 definitions are compiler-specific.
-    The C standard does not guarantee that wchar_t has at least
-    16 bits, so wchar_t is no less portable than unsigned short!
-    All should be unsigned values to avoid sign extension during
-    bit mask & shift operations.
------------------------------------------------------------------------- */
-
-#ifdef __cplusplus
 #include "libtorrent/config.hpp"
-// these are standard C types, but they might
-// not be available in c++
-#include <stdint.h>
-typedef uint32_t UTF32;
-typedef uint16_t UTF16;
-typedef uint8_t  UTF8;
+#include <cstdint>
+typedef std::uint32_t UTF32;
+typedef std::uint16_t UTF16;
+typedef std::uint8_t  UTF8;
 extern "C" {
-#else
-#define TORRENT_EXTRA_EXPORT
-#ifdef _MSC_VER
-// msvc doesn't seem to have stdint.h
-typedef unsigned __int32 UTF32;
-typedef unsigned __int16 UTF16;
-typedef unsigned __int8  UTF8;
-#else
-#include <stdint.h>
-typedef uint32_t UTF32;
-typedef uint16_t UTF16;
-typedef uint8_t  UTF8;
-#endif
-#endif
 
-typedef unsigned char	Boolean; /* 0 or 1 */
+typedef unsigned char Boolean; /* 0 or 1 */
 
 /* Some fundamental constants */
 #define UNI_REPLACEMENT_CHAR UTF32(0x0000FFFD)

--- a/src/ConvertUTF.cpp
+++ b/src/ConvertUTF.cpp
@@ -219,7 +219,7 @@ ConversionResult ConvertUTF16toUTF8 (
 	UTF8* target = *targetStart;
 	while (source < sourceEnd) {
 	UTF32 ch;
-	unsigned short bytesToWrite = 0;
+	std::uint16_t bytesToWrite = 0;
 	const UTF32 byteMask = 0xBF;
 	const UTF32 byteMark = 0x80;
 	const UTF16* oldSource = source; /* In case we have to back up because of target overflow. */
@@ -341,7 +341,7 @@ ConversionResult ConvertUTF8toUTF16 (
 	UTF16* target = *targetStart;
 	while (source < sourceEnd) {
 	UTF32 ch = 0;
-	unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+	std::uint16_t extraBytesToRead = trailingBytesForUTF8[*source];
 	if (source + extraBytesToRead >= sourceEnd) {
 		result = sourceExhausted; break;
 	}
@@ -414,7 +414,7 @@ ConversionResult ConvertUTF32toUTF8 (
 	UTF8* target = *targetStart;
 	while (source < sourceEnd) {
 	UTF32 ch;
-	unsigned short bytesToWrite = 0;
+	std::uint16_t bytesToWrite = 0;
 	const UTF32 byteMask = 0xBF;
 	const UTF32 byteMark = 0x80;
 	ch = *source++;
@@ -467,7 +467,7 @@ ConversionResult ConvertUTF8toUTF32 (
 	UTF32* target = *targetStart;
 	while (source < sourceEnd) {
 	UTF32 ch = 0;
-	unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+	std::uint16_t extraBytesToRead = trailingBytesForUTF8[*source];
 	if (source + extraBytesToRead >= sourceEnd) {
 		result = sourceExhausted; break;
 	}

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -2079,7 +2079,7 @@ namespace libtorrent
 		if (!pe->hash) return;
 		if (pe->hashing) return;
 
-		int piece_size = pe->storage.get()->files()->piece_size(pe->piece);
+		int piece_size = pe->storage->files()->piece_size(pe->piece);
 		partial_hash* ph = pe->hash;
 
 		// are we already done?

--- a/src/metadata_transfer.cpp
+++ b/src/metadata_transfer.cpp
@@ -559,7 +559,7 @@ namespace libtorrent { namespace
 		if (pc.type() != peer_connection::bittorrent_connection)
 			return boost::shared_ptr<peer_plugin>();
 
-		return boost::shared_ptr<peer_plugin>(new metadata_peer_plugin(m_torrent, *pc.native_handle().get(), *this));
+		return boost::shared_ptr<peer_plugin>(new metadata_peer_plugin(m_torrent, *pc.native_handle(), *this));
 	}
 
 	std::pair<int, int> metadata_plugin::metadata_request()

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6250,7 +6250,7 @@ namespace libtorrent
 		for (auto& ext : m_extensions)
 		{
 			boost::shared_ptr<peer_plugin>
-				pp(ext->new_connection(peer_connection_handle(c.get()->self())));
+				pp(ext->new_connection(peer_connection_handle(c->self())));
 			if (pp) c->add_extension(pp);
 		}
 #endif
@@ -6950,7 +6950,7 @@ namespace libtorrent
 			{
 				TORRENT_TRY {
 					boost::shared_ptr<peer_plugin> pp(ext->new_connection(
-						peer_connection_handle(c.get()->self())));
+						peer_connection_handle(c->self())));
 					if (pp) c->add_extension(pp);
 				} TORRENT_CATCH (std::exception&) {}
 			}

--- a/test/test_dht_storage.cpp
+++ b/test/test_dht_storage.cpp
@@ -88,7 +88,7 @@ namespace
 		dht_settings const& sett)
 	{
 		std::unique_ptr<dht_storage_interface> s(dht_default_storage_constructor(sett));
-		TEST_CHECK(s.get() != nullptr);
+		TEST_CHECK(s != nullptr);
 
 		s->update_node_ids({to_hash("0000000000000000000000000000000000000200")});
 
@@ -316,7 +316,7 @@ TORRENT_TEST(update_node_ids)
 {
 	dht_settings sett = test_settings();
 	std::unique_ptr<dht_storage_interface> s(dht_default_storage_constructor(sett));
-	TEST_CHECK(s.get() != nullptr);
+	TEST_CHECK(s != nullptr);
 
 	node_id const n1 = to_hash("0000000000000000000000000000000000000200");
 	node_id const n2 = to_hash("0000000000000000000000000000000000000400");

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -330,7 +330,7 @@ TORRENT_TEST(resume_save_load_deprecated)
 
 	TEST_CHECK(a->resume_data);
 
-	entry& e = *a->resume_data.get();
+	entry& e = *a->resume_data;
 	entry::list_type& l = e["file_priority"].list();
 	entry::list_type::iterator i = l.begin();
 
@@ -357,7 +357,7 @@ TORRENT_TEST(resume_save_load_resume_deprecated)
 
 	TEST_CHECK(a->resume_data);
 
-	entry& e = *a->resume_data.get();
+	entry& e = *a->resume_data;
 	entry::list_type& l = e["file_priority"].list();
 	entry::list_type::iterator i = l.begin();
 
@@ -916,7 +916,7 @@ TORRENT_TEST(resume_save_load)
 
 	TEST_CHECK(a->resume_data);
 
-	entry& e = *a->resume_data.get();
+	entry& e = *a->resume_data;
 	entry::list_type& l = e["file_priority"].list();
 	entry::list_type::iterator i = l.begin();
 
@@ -943,7 +943,7 @@ TORRENT_TEST(resume_save_load_resume)
 
 	TEST_CHECK(a->resume_data);
 
-	entry& e = *a->resume_data.get();
+	entry& e = *a->resume_data;
 	entry::list_type& l = e["file_priority"].list();
 	entry::list_type::iterator i = l.begin();
 


### PR DESCRIPTION
use fixed-width integer types