### PR TITLE
removed const_interval, mutable_buffer and const_buffer types

### DIFF
--- a/include/libtorrent/aux_/io.hpp
+++ b/include/libtorrent/aux_/io.hpp
@@ -72,6 +72,40 @@ namespace libtorrent { namespace aux
 		view = view.subspan(sizeof(T));
 	}
 
+	template <class Byte>
+	inline typename std::enable_if<sizeof(Byte)==1, void>::type
+	write_impl(std::uint8_t val, span<Byte>& view)
+	{
+		view[0] = val;
+		view = view.subspan(1);
+	}
+
+	template <class Byte>
+	inline typename std::enable_if<sizeof(Byte)==1, void>::type
+	write_impl(std::int8_t val, span<Byte>& view)
+	{
+		view[0] = val;
+		view = view.subspan(1);
+	}
+
+	template <class Byte>
+	inline typename std::enable_if<sizeof(Byte)==1, std::uint8_t>::type
+	read_impl(span<Byte>& view, type<std::uint8_t>)
+	{
+		std::uint8_t ret = static_cast<std::uint8_t>(view[0]);
+		view = view.subspan(1);
+		return ret;
+	}
+
+	template <class Byte>
+	inline typename std::enable_if<sizeof(Byte)==1, std::int8_t>::type
+	read_impl(span<Byte>& view, type<std::int8_t>)
+	{
+		std::uint8_t ret = static_cast<std::int8_t>(view[0]);
+		view = view.subspan(1);
+		return ret;
+	}
+
 	// -- adaptors
 
 	template <typename Byte>

--- a/include/libtorrent/aux_/io.hpp
+++ b/include/libtorrent/aux_/io.hpp
@@ -153,4 +153,3 @@ namespace libtorrent { namespace aux
 }}
 
 #endif // TORRENT_AUX_IO_HPP_INCLUDED
-

--- a/include/libtorrent/bloom_filter.hpp
+++ b/include/libtorrent/bloom_filter.hpp
@@ -33,8 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_BLOOM_FILTER_HPP_INCLUDED
 #define TORRENT_BLOOM_FILTER_HPP_INCLUDED
 
-#include "libtorrent/peer_id.hpp" // for sha1_hash
-#include "libtorrent/config.hpp" // for sha1_hash
+#include "libtorrent/sha1_hash.hpp"
 
 #include <cmath> // for log()
 #include <cstdint>
@@ -77,5 +76,4 @@ namespace libtorrent
 
 }
 
-#endif
-
+#endif // TORRENT_BLOOM_FILTER_HPP_INCLUDED

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -161,8 +161,8 @@ namespace libtorrent
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 		// next_barrier, buffers-to-prepend
 		virtual
-		std::tuple<int, span<aux::const_buffer>>
-		hit_send_barrier(span<aux::mutable_buffer> iovec) override;
+		std::tuple<int, span<span<char const>>>
+		hit_send_barrier(span<span<char>> iovec) override;
 #endif
 
 		virtual void get_specific_peer_info(peer_info& p) const override;

--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -59,13 +59,6 @@ namespace libtorrent {
 		}
 	}
 
-	// TODO: eventually move this file to aux_ or create a new one
-	namespace aux
-	{
-		using mutable_buffer = span<char>;
-		using const_buffer = span<char const>;
-	}
-
 // the buffer is allocated once and cannot be resized. The size() may be
 // larger than requested, in case the underlying allocator over allocated. In
 // order to "grow" an allocation, create a new buffer and initialize it by
@@ -74,36 +67,6 @@ namespace libtorrent {
 class buffer
 {
 public:
-
-	struct const_interval
-	{
-	const_interval(char const* b, char const* e)
-		: begin(b)
-		, end(e)
-		{}
-
-		char operator[](int index) const
-		{
-			TORRENT_ASSERT(begin + index < end);
-			return begin[index];
-		}
-
-		bool operator==(const const_interval& p_interval)
-		{
-			return begin == p_interval.begin
-				&& end == p_interval.end;
-		}
-
-		int left() const
-		{
-			TORRENT_ASSERT(end >= begin);
-			TORRENT_ASSERT(end - begin < (std::numeric_limits<int>::max)());
-			return int(end - begin);
-		}
-
-		char const* begin;
-		char const* end;
-	};
 
 	// allocate an uninitialized buffer of the specified size
 	buffer(std::size_t size = 0)

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -112,7 +112,7 @@ namespace libtorrent
 
 		void clear();
 
-		void build_mutable_iovec(int bytes, std::vector<aux::mutable_buffer>& vec);
+		void build_mutable_iovec(int bytes, std::vector<span<char>>& vec);
 
 		~chained_buffer();
 

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -464,12 +464,12 @@ namespace libtorrent
 		// received. The purpose of this is to allow early disconnects for invalid
 		// messages and for reporting progress of receiving large messages.
 		virtual bool on_extended(int /*length*/, int /*msg*/,
-			buffer::const_interval /*body*/)
+			span<char const> /*body*/)
 		{ return false; }
 
 		// this is not called for web seeds
 		virtual bool on_unknown_message(int /*length*/, int /*msg*/,
-			buffer::const_interval /*body*/)
+			span<char const> /*body*/)
 		{ return false; }
 
 		// called when a piece that this peer participated in either

