### PR TITLE
fix range of lsd::cookie

### DIFF
--- a/src/lsd.cpp
+++ b/src/lsd.cpp
@@ -91,7 +91,7 @@ lsd::lsd(io_service& ios, peer_callback_t const& cb
 	, m_log_cb(log)
 #endif
 	, m_broadcast_timer(ios)
-	, m_cookie(random())
+	, m_cookie(random() & 0x7fffffff)
 	, m_disabled(false)
 #if TORRENT_USE_IPV6
 	, m_disabled6(false)


### PR DESCRIPTION
in lsd::on_announce:
```
...
std::int32_t cookie = strtol(cookie_iter->second.c_str(), nullptr, 16);
if (cookie == m_cookie)
...
```

if m_cookie is big than 0x7fffffff, it will cause an overflow, the cookie of local will not equal with m_cookie.
then 127.0.0.1 and other local ip will be accepted (It's shoud be "ignoring packet (cookie matched our own)")。