### PR TITLE
Use std::random instead of Boost.Random when in c++11 mode.

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/random.hpp"
 #include "libtorrent/assert.hpp"
 
+#ifdef BOOST_NO_CXX11_HDR_RANDOM
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
 #include <boost/random/random_device.hpp>
@@ -41,6 +42,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/random/uniform_int_distribution.hpp>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
+#else
+#include <random>
+#endif
 
 #if !TORRENT_THREADSAFE_STATIC
 #include "libtorrent/thread.hpp"
@@ -48,9 +52,15 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
+#ifdef BOOST_NO_CXX11_HDR_RANDOM
 	using boost::random::random_device;
 	using boost::random::mt19937;
 	using boost::random::uniform_int_distribution;
+#else
+	using std::random_device;
+	using std::mt19937;
+	using std::uniform_int_distribution;
+#endif
 
 #ifdef TORRENT_BUILD_SIMULATOR
 


### PR DESCRIPTION
I am sorry but I couldn't modify the different build systems.

Especially autotools require extra work. At this point configure.ac hardcodes dependencies of Boost.Chrono and Boost.Random regardless if you're in c++11 mode. I think it would be best if the script was updated to include one option to enable c++11. And then depending on that require Boost.Chrono and Boost.Random. And maybe make enabling c++11 the default?
(PS: It should be checked if c++11 is enabled anyway either by the compiler itself or by user passing the relevant CXXFLAGS to the script without using the script's dedicated option)

I have no idea how jamfiles or cmake work and what they require.

Currently I tested only on Windows with msvc 2015 (static builds) and the dependency on Boost.Random is indeed dropped. (Hint: On msvc 2015 c++11 is always on).
Due the simplicity of the patch I expect that it will work with any other compiler provided that the build system is fixed.