### PR TITLE
fix inconsistant prefix calulcation

### DIFF
--- a/include/libtorrent/kademlia/node_id.hpp
+++ b/include/libtorrent/kademlia/node_id.hpp
@@ -72,7 +72,7 @@ bool TORRENT_EXTRA_EXPORT verify_secret_id(node_id const& nid);
 node_id TORRENT_EXTRA_EXPORT generate_id_impl(address const& ip_, boost::uint32_t r);
 
 bool TORRENT_EXTRA_EXPORT verify_id(node_id const& nid, address const& source_ip);
-bool TORRENT_EXTRA_EXPORT matching_prefix(node_entry const& n, int mask, int prefix, int bucket_index);
+bool TORRENT_EXTRA_EXPORT matching_prefix(node_entry const& n, int mask, int prefix, int offset);
 node_id TORRENT_EXTRA_EXPORT generate_prefix_mask(int bits);
 
 } } // namespace libtorrent::dht

--- a/src/kademlia/node_id.cpp
+++ b/src/kademlia/node_id.cpp
@@ -216,10 +216,10 @@ node_id generate_id(address const& ip)
 	return generate_id_impl(ip, random());
 }
 
-bool matching_prefix(node_entry const& n, int mask, int prefix, int bucket_index)
+bool matching_prefix(node_entry const& n, int mask, int prefix, int offset)
 {
 	node_id id = n.id;
-	id <<= bucket_index + 1;
+	id <<= offset;
 	return (id[0] & mask) == prefix;
 }
 

--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -809,18 +809,19 @@ ip_ok:
 		std::vector<bucket_t::iterator> nodes;
 		bool force_replace = false;
 
+		// the last bucket is special, since it hasn't been split yet, it
+		// includes that top bit as well
+		int const prefix_offset =
+			bucket_index + 1 == m_buckets.size() ? bucket_index : bucket_index + 1;
+
 		{
 			node_id id = e.id;
-			// the last bucket is special, since it hasn't been split yet, it
-			// includes that top bit as well
-			if (bucket_index + 1 == m_buckets.size())
-				id <<= bucket_index;
-			else
-				id <<= bucket_index + 1;
+			id <<= prefix_offset;
+			int const candidate_prefix = id[0] & mask;
 
 			for (j = b.begin(); j != b.end(); ++j)
 			{
-				if (!matching_prefix(*j, mask, id[0] & mask, bucket_index)) continue;
+				if (!matching_prefix(*j, mask, candidate_prefix, prefix_offset)) continue;
 				nodes.push_back(j);
 			}
 		}
@@ -850,7 +851,7 @@ ip_ok:
 			for (j = b.begin(); j != b.end(); ++j)
 			{
 				node_id id = j->id;
-				id <<= bucket_index + 1;
+				id <<= prefix_offset;
 				int this_prefix = (id[0] & mask) >> mask_shift;
 				TORRENT_ASSERT(this_prefix >= 0);
 				TORRENT_ASSERT(this_prefix < int(prefix.size()));


### PR DESCRIPTION
The special case for calculating the prefix in the last bucket was being
applied to the condidate node but not the existing nodes in the bucket.