### PR TITLE
add ppc64le as 64-bit system libraries

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -92,7 +92,7 @@ if test "x$want_boost" = "xyes"; then
     libsubdirs="lib"
     ax_arch=`uname -m`
     case $ax_arch in
-      x86_64|ppc64|s390x|sparc64|aarch64)
+      x86_64|ppc64|ppc64le|s390x|sparc64|aarch64)
         libsubdirs="lib64 lib lib64"
         ;;
     esac


### PR DESCRIPTION
required to avoid configure error like:
===
configure: error: Boost.System library not found. Try using --with-boost-system=lib
===