--- a/include/libtorrent/pe_crypto.hpp
+++ b/include/libtorrent/pe_crypto.hpp
@@ -99,8 +99,8 @@ namespace libtorrent
 
 	struct encryption_handler
 	{
-		std::tuple<int, span<aux::const_buffer>>
-		encrypt(span<aux::mutable_buffer> iovec);
+		std::tuple<int, span<span<char const>>>
+		encrypt(span<span<char>> iovec);
 
 		int decrypt(crypto_receive_buffer& recv_buffer
 			, std::size_t& bytes_transferred);
@@ -144,10 +144,10 @@ namespace libtorrent
 		void set_incoming_key(unsigned char const* key, int len) override;
 		void set_outgoing_key(unsigned char const* key, int len) override;
 
-		std::tuple<int, span<aux::const_buffer>>
-		encrypt(span<aux::mutable_buffer> buf) override;
+		std::tuple<int, span<span<char const>>>
+		encrypt(span<span<char>> buf) override;
 
-		void decrypt(span<aux::mutable_buffer> buf
+		void decrypt(span<span<char>> buf
 			, int& consume
 			, int& produce
 			, int& packet_size) override;

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -747,11 +747,11 @@ namespace libtorrent
 		void send_piece_suggestions(int num);
 
 		virtual
-		std::tuple<int, span<aux::const_buffer>>
-		hit_send_barrier(span<aux::mutable_buffer> /* iovec */)
+		std::tuple<int, span<span<char const>>>
+		hit_send_barrier(span<span<char>> /* iovec */)
 		{
 			return std::make_tuple(INT_MAX
-				, span<aux::const_buffer>());
+				, span<span<char const>>());
 		}
 
 		void attach_to_torrent(sha1_hash const& ih);

--- a/include/libtorrent/receive_buffer.hpp
+++ b/include/libtorrent/receive_buffer.hpp
@@ -85,8 +85,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 
 	// return the interval between the start of the buffer to the read cursor.
 	// This is the "current" packet.
-	// TODO: 3 use span
-	buffer::const_interval get() const;
+	span<char const> get() const;
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 	// returns the buffer from the current packet start position to the last
@@ -94,7 +93,7 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 	span<char> mutable_buffer();
 
 	// returns the last 'bytes' from the receive buffer
-	aux::mutable_buffer mutable_buffer(int bytes);
+	span<char> mutable_buffer(int bytes);
 #endif
 
 	// the purpose of this function is to free up and cut off all messages
@@ -203,10 +202,9 @@ struct crypto_receive_buffer
 
 	int advance_pos(int bytes);
 
-	// TODO: 3 use span
-	buffer::const_interval get() const;
+	span<char const> get() const;
 
-	aux::mutable_buffer mutable_buffer(std::size_t bytes);
+	span<char> mutable_buffer(std::size_t bytes);
 
 private:
 	// explicitly disallow assignment, to silence msvc warning

--- a/src/bloom_filter.cpp
+++ b/src/bloom_filter.cpp
@@ -73,4 +73,3 @@ namespace libtorrent
 		return ret;
 	}
 }
-

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -62,6 +62,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/invariant_check.hpp"
 #include "libtorrent/io.hpp"
+#include "libtorrent/aux_/io.hpp"
 #include "libtorrent/socket_io.hpp"
 #include "libtorrent/version.hpp"
 #include "libtorrent/extensions.hpp"
@@ -1640,9 +1641,7 @@ namespace libtorrent
 		TORRENT_ASSERT(recv_buffer.front() == msg_extended);
 		recv_buffer = recv_buffer.subspan(1);
 
-		char const* pos = recv_buffer.begin();
-		int extended_id = detail::read_uint8(pos);
-		recv_buffer = recv_buffer.subspan(1);
+		int extended_id = aux::read_uint8(recv_buffer);
 
 		if (extended_id == 0)
 		{
@@ -1662,9 +1661,7 @@ namespace libtorrent
 #endif
 				return;
 			}
