### PR TITLE
fix adding a node with unknown id

### DIFF
--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -512,6 +512,12 @@ routing_table::add_node_status_t routing_table::add_node_impl(node_entry e)
 			}
 			return node_added;
 		}
+		else if (existing->id.is_all_zeros())
+		{
+			// this node's ID was unknown. remove the old entry and
+			// replace it with the node's real ID
+			remove_node(existing, existing_bucket);
+		}
 		else if (!e.pinged())
 		{
 			// this may be a routing table poison attack. If we haven't confirmed

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -1761,7 +1761,7 @@ void test_bootstrap(address(&rand_addr)())
 			|| find_node_keys[2].string_value() == "get_peers");
 		if (find_node_keys[0].string_value() != "q"
 			|| (find_node_keys[2].string_value() != "find_node"
-				&& find_node_keys[2].string_value() == "get_peers")) return;
+				&& find_node_keys[2].string_value() != "get_peers")) return;
 	}
 	else
 	{


### PR DESCRIPTION
Commit a414e4c3 broke adding nodes with unknown id to the routing table by
causing them to be evicted when they responded with their real id. This should
have been caught by test_bootstrap, but a typo caused that test to silently
exit early.