### PR TITLE
ensure posix calls with LFS support are used in android

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -124,6 +124,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifdef TORRENT_ANDROID
 #include <sys/syscall.h>
 #define lseek lseek64
+#define pread pread64
+#define pwrite pwrite64
+#define ftruncate ftruncate64
 #endif
 
 #elif defined __APPLE__ && defined __MACH__ && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050


### PR DESCRIPTION
This was a hard one to find. There is no mention of `_FILE_OFFSET_BITS` in any header in the android toolchain. Without this, android picks the calls with `off_t` (instead of `off64_t`) and libtorrent fails while writing.