### PR TITLE
session.get_ip_filter() first call crash fix

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1239,6 +1239,7 @@ namespace aux {
 	ip_filter const& session_impl::get_ip_filter()
 	{
 		TORRENT_ASSERT(is_single_thread());
+		if (!m_ip_filter) m_ip_filter = boost::make_shared<ip_filter>();
 		return *m_ip_filter;
 	}
 


### PR DESCRIPTION
Fix the crash that happens when libtorrent::session.get_ip_filter() is called before any filter is set.
This is a regression caused by https://github.com/arvidn/libtorrent/commit/2bf4519.
Affected applications: Deluge.

Examples to reproduce the issue:
```c++
#include <libtorrent/session.hpp>
#include <libtorrent/ip_filter.hpp>

int main() {
    libtorrent::session session;
    session.get_ip_filter();
    return 0;
}
```
```python
python -c 'import libtorrent; libtorrent.session().get_ip_filter()'
```