-			char const* pos1 = recv_buffer.begin();
-			bool ul = detail::read_uint8(pos1) != 0;
-			recv_buffer = recv_buffer.subspan(1);
+			bool ul = aux::read_uint8(recv_buffer) != 0;
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::incoming_message, "UPLOAD_ONLY"
 				, "%s", (ul?"true":"false"));
@@ -1684,9 +1681,7 @@ namespace libtorrent
 #endif
 				return;
 			}
-			char const* pos1 = recv_buffer.begin();
-			bool sm = detail::read_uint8(pos1) != 0;
-			recv_buffer = recv_buffer.subspan(1);
+			bool sm = aux::read_uint8(recv_buffer) != 0;
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::incoming_message, "SHARE_MODE"
 				, "%s", (sm?"true":"false"));
@@ -1716,9 +1711,7 @@ namespace libtorrent
 #endif
 				return;
 			}
-			char const* pos1 = recv_buffer.begin();
-			int piece = detail::read_uint32(pos1);
-			recv_buffer = recv_buffer.subspan(4);
+			int piece = aux::read_uint32(recv_buffer);
 			incoming_dont_have(piece);
 			return;
 		}
@@ -2853,9 +2846,7 @@ namespace libtorrent
 
 			recv_buffer = m_recv_buffer.get();
 
-			char const* pos = recv_buffer.begin();
-			std::uint32_t crypto_field = detail::read_uint32(pos);
-			recv_buffer = recv_buffer.subspan(4);
+			std::uint32_t crypto_field = aux::read_uint32(recv_buffer);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, "ENCRYPTION", "crypto %s : [%s%s ]"
@@ -2919,9 +2910,7 @@ namespace libtorrent
 					m_rc4_encrypted = true;
 			}
 
