### PR TITLE
added TORRENT_EXPORT to avoid link weak symbol warning

### DIFF
--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -511,4 +511,3 @@ namespace libtorrent
 }
 
 #endif
-

--- a/include/libtorrent/bencode.hpp
+++ b/include/libtorrent/bencode.hpp
@@ -47,10 +47,10 @@ POSSIBILITY OF SUCH DAMAGE.
 // Strings are raw byte buffers of a certain length. If a string is meant to be
 // interpreted as text, it is required to be UTF-8 encoded. See `BEP 3`_.
 //
-// There are two mechanims to *decode* bencoded buffers in libtorrent.
+// There are two mechanisms to *decode* bencoded buffers in libtorrent.
 //
 // The most flexible one is `bdecode() bencode()`_, which returns a structure
-// represented by entry. Oncea buffer has been decoded with this function, it
+// represented by entry. Once a buffer has been decoded with this function, it
 // can be discarded. The entry does not contain any references back to it. This
 // means that bdecode() copies all the data out of the buffer and into its own
 // hierarchy. This makes this function expensive, which might matter if you're
@@ -439,4 +439,3 @@ namespace libtorrent
 }
 
 #endif // TORRENT_BENCODE_HPP_INCLUDED
-

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -69,7 +69,7 @@ POSSIBILITY OF SUCH DAMAGE.
 //
 // libtorrent provides a customization point for storage of data. By default,
 // (``default_storage``) downloaded files are saved to disk according with the
-// general conventions of bittorrent clients, mimicing the original file layout
+// general conventions of bittorrent clients, mimicking the original file layout
 // when the torrent was created. The libtorrent user may define a custom
 // storage to store piece data in a different way.
 // 
@@ -634,4 +634,3 @@ namespace libtorrent
 }
 
 #endif // TORRENT_STORAGE_HPP_INCLUDED
-

--- a/include/libtorrent/storage_defs.hpp
+++ b/include/libtorrent/storage_defs.hpp
@@ -34,13 +34,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_STORAGE_DEFS_HPP_INCLUDE
 
 #include "libtorrent/config.hpp"
-#include <boost/function.hpp>
+#include <functional>
 #include <string>
 #include <vector>
 
 namespace libtorrent
 {
-	struct storage_interface;
+	struct TORRENT_EXPORT storage_interface;
 	class file_storage;
 	struct file_pool;
 	class torrent_info;
@@ -72,7 +72,7 @@ namespace libtorrent
 		torrent_info const* info; // optional
 	};
 
-	typedef boost::function<storage_interface*(storage_params const& params)> storage_constructor_type;
+	using storage_constructor_type = std::function<storage_interface*(storage_params const& params)>;
 
 	// the constructor function for the regular file storage. This is the
 	// default value for add_torrent_params::storage.
@@ -87,4 +87,3 @@ namespace libtorrent
 }
 
 #endif
-

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -35,7 +35,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #if TORRENT_USE_IOSTREAM
 #include <iostream>
 #endif
-#include <algorithm>
 
 #ifndef TORRENT_NO_DEPRECATE
 #include "libtorrent/lazy_entry.hpp"
@@ -753,4 +752,3 @@ namespace libtorrent
 		}
 	}
 }
-

--- a/src/kademlia/dos_blocker.cpp
+++ b/src/kademlia/dos_blocker.cpp
@@ -79,8 +79,8 @@ namespace libtorrent { namespace dht
 #ifndef TORRENT_DISABLE_LOGGING
 						logger->log(dht_logger::tracker, "BANNING PEER [ ip: %s time: %f count: %d ]"
 							, print_address(addr).c_str()
-							, total_milliseconds((now - match->limit) + seconds(10)) / 1000.f
-							, int(match->count));
+							, total_milliseconds((now - match->limit) + seconds(10)) / 1000.0
+							, match->count);
 #endif
 						// we've received too many messages in less than 10 seconds
 						// from this node. Ignore it until it's silent for 5 minutes


### PR DESCRIPTION
Solve this warnings
```
ld: warning: direct access in boost::detail::function::functor_manager<libtorrent::storage_interface* (*)(libtorrent::storage_params const&)>::manage(boost::detail::function::function_buffer const&, boost::detail::function::function_buffer&, boost::detail::function::functor_manager_operation_type) to global weak symbol typeinfo for libtorrent::storage_interface* (*)(libtorrent::storage_params const&) means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in boost::detail::function::functor_manager_common<libtorrent::storage_interface* (*)(libtorrent::storage_params const&)>::manage_ptr(boost::detail::function::function_buffer const&, boost::detail::function::function_buffer&, boost::detail::function::functor_manager_operation_type) to global weak symbol typeinfo for libtorrent::storage_interface* (*)(libtorrent::storage_params const&) means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in boost::detail::function::functor_manager_common<libtorrent::storage_interface* (*)(libtorrent::storage_params const&)>::manage_ptr(boost::detail::function::function_buffer const&, boost::detail::function::function_buffer&, boost::detail::function::functor_manager_operation_type) to global weak symbol typeinfo for libtorrent::storage_interface* (*)(libtorrent::storage_params const&) means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```
and
```
../src/kademlia/dos_blocker.cpp:82:10: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
```