### PR TITLE
fix buffer overrun in dht_get_peers_reply_alert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ before_install:
     fi
   - 'if [[ $toolset == "gcc-sanitizer" ]]; then export test_args=testing.arg="--no-stderr-redirect"; fi'
   - 'echo "toolset: " ${toolset}'
-  - 'echo "coverage_toolset: " ${coverage_toolset}'
   - 'echo "variant: " ${variant}'
 # disable leak checking for now. it reports some suspicious reports against some
 # tests

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1895,7 +1895,7 @@ namespace libtorrent {
 		, m_alloc(alloc)
 		, m_num_peers(int(peers.size()))
 	{
-		std::size_t total_size = 0; // num bytes for sizes
+		std::size_t total_size = peers.size(); // num bytes for sizes
 		for (int i = 0; i < m_num_peers; i++) {
 			total_size += peers[i].size();
 		}
@@ -1905,7 +1905,7 @@ namespace libtorrent {
 		char *ptr = alloc.ptr(m_peers_idx);
 		for (int i = 0; i < m_num_peers; i++) {
 			tcp::endpoint const& endp = peers[i];
-			std::size_t size = endp.size();
+			std::size_t const size = endp.size();
 			TORRENT_ASSERT(size < 0x100);
 			detail::write_uint8(uint8_t(size), ptr);
 			std::memcpy(ptr, endp.data(), size);


### PR DESCRIPTION
I wonder why address sanitizer on g++-5 didn't catch this (clang++ sanitizer caught it on macOS)