### PR TITLE
using span in torrent_handle and no optional in torrent_info

### DIFF
--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -304,7 +304,7 @@ list get_download_queue(torrent_handle& handle)
 
 void set_metadata(torrent_handle& handle, std::string const& buf)
 {
-   handle.set_metadata(buf.c_str(), int(buf.size()));
+   handle.set_metadata(buf);
 }
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1015,7 +1015,7 @@ namespace libtorrent
 		// to the checker thread for initial checking
 		// of the storage.
 		// a return value of false indicates an error
-		bool set_metadata(char const* metadata_buf, int metadata_size);
+		bool set_metadata(span<char const> metadata);
 
 #ifndef TORRENT_NO_DEPRECATE
 		void on_torrent_download(error_code const& ec, http_parser const& parser

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -51,6 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/address.hpp"
 #include "libtorrent/socket.hpp" // tcp::endpoint
+#include "libtorrent/span.hpp"
 
 namespace libtorrent
 {
@@ -521,7 +522,13 @@ namespace libtorrent
 		// if the metadata is successfully set on the torrent, and false
 		// otherwise. If the torrent already has metadata, this function will not
 		// affect the torrent, and false will be returned.
-		bool set_metadata(char const* metadata, int size) const;
+		bool set_metadata(span<char const> metadata) const;
+
+#ifndef TORRENT_NO_DEPRECATE
+		TORRENT_DEPRECATED
+		bool set_metadata(char const* metadata, int size) const
+		{ return set_metadata({metadata, size_t(size)}); }
+#endif
 
 		// Returns true if this handle refers to a valid torrent and false if it
 		// hasn't been initialized or if the torrent it refers to has been

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -36,12 +36,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
-
-#include <boost/optional.hpp>
 #include <boost/shared_array.hpp>
-
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include "libtorrent/config.hpp"
@@ -63,8 +61,6 @@ namespace libtorrent
 	struct announce_entry;
 	struct lazy_entry;
 
-	namespace aux { struct session_settings; }
-
 	// internal, exposed for the unit test
 	TORRENT_EXTRA_EXPORT void sanitize_append_path_element(std::string& path
 		, string_view element);
@@ -80,7 +76,7 @@ namespace libtorrent
 		// http seed spec. by John Hoffman
 		enum type_t { url_seed, http_seed };
 
-		typedef std::vector<std::pair<std::string, std::string> > headers_t;
+		typedef std::vector<std::pair<std::string, std::string>> headers_t;
 
 		web_seed_entry(std::string const& url_, type_t type_
 			, std::string const& auth_ = std::string()
@@ -399,7 +395,7 @@ namespace libtorrent
 		// returns true if this torrent_info object has a torrent loaded.
 		// This is primarily used to determine if a magnet link has had its
 		// metadata resolved yet or not.
-		bool is_valid() const { return (m_files.is_valid()) != 0; }
+		bool is_valid() const { return m_files.is_valid(); }
 
 		// returns true if this torrent is private. i.e., it should not be
 		// distributed on the trackerless network (the kademlia DHT).
@@ -469,7 +465,8 @@ namespace libtorrent
 		// 
 		// .. _`posix time`: http://www.opengroup.org/onlinepubs/009695399/functions/time.html
 		const std::string& name() const { return m_files.name(); }
-		boost::optional<time_t> creation_date() const;
+		time_t creation_date() const
+		{ return m_creation_date; }
 		const std::string& creator() const
 		{ return m_created_by; }
 		const std::string& comment() const
@@ -565,7 +562,7 @@ namespace libtorrent
 		// pointers point directly into the info_section buffer and when copied,
 		// these pointers must be corrected to point into the new buffer. The
 		// int is the length of the string. Strings are not 0-terminated.
-		std::vector<std::pair<char const*, int> > m_collections;
+		std::vector<std::pair<char const*, int>> m_collections;
 
 		// these are the collections from outside of the info-dict. These are
 		// owning strings, since we only keep the info-section around, these
@@ -580,6 +577,7 @@ namespace libtorrent
 		// this is a copy of the info section from the torrent.
 		// it use maintained in this flat format in order to
 		// make it available through the metadata extension
+		// TODO: change the type to std::shared_ptr in C++17
 		boost::shared_array<char> m_info_section;
 
 		// this is a pointer into the m_info_section buffer
@@ -640,4 +638,3 @@ namespace libtorrent
 }
 
 #endif // TORRENT_TORRENT_INFO_HPP_INCLUDED
-

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -1743,10 +1743,9 @@ namespace libtorrent
 				, "msg: %d size: %d", extended_id, m_recv_buffer.packet_size());
 #endif
 
-		for (extension_list_t::iterator i = m_extensions.begin()
-			, end(m_extensions.end()); i != end; ++i)
+		for (auto const& e : m_extensions)
 		{
-			if ((*i)->on_extended(m_recv_buffer.packet_size() - 2, extended_id
+			if (e->on_extended(m_recv_buffer.packet_size() - 2, extended_id
 				, recv_buffer))
 				return;
 		}

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -386,7 +386,7 @@ namespace libtorrent
 		TORRENT_ASSERT(ti.num_files() > 0);
 		TORRENT_ASSERT(ti.total_size() > 0);
 
-		if (ti.creation_date()) m_creation_date = *ti.creation_date();
+		if (ti.creation_date() > 0) m_creation_date = ti.creation_date();
 
 		if (!ti.creator().empty()) set_creator(ti.creator().c_str());
 		if (!ti.comment().empty()) set_comment(ti.comment().c_str());
@@ -394,19 +394,15 @@ namespace libtorrent
 		for (auto const& n : ti.nodes())
 			add_node(n);
 
-		std::vector<libtorrent::announce_entry> const& trackers = ti.trackers();
-		for (std::vector<libtorrent::announce_entry>::const_iterator i = trackers.begin()
-			, end(trackers.end()); i != end; ++i)
-			add_tracker(i->url, i->tier);
+		for (auto const& t : ti.trackers())
+			add_tracker(t.url, t.tier);
 
-		std::vector<web_seed_entry> const& web_seeds = ti.web_seeds();
-		for (std::vector<web_seed_entry>::const_iterator i = web_seeds.begin()
-			, end(web_seeds.end()); i != end; ++i)
+		for (auto const& s : ti.web_seeds())
 		{
-			if (i->type == web_seed_entry::url_seed)
-				add_url_seed(i->url);
-			else if (i->type == web_seed_entry::http_seed)
-				add_http_seed(i->url);
+			if (s.type == web_seed_entry::url_seed)
+				add_url_seed(s.url);
+			else if (s.type == web_seed_entry::http_seed)
+				add_http_seed(s.url);
 		}
 
 		m_piece_hash.resize(m_files.num_pieces());

--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -112,13 +112,13 @@ namespace
 		std::string salt;
 	};
 
-	void touch_item(dht_immutable_item* f, address const& address)
+	void touch_item(dht_immutable_item* f, address const& addr)
 	{
 		f->last_seen = aux::time_now();
 
 		// maybe increase num_announcers if we haven't seen this IP before
 		sha1_hash iphash;
-		hash_address(address, iphash);
+		hash_address(addr, iphash);
 		if (!f->ips.find(iphash))
 		{
 			f->ips.set(iphash);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6375,8 +6375,7 @@ namespace libtorrent
 		}
 
 		// blocks per piece
-		int num_blocks_per_piece =
-			static_cast<int>(torrent_file().piece_length()) / block_size();
+		int num_blocks_per_piece = torrent_file().piece_length() / block_size();
 		ret["blocks per piece"] = num_blocks_per_piece;
 
 		if (m_torrent_file->is_merkle_torrent())
@@ -7002,15 +7001,14 @@ namespace libtorrent
 		return peerinfo->connection != nullptr;
 	}
 
-	// TODO: 3 make this take a span<char const> instead
-	bool torrent::set_metadata(char const* metadata_buf, int metadata_size)
+	bool torrent::set_metadata(span<char const> metadata_buf)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		INVARIANT_CHECK;
 
 		if (m_torrent_file->is_valid()) return false;
 
-		sha1_hash const info_hash = hasher(metadata_buf, metadata_size).final();
+		sha1_hash const info_hash = hasher(metadata_buf).final();
 		if (info_hash != m_torrent_file->info_hash())
 		{
 			if (alerts().should_post<metadata_failed_alert>())
@@ -7023,8 +7021,7 @@ namespace libtorrent
 
 		bdecode_node metadata;
 		error_code ec;
-		int ret = bdecode(metadata_buf
-			, metadata_buf + metadata_size, metadata, ec);
+		int ret = bdecode(metadata_buf.begin(), metadata_buf.end(), metadata, ec);
 		if (ret != 0 || !m_torrent_file->parse_info_section(metadata, ec, 0))
 		{
 			update_gauge();

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -217,9 +217,9 @@ namespace libtorrent
 #endif
 	}
 
-	bool torrent_handle::set_metadata(char const* metadata, int size) const
+	bool torrent_handle::set_metadata(span<char const> metadata) const
 	{
-		return sync_call_ret<bool>(false, &torrent::set_metadata, metadata, size);
+		return sync_call_ret<bool>(false, &torrent::set_metadata, metadata);
 	}
 
 	void torrent_handle::pause(int flags) const

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -662,9 +662,8 @@ namespace libtorrent
 		if (m_info_section_size == 0) return;
 		TORRENT_ASSERT(m_piece_hashes);
 
-		error_code ec;
 		m_info_section.reset(new char[m_info_section_size]);
-		memcpy(m_info_section.get(), t.m_info_section.get(), m_info_section_size);
+		std::memcpy(m_info_section.get(), t.m_info_section.get(), m_info_section_size);
 
 		ptrdiff_t offset = m_info_section.get() - t.m_info_section.get();
 
@@ -1544,16 +1543,6 @@ namespace libtorrent
 		verify_encoding(m_created_by);
 
 		return true;
-	}
-
-	boost::optional<time_t>
-	torrent_info::creation_date() const
-	{
-		if (m_creation_date != 0)
-		{
-			return boost::optional<time_t>(m_creation_date);
-		}
-		return boost::optional<time_t>();
 	}
 
 	void torrent_info::add_tracker(std::string const& url, int tier)

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -53,8 +53,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/time.hpp"
 
-using namespace std::placeholders;
-
 namespace libtorrent { namespace
 {
 	enum
@@ -604,7 +602,7 @@ namespace libtorrent { namespace
 
 		if (!have_all) return false;
 
-		if (!m_torrent.set_metadata(&m_metadata[0], m_metadata_size))
+		if (!m_torrent.set_metadata({m_metadata.get(), size_t(m_metadata_size)}))
 		{
 			if (!m_torrent.valid_metadata())
 			{

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -166,7 +166,7 @@ TORRENT_TEST(read_resume_mismatching_torrent)
 	TEST_CHECK(!atp.ti);
 }
 
-boost::shared_ptr<torrent_info> generate_torrent()
+std::shared_ptr<torrent_info> generate_torrent()
 {
 	file_storage fs;
 	fs.add_file("test_resume/tmp1", 128 * 1024 * 8);
@@ -188,12 +188,12 @@ boost::shared_ptr<torrent_info> generate_torrent()
 
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), t.generate());
-	return boost::make_shared<torrent_info>(&buf[0], buf.size());
+	return std::make_shared<torrent_info>(&buf[0], buf.size());
 }
 
 TORRENT_TEST(read_resume_torrent)
 {
-	boost::shared_ptr<torrent_info> ti = generate_torrent();
+	std::shared_ptr<torrent_info> ti = generate_torrent();
 
 	entry rd;
 	rd["file-format"] = "libtorrent resume file";

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -38,10 +38,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/escape_string.hpp" // for convert_path_to_posix
 #include "libtorrent/hex.hpp" // to_hex
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-#include <boost/make_shared.hpp>
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #include <iostream>
 
 using namespace libtorrent;
@@ -617,7 +613,7 @@ TORRENT_TEST(parse_torrents)
 		std::fprintf(stderr, "loading %s\n", test_torrents[i].file);
 		std::string filename = combine_path(combine_path(root_dir, "test_torrents")
 			, test_torrents[i].file);
-		auto ti = boost::make_shared<torrent_info>(filename, ec);
+		auto ti = std::make_shared<torrent_info>(filename, ec);
 		TEST_CHECK(!ec);
 		if (ec) std::fprintf(stderr, " loading(\"%s\") -> failed %s\n", filename.c_str()
 			, ec.message().c_str());
@@ -644,7 +640,7 @@ TORRENT_TEST(parse_torrents)
 		}
 		else if (std::string(test_torrents[i].file) == "creation_date.torrent")
 		{
-			TEST_EQUAL(*ti->creation_date(), 1234567);
+			TEST_EQUAL(ti->creation_date(), 1234567);
 		}
 		else if (std::string(test_torrents[i].file) == "duplicate_web_seeds.torrent")
 		{
@@ -753,7 +749,7 @@ TORRENT_TEST(parse_torrents)
 	{
 		error_code ec;
 		std::fprintf(stderr, "loading %s\n", test_error_torrents[i].file);
-		auto ti = boost::make_shared<torrent_info>(combine_path(
+		auto ti = std::make_shared<torrent_info>(combine_path(
 			combine_path(root_dir, "test_torrents"), test_error_torrents[i].file), ec);
 		std::fprintf(stderr, "E:        \"%s\"\nexpected: \"%s\"\n", ec.message().c_str()
 			, test_error_torrents[i].error.message().c_str());
@@ -859,7 +855,7 @@ TORRENT_TEST(resolve_duplicates)
 TORRENT_TEST(empty_file)
 {
 	error_code ec;
-	auto ti = boost::make_shared<torrent_info>("", 0, ec);
+	auto ti = std::make_shared<torrent_info>("", 0, ec);
 	TEST_CHECK(ec);
 }
 
@@ -867,7 +863,7 @@ TORRENT_TEST(empty_file2)
 {
 	try
 	{
-		auto ti = boost::make_shared<torrent_info>("", 0);
+		auto ti = std::make_shared<torrent_info>("", 0);
 		TEST_ERROR("expected exception thrown");
 	}
 	catch (system_error& e)
@@ -880,9 +876,9 @@ TORRENT_TEST(copy)
 {
 	using namespace libtorrent;
 
-	boost::shared_ptr<torrent_info> a(boost::make_shared<torrent_info>(
+	std::shared_ptr<torrent_info> a = std::make_shared<torrent_info>(
 		combine_path(parent_path(current_working_directory())
-		, combine_path("test_torrents", "sample.torrent"))));
+		, combine_path("test_torrents", "sample.torrent")));
 
 	char const* expected_files[] =
 	{
@@ -909,12 +905,12 @@ TORRENT_TEST(copy)
 	}
 
 	// copy the torrent_info object
-	boost::shared_ptr<torrent_info> b(boost::make_shared<torrent_info>(*a));
+	std::shared_ptr<torrent_info> b = std::make_shared<torrent_info>(*a);
 
 	// clear out the  buffer for a, just to make sure b doesn't have any
 	// references into it by mistake
 	int s = a->metadata_size();
-	memset(a->metadata().get(), 0, s);
+	std::memset(a->metadata().get(), 0, s);
 
 	a.reset();
 
@@ -930,5 +926,3 @@ TORRENT_TEST(copy)
 		TEST_EQUAL(b->files().hash(i), file_hashes[i]);
 	}
 }
-
-


### PR DESCRIPTION
Some context:
1- For what I see in this case, the `boost::optional` was essentially a comparison to `0` since the internal field was a raw `time_t`. Not using it is very swig friendly and I think it is acceptable that upper app layers (meaning UI) just filter out the value.
2- The internal `m_info_section` field was treated essentially like a `unique_ptr`, I think this simplify a little bit the logic, but needs careful review.