### PR TITLE
use of std::unordered_multimap and fix in resolve_links::match

### DIFF
--- a/include/libtorrent/resolve_links.hpp
+++ b/include/libtorrent/resolve_links.hpp
@@ -33,12 +33,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_RESOLVE_LINKS_HPP
 #define TORRENT_RESOLVE_LINKS_HPP
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-#include <boost/unordered_map.hpp>
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #include <vector>
 #include <utility>
+#include <unordered_map>
+#include <memory>
+#include <string>
 
 #include "libtorrent/export.hpp"
 
@@ -77,7 +76,7 @@ namespace libtorrent
 		std::vector<link_t> m_links;
 
 		// maps file size to file index, in m_torrent_file
-		boost::unordered_multimap<std::int64_t, int> m_file_sizes;
+		std::unordered_multimap<std::int64_t, int> m_file_sizes;
 	};
 #endif // TORRENT_DISABLE_MUTABLE_TORRENTS
 

--- a/src/resolve_links.cpp
+++ b/src/resolve_links.cpp
@@ -84,48 +84,49 @@ void resolve_links::match(std::shared_ptr<const torrent_info> const& ti
 
 		std::int64_t file_size = fs.file_size(i);
 
-		auto iter = m_file_sizes.find(file_size);
-
-		// we don't have a file whose size matches, look at the next one
-		if (iter == m_file_sizes.end()) continue;
-
-		TORRENT_ASSERT(iter->second < m_torrent_file->files().num_files());
-		TORRENT_ASSERT(iter->second >= 0);
-
-		// if we already have found a duplicate for this file, no need
-		// to keep looking
-		if (m_links[iter->second].ti) continue;
-
-		// files are aligned and have the same size, now start comparing
-		// piece hashes, to see if the files are identical
-
-		// the pieces of the incoming file
-		int their_piece = fs.map_file(i, 0, 0).piece;
-		// the pieces of "this" file (from m_torrent_file)
-		int our_piece = m_torrent_file->files().map_file(
-			iter->second, 0, 0).piece;
-
-		int num_pieces = (file_size + piece_size - 1) / piece_size;
-
-		bool match = true;
-		for (int p = 0; p < num_pieces; ++p, ++their_piece, ++our_piece)
+		auto range = m_file_sizes.equal_range(file_size);
+		for (auto iter = range.first; iter != range.second; ++iter)
 		{
-			if (m_torrent_file->hash_for_piece(our_piece)
-				!= ti->hash_for_piece(their_piece))
-			{
-				match = false;
-				break;
+			// we don't have a file whose size matches, look at the next one
+			if (iter == m_file_sizes.end()) continue;
+
+			TORRENT_ASSERT(iter->second < m_torrent_file->files().num_files());
+			TORRENT_ASSERT(iter->second >= 0);
+
+			// if we already have found a duplicate for this file, no need
+			// to keep looking
+			if (m_links[iter->second].ti) continue;
+
+			// files are aligned and have the same size, now start comparing
+			// piece hashes, to see if the files are identical
+
+			// the pieces of the incoming file
+			int their_piece = fs.map_file(i, 0, 0).piece;
+			// the pieces of "this" file (from m_torrent_file)
+			int our_piece = m_torrent_file->files().map_file(
+					iter->second, 0, 0).piece;
+
+			int num_pieces = (file_size + piece_size - 1) / piece_size;
+
+			bool match = true;
+			for (int p = 0; p < num_pieces; ++p, ++their_piece, ++our_piece) {
+				if (m_torrent_file->hash_for_piece(our_piece)
+					!= ti->hash_for_piece(their_piece)) {
+					match = false;
+					break;
+				}
 			}
+			if (!match) continue;
+
+			m_links[iter->second].ti = ti;
+			m_links[iter->second].save_path = save_path;
+			m_links[iter->second].file_idx = i;
+
+			// since we have a duplicate for this file, we may as well remove
+			// it from the file-size map, so we won't find it again.
+			m_file_sizes.erase(iter);
+			break;
 		}
-		if (!match) continue;
-
-		m_links[iter->second].ti = ti;
-		m_links[iter->second].save_path = save_path;
-		m_links[iter->second].file_idx = i;
-
-		// since we have a duplicate for this file, we may as well remove
-		// it from the file-size map, so we won't find it again.
-		m_file_sizes.erase(iter);
 	}
 
 }

--- a/src/resolve_links.cpp
+++ b/src/resolve_links.cpp
@@ -87,9 +87,6 @@ void resolve_links::match(std::shared_ptr<const torrent_info> const& ti
 		auto range = m_file_sizes.equal_range(file_size);
 		for (auto iter = range.first; iter != range.second; ++iter)
 		{
-			// we don't have a file whose size matches, look at the next one
-			if (iter == m_file_sizes.end()) continue;
-
 			TORRENT_ASSERT(iter->second < m_torrent_file->files().num_files());
 			TORRENT_ASSERT(iter->second >= 0);
 
@@ -104,14 +101,16 @@ void resolve_links::match(std::shared_ptr<const torrent_info> const& ti
 			int their_piece = fs.map_file(i, 0, 0).piece;
 			// the pieces of "this" file (from m_torrent_file)
 			int our_piece = m_torrent_file->files().map_file(
-					iter->second, 0, 0).piece;
+				iter->second, 0, 0).piece;
 
 			int num_pieces = (file_size + piece_size - 1) / piece_size;
 
 			bool match = true;
-			for (int p = 0; p < num_pieces; ++p, ++their_piece, ++our_piece) {
+			for (int p = 0; p < num_pieces; ++p, ++their_piece, ++our_piece)
+			{
 				if (m_torrent_file->hash_for_piece(our_piece)
-					!= ti->hash_for_piece(their_piece)) {
+					!= ti->hash_for_piece(their_piece))
+				{
 					match = false;
 					break;
 				}


### PR DESCRIPTION
Hi @arvidn, before continue with this PR, I want to confirm if in fact there is a bug (and fix) in `resolve_links::match`. The change is
```
- auto iter = m_file_sizes.find(file_size);
```
for
```
+ auto range = m_file_sizes.equal_range(file_size);
  for (auto iter = range.first; iter != range.second; ++iter)
```