### PR TITLE
peer_plugin refactor

### DIFF
--- a/include/libtorrent/address.hpp
+++ b/include/libtorrent/address.hpp
@@ -33,7 +33,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_ADDRESS_HPP_INCLUDED
 #define TORRENT_ADDRESS_HPP_INCLUDED
 
-#include <boost/version.hpp>
 #include "libtorrent/config.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
@@ -77,4 +76,3 @@ namespace libtorrent
 }
 
 #endif
-

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -222,7 +222,6 @@ namespace libtorrent
 			struct session_plugin_wrapper : plugin
 			{
 				explicit session_plugin_wrapper(ext_function_t const& f) : m_f(f) {}
-				explicit session_plugin_wrapper(session_plugin_wrapper const& p) : m_f(p.m_f) {}
 
 				boost::shared_ptr<torrent_plugin> new_torrent(torrent_handle const& t, void* user) override
 				{ return m_f(t, user); }

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -61,11 +61,32 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/piece_block_progress.hpp"
 #include "libtorrent/config.hpp"
 #include "libtorrent/pe_crypto.hpp"
-#include "libtorrent/extensions/ut_pex.hpp"
 
 namespace libtorrent
 {
 	class torrent;
+
+#ifndef TORRENT_DISABLE_EXTENSIONS
+	struct TORRENT_EXTRA_EXPORT ut_pex_peer_store
+	{
+		// stores all peers this peer is connected to. These lists
+		// are updated with each pex message and are limited in size
+		// to protect against malicious clients. These lists are also
+		// used for looking up which peer a peer that supports holepunch
+		// came from.
+		// these are vectors to save memory and keep the items close
+		// together for performance. Inserting and removing is relatively
+		// cheap since the lists' size is limited
+		using peers4_t = std::vector<std::pair<address_v4::bytes_type, std::uint16_t>>;
+		peers4_t m_peers;
+#if TORRENT_USE_IPV6
+		using peers6_t = std::vector<std::pair<address_v6::bytes_type, std::uint16_t>>;
+		peers6_t m_peers6;
+#endif
+
+		bool was_introduced_by(tcp::endpoint const& ep);
+	};
+#endif
 
 	class TORRENT_EXTRA_EXPORT bt_peer_connection
 		: public peer_connection

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -61,6 +61,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/piece_block_progress.hpp"
 #include "libtorrent/config.hpp"
 #include "libtorrent/pe_crypto.hpp"
+#include "libtorrent/extensions/ut_pex.hpp"
 
 namespace libtorrent
 {
@@ -170,6 +171,10 @@ namespace libtorrent
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		bool supports_holepunch() const { return m_holepunch_id != 0; }
+		void set_ut_pex(boost::shared_ptr<ut_pex_peer_store> ut_pex)
+		{ m_ut_pex = ut_pex; }
+		bool was_introduced_by(tcp::endpoint const& ep) const
+		{ return m_ut_pex && m_ut_pex->was_introduced_by(ep); }
 #endif
 
 		bool support_extensions() const { return m_supports_extensions; }
@@ -430,6 +435,8 @@ private:
 		// the message ID for share mode message
 		// 0 if not supported
 		std::uint8_t m_share_mode_id;
+
+		boost::shared_ptr<ut_pex_peer_store> m_ut_pex;
 
 		char m_reserved_bits[8];
 #endif

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -374,10 +374,6 @@ namespace libtorrent
 		// hidden
 		virtual ~peer_plugin() {}
 
-		// This function is expected to return the name of
-		// the plugin.
-		virtual char const* type() const { return ""; }
-
 		// can add entries to the extension handshake
 		// this is not called for web seeds
 		virtual void add_handshake(entry&) {}

--- a/include/libtorrent/extensions/ut_pex.hpp
+++ b/include/libtorrent/extensions/ut_pex.hpp
@@ -48,28 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent
 {
 	struct torrent_plugin;
-	struct peer_plugin;
 	struct torrent_handle;
-
-	struct TORRENT_EXPORT ut_pex_peer_store
-	{
-		// stores all peers this peer is connected to. These lists
-		// are updated with each pex message and are limited in size
-		// to protect against malicious clients. These lists are also
-		// used for looking up which peer a peer that supports holepunch
-		// came from.
-		// these are vectors to save memory and keep the items close
-		// together for performance. Inserting and removing is relatively
-		// cheap since the lists' size is limited
-		using peers4_t = std::vector<std::pair<address_v4::bytes_type, std::uint16_t>>;
-		peers4_t m_peers;
-#if TORRENT_USE_IPV6
-		using peers6_t = std::vector<std::pair<address_v6::bytes_type, std::uint16_t>>;
-		peers6_t m_peers6;
-#endif
-
-		bool was_introduced_by(tcp::endpoint const& ep);
-	};
 
 	// constructor function for the ut_pex extension. The ut_pex
 	// extension allows peers to gossip about their connections, allowing

--- a/include/libtorrent/extensions/ut_pex.hpp
+++ b/include/libtorrent/extensions/ut_pex.hpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/socket.hpp" // for endpoint
-#include "libtorrent/address.hpp" // for endpoint
+#include "libtorrent/address.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
@@ -61,10 +61,10 @@ namespace libtorrent
 		// these are vectors to save memory and keep the items close
 		// together for performance. Inserting and removing is relatively
 		// cheap since the lists' size is limited
-		typedef std::vector<std::pair<address_v4::bytes_type, std::uint16_t>> peers4_t;
+		using peers4_t = std::vector<std::pair<address_v4::bytes_type, std::uint16_t>>;
 		peers4_t m_peers;
 #if TORRENT_USE_IPV6
-		typedef std::vector<std::pair<address_v6::bytes_type, std::uint16_t>> peers6_t;
+		using peers6_t = std::vector<std::pair<address_v6::bytes_type, std::uint16_t>>;
 		peers6_t m_peers6;
 #endif
 
@@ -80,8 +80,6 @@ namespace libtorrent
 	// This can either be passed in the add_torrent_params::extensions field, or
 	// via torrent_handle::add_extension().
 	TORRENT_EXPORT boost::shared_ptr<torrent_plugin> create_ut_pex_plugin(torrent_handle const&, void*);
-
-	bool was_introduced_by(ut_pex_peer_store const* p, tcp::endpoint const& ep);
 }
 
 #endif // TORRENT_DISABLE_EXTENSIONS

--- a/include/libtorrent/extensions/ut_pex.hpp
+++ b/include/libtorrent/extensions/ut_pex.hpp
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/socket.hpp" // for endpoint
+#include "libtorrent/address.hpp" // for endpoint
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
@@ -50,6 +51,26 @@ namespace libtorrent
 	struct peer_plugin;
 	struct torrent_handle;
 
+	struct TORRENT_EXPORT ut_pex_peer_store
+	{
+		// stores all peers this peer is connected to. These lists
+		// are updated with each pex message and are limited in size
+		// to protect against malicious clients. These lists are also
+		// used for looking up which peer a peer that supports holepunch
+		// came from.
+		// these are vectors to save memory and keep the items close
+		// together for performance. Inserting and removing is relatively
+		// cheap since the lists' size is limited
+		typedef std::vector<std::pair<address_v4::bytes_type, std::uint16_t>> peers4_t;
+		peers4_t m_peers;
+#if TORRENT_USE_IPV6
+		typedef std::vector<std::pair<address_v6::bytes_type, std::uint16_t>> peers6_t;
+		peers6_t m_peers6;
+#endif
+
+		bool was_introduced_by(tcp::endpoint const& ep);
+	};
+
 	// constructor function for the ut_pex extension. The ut_pex
 	// extension allows peers to gossip about their connections, allowing
 	// the swarm stay well connected and peers aware of more peers in the
@@ -60,7 +81,7 @@ namespace libtorrent
 	// via torrent_handle::add_extension().
 	TORRENT_EXPORT boost::shared_ptr<torrent_plugin> create_ut_pex_plugin(torrent_handle const&, void*);
 
-	bool was_introduced_by(peer_plugin const* pp, tcp::endpoint const& ep);
+	bool was_introduced_by(ut_pex_peer_store const* p, tcp::endpoint const& ep);
 }
 
 #endif // TORRENT_DISABLE_EXTENSIONS

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -331,7 +331,6 @@ namespace libtorrent
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		void add_extension(boost::shared_ptr<peer_plugin>);
-		peer_plugin const* find_plugin(char const* type);
 #endif
 
 		// this function is called once the torrent associated

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -60,7 +60,6 @@ struct TORRENT_EXPORT peer_connection_handle
 	int type() const;
 
 	void add_extension(boost::shared_ptr<peer_plugin>);
-	peer_plugin const* find_plugin(char const* type);
 
 	bool is_seed() const;
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -131,6 +131,28 @@ namespace libtorrent
 	} // anonymous namespace
 #endif
 
+#ifndef TORRENT_DISABLE_EXTENSIONS
+	bool ut_pex_peer_store::was_introduced_by(tcp::endpoint const &ep)
+	{
+#if TORRENT_USE_IPV6
+		if (ep.address().is_v4())
+		{
+#endif
+			peers4_t::value_type v(ep.address().to_v4().to_bytes(), ep.port());
+			auto i = std::lower_bound(m_peers.begin(), m_peers.end(), v);
+			return i != m_peers.end() && *i == v;
+#if TORRENT_USE_IPV6
+		}
+		else
+		{
+			peers6_t::value_type v(ep.address().to_v6().to_bytes(), ep.port());
+			auto i = std::lower_bound(m_peers6.begin(), m_peers6.end(), v);
+			return i != m_peers6.end() && *i == v;
+		}
+#endif
+	}
+#endif // TORRENT_DISABLE_EXTENSIONS
+
 	bt_peer_connection::bt_peer_connection(peer_connection_args const& pack
 		, peer_id const& pid)
 		: peer_connection(pack)

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -528,16 +528,6 @@ namespace libtorrent
 		TORRENT_ASSERT(is_single_thread());
 		m_extensions.push_back(ext);
 	}
