### PR TITLE
fixed python scrape_tracker arguments

### DIFF
--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -460,7 +460,7 @@ void bind_torrent_handle()
 #ifndef TORRENT_DISABLE_DHT
         .def("force_dht_announce", _(&torrent_handle::force_dht_announce))
 #endif
-        .def("scrape_tracker", _(&torrent_handle::scrape_tracker))
+        .def("scrape_tracker", _(&torrent_handle::scrape_tracker), arg("index") = -1)
         .def("set_upload_mode", _(&torrent_handle::set_upload_mode))
         .def("set_share_mode", _(&torrent_handle::set_share_mode))
         .def("flush_cache", &torrent_handle::flush_cache)


### PR DESCRIPTION
`torrent_handle::scrape_tracker` has a default value for the index argument; the python api was missing that, causing Deluge to throw errors.
```
  File "/usr/lib/python2.7/site-packages/deluge/core/torrentmanager.py", line 1042, in on_alert_tracker_reply
    torrent.scrape_tracker()
  File "/usr/lib/python2.7/site-packages/deluge/core/torrent.py", line 1244, in scrape_tracker
    self.handle.scrape_tracker()
Boost.Python.ArgumentError: Python argument types in
    torrent_handle.scrape_tracker(torrent_handle)
did not match C++ signature:
    scrape_tracker(libtorrent::torrent_handle {lvalue}, int)
```