### PR TITLE
no more deprecated std::random_shuffle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ script:
 # libtorrent is the name of the test suite target
   - cd test
   - 'if [ "$variant" != "" ]; then
-      bjam -j3 warnings-as-errors=on ssl=$ssl crypto=$crypto debug-iterators=on picker-debugging=on invariant-checks=full $toolset variant=$variant libtorrent test_natpmp enum_if -l300 &&
+      travis_retry bjam -j3 warnings-as-errors=on ssl=$ssl crypto=$crypto debug-iterators=on picker-debugging=on invariant-checks=full $toolset variant=$variant libtorrent test_natpmp enum_if -l300 &&
       if [ "$coverage" == "1" ]; then
         codecov --root .. --gcov-exec gcov-5;
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,8 @@ install:
       wget -O boost.zip http://pilotfiber.dl.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.zip;
       unzip -qq boost.zip;
       export BOOST_ROOT=$PWD/boost_1_55_0;
-      sudo apt-get install -y qemu-user-static debootstrap;
-      sudo debootstrap --variant=minbase --arch armhf --foreign --include=build-essential testing rootfs;
+      travis_retry sudo apt-get install -y qemu-user-static debootstrap;
+      travis_retry sudo debootstrap --variant=minbase --arch armhf --foreign --include=build-essential testing rootfs;
       sudo cp /usr/bin/qemu-arm-static rootfs/usr/bin/;
       sudo chroot rootfs /debootstrap/debootstrap --second-stage;
       sudo chroot rootfs mount -t proc none /proc;

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -553,7 +553,7 @@ struct peer_conn
 				pieces.resize(num_pieces);
 				for (int i = 0; i < int(pieces.size()); ++i)
 					pieces[i] = i;
-				std::random_shuffle(pieces.begin(), pieces.end());
+				aux::random_shuffle(pieces.begin(), pieces.end());
 			}
 			else if (msg == 4) // have
 			{
@@ -577,7 +577,7 @@ struct peer_conn
 					}
 					++ptr;
 				}
-				std::random_shuffle(pieces.begin(), pieces.end());
+				aux::random_shuffle(pieces.begin(), pieces.end());
 			}
 			else if (msg == 7) // piece
 			{

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/hasher.hpp"
 #include "libtorrent/socket_io.hpp"
 #include "libtorrent/file_pool.hpp"
+#include "libtorrent/random.hpp"
 #include <cstring>
 #include <thread>
 #include <functional>

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -123,9 +123,6 @@ POSSIBILITY OF SUCH DAMAGE.
 // 
 // 	virtual std::string message() const;
 // 
-// 	virtual std::auto_ptr<alert> clone() const
-// 	{ return std::auto_ptr<alert>(new name(\*this)); }
-// 
 // 	static const int static_category = *<bitmask of alert::category_t flags>*;
 // 	virtual int category() const { return static_category; }
 // 

--- a/include/libtorrent/ip_voter.hpp
+++ b/include/libtorrent/ip_voter.hpp
@@ -62,7 +62,7 @@ namespace libtorrent
 
 			bool add_vote(sha1_hash const& k, int type);
 
-			// we want to sort decending
+			// we want to sort descending
 			bool operator<(external_ip_t const& rhs) const
 			{
 				if (num_votes > rhs.num_votes) return true;
@@ -128,4 +128,3 @@ namespace libtorrent
 }
 
 #endif
-

--- a/include/libtorrent/random.hpp
+++ b/include/libtorrent/random.hpp
@@ -31,10 +31,23 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/config.hpp"
+
 #include <cstdint>
+#include <random>
+#include <algorithm>
 
 namespace libtorrent
 {
+	namespace aux
+	{
+		extern std::mt19937 random_engine;
+
+		template<class RandomIt>
+		void random_shuffle(RandomIt first, RandomIt last)
+		{
+			std::shuffle(first, last, random_engine);
+		}
+	}
+
 	std::uint32_t TORRENT_EXTRA_EXPORT random(std::uint32_t max);
-	std::uint32_t TORRENT_EXTRA_EXPORT randint(std::uint32_t one_past_end);
 }

--- a/include/libtorrent/random.hpp
+++ b/include/libtorrent/random.hpp
@@ -40,14 +40,14 @@ namespace libtorrent
 {
 	namespace aux
 	{
-		extern std::mt19937 random_engine;
+		TORRENT_EXTRA_EXPORT std::mt19937& random_engine();
 
 		template<class RandomIt>
 		void random_shuffle(RandomIt first, RandomIt last)
 		{
-			std::shuffle(first, last, random_engine);
+			std::shuffle(first, last, random_engine());
 		}
 	}
 
-	std::uint32_t TORRENT_EXTRA_EXPORT random(std::uint32_t max);
+	TORRENT_EXTRA_EXPORT std::uint32_t random(std::uint32_t max);
 }

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -311,7 +311,7 @@ namespace libtorrent
 		// 
 		virtual void release_files(storage_error& ec) = 0;
 
-		// Rename file with index ``file`` to the thame ``new_name``.
+		// Rename file with index ``index`` to the name ``new_filename``.
 		// 
 		// If an error occurs, ``storage_error`` should be set to reflect it.
 		// 

--- a/include/libtorrent/time.hpp
+++ b/include/libtorrent/time.hpp
@@ -81,4 +81,3 @@ namespace libtorrent {
 }
 
 #endif // TORRENT_TIME_HPP_INCLUDED
-

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -296,7 +296,7 @@ dht_network::dht_network(sim::simulation& sim, int num_nodes, std::uint32_t flag
 		{
 			// every now and then, shuffle all_nodes to make the
 			// routing tables more randomly distributed
-			std::random_shuffle(all_nodes.begin(), all_nodes.end());
+			aux::random_shuffle(all_nodes.begin(), all_nodes.end());
 			cnt = 0;
 		}
 	}

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -214,7 +214,7 @@ struct dht_node final : lt::dht::udp_socket_interface
 				, to_hex(dht::distance(id, n.first).to_string()).c_str()
 				, bucket);
 */
