### PR TITLE
refactor to use unique_ptr with session_impl::m_work

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -93,10 +93,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdarg> // for va_start, va_end
 #include <unordered_map>
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-#include <boost/optional.hpp>
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 namespace libtorrent
 {
 
@@ -835,7 +831,7 @@ namespace libtorrent
 
 			// keep the io_service alive until we have posted the job
 			// to clear the undead peers
-			boost::optional<io_service::work> m_work;
+			std::unique_ptr<io_service::work> m_work;
 
 			// this maps sockets to their peer_connection
 			// object. It is the complete list of all connected

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -320,7 +320,7 @@ namespace aux {
 			, *this
 #endif
 			)
-		, m_work(io_service::work(m_io_service))
+		, m_work(new io_service::work(m_io_service))
 #if TORRENT_USE_I2P
 		, m_i2p_conn(m_io_service)
 #endif
@@ -821,20 +821,19 @@ namespace aux {
 		m_incoming_sockets.clear();
 
 		// close the listen sockets
-		for (std::list<listen_socket_t>::iterator i = m_listen_sockets.begin()
-			, end(m_listen_sockets.end()); i != end; ++i)
+		for (auto const& l : m_listen_sockets)
 		{
-			if (i->sock)
+			if (l.sock)
 			{
-				i->sock->close(ec);
+				l.sock->close(ec);
 				TORRENT_ASSERT(!ec);
 			}
 
 			// TODO: 3 closing the udp sockets here means that
 			// the uTP connections cannot be closed gracefully
-			if (i->udp_sock)
+			if (l.udp_sock)
 			{
-				i->udp_sock->close();
+				l.udp_sock->close();
 			}
 		}
 		if (m_socks_listen_socket && m_socks_listen_socket->is_open())
@@ -857,10 +856,9 @@ namespace aux {
 		session_log(" aborting all torrents (%d)", int(m_torrents.size()));
 #endif
 		// abort all torrents
-		for (torrent_map::iterator i = m_torrents.begin()
-			, end(m_torrents.end()); i != end; ++i)
+		for (auto const& te : m_torrents)
 		{
-			i->second->abort();
+			te.second->abort();
 		}
 		m_torrents.clear();
 


### PR DESCRIPTION
Ok, this should be relatively easy to justify. I'm aware that using `optional` is suggested here (http://think-async.com/Asio/TipsAndTricks), but the context should be the "pining" of the `io_service` inside a function call. It happens that `optional` is not thread safe and additionally, the call to `optional::reset()` is deprecated.

In this particular case, `session` is usually a long live object, having one more heap pointer during the session's life is not a problem.