### PR TITLE
using consts refs in add_torrent_alert

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1815,8 +1815,8 @@ namespace libtorrent
 	struct TORRENT_EXPORT add_torrent_alert final : torrent_alert
 	{
 		// internal
-		add_torrent_alert(aux::stack_allocator& alloc, torrent_handle h
-			, add_torrent_params const& p, error_code ec);
+		add_torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h
+			, add_torrent_params const& p, error_code const& ec);
 
 		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67)
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1358,8 +1358,8 @@ namespace libtorrent {
 		return msg;
 	}
 
-	add_torrent_alert::add_torrent_alert(aux::stack_allocator& alloc, torrent_handle h
-		, add_torrent_params const& p, error_code ec)
+	add_torrent_alert::add_torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h
+		, add_torrent_params const& p, error_code const& ec)
 		: torrent_alert(alloc, h)
 		, params(p)
 		, error(ec)


### PR DESCRIPTION
Finally I'm integrating with `master` and nothing like a real test :)

This is only to document, since I'm unable to replicate the issue, with or without this change. I was getting this crash:
```
siginfo: si_signo: 11 (SIGSEGV), si_code: 0 (unknown), si_addr: 0x0000000000000000

Register to memory mapping:

RAX=0x0000000800000000 is an unknown value
RBX=0x00007f8ebb36fd78 is an unknown value
RCX=0x0000000179e04670: _ZZN5boost6system15system_categoryEvE21system_category_const+0 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x0000000179b1c000
RDX=0x0000000000000000 is an unknown value
RSP=0x000070000238e9a0 is an unknown value
RBP=0x000070000238e9d0 is an unknown value
RSI=0x00007f8ebb36ff50 is an unknown value
RDI=0x00007f8ebc966b50 is an unknown value
R8 =0x0000000000000000 is an unknown value
R9 =0x000000000000000d is an unknown value
R10=0x00000000666d58a6 is an unknown value
R11=0x00000000666dd828 is an unknown value
R12=0x0000000179dde610: _ZTVN10libtorrent13torrent_alertE+0x10 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x0000000179b1c000
R13=0x0000000179ddf740: _ZTVN10libtorrent17add_torrent_alertE+0x10 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x0000000179b1c000
R14=0x00007f8ebc966978 is an unknown value
R15=0x00007f8ebb36fda8 is an unknown value


Stack: [0x000070000230f000,0x000070000238f000],  sp=0x000070000238e9a0,  free space=510k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libjlibtorrent.dylib+0x10b4e8]  void libtorrent::heterogeneous_queue<libtorrent::alert>::move<libtorrent::add_torrent_alert>(unsigned long*, unsigned long*)+0x70
C  [libjlibtorrent.dylib+0x18e0f0]  libtorrent::heterogeneous_queue<libtorrent::alert>::grow_capacity(int)+0x90
C  [libjlibtorrent.dylib+0x142f19]  std::__1::enable_if<std::is_base_of<libtorrent::alert, libtorrent::piece_finished_alert>::value, libtorrent::piece_finished_alert&>::type libtorrent::heterogeneous_queue<libtorrent::alert>::emplace_back<libtorrent::piece_finished_alert, libtorrent::aux::stack_allocator&, libtorrent::torrent_handle, int&>(libtorrent::aux::stack_allocator&&&, libtorrent::torrent_handle&&, int&&&)+0x35
C  [libjlibtorrent.dylib+0x13da1b]  void libtorrent::alert_manager::emplace_alert<libtorrent::piece_finished_alert, libtorrent::torrent_handle, int&>(libtorrent::torrent_handle&&, int&&&)+0x55
C  [libjlibtorrent.dylib+0x1230ec]  libtorrent::torrent::we_have(int)+0x23c
C  [libjlibtorrent.dylib+0x12488e]  libtorrent::torrent::on_piece_hashed(libtorrent::disk_io_job const*)+0x2c2
C  [libjlibtorrent.dylib+0x7279b]  std::__1::function<void (libtorrent::disk_io_job const*)>::operator()(libtorrent::disk_io_job const*) const+0x1f
C  [libjlibtorrent.dylib+0x7250b]  libtorrent::disk_io_thread::call_job_handlers(void*)+0xa9
C  [libjlibtorrent.dylib+0x73ab0]  boost::asio::detail::completion_handler<std::__1::__bind<void (libtorrent::disk_io_thread::*)(void*), libtorrent::disk_io_thread*, void*&> >::do_complete(boost::asio::detail::task_io_service*, boost::asio::detail::task_io_service_operation*, boost::system::error_code const&, unsigned long)+0x7a
C  [libjlibtorrent.dylib+0xde7a9]  boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code const&)+0x1a9
C  [libjlibtorrent.dylib+0x1080b5]  boost::asio::detail::task_io_service::run(boost::system::error_code&)+0xa5
C  [libjlibtorrent.dylib+0xdde5f]  void* std::__1::__thread_proxy<std::__1::tuple<libtorrent::session::start(libtorrent::session_params, boost::asio::io_service*)::$_0> >(void*)+0x5c
C  [libsystem_pthread.dylib+0x399d]  _pthread_body+0x83
C  [libsystem_pthread.dylib+0x391a]  _pthread_body+0x0
C  [libsystem_pthread.dylib+0x1351]  thread_start+0xd
```

