### PR TITLE
refactor to avoid use of optional with piece_block_progress

### DIFF
--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -284,7 +284,7 @@ namespace libtorrent
 		// block. If the peer isn't downloading
 		// a piece for the moment, the boost::optional
 		// will be invalid.
-		boost::optional<piece_block_progress> downloading_piece_progress() const override;
+		piece_block_progress downloading_piece_progress() const override;
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 

--- a/include/libtorrent/http_seed_connection.hpp
+++ b/include/libtorrent/http_seed_connection.hpp
@@ -85,7 +85,7 @@ namespace libtorrent
 		// block. If the peer isn't downloading
 		// a piece for the moment, the boost::optional
 		// will be invalid.
-		boost::optional<piece_block_progress> downloading_piece_progress() const override;
+		piece_block_progress downloading_piece_progress() const override;
 
 		// this is const since it's used as a key in the web seed list in the torrent
 		// if it's changed referencing back into that list will fail

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -640,10 +640,10 @@ namespace libtorrent
 		// returns the block currently being
 		// downloaded. And the progress of that
 		// block. If the peer isn't downloading
-		// a piece for the moment, the boost::optional
-		// will be invalid.
-		virtual boost::optional<piece_block_progress>
-		downloading_piece_progress() const;
+		// a piece for the moment, implementors
+		// must return an object with the piece_index
+		// value invalid (the default constructor).
+		virtual piece_block_progress downloading_piece_progress() const;
 
 		enum message_type_flags { message_type_request = 1 };
 		void send_buffer(char const* begin, int size, int flags = 0);

--- a/include/libtorrent/piece_block_progress.hpp
+++ b/include/libtorrent/piece_block_progress.hpp
@@ -39,11 +39,13 @@ namespace libtorrent
 {
 	struct piece_block_progress
 	{
+		constexpr static int invalid_index = -1;
+
 		// the piece and block index
 		// determines exactly which
 		// part of the torrent that
 		// is currently being downloaded
-		int piece_index;
+		int piece_index = invalid_index;
 		int block_index;
 		// the number of bytes we have received
 		// of this block
@@ -54,4 +56,3 @@ namespace libtorrent
 }
 
 #endif // TORRENT_PIECE_BLOCK_PROGRESS_HPP_INCLUDED
-

--- a/include/libtorrent/web_peer_connection.hpp
+++ b/include/libtorrent/web_peer_connection.hpp
@@ -104,7 +104,7 @@ namespace libtorrent
 		// block. If the peer isn't downloading
 		// a piece for the moment, the boost::optional
 		// will be invalid.
-		boost::optional<piece_block_progress> downloading_piece_progress() const override;
+		piece_block_progress downloading_piece_progress() const override;
 
 		void handle_padfile();
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -839,7 +839,7 @@ namespace libtorrent
 		send_buffer(handshake, sizeof(handshake));
 	}
 
-	boost::optional<piece_block_progress> bt_peer_connection::downloading_piece_progress() const
+	piece_block_progress bt_peer_connection::downloading_piece_progress() const
 	{
 		std::shared_ptr<torrent> t = associated_torrent().lock();
 		TORRENT_ASSERT(t);
@@ -849,7 +849,7 @@ namespace libtorrent
 		if (m_state != state_t::read_packet
 			|| int(recv_buffer.size()) <= 9
 			|| recv_buffer[0] != msg_piece)
-			return boost::optional<piece_block_progress>();
+			return piece_block_progress();
 
 		const char* ptr = recv_buffer.begin() + 1;
 		peer_request r;
@@ -859,7 +859,7 @@ namespace libtorrent
 
 		// is any of the piece message header data invalid?
 		if (!verify_piece(r))
-			return boost::optional<piece_block_progress>();
+			return piece_block_progress();
 
 		piece_block_progress p;
 
@@ -868,7 +868,7 @@ namespace libtorrent
 		p.bytes_downloaded = int(recv_buffer.size()) - 9;
 		p.full_block_bytes = r.length;
 
-		return boost::optional<piece_block_progress>(p);
+		return p;
 	}
 
 

