### PR TITLE
restore timeout in travis to 900

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ script:
 # libtorrent is the name of the test suite target
   - cd test
   - 'if [ "$variant" != "" ]; then
-      bjam -j3 warnings-as-errors=on ssl=$ssl crypto=$crypto debug-iterators=on picker-debugging=on invariant-checks=full $toolset variant=$variant libtorrent test_natpmp enum_if -l300 &&
+      bjam -j3 warnings-as-errors=on ssl=$ssl crypto=$crypto debug-iterators=on picker-debugging=on invariant-checks=full $toolset variant=$variant libtorrent test_natpmp enum_if -l900 &&
       if [ "$coverage" == "1" ]; then
         codecov --root .. --gcov-exec gcov-5;
       fi;

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -31,7 +31,6 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <fstream>
-#include <deque>
 #include <map>
 #include <tuple>
 #include <functional>
@@ -45,7 +44,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/create_torrent.hpp"
 #include "libtorrent/socket_io.hpp" // print_endpoint
 #include "libtorrent/socket_type.hpp"
-#include "libtorrent/instantiate_connection.hpp"
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/session_stats.hpp"
 #include "libtorrent/random.hpp"
@@ -1030,4 +1028,3 @@ libtorrent::address_v6 addr6(char const* ip)
 	return ret;
 }
 #endif
-

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -119,4 +119,3 @@ EXPORT libtorrent::address_v6 addr6(char const* ip);
 #endif
 
 #endif
-

--- a/test/web_seed_suite.cpp
+++ b/test/web_seed_suite.cpp
@@ -210,7 +210,7 @@ void test_transfer(lt::session& ses, boost::shared_ptr<torrent_info> torrent_fil
 	}
 	else
 	{
-		// if the web seed senr corrupt data and we banned it, we probably didn't
+		// if the web seed sent corrupt data and we banned it, we probably didn't
 		// end up using all the cache anyway
 		torrent_status st = th.status();
 		TEST_EQUAL(st.is_seeding, true);
@@ -423,4 +423,3 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 	stop_web_server();
 	return 0;
 }
-

--- a/test/web_seed_suite.hpp
+++ b/test/web_seed_suite.hpp
@@ -41,4 +41,3 @@ void EXPORT test_transfer(libtorrent::session& ses
 	, int proxy = 0, char const* protocol = "http"
 	, bool url_seed = true, bool chunked_encoding = false
 	, bool test_ban = false, bool keepalive = true, bool proxy_peers = true);
-


### PR DESCRIPTION
Don't know the reason for the lower value, but restoring it seems to improve the timeout in the test `test_web_seed_socks5_pw`. 