### PR TITLE
use of piece_refcount_holder in disk_io_thread::do_flush_piece

### DIFF
--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -2792,11 +2792,19 @@ namespace libtorrent
 		cached_piece_entry* pe = m_disk_cache.find_piece(j);
 		if (pe == nullptr) return 0;
 
+		piece_refcount_holder refcount_holder(pe);
+
 #if TORRENT_USE_ASSERTS
 		pe->piece_log.push_back(piece_log_t(j->action));
 #endif
 		try_flush_hashed(pe, m_settings.get_int(
 			settings_pack::write_cache_line_size), completed_jobs, l);
+
+		TORRENT_ASSERT(l.owns_lock());
+
+		refcount_holder.release();
+
+		m_disk_cache.maybe_free_piece(pe);
 
 		return 0;
 	}


### PR DESCRIPTION
I see the code in disk_io_thread::do_flush_hashed and it seems to me like this code should be added to disk_io_thread::do_flush_piece. But I have no deep knowledge of the logic behind. Related to https://github.com/arvidn/libtorrent/issues/1225