--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -88,11 +88,10 @@ namespace libtorrent
 		if (t) t->disconnect_web_seed(this);
 	}
 
-	boost::optional<piece_block_progress>
-	http_seed_connection::downloading_piece_progress() const
+	piece_block_progress http_seed_connection::downloading_piece_progress() const
 	{
 		if (m_requests.empty())
-			return boost::optional<piece_block_progress>();
+			return piece_block_progress();
 
 		std::shared_ptr<torrent> t = associated_torrent().lock();
 		TORRENT_ASSERT(t);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4163,12 +4163,12 @@ namespace libtorrent
 			if (!m_ignore_stats)
 			{
 				// report any partially received payload as redundant
-				boost::optional<piece_block_progress> pbp = downloading_piece_progress();
-				if (pbp
-					&& pbp->bytes_downloaded > 0
-					&& pbp->bytes_downloaded < pbp->full_block_bytes)
+				piece_block_progress pbp = downloading_piece_progress();
+				if (pbp.piece_index != piece_block_progress::invalid_index
+					&& pbp.bytes_downloaded > 0
+					&& pbp.bytes_downloaded < pbp.full_block_bytes)
 				{
-					t->add_redundant_bytes(pbp->bytes_downloaded, waste_reason::piece_closing);
+					t->add_redundant_bytes(pbp.bytes_downloaded, waste_reason::piece_closing);
 				}
 			}
 
@@ -4325,12 +4325,13 @@ namespace libtorrent
 			if (i->busy) ++p.busy_requests;
 		}
 
-		if (boost::optional<piece_block_progress> ret = downloading_piece_progress())
+		piece_block_progress ret = downloading_piece_progress();
+		if (ret.piece_index != piece_block_progress::invalid_index)
 		{
-			p.downloading_piece_index = ret->piece_index;
-			p.downloading_block_index = ret->block_index;
-			p.downloading_progress = ret->bytes_downloaded;
-			p.downloading_total = ret->full_block_bytes;
+			p.downloading_piece_index = ret.piece_index;
+			p.downloading_block_index = ret.block_index;
+			p.downloading_progress = ret.bytes_downloaded;
+			p.downloading_total = ret.full_block_bytes;
 		}
 		else
 		{
@@ -5582,14 +5583,13 @@ namespace libtorrent
 			, userdata, ref);
 	}
 
-	boost::optional<piece_block_progress>
-	peer_connection::downloading_piece_progress() const
+	piece_block_progress peer_connection::downloading_piece_progress() const
 	{
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, "ERROR"
 			, "downloading_piece_progress() dispatched to the base class!");
 #endif
-		return boost::optional<piece_block_progress>();
+		return piece_block_progress();
 	}
 
 	namespace {

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -222,11 +222,10 @@ void web_peer_connection::disconnect(error_code const& ec
 	if (t) t->disconnect_web_seed(this);
 }
 
-boost::optional<piece_block_progress>
-web_peer_connection::downloading_piece_progress() const
+piece_block_progress web_peer_connection::downloading_piece_progress() const
 {
 	if (m_requests.empty())
-		return boost::optional<piece_block_progress>();
+		return piece_block_progress();
 
 	std::shared_ptr<torrent> t = associated_torrent().lock();
 	TORRENT_ASSERT(t);


### PR DESCRIPTION
Ok, this requires a "why" explanation. The main reason is that I'm looking for opportunities to remove `boost` dependencies. The advantages of this change are:

- Less `boost`
- `boost::optional` is not cost-free space wise.

The disadvantage is a little "less clear" API, but reading about `boost::optional`, it looks to me like a `null` version for value types. This should compose seamless in a more functional style, but that requires a lot more in the type (or even the type system).

It is of course, a tradeoff.