### PR TITLE
user agent anonymous mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 	* fix tail-padding for last file in create_torrent
+	* don't send user-agent in metadata http downloads or UPnP requests when
+	  in anonymous mode
 	* fix internal resolve links lookup for mutable torrents
 	* hint DHT bootstrap nodes of actual bootstrap request
 

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -138,6 +138,8 @@ public:
 		, bool ignore_nonrouters);
 	~upnp();
 
+	void set_user_agent(std::string const& v) { m_user_agent = v; }
+
 	void start();
 
 	enum protocol_type { none = 0, udp = 1, tcp = 2 };
@@ -357,7 +359,7 @@ private:
 
 	std::vector<global_mapping_t> m_mappings;
 
-	std::string const& m_user_agent;
+	std::string m_user_agent;
 
 	// the set of devices we've found
 	std::set<rootdevice> m_devices;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -882,7 +882,9 @@ namespace libtorrent
 				));
 		aux::proxy_settings ps = m_ses.proxy();
 		conn->get(m_url, seconds(30), 0, &ps
-			, 5, settings().get_str(settings_pack::user_agent));
+			, 5
+			, settings().get_bool(settings_pack::anonymous_mode)
+				? "" : settings().get_str(settings_pack::user_agent));
 		set_state(torrent_status::downloading_metadata);
 	}
 

--- a/src/web_connection_base.cpp
+++ b/src/web_connection_base.cpp
@@ -140,7 +140,8 @@ namespace libtorrent
 	{
 		request += "Host: ";
 		request += m_host;
-		if (m_first_request || m_settings.get_bool(settings_pack::always_send_user_agent)) {
+		if ((m_first_request || m_settings.get_bool(settings_pack::always_send_user_agent))
+			&& !m_settings.get_bool(settings_pack::anonymous_mode)) {
 			request += "\r\nUser-Agent: ";
 			request += m_settings.get_str(settings_pack::user_agent);
 		}


### PR DESCRIPTION
 don't send user-agent in metadata http downloads or UPnP requests when in anonymous mode