### PR TITLE
avoid exporting integer_to_str

### DIFF
--- a/include/libtorrent/bencode.hpp
+++ b/include/libtorrent/bencode.hpp
@@ -88,6 +88,28 @@ namespace libtorrent
 
 	namespace detail
 	{
+		template <typename T, typename Cond = typename std::enable_if<
+			std::is_same<T, char*>::value>::type>
+		char const* integer_to_str(T buf, int size
+			, entry::integer_type val)
+		{
+			int sign = 0;
+			if (val < 0)
+			{
+				sign = 1;
+				val = -val;
+			}
+			buf[--size] = '\0';
+			if (val == 0) buf[--size] = '0';
+			for (; size > sign && val != 0;)
+			{
+				buf[--size] = '0' + char(val % 10);
+				val /= 10;
+			}
+			if (sign) buf[--size] = '-';
+			return buf + size;
+		}
+
 		template <class OutIt>
 		int write_integer(OutIt& out, entry::integer_type val)
 		{

--- a/include/libtorrent/entry.hpp
+++ b/include/libtorrent/entry.hpp
@@ -309,12 +309,6 @@ namespace libtorrent
 		mutable std::uint8_t m_type_queried:1;
 	};
 
-	namespace detail
-	{
-		TORRENT_EXPORT char const* integer_to_str(char* buf, int size
-			, entry::integer_type val);
-	}
-
 #if TORRENT_USE_IOSTREAM
 	// prints the bencoded structure to the ostream as a JSON-style structure.
 	inline std::ostream& operator<<(std::ostream& os, const entry& e)

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -45,29 +45,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
-	namespace detail
-	{
-		char const* integer_to_str(char* buf, int size
-			, entry::integer_type val)
-		{
-			int sign = 0;
-			if (val < 0)
-			{
-				sign = 1;
-				val = -val;
-			}
-			buf[--size] = '\0';
-			if (val == 0) buf[--size] = '0';
-			for (; size > sign && val != 0;)
-			{
-				buf[--size] = '0' + char(val % 10);
-				val /= 10;
-			}
-			if (sign) buf[--size] = '-';
-			return buf + size;
-		}
-	}
-
 	namespace
 	{
 		TORRENT_NO_RETURN inline void throw_error()


### PR DESCRIPTION
do you think this avoid the problem of "one definition rule"?