### PR TITLE
fix re-prioritizing a piece while it is downloading

### DIFF
--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1834,6 +1834,18 @@ namespace libtorrent
 		p.piece_priority = new_piece_priority;
 		int new_priority = p.priority(this);
 
+		if (prev_priority != new_priority && !m_dirty)
+		{
+			if (prev_priority == -1)
+			{
+				add(index);
+			}
+			else
+			{
+				update(prev_priority, p.index);
+			}
+		}
+
 		if (p.downloading())
 		{
 			std::vector<downloading_piece>::iterator i = find_dl_piece(
@@ -1842,17 +1854,6 @@ namespace libtorrent
 				update_piece_state(i);
 		}
 
-		if (prev_priority == new_priority) return ret;
-
-		if (m_dirty) return ret;
-		if (prev_priority == -1)
-		{
-			add(index);
-		}
-		else
-		{
-			update(prev_priority, p.index);
-		}
 		return ret;
 	}
 


### PR DESCRIPTION
update_piece_state does not expect that the piece's priority has also changed
since the last time the piece was updated. Make sure the piece's priority is
updated before trying to update the state.

@arvid: I'm not very confident about the correctness of this fix since I still don't fully understand the code. I at least don't seem to be hitting the assert on line 955 any more.