### PR TITLE
std::count -> std::find

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4457,7 +4457,7 @@ namespace aux {
 			std::shared_ptr<torrent> t = i->second;
 			if (!t) continue;
 			std::vector<std::string> const& c = t->torrent_file().collections();
-			if (std::count(c.begin(), c.end(), collection) == 0) continue;
+			if (std::find(c.begin(), c.end(), collection) == c.end()) continue;
 			ret.push_back(t);
 		}
 		return ret;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -360,9 +360,9 @@ namespace libtorrent
 			// that case. Also, if the resume data says we're missing a piece, we
 			// can't be in seed-mode.
 			m_seed_mode = (p.flags & add_torrent_params::flag_seed_mode) != 0
-				&& std::count(p.file_priorities.begin(), p.file_priorities.end(), 0) == 0
-				&& std::count(p.piece_priorities.begin(), p.piece_priorities.end(), 0) == 0
-				&& std::count(p.have_pieces.begin(), p.have_pieces.end(), false) == 0;
+				&& std::find(p.file_priorities.begin(), p.file_priorities.end(), 0) == p.file_priorities.end()
+				&& std::find(p.piece_priorities.begin(), p.piece_priorities.end(), 0) == p.piece_priorities.end()
+				&& std::find(p.have_pieces.begin(), p.have_pieces.end(), false) == p.have_pieces.end();
 
 			m_connections_initialized = true;
 			m_block_size_shift = root2((std::min)(block_size, m_torrent_file->piece_length()));


### PR DESCRIPTION
V812. Decreased performance. Ineffective use of the 'count' function. It can possibly be replaced by the call to the 'find' function