### PR TITLE
no aux::settings in storage_interface

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* storage_interface API changed to use file flags and no settings
 	* storage_interface API changed to use span and references
 	* changes in public API to work with std::shared_ptr<torrent_info>
 	* extensions API changed to use span and std::shared_ptr

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -835,7 +835,7 @@ void generate_data(char const* path, torrent_info const& ti)
 
 	{
 		storage_error error;
-		st->initialize(error);
+		st->initialize(0, error);
 	}
 
 	std::uint32_t piece[0x4000 / 4];
@@ -846,7 +846,7 @@ void generate_data(char const* path, torrent_info const& ti)
 			generate_block(piece, i, j, 0x4000);
 			file::iovec_t b = { piece, 0x4000};
 			storage_error error;
-			st->writev(b, i, j, 0, error);
+			st->writev(b, i, j, 0, 0, error);
 			if (error)
 				std::fprintf(stderr, "storage error: %s\n", error.ec.message().c_str());
 		}

--- a/test/make_torrent.cpp
+++ b/test/make_torrent.cpp
@@ -190,7 +190,7 @@ void generate_files(libtorrent::torrent_info const& ti, std::string const& path
 
 		file::iovec_t b = { &buffer[0], size_t(piece_size) };
 		storage_error ec;
-		int ret = st.writev(b, i, 0, 0, ec);
+		int ret = st.writev(b, i, 0, 0, 0, ec);
 		if (ret != piece_size || ec)
 		{
 			std::fprintf(stderr, "ERROR writing files: (%d expected %d) %s\n"

--- a/test/test_block_cache.cpp
+++ b/test/test_block_cache.cpp
@@ -47,22 +47,22 @@ using namespace libtorrent;
 
 struct test_storage_impl : storage_interface
 {
-	void initialize(storage_error& ec) override {}
+	void initialize(int, storage_error& ec) override {}
 
 	int readv(span<file::iovec_t const> bufs
-		, int piece, int offset, int flags, storage_error& ec) override
+		, int piece, int offset, int flags, int, storage_error& ec) override
 	{
 		return bufs_size(bufs.data(), int(bufs.size()));
 	}
 	int writev(span<file::iovec_t const> bufs
-		, int piece, int offset, int flags, storage_error& ec) override
+		, int piece, int offset, int flags, int, storage_error& ec) override
 	{
 		return bufs_size(bufs.data(), int(bufs.size()));
 	}
 
 	bool has_any_file(storage_error& ec) override { return false; }
 	void set_file_priority(std::vector<std::uint8_t> const& prio
-		, storage_error& ec) override {}
+		, int, storage_error& ec) override {}
 	int move_storage(std::string const& save_path, int flags
 		, storage_error& ec) override { return 0; }
 	bool verify_resume_data(add_torrent_params const& rd
@@ -104,7 +104,6 @@ static void nop() {}
 	boost::shared_ptr<piece_manager> pm(boost::make_shared<piece_manager>(st, boost::shared_ptr<int>(new int), &fs)); \
 	error_code ec; \
 	bc.set_settings(sett, ec); \
-	st->m_settings = &sett; \
 	disk_io_job rj; \
 	disk_io_job wj; \
 	INITIALIZE_JOB(rj) \

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -78,7 +78,7 @@ struct test_storage : default_storage
 	{}
 
 	void set_file_priority(std::vector<std::uint8_t> const& p
-		, storage_error& ec) override {}
+		, int, storage_error& ec) override {}
 
 	void set_limit(int lim)
 	{
@@ -91,6 +91,7 @@ struct test_storage : default_storage
 		, int piece_index
 		, int offset
 		, int flags
+		, int open_flags
 		, storage_error& se) override
 	{
 		std::unique_lock<std::mutex> l(m_mutex);
@@ -105,7 +106,7 @@ struct test_storage : default_storage
 
 		for (auto const& b : bufs) m_written += int(b.iov_len);
 		l.unlock();
-		return default_storage::writev(bufs, piece_index, offset, flags, se);
+		return default_storage::writev(bufs, piece_index, offset, flags, open_flags, se);
 	}
 
 	~test_storage() override = default;


### PR DESCRIPTION
I think this PR is more easy to read and safer. I didn't mix the general "flags" with the "open flags" and in fact, I discovered serious bugs mixing flags in my previous PR.