-			// there are no more slots in this bucket, just move ont
+			// there are no more slots in this bucket, just move on
 			if (nodes_per_bucket[bucket] == 0) continue;
 			--nodes_per_bucket[bucket];
 			bool const added = dht().m_table.node_seen(n.first, n.second, lt::random(300) + 10);
@@ -292,7 +292,7 @@ dht_network::dht_network(sim::simulation& sim, int num_nodes, std::uint32_t flag
 	for (auto& n : m_nodes)
 	{
 		n.bootstrap(all_nodes);
-		if (++cnt == 50)
+		if (++cnt == 25)
 		{
 			// every now and then, shuffle all_nodes to make the
 			// routing tables more randomly distributed

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -296,7 +296,7 @@ dht_network::dht_network(sim::simulation& sim, int num_nodes, std::uint32_t flag
 		{
 			// every now and then, shuffle all_nodes to make the
 			// routing tables more randomly distributed
-			aux::random_shuffle(all_nodes.begin(), all_nodes.end());
+			lt::aux::random_shuffle(all_nodes.begin(), all_nodes.end());
 			cnt = 0;
 		}
 	}

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -1082,7 +1082,7 @@ namespace libtorrent
 		if (storage && storage->get_storage_impl()->m_settings == nullptr)
 			storage->get_storage_impl()->m_settings = &m_settings;
 
-		TORRENT_ASSERT(j->action < sizeof(job_functions)/sizeof(job_functions[0]));
+		TORRENT_ASSERT(j->action < sizeof(job_functions) / sizeof(job_functions[0]));
 
 		time_point start_time = clock_type::now();
 
@@ -1091,7 +1091,7 @@ namespace libtorrent
 		// call disk function
 		int ret = (this->*(job_functions[j->action]))(j, completed_jobs);
 
-		// note that -2 erros are OK
+		// note that -2 errors are OK
 		TORRENT_ASSERT(ret != -1 || (j->error.ec && j->error.operation != 0));
 
 		m_stats_counters.inc_stats_counter(counters::num_running_disk_jobs, -1);
@@ -1226,7 +1226,7 @@ namespace libtorrent
 			- (iov_len-1) * block_size, block_size);
 		TORRENT_ASSERT(iov[iov_len-1].iov_len > 0);
 
-		// at this point, all the buffers are allocated and iov is initizalied
+		// at this point, all the buffers are allocated and iov is initialized
 		// and the blocks have their refcounters incremented, so no other thread
 		// can remove them. We can now release the cache std::mutex and dive into the
 		// disk operations.
@@ -2898,7 +2898,7 @@ namespace libtorrent
 
 	int disk_io_thread::do_file_priority(disk_io_job* j, jobqueue_t& /* completed_jobs */ )
 	{
-		std::unique_ptr<std::vector<std::uint8_t> > p(j->buffer.priorities);
+		std::unique_ptr<std::vector<std::uint8_t>> p(j->buffer.priorities);
 		j->storage->get_storage_impl()->set_file_priority(*p, j->error);
 		return 0;
 	}

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -529,7 +529,7 @@ void http_connection::on_resolve(error_code const& e
 		return;
 	}
 
-	std::random_shuffle(m_endpoints.begin(), m_endpoints.end(), randint);
+	aux::random_shuffle(m_endpoints.begin(), m_endpoints.end());
 
 	// sort the endpoints so that the ones with the same IP version as our
 	// bound listen socket are first. So that when contacting a tracker,

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1515,7 +1515,7 @@ namespace libtorrent
 		for (int b : m_priority_boundaries)
 		{
 			if (start == b) continue;
-			std::random_shuffle(&m_pieces[0] + start, &m_pieces[0] + b, randint);
+			aux::random_shuffle(&m_pieces[0] + start, &m_pieces[0] + b);
 			start = b;
 		}
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -33,41 +33,21 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/random.hpp"
 
-#include <random>
-
 namespace libtorrent
 {
-	using std::random_device;
-	using std::mt19937;
-	using std::uniform_int_distribution;
-
+	namespace aux
+	{
 #ifdef TORRENT_BUILD_SIMULATOR
-
-	std::uint32_t random(std::uint32_t max)
-	{
 		// make sure random numbers are deterministic. Seed with a fixed number
-		static mt19937 random_engine(0x82daf973);
-		return uniform_int_distribution<std::uint32_t>(0, max)(random_engine);
-	}
-
+		std::mt19937 random_engine(0x82daf973);
 #else
+		static std::random_device dev;
+		std::mt19937 random_engine(dev());
+#endif
+	}
 
 	std::uint32_t random(std::uint32_t max)
 	{
-		// TODO: versions prior to msvc-14 (visual studio 2015) do
-		// not generate thread safe initialization of statics
-		static random_device dev;
-		static mt19937 random_engine(dev());
-		return uniform_int_distribution<std::uint32_t>(0, max)(random_engine);
+		return std::uniform_int_distribution<std::uint32_t>(0, max)(aux::random_engine);
 	}
-
-#endif // TORRENT_BUILD_SIMULATOR
-
-
-	std::uint32_t randint(std::uint32_t one_past_end)
-	{
-		return random(one_past_end - 1);
-	}
-
-
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -37,17 +37,21 @@ namespace libtorrent
 {
 	namespace aux
 	{
+		std::mt19937& random_engine()
+		{
 #ifdef TORRENT_BUILD_SIMULATOR
-		// make sure random numbers are deterministic. Seed with a fixed number
-		std::mt19937 random_engine(0x82daf973);
+			// make sure random numbers are deterministic. Seed with a fixed number
+			static std::mt19937 rng(0x82daf973);
 #else
-		static std::random_device dev;
-		std::mt19937 random_engine(dev());
+			static std::random_device dev;
+			static std::mt19937 rng(dev());
 #endif
+			return rng;
+		}
 	}
 
 	std::uint32_t random(std::uint32_t max)
 	{
-		return std::uniform_int_distribution<std::uint32_t>(0, max)(aux::random_engine);
+		return std::uniform_int_distribution<std::uint32_t>(0, max)(aux::random_engine());
 	}
 }

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6609,7 +6609,7 @@ namespace libtorrent
 		// if we didn't save 100 peers, fill in with second choice peers
 		if (num_saved_peers < 100)
 		{
-			std::random_shuffle(deferred_peers.begin(), deferred_peers.end(), randint);
+			aux::random_shuffle(deferred_peers.begin(), deferred_peers.end());
 			for (std::vector<torrent_peer const*>::const_iterator i = deferred_peers.begin()
 				, end(deferred_peers.end()); i != end && num_saved_peers < 100; ++i)
 			{
@@ -9629,7 +9629,7 @@ namespace libtorrent
 				if (p->is_seed()) seeds.push_back(p);
 			}
 
-			std::random_shuffle(seeds.begin(), seeds.end(), randint);
+			aux::random_shuffle(seeds.begin(), seeds.end());
 			TORRENT_ASSERT(to_disconnect <= int(seeds.size()));
 			for (int i = 0; i < to_disconnect; ++i)
 				seeds[i]->disconnect(errors::upload_upload_connection

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5244,7 +5244,7 @@ namespace libtorrent
 
 		if (!valid_metadata()) return;
 
-		// stoage may be nullptr during shutdown
+		// storage may be nullptr during shutdown
 		if (m_storage)
 		{
 			inc_refcount("file_priority");

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1402,12 +1402,12 @@ namespace libtorrent
 				{
 					if (stop->tier != current_tier)
 					{
-						std::random_shuffle(start, stop, randint);
+						aux::random_shuffle(start, stop);
 						start = stop;
 						current_tier = stop->tier;
 					}
 				}
-				std::random_shuffle(start, stop, randint);
+				aux::random_shuffle(start, stop);
 			}
 		}
 

--- a/test/bittorrent_peer.cpp
+++ b/test/bittorrent_peer.cpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/io_service.hpp"
 #include "libtorrent/io.hpp"
+#include "libtorrent/random.hpp"
 
 #include <cstdlib>
 #include <functional>
@@ -400,7 +401,7 @@ void peer_conn::on_message(error_code const& ec, size_t bytes_transferred)
 			pieces.resize(m_ti.num_pieces());
 			for (int i = 0; i < int(pieces.size()); ++i)
 				pieces[i] = i;
-			std::random_shuffle(pieces.begin(), pieces.end());
+			aux::random_shuffle(pieces.begin(), pieces.end());
 		}
 		else if (msg == 4) // have
 		{
@@ -424,7 +425,7 @@ void peer_conn::on_message(error_code const& ec, size_t bytes_transferred)
 				}
 				++ptr;
 			}
-			std::random_shuffle(pieces.begin(), pieces.end());
+			aux::random_shuffle(pieces.begin(), pieces.end());
 		}
 		else if (msg == 7) // piece
 		{

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -2623,7 +2623,7 @@ TORRENT_TEST(routing_table_extended)
 	std::vector<std::uint8_t> node_id_prefix;
 	node_id_prefix.reserve(256);
 	for (int i = 0; i < 256; ++i) node_id_prefix.push_back(i);
-	std::random_shuffle(node_id_prefix.begin(), node_id_prefix.end());
+	aux::random_shuffle(node_id_prefix.begin(), node_id_prefix.end());
 
 	routing_table tbl(id, udp::v4(), 8, sett, &observer);
 	for (int i = 0; i < 256; ++i)
@@ -2657,7 +2657,7 @@ TORRENT_TEST(routing_table_set_id)
 	std::vector<std::uint8_t> node_id_prefix;
 	node_id_prefix.reserve(256);
 	for (int i = 0; i < 256; ++i) node_id_prefix.push_back(i);
-	std::random_shuffle(node_id_prefix.begin(), node_id_prefix.end());
+	aux::random_shuffle(node_id_prefix.begin(), node_id_prefix.end());
 	routing_table tbl(id, udp::v4(), 8, sett, &observer);
 	for (int i = 0; i < 256; ++i)
 	{


### PR DESCRIPTION
No a big fan of `extern std::mt19937 random_engine;` but I can't see any other solution