### PR TITLE
mark advanced used of template with __cplusplus

### DIFF
--- a/include/libtorrent/entry.hpp
+++ b/include/libtorrent/entry.hpp
@@ -117,6 +117,7 @@ namespace libtorrent
 		// newly constructed entry
 		entry(dictionary_type);
 		entry(span<char const>);
+#if __cplusplus >= 201103L
 		template <typename U, typename = typename std::enable_if<
 			std::is_same<U, entry::string_type>::value
 			|| std::is_same<U, char const*>::value >::type>
@@ -129,6 +130,7 @@ namespace libtorrent
 			new(&data) string_type(std::move(v));
 			m_type = string_t;
 		}
+#endif
 		entry(list_type);
 		entry(integer_type);
 		entry(preformatted_type);
@@ -161,6 +163,7 @@ namespace libtorrent
 		entry& operator=(entry&&);
 		entry& operator=(dictionary_type);
 		entry& operator=(span<char const>);
+#if __cplusplus >= 201103L
 		template <typename U, typename = typename std::enable_if<
 			std::is_same<U, entry::string_type>::value
 			|| std::is_same<U, char const*>::value >::type>
@@ -174,6 +177,7 @@ namespace libtorrent
 #endif
 			return *this;
 		}
+#endif
 		entry& operator=(list_type);
 		entry& operator=(integer_type);
 		entry& operator=(preformatted_type);

--- a/include/libtorrent/span.hpp
+++ b/include/libtorrent/span.hpp
@@ -60,10 +60,12 @@ namespace libtorrent
 		span(U (&arr)[N])
 			: m_ptr(&arr[0]), m_len(N) {}
 
+#if __cplusplus >= 201103L
 		// anything with a .data() member function is considered a container
 		template <typename Cont, typename = decltype(std::declval<Cont>().data())>
 		span(Cont& c)
 			: m_ptr(c.data()), m_len(c.size()) {}
+#endif
 
 		size_t size() const { return m_len; }
 		bool empty() const { return m_len == 0; }


### PR DESCRIPTION
@arvidn, swig is having a very hard time with the template/typename syntax, but just surrounding them with the `__cplusplus` allows swig to ignore them in the parsing process. Do you think this PR is acceptable?