### PR TITLE
session constructor with plugins and better api for dht storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+<break>
 language: cpp
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+<break>
 version: "{build}"
 branches:
   only:

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -746,18 +746,6 @@ namespace libtorrent
 			delete_partfile = 2
 		};
 
-		// flags to be passed in to the session constructor
-		enum session_flags_t
-		{
-			// this will add common extensions like ut_pex, ut_metadata, lt_tex
-			// smart_ban and possibly others.
-			add_default_plugins = 1,
-
-			// this will start features like DHT, local service discovery, UPnP
-			// and NAT-PMP.
-			start_default_features = 2
-		};
-
 		// ``remove_torrent()`` will close all peer connections associated with
 		// the torrent and tell the tracker that we've stopped participating in
 		// the swarm. This operation cannot fail. When it completes, you will

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1680,9 +1680,9 @@ namespace libtorrent
 		};
 	private:
 
-		std::vector<std::pair<std::uint16_t, std::string> > m_strings;
-		std::vector<std::pair<std::uint16_t, int> > m_ints;
-		std::vector<std::pair<std::uint16_t, bool> > m_bools;
+		std::vector<std::pair<std::uint16_t, std::string>> m_strings;
+		std::vector<std::pair<std::uint16_t, int>> m_ints;
+		std::vector<std::pair<std::uint16_t, bool>> m_bools;
 	};
 }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -322,7 +322,7 @@ namespace libtorrent
 	// configurations this will give a link error
 	void TORRENT_EXPORT TORRENT_CFG() {}
 
-	void session::start(int flags, settings_pack const& pack, io_service* ios)
+	void session::start(settings_pack const& pack, session_params const& params, io_service* ios)
 	{
 		bool const internal_executor = ios == nullptr;
 
@@ -337,7 +337,7 @@ namespace libtorrent
 		*static_cast<session_handle*>(this) = session_handle(m_impl.get());
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-		if (flags & add_default_plugins)
+		if (params.flags & session_params::add_default_plugins)
 		{
 			add_extension(create_ut_pex_plugin);
 			add_extension(create_ut_metadata_plugin);
@@ -346,6 +346,13 @@ namespace libtorrent
 #else
 		TORRENT_UNUSED(flags);
 #endif
+		for (auto const& ext : params.extensions)
+		{
+			add_extension(ext);
+		}
+
+		set_dht_settings(params.dht_settings);
+		set_dht_storage(params.dht_storage_constructor);
 
 		m_impl->start_session(pack);
 


### PR DESCRIPTION
This is for review (before adding documentation and tests). The main reasons for this change are:

1- There is no opportunity to inject plugins very early in the session construction. This put custom plugins in the same level as the default ones.

2- Now that plugins are economical to add, I think customizing the dht storage via plugins is a lot better (API wise). It's a trade off here, I rather go for better API (assuming the point 1 is accepted).