### PR TITLE
fix invalid memory access in utp_stream and torrent

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1989,9 +1989,10 @@ namespace libtorrent
 		file_storage const& fs = m_torrent_file->files();
 		for (int i = 0; i < fs.num_files(); ++i)
 		{
+			if (!fs.pad_file_at(i) || fs.file_size(i) == 0) continue;
+
 			if (fs.pad_file_at(i)) ++num_pad_files;
 
-			if (!fs.pad_file_at(i) || fs.file_size(i) == 0) continue;
 			m_padding += boost::uint32_t(fs.file_size(i));
 
 			// TODO: instead of creating the picker up front here,

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1822,7 +1822,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 	int const effective_mtu = mtu_probe ? m_mtu : m_mtu_floor;
 	int payload_size = (std::min)(m_write_buffer_size
 		, effective_mtu - header_size);
-    TORRENT_ASSERT(payload_size >= 0);
+	TORRENT_ASSERT(payload_size >= 0);
 
 	// if we have one MSS worth of data, make sure it fits in our
 	// congestion window and the advertised receive window from

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1924,6 +1924,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 #ifdef TORRENT_DEBUG
 		p->num_fast_resend = 0;
 #endif
+		p->mtu_probe = false;
 		p->need_resend = false;
 		ptr = p->buf;
 		h = reinterpret_cast<utp_header*>(ptr);

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1822,6 +1822,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 	int const effective_mtu = mtu_probe ? m_mtu : m_mtu_floor;
 	int payload_size = (std::min)(m_write_buffer_size
 		, effective_mtu - header_size);
+    TORRENT_ASSERT(payload_size >= 0);
 
 	// if we have one MSS worth of data, make sure it fits in our
 	// congestion window and the advertised receive window from


### PR DESCRIPTION
1. packet->mtu_probe in utp_stream is not initialized, which can make mtu probe enable on small packet，lead to a lower mtu or even be attacked
2. torrent with a 0 size padding leads crash when init torrent

see `#1083` also