### PR TITLE
Changes for fixing mutable dht_get_item failure when salt is non-empty

### DIFF
--- a/include/libtorrent/kademlia/get_item.hpp
+++ b/include/libtorrent/kademlia/get_item.hpp
@@ -72,7 +72,6 @@ protected:
 
 	data_callback m_data_callback;
 	item m_data;
-	std::string m_salt;
 	bool m_immutable;
 };
 

--- a/src/kademlia/get_item.cpp
+++ b/src/kademlia/get_item.cpp
@@ -78,7 +78,8 @@ void get_item::got_data(bdecode_node const& v,
 	// data can reach here, which means pk and sig must be valid.
 	if (!pk || !sig) return;
 
-	std::pair<char const*, int> salt(m_salt.c_str(), int(m_salt.size()));
+    std::string temp_copy(m_data.salt());
+	std::pair<char const*, int> salt(temp_copy.c_str(), int(temp_copy.size()));
 	sha1_hash incoming_target = item_target_id(salt, pk);
 	if (incoming_target != m_target) return;
 


### PR DESCRIPTION
When get_item reply is received, the item target id was computed based on an uninitialised/unused salt variable. Because of this the request and reply target id didn't match.

Now the uninitialised/unused salt variable is removed and proper the salt variable is referred.

@arvidn  