```
siginfo: si_signo: 11 (SIGSEGV), si_code: 0 (unknown), si_addr: 0x0000000000000000

Register to memory mapping:

RAX=0x0000000800000000 is an unknown value
RBX=0x00007ff462bc0fe8 is an unknown value
RCX=0x0000000177956670: _ZZN5boost6system15system_categoryEvE21system_category_const+0 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x000000017766e000
RDX=0x0000000000000000 is an unknown value
RSP=0x0000700002411a60 is an unknown value
RBP=0x0000700002411a90 is an unknown value
RSI=0x00007ff462bc11c0 is an unknown value
RDI=0x000000017d59b5c0 is an unknown value
R8 =0x0000000000000000 is an unknown value
R9 =0x0000000000000001 is an unknown value
R10=0x0000000000000003 is an unknown value
R11=0xffff800d1a9da400 is an unknown value
R12=0x0000000177930610: _ZTVN10libtorrent13torrent_alertE+0x10 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x000000017766e000
R13=0x0000000177931740: _ZTVN10libtorrent17add_torrent_alertE+0x10 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x000000017766e000
R14=0x000000017d59b3e8 is an unknown value
R15=0x00007ff462bc1018 is an unknown value


Stack: [0x0000700002392000,0x0000700002412000],  sp=0x0000700002411a60,  free space=510k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libjlibtorrent.dylib+0x10b478]  _ZN10libtorrent19heterogeneous_queueINS_5alertEE4moveINS_17add_torrent_alertEEEvPmS5_+0x70
C  [libjlibtorrent.dylib+0x18e080]  _ZN10libtorrent19heterogeneous_queueINS_5alertEE13grow_capacityEi+0x90
C  [libjlibtorrent.dylib+0xacdf5]  _ZN10libtorrent19heterogeneous_queueINS_5alertEE12emplace_backINS_20block_finished_alertEJRNS_3aux15stack_allocatorENS_14torrent_handleERKN5boost4asio2ip14basic_endpointINSB_3tcpEEERKNS_8digest32ILi160EEERiSL_EEENSt3__19enable_ifIXsr3std10is_base_ofIS1_T_EE5valueERSO_E4typeEDpOT0_+0x43
C  [libjlibtorrent.dylib+0xa6576]  _ZN10libtorrent13alert_manager13emplace_alertINS_20block_finished_alertEJNS_14torrent_handleERKN5boost4asio2ip14basic_endpointINS6_3tcpEEERKNS_8digest32ILi160EEERiSG_EEEvDpOT0_+0x6e
C  [libjlibtorrent.dylib+0x9f3f7]  _ZN10libtorrent15peer_connection22on_disk_write_completeEPKNS_11disk_io_jobENS_12peer_requestENSt3__110shared_ptrINS_7torrentEEE+0x223
C  [libjlibtorrent.dylib+0xaccee]  _ZNSt3__128__invoke_void_return_wrapperIvE6__callIJRNS_6__bindIMN10libtorrent15peer_connectionEFvPKNS4_11disk_io_jobENS4_12peer_requestENS_10shared_ptrINS4_7torrentEEEEJNSA_IS5_EERNS_12placeholders4__phILi1EEERKS9_RSC_EEES8_EEEvDpOT_+0x62
C  [libjlibtorrent.dylib+0x726db]  _ZNKSt3__18functionIFvPKN10libtorrent11disk_io_jobEEEclES4_+0x1f
C  [libjlibtorrent.dylib+0x7244b]  _ZN10libtorrent14disk_io_thread17call_job_handlersEPv+0xa9
C  [libjlibtorrent.dylib+0x739f0]  _ZN5boost4asio6detail18completion_handlerINSt3__16__bindIMN10libtorrent14disk_io_threadEFvPvEJPS6_RS7_EEEE11do_completeEPNS1_15task_io_serviceEPNS1_25task_io_service_operationERKNS_6system10error_codeEm+0x7a
C  [libjlibtorrent.dylib+0xde6e9]  _ZN5boost4asio6detail15task_io_service10do_run_oneERNS1_11scoped_lockINS1_11posix_mutexEEERNS1_27task_io_service_thread_infoERKNS_6system10error_codeE+0x1a9
C  [libjlibtorrent.dylib+0x108045]  _ZN5boost4asio6detail15task_io_service3runERNS_6system10error_codeE+0xa5
C  [libjlibtorrent.dylib+0xddd9f]  _ZNSt3__114__thread_proxyINS_5tupleIJZN10libtorrent7session5startENS2_14session_paramsEPN5boost4asio10io_serviceEE3$_0EEEEEPvSB_+0x5c
C  [libsystem_pthread.dylib+0x399d]  _pthread_body+0x83
C  [libsystem_pthread.dylib+0x391a]  _pthread_body+0x0
C  [libsystem_pthread.dylib+0x1351]  thread_start+0xd
```
```
siginfo: si_signo: 11 (SIGSEGV), si_code: 0 (unknown), si_addr: 0x0000000000000000

Register to memory mapping:

RAX=0x0000000800000000 is an unknown value
RBX=0x00007f921a1b1df8 is an unknown value
RCX=0x000000017b1b6670: _ZZN5boost6system15system_categoryEvE21system_category_const+0 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x000000017aece000
RDX=0x0000000000000000 is an unknown value
RSP=0x000070000238e530 is an unknown value
RBP=0x000070000238e560 is an unknown value
RSI=0x00007f921a1b1fd0 is an unknown value
RDI=0x000000017d399bd0 is an unknown value
R8 =0x0000000000000000 is an unknown value
R9 =0x000000000000000c is an unknown value
R10=0x000000000000000f is an unknown value
R11=0xffffffff00000000 is an unknown value
R12=0x000000017b190610: _ZTVN10libtorrent13torrent_alertE+0x10 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x000000017aece000
R13=0x000000017b191740: _ZTVN10libtorrent17add_torrent_alertE+0x10 in /Users/aldenml/Development/frostwire/desktop/lib/native/libjlibtorrent.dylib at 0x000000017aece000
R14=0x000000017d3999f8 is an unknown value
R15=0x00007f921a1b1e28 is an unknown value


Stack: [0x000070000230f000,0x000070000238f000],  sp=0x000070000238e530,  free space=509k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libjlibtorrent.dylib+0x10b478]  _ZN10libtorrent19heterogeneous_queueINS_5alertEE4moveINS_17add_torrent_alertEEEvPmS5_+0x70
C  [libjlibtorrent.dylib+0x18e080]  _ZN10libtorrent19heterogeneous_queueINS_5alertEE13grow_capacityEi+0x90
C  [libjlibtorrent.dylib+0xacf97]  _ZN10libtorrent19heterogeneous_queueINS_5alertEE12emplace_backINS_23block_downloading_alertEJRNS_3aux15stack_allocatorENS_14torrent_handleERKN5boost4asio2ip14basic_endpointINSB_3tcpEEERKNS_8digest32ILi160EEERKiSM_EEENSt3__19enable_ifIXsr3std10is_base_ofIS1_T_EE5valueERSP_E4typeEDpOT0_+0x43
C  [libjlibtorrent.dylib+0xa662c]  _ZN10libtorrent13alert_manager13emplace_alertINS_23block_downloading_alertEJNS_14torrent_handleERKN5boost4asio2ip14basic_endpointINS6_3tcpEEERKNS_8digest32ILi160EEERKiSH_EEEvDpOT0_+0x6e
C  [libjlibtorrent.dylib+0xa01ce]  _ZN10libtorrent15peer_connection11add_requestERKNS_11piece_blockEi+0x17a
C  [libjlibtorrent.dylib+0x18dcfa]  _ZN10libtorrent15request_a_blockERNS_7torrentERNS_15peer_connectionE+0x685
C  [libjlibtorrent.dylib+0x9eeb2]  _ZN10libtorrent15peer_connection14incoming_pieceERKNS_12peer_requestENS_18disk_buffer_holderE+0xe38
C  [libjlibtorrent.dylib+0x9dfee]  _ZN10libtorrent15peer_connection14incoming_pieceERKNS_12peer_requestEPKc+0x130
C  [libjlibtorrent.dylib+0xbd4e4]  _ZN10libtorrent19web_peer_connection16incoming_payloadEPKci+0x1e4
C  [libjlibtorrent.dylib+0xbcfee]  _ZN10libtorrent19web_peer_connection10on_receiveERKN5boost6system10error_codeEm+0x97c
C  [libjlibtorrent.dylib+0xa4deb]  _ZN10libtorrent15peer_connection15on_receive_dataERKN5boost6system10error_codeEm+0x443
C  [libjlibtorrent.dylib+0xaef16]  _ZN5boost4asio6detail23reactive_socket_recv_opINS0_17mutable_buffers_1EN10libtorrent3aux18allocating_handlerINSt3__16__bindIMNS4_15peer_connectionEFvRKNS_6system10error_codeEmEJNS7_10shared_ptrIS9_EERNS7_12placeholders4__phILi1EEERNSJ_ILi2EEEEEELm336EEEE11do_completeEPNS1_15task_io_serviceEPNS1_25task_io_service_operationESD_m+0x66
C  [libjlibtorrent.dylib+0xde6e9]  _ZN5boost4asio6detail15task_io_service10do_run_oneERNS1_11scoped_lockINS1_11posix_mutexEEERNS1_27task_io_service_thread_infoERKNS_6system10error_codeE+0x1a9
C  [libjlibtorrent.dylib+0x108045]  _ZN5boost4asio6detail15task_io_service3runERNS_6system10error_codeE+0xa5
C  [libjlibtorrent.dylib+0xddd9f]  _ZNSt3__114__thread_proxyINS_5tupleIJZN10libtorrent7session5startENS2_14session_paramsEPN5boost4asio10io_serviceEE3$_0EEEEEPvSB_+0x5c
C  [libsystem_pthread.dylib+0x399d]  _pthread_body+0x83
C  [libsystem_pthread.dylib+0x391a]  _pthread_body+0x0
C  [libsystem_pthread.dylib+0x1351]  thread_start+0xd
```