### PR TITLE
Fix reoccurrence of py bindings -Wstrict-prototype warning

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup, Extension
-from distutils.sysconfig import get_config_var
+from distutils.sysconfig import get_config_vars
 import os
 import platform
 import sys
@@ -102,8 +102,10 @@ if '--bjam' in sys.argv:
 
 else:
 	# Remove the '-Wstrict-prototypes' compiler option, which isn't valid for C++.
-	os.environ['OPT'] = ' '.join(
-		flag for flag in get_config_var('OPT').split() if flag != '-Wstrict-prototypes')
+	cfg_vars = get_config_vars()
+	for key, value in cfg_vars.items():
+		if isinstance(value, str):
+			cfg_vars[key] = value.replace('-Wstrict-prototypes', '')
 
 	source_list = os.listdir(os.path.join(os.path.dirname(__file__), "src"))
 	source_list = [os.path.abspath(os.path.join(os.path.dirname(__file__), "src", s)) for s in source_list if s.endswith(".cpp")]


### PR DESCRIPTION
 * Recent commit df368c2d158 has allowed the -Wstrict-prototype flag to
once again be passed to gcc so this fix removes all occurrences not just from 'OPT'.