-			char const* pos1 = recv_buffer.begin();
-			int len_pad = detail::read_int16(pos1);
-			recv_buffer = recv_buffer.subspan(2);
+			int len_pad = aux::read_int16(recv_buffer);
 			if (len_pad < 0 || len_pad > 512)
 			{
 				disconnect(errors::invalid_pad_size, op_encryption, 2);
@@ -2967,9 +2956,7 @@ namespace libtorrent
 			if (!is_outgoing())
 			{
 				recv_buffer = recv_buffer.subspan(pad_size);
-				char const* pos = recv_buffer.begin();
-				int len_ia = detail::read_int16(pos);
-				recv_buffer = recv_buffer.subspan(2);
+				int len_ia = aux::read_int16(recv_buffer);
 
 				if (len_ia < 0)
 				{

--- a/src/chained_buffer.cpp
+++ b/src/chained_buffer.cpp
@@ -151,7 +151,7 @@ namespace libtorrent
 		return m_tmp_vec;
 	}
 
-	void chained_buffer::build_mutable_iovec(int bytes, std::vector<aux::mutable_buffer> &vec)
+	void chained_buffer::build_mutable_iovec(int bytes, std::vector<span<char>> &vec)
 	{
 		build_vec(bytes, vec);
 	}

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2497,8 +2497,8 @@ namespace libtorrent
 		check_invariant();
 #endif
 #if TORRENT_USE_ASSERTS
-		buffer::const_interval recv_buffer = m_recv_buffer.get();
-		int recv_pos = recv_buffer.end - recv_buffer.begin;
+		span<char const> recv_buffer = m_recv_buffer.get();
+		int recv_pos = recv_buffer.end() - recv_buffer.begin();
 		TORRENT_ASSERT(recv_pos >= 9);
 #endif
 
@@ -5468,12 +5468,12 @@ namespace libtorrent
 
 		if (m_send_barrier == 0)
 		{
-			std::vector<aux::mutable_buffer> vec;
+			std::vector<span<char>> vec;
 			// limit outgoing crypto messages to 1MB
 			int const send_bytes = (std::min)(m_send_buffer.size(), 1024*1024);
 			m_send_buffer.build_mutable_iovec(send_bytes, vec);
 			int next_barrier;
-			span<aux::const_buffer> inject_vec;
+			span<span<char const>> inject_vec;
 			std::tie(next_barrier, inject_vec) = hit_send_barrier(vec);
 			for (auto i = inject_vec.rbegin(); i != inject_vec.rend(); ++i)
 			{

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -280,7 +280,7 @@ namespace libtorrent { namespace
 			return true;
 		}
 
-		bool on_extended(int length, int msg, buffer::const_interval body) override
+		bool on_extended(int length, int msg, span<char const> body) override
 		{
 			if (msg != extension_index) return false;
 			if (m_message_index == 0) return false;
@@ -291,7 +291,7 @@ namespace libtorrent { namespace
 				return true;
 			}
 
-			if (body.left() < length) return true;
+			if (int(body.size()) < length) return true;
 
 			time_point now = aux::time_now();
 			if (now - seconds(60) <  m_last_pex[0])
@@ -309,7 +309,7 @@ namespace libtorrent { namespace
 
 			bdecode_node pex_msg;
 			error_code ec;
-			int const ret = bdecode(body.begin, body.end, pex_msg, ec);
+			int const ret = bdecode(body.begin(), body.end(), pex_msg, ec);
 			if (ret != 0 || pex_msg.type() != bdecode_node::dict_t)
 			{
 				m_pc.disconnect(errors::invalid_pex_message, op_bittorrent, 2);

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -655,7 +655,7 @@ void web_peer_connection::on_receive(error_code const& error
 
 	// in case the first file on this series of requests is a padfile
 	// we need to handle it right now
-	span<char const> recv_buffer(m_recv_buffer.get().begin, m_recv_buffer.get().left());
+	span<char const> recv_buffer = m_recv_buffer.get();
 	handle_padfile();
 	if (associated_torrent().expired()) return;
 
@@ -927,7 +927,7 @@ void web_peer_connection::on_receive(error_code const& error
 done:
 
 	// now, remove all the bytes we've processed from the receive buffer
-	m_recv_buffer.cut(recv_buffer.data() - m_recv_buffer.get().begin
+	m_recv_buffer.cut(recv_buffer.data() - m_recv_buffer.get().begin()
 		, t->block_size() + request_size_overhead);
 }
 
@@ -1087,4 +1087,3 @@ void web_peer_connection::handle_padfile()
 }
 
 } // libtorrent namespace
-

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -62,9 +62,9 @@ void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b
 		using namespace libtorrent::aux;
 
 		{
-			mutable_buffer iovec(&buf[0], buf_len);
+			lt::span<char> iovec(&buf[0], buf_len);
 			int next_barrier;
-			lt::span<const_buffer> iovec_out;
+			lt::span<lt::span<char const>> iovec_out;
 			std::tie(next_barrier, iovec_out) = a.encrypt(iovec);
 			TEST_CHECK(buf != cmp_buf);
 			TEST_EQUAL(iovec_out.size(), 0);
@@ -75,7 +75,7 @@ void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b
 			int consume = 0;
 			int produce = buf_len;
 			int packet_size = 0;
-			mutable_buffer iovec(&buf[0], buf_len);
+			lt::span<char> iovec(&buf[0], buf_len);
 			b.decrypt(iovec, consume, produce, packet_size);
 			TEST_CHECK(buf == cmp_buf);
 			TEST_EQUAL(consume, 0);
@@ -84,9 +84,9 @@ void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b
 		}
 
 		{
-			mutable_buffer iovec(&buf[0], buf_len);
+			lt::span<char> iovec(&buf[0], buf_len);
 			int next_barrier;
-			lt::span<const_buffer> iovec_out;
+			lt::span<lt::span<char const>> iovec_out;
 			std::tie(next_barrier, iovec_out) = b.encrypt(iovec);
 			TEST_EQUAL(iovec_out.size(), 0);
 			TEST_CHECK(buf != cmp_buf);
@@ -95,7 +95,7 @@ void test_enc_handler(libtorrent::crypto_plugin& a, libtorrent::crypto_plugin& b
 			int consume = 0;
 			int produce = buf_len;
 			int packet_size = 0;
-			mutable_buffer iovec2(&buf[0], buf_len);
+			lt::span<char> iovec2(&buf[0], buf_len);
 			a.decrypt(iovec2, consume, produce, packet_size);
 			TEST_CHECK(buf == cmp_buf);
 			TEST_EQUAL(consume, 0);

--- a/test/test_receive_buffer.cpp
+++ b/test/test_receive_buffer.cpp
@@ -229,7 +229,7 @@ TORRENT_TEST(recv_buffer_mutable_buffers)
 	b.cut(100, 1000); // packet size = 1000
 	packet_transferred = b.advance_pos(999);
 	TEST_EQUAL(packet_transferred, 999);
-	aux::mutable_buffer vec = b.mutable_buffer(999);
+	span<char> vec = b.mutable_buffer(999);
 
 	// previous packet
 	//   |


### PR DESCRIPTION
I expect some comments related to the few needed extra calls to `subspan` due to the way `detail::read_*` works.