### PR TITLE
refactor log methods in public peer_connection_handle for stable ABI

### DIFF
--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/peer_id.hpp"
 #include "libtorrent/operations.hpp"
+#include "libtorrent/alert_types.hpp"
 #include "libtorrent/peer_connection.hpp" // for connection_type
 #include "libtorrent/error_code.hpp"
 
@@ -90,6 +91,10 @@ struct TORRENT_EXPORT peer_connection_handle
 	bool ignore_unchoke_slots() const;
 
 	bool failed() const;
+
+	bool should_log(peer_log_alert::direction_t direction) const;
+	void peer_log(peer_log_alert::direction_t direction
+		, char const* event, char const* fmt = "", ...) const TORRENT_FORMAT(4,5);
 
 	bool can_disconnect(error_code const& ec) const;
 

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -36,22 +36,18 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/peer_id.hpp"
 #include "libtorrent/operations.hpp"
-#include "libtorrent/alert_types.hpp"
 #include "libtorrent/peer_connection.hpp" // for connection_type
+#include "libtorrent/error_code.hpp"
 
 namespace libtorrent
 {
 
-class peer_connection;
 class bt_peer_connection;
 struct torrent_handle;
 struct peer_plugin;
 struct peer_info;
 struct crypto_plugin;
 
-typedef boost::system::error_code error_code;
-
-// hidden
 struct TORRENT_EXPORT peer_connection_handle
 {
 	peer_connection_handle(std::weak_ptr<peer_connection> impl)
@@ -94,14 +90,6 @@ struct TORRENT_EXPORT peer_connection_handle
 	bool ignore_unchoke_slots() const;
 
 	bool failed() const;
-
-#ifndef TORRENT_DISABLE_LOGGING
-
-	bool should_log(peer_log_alert::direction_t direction) const;
-	void peer_log(peer_log_alert::direction_t direction
-		, char const* event, char const* fmt = "", ...) const TORRENT_FORMAT(4,5);
-
-#endif // TORRENT_DISABLE_LOGGING
 
 	bool can_disconnect(error_code const& ec) const;
 

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -31,12 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/peer_connection_handle.hpp"
-#include "libtorrent/peer_connection.hpp"
 #include "libtorrent/bt_peer_connection.hpp"
-
-#ifndef TORRENT_DISABLE_LOGGING
-#include <cstdarg> // for va_start, va_end
-#endif
 
 namespace libtorrent
 {
@@ -207,37 +202,6 @@ bool peer_connection_handle::failed() const
 	TORRENT_ASSERT(pc);
 	return pc->failed();
 }
-
-#ifndef TORRENT_DISABLE_LOGGING
-
-bool peer_connection_handle::should_log(peer_log_alert::direction_t direction) const
-{
-	std::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	return pc->should_log(direction);
-}
-
-TORRENT_FORMAT(4,5)
-void peer_connection_handle::peer_log(peer_log_alert::direction_t direction
-	, char const* event, char const* fmt, ...) const
-{
-	std::shared_ptr<peer_connection> pc = native_handle();
-	TORRENT_ASSERT(pc);
-	va_list v;
-	va_start(v, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#pragma clang diagnostic ignored "-Wclass-varargs"
-#endif
-	pc->peer_log(direction, event, fmt, v);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-	va_end(v);
-}
-
-#endif // TORRENT_DISABLE_LOGGING
 
 bool peer_connection_handle::can_disconnect(error_code const& ec) const
 {


### PR DESCRIPTION
This breaks the ABI, and it's very internal to libtorrent, if a client insist in using the "peer log" methods, he can get the `native_handle()`.