### PR TITLE
web_peer_connection: make a copy of the request before calling incomi…

### DIFF
--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -979,8 +979,11 @@ void web_peer_connection::incoming_payload(char const* buf, int len)
 				, front_request.piece, front_request.start, front_request.length);
 #endif
 
-			incoming_piece(front_request, &m_piece[0]);
+			peer_request const front_request_copy = front_request;
 			m_requests.pop_front();
+
+			incoming_piece(front_request_copy, &m_piece[0]);
+
 			m_piece.clear();
 		}
 	}

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -979,6 +979,10 @@ void web_peer_connection::incoming_payload(char const* buf, int len)
 				, front_request.piece, front_request.start, front_request.length);
 #endif
 
+			// Make a copy of the request and pop it off the queue before calling
+			// incoming_piece because that may lead to a call to disconnect()
+			// which will clear the request queue and invalidate any references
+			// to the request
 			peer_request const front_request_copy = front_request;
 			m_requests.pop_front();
 


### PR DESCRIPTION
…ng_piece

This is a revision of 850eca1f21d1f6e2ae6f0177b91e077c42486534. After further
consideration I realized that it may not be safe to pop the request after
calling incoming_piece because it might lead to calling disconnect which
clears the request queue. A call to disconnect would also invalidate the
reference to the request which, although unlikely, might cause supreme
confusion for an extension author who tried to access the dangling reference.