-
-	peer_plugin const* peer_connection::find_plugin(char const* type)
-	{
-		TORRENT_ASSERT(is_single_thread());
-		for (auto p : m_extensions)
-		{
-			if (std::strcmp(p->type(), type) == 0) return p.get();
-		}
-		return nullptr;
-	}
 #endif
 
 	void peer_connection::send_allowed_set()

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -59,18 +59,6 @@ void peer_connection_handle::add_extension(boost::shared_ptr<peer_plugin> ext)
 #endif
 }
 
-peer_plugin const* peer_connection_handle::find_plugin(char const* type)
-{
-#ifndef TORRENT_DISABLE_EXTENSIONS
-	boost::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->find_plugin(type);
-#else
-	TORRENT_UNUSED(type);
-	return nullptr;
-#endif
-}
-
 bool peer_connection_handle::is_seed() const
 {
 	boost::shared_ptr<peer_connection> pc = native_handle();

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -332,9 +332,9 @@ namespace libtorrent
 			if (empty) return {};
 			using wrapper = session_impl::session_plugin_wrapper;
 			return {
-				boost::make_shared<wrapper>(wrapper(create_ut_pex_plugin)),
-				boost::make_shared<wrapper>(wrapper(create_ut_metadata_plugin)),
-				boost::make_shared<wrapper>(wrapper(create_smart_ban_plugin))
+				boost::make_shared<wrapper>(create_ut_pex_plugin),
+				boost::make_shared<wrapper>(create_ut_metadata_plugin),
+				boost::make_shared<wrapper>(create_smart_ban_plugin)
 			};
 #else
 			TORRENT_UNUSED(empty);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -776,8 +776,7 @@ namespace aux {
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(ext);
 
-		add_ses_extension(boost::make_shared<session_plugin_wrapper>(
-			session_plugin_wrapper(ext)));
+		add_ses_extension(boost::make_shared<session_plugin_wrapper>(ext));
 	}
 
 	void session_impl::add_ses_extension(boost::shared_ptr<plugin> ext)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -104,10 +104,6 @@ POSSIBILITY OF SUCH DAMAGE.
 // TODO: factor out cache_status to its own header
 #include "libtorrent/disk_io_thread.hpp" // for cache_status
 
-#ifndef TORRENT_DISABLE_EXTENSIONS
-#include "libtorrent/extensions/ut_pex.hpp" // for was_introduced_by
-#endif
-
 #ifndef TORRENT_DISABLE_LOGGING
 #include "libtorrent/aux_/session_impl.hpp" // for tracker_logger
 #endif

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2160,9 +2160,7 @@ namespace libtorrent
 			if (pe->type() != peer_connection::bittorrent_connection) continue;
 			bt_peer_connection* p = static_cast<bt_peer_connection*>(pe);
 			if (!p->supports_holepunch()) continue;
-			peer_plugin const* pp = p->find_plugin("ut_pex");
-			if (!pp) continue;
-			if (was_introduced_by(pp, ep)) return p;
+			if (p->was_introduced_by(ep)) return p;
 		}
 #else
 		TORRENT_UNUSED(ep);

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -217,8 +217,6 @@ namespace libtorrent { namespace
 			, m_tp(tp)
 		{}
 
-		char const* type() const override { return "ut_metadata"; }
-
 		// can add entries to the extension handshake
 		void add_handshake(entry& h) override
 		{

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -655,26 +655,6 @@ namespace libtorrent { namespace
 
 namespace libtorrent
 {
-	bool ut_pex_peer_store::was_introduced_by(tcp::endpoint const &ep)
-	{
-#if TORRENT_USE_IPV6
-		if (ep.address().is_v4())
-		{
-#endif
-			peers4_t::value_type v(ep.address().to_v4().to_bytes(), ep.port());
-			auto i = std::lower_bound(m_peers.begin(), m_peers.end(), v);
-			return i != m_peers.end() && *i == v;
-#if TORRENT_USE_IPV6
-		}
-		else
-		{
-			peers6_t::value_type v(ep.address().to_v6().to_bytes(), ep.port());
-			auto i = std::lower_bound(m_peers6.begin(), m_peers6.end(), v);
-			return i != m_peers6.end() && *i == v;
-		}
-#endif
-	}
-
 	boost::shared_ptr<torrent_plugin> create_ut_pex_plugin(torrent_handle const& th, void*)
 	{
 		torrent* t = th.native_handle().get();

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -253,13 +253,6 @@ namespace libtorrent { namespace
 			}
 		}
 
-		// constructor necessary due to compiler error with clang
-		// definition of implicit copy constructor for <class> is deprecated because
-		// it has a user-declared destructor
-		ut_pex_peer_plugin(ut_pex_peer_plugin const& p)
-			: ut_pex_peer_plugin(p.m_torrent, p.m_pc, p.m_tp)
-		{}
-
 		void add_handshake(entry& h) override
 		{
 			entry& messages = h["m"];
@@ -654,7 +647,7 @@ namespace libtorrent { namespace
 			return boost::shared_ptr<peer_plugin>();
 
 		bt_peer_connection* c = static_cast<bt_peer_connection*>(pc.native_handle().get());
-		auto p = boost::make_shared<ut_pex_peer_plugin>(ut_pex_peer_plugin(m_torrent, *c, *this));
+		auto p = boost::make_shared<ut_pex_peer_plugin>(m_torrent, *c, *this);
 		c->set_ut_pex(p);
 		return p;
 	}
@@ -669,16 +662,14 @@ namespace libtorrent
 		{
 #endif
 			peers4_t::value_type v(ep.address().to_v4().to_bytes(), ep.port());
-			peers4_t::const_iterator i
-				= std::lower_bound(m_peers.begin(), m_peers.end(), v);
+			auto i = std::lower_bound(m_peers.begin(), m_peers.end(), v);
 			return i != m_peers.end() && *i == v;
 #if TORRENT_USE_IPV6
 		}
 		else
 		{
 			peers6_t::value_type v(ep.address().to_v6().to_bytes(), ep.port());
-			peers6_t::const_iterator i
-				= std::lower_bound(m_peers6.begin(), m_peers6.end(), v);
+			auto i = std::lower_bound(m_peers6.begin(), m_peers6.end(), v);
 			return i != m_peers6.end() && *i == v;
 		}
 #endif
@@ -692,7 +683,7 @@ namespace libtorrent
 		{
 			return boost::shared_ptr<torrent_plugin>();
 		}
-		return boost::shared_ptr<torrent_plugin>(new ut_pex_plugin(*t));
+		return boost::make_shared<ut_pex_plugin>(*t);
 	}
 }
 


### PR DESCRIPTION
Before going any further, I want to get review for this idea. My goal is remove the method `peer_plugin::type()` because it is hard to see a clear use of it. It seems to me that it was added mainly because of `ut_pex`.  But in order to do that I need to perform this refactor and a mayor drawback is the additional field in `bt_peer_connection`, that could be a waste of memory if no `ut_pex` is active.

Design wise, the special nature of the `ut_pex` is already captured implicitly in the cross reference via the standalone method `was_introduced_by`. With the additional field, it is explicit.