### PR TITLE
return a span from TORRENT_ALLOCA

### DIFF
--- a/include/libtorrent/disk_buffer_pool.hpp
+++ b/include/libtorrent/disk_buffer_pool.hpp
@@ -54,6 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/io_service_fwd.hpp"
 #include "libtorrent/file.hpp" // for iovec_t
+#include "libtorrent/span.hpp"
 
 namespace libtorrent
 {
@@ -77,7 +78,7 @@ namespace libtorrent
 		char* allocate_buffer(bool& exceeded, std::shared_ptr<disk_observer> o
 			, char const* category);
 		void free_buffer(char* buf);
-		void free_multiple_buffers(char** bufvec, int numbufs);
+		void free_multiple_buffers(span<char*> bufvec);
 
 		int allocate_iovec(file::iovec_t* iov, int iov_len);
 		void free_iovec(file::iovec_t* iov, int iov_len);

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -149,7 +149,7 @@ namespace libtorrent
 	struct add_torrent_params;
 
 	TORRENT_EXTRA_EXPORT int copy_bufs(file::iovec_t const* bufs, int bytes, file::iovec_t* target);
-	TORRENT_EXTRA_EXPORT void advance_bufs(file::iovec_t*& bufs, int bytes);
+	TORRENT_EXTRA_EXPORT span<file::iovec_t> advance_bufs(span<file::iovec_t> bufs, int bytes);
 	TORRENT_EXTRA_EXPORT void clear_bufs(file::iovec_t const* bufs, int num_bufs);
 
 	// flags for async_move_storage

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -72,6 +72,9 @@ struct alloc_header
 
 #endif
 
+// see alloca.hpp
+thread_local void* TORRENT_ALLOCA_tmp;
+
 namespace libtorrent
 {
 

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -653,7 +653,7 @@ namespace libtorrent
 		// this is the stack of bdecode_token indices, into m_tokens.
 		// sp is the stack pointer, as index into the array, stack
 		int sp = 0;
-		stack_frame* stack = TORRENT_ALLOCA(stack_frame, depth_limit);
+		span<stack_frame> stack = TORRENT_ALLOCA(stack_frame, depth_limit);
 
 		char const* const orig_start = start;
 

--- a/src/disk_buffer_pool.cpp
+++ b/src/disk_buffer_pool.cpp
@@ -340,16 +340,14 @@ namespace libtorrent
 		return ret;
 	}
 
-	void disk_buffer_pool::free_multiple_buffers(char** bufvec, int numbufs)
+	void disk_buffer_pool::free_multiple_buffers(span<char*> bufvec)
 	{
-		char** end = bufvec + numbufs;
 		// sort the pointers in order to maximize cache hits
-		std::sort(bufvec, end);
+		std::sort(bufvec.begin(), bufvec.end());
 
 		std::unique_lock<std::mutex> l(m_pool_mutex);
-		for (; bufvec != end; ++bufvec)
+		for (char* buf : bufvec)
 		{
-			char* buf = *bufvec;
 			TORRENT_ASSERT(is_disk_buffer(buf, l));
 			free_buffer_impl(buf, l);
 			remove_buffer_in_use(buf);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -173,10 +173,10 @@ namespace
 
 	int preadv(HANDLE fd, libtorrent::file::iovec_t const* bufs, int num_bufs, std::int64_t file_offset)
 	{
-		OVERLAPPED* ol = TORRENT_ALLOCA(OVERLAPPED, num_bufs);
-		std::memset(ol, 0, sizeof(OVERLAPPED) * num_bufs);
+		libtorrent::span<OVERLAPPED> ol = TORRENT_ALLOCA(OVERLAPPED, num_bufs);
+		std::memset(ol.data(), 0, sizeof(OVERLAPPED) * num_bufs);
 
-		HANDLE* h = TORRENT_ALLOCA(HANDLE, num_bufs);
+		libtorrent::span<HANDLE> h = TORRENT_ALLOCA(HANDLE, num_bufs);
 
 		for (int i = 0; i < num_bufs; ++i)
 		{
@@ -209,7 +209,7 @@ namespace
 			}
 		}
 
-		if (wait_for_multiple_objects(num_bufs, h) == WAIT_FAILED)
+		if (wait_for_multiple_objects(num_bufs, h.data()) == WAIT_FAILED)
 		{
 			ret = -1;
 			goto done;
@@ -243,10 +243,10 @@ done:
 
 	int pwritev(HANDLE fd, libtorrent::file::iovec_t const* bufs, int num_bufs, std::int64_t file_offset)
 	{
-		OVERLAPPED* ol = TORRENT_ALLOCA(OVERLAPPED, num_bufs);
-		std::memset(ol, 0, sizeof(OVERLAPPED) * num_bufs);
+		libtorrent::span<OVERLAPPED> ol = TORRENT_ALLOCA(OVERLAPPED, num_bufs);
+		std::memset(ol.data(), 0, sizeof(OVERLAPPED) * num_bufs);
 
-		HANDLE* h = TORRENT_ALLOCA(HANDLE, num_bufs);
+		libtorrent::span<HANDLE> h = TORRENT_ALLOCA(HANDLE, num_bufs);
 
 		for (int i = 0; i < num_bufs; ++i)
 		{
@@ -279,7 +279,7 @@ done:
 			}
 		}
 
-		if (wait_for_multiple_objects(num_bufs, h) == WAIT_FAILED)
+		if (wait_for_multiple_objects(num_bufs, h.data()) == WAIT_FAILED)
 		{
 			ret = -1;
 			goto done;

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -128,14 +128,13 @@ namespace libtorrent
 
 		int to_process = m_send_barriers.front().next;
 
-		span<char>* bufs;
-		size_t num_bufs;
+		span<span<char>> bufs;
 		bool need_destruct = false;
 		if (to_process != INT_MAX)
 		{
 			bufs = TORRENT_ALLOCA(span<char>, iovec.size());
 			need_destruct = true;
-			num_bufs = 0;
+			size_t num_bufs = 0;
 			for (int i = 0; to_process > 0 && i < iovec.size(); ++i)
 			{
 				++num_bufs;
@@ -152,19 +151,19 @@ namespace libtorrent
 					to_process -= size;
 				}
 			}
+			bufs = bufs.first(num_bufs);
 		}
 		else
 		{
-			bufs = iovec.data();
-			num_bufs = iovec.size();
+			bufs = iovec;
 		}
 
 		int next_barrier = 0;
 		span<span<char const>> out_iovec;
-		if (num_bufs != 0)
+		if (bufs.size() != 0)
 		{
 			std::tie(next_barrier, out_iovec)
-				= m_send_barriers.front().enc_handler->encrypt({bufs, size_t(num_bufs)});
+				= m_send_barriers.front().enc_handler->encrypt(bufs);
 		}
 
 		if (m_send_barriers.front().next != INT_MAX)
@@ -192,8 +191,8 @@ namespace libtorrent
 		if (next_barrier != INT_MAX && next_barrier != 0)
 		{
 			int payload = 0;
-			for (int i = 0; i < num_bufs; ++i)
-				payload += int(bufs[i].size());
+			for (auto buf : bufs)
+				payload += int(buf.size());
 
 			int overhead = 0;
 			for (auto buf : out_iovec)
@@ -203,8 +202,8 @@ namespace libtorrent
 #endif
 		if (need_destruct)
 		{
-			for (int i = 0; i < num_bufs; ++i)
-				bufs[i].~span<char>();
+			for (auto buf : bufs)
+				buf.~span<char>();
 		}
 		return std::make_tuple(next_barrier, out_iovec);
 	}

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5373,18 +5373,18 @@ namespace libtorrent
 		int priority = get_priority(channel);
 
 		int max_channels = num_classes() + (t ? t->num_classes() : 0) + 2;
-		bandwidth_channel** channels = TORRENT_ALLOCA(bandwidth_channel*, max_channels);
+		span<bandwidth_channel*> channels = TORRENT_ALLOCA(bandwidth_channel*, max_channels);
 
 		// collect the pointers to all bandwidth channels
 		// that apply to this torrent
 		int c = 0;
 
 		c += m_ses.copy_pertinent_channels(*this, channel
-			, channels + c, max_channels - c);
+			, channels.subspan(c).data(), max_channels - c);
 		if (t)
 		{
 			c += m_ses.copy_pertinent_channels(*t, channel
-				, channels + c, max_channels - c);
+				, channels.subspan(c).data(), max_channels - c);
 		}
 
 #if TORRENT_USE_ASSERTS
@@ -5402,7 +5402,7 @@ namespace libtorrent
 		bandwidth_manager* manager = m_ses.get_bandwidth_manager(channel);
 
 		int ret = manager->request_bandwidth(self()
-			, bytes, priority, channels, c);
+			, bytes, priority, channels.data(), c);
 
 		if (ret == 0)
 		{

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1275,7 +1275,7 @@ namespace libtorrent
 		// pieces end up changing, instead of making
 		// the piece list dirty, just update those pieces
 		// instead
-		int* incremented = TORRENT_ALLOCA(int, size);
+		span<int> incremented = TORRENT_ALLOCA(int, size);
 		int num_inc = 0;
 
 		if (!m_dirty)
@@ -1372,7 +1372,7 @@ namespace libtorrent
 		// pieces end up changing, instead of making
 		// the piece list dirty, just update those pieces
 		// instead
-		int* decremented = TORRENT_ALLOCA(int, size);
+		span<int> decremented = TORRENT_ALLOCA(int, size);
 		int num_dec = 0;
 
 		if (!m_dirty)
@@ -1964,7 +1964,7 @@ namespace libtorrent
 			// lookups when finding a downloading_piece for a specific piece index.
 			// this is important and needs to stay sorted that way, that's why
 			// we're copying it here
-			downloading_piece const** ordered_partials = TORRENT_ALLOCA(
+			auto ordered_partials = TORRENT_ALLOCA(
 				downloading_piece const*, m_downloads[piece_pos::piece_downloading].size());
 			int num_ordered_partials = 0;
 
@@ -2000,7 +2000,7 @@ namespace libtorrent
 				// chances are that we'll just need a single piece, and once we've
 				// picked from it we're done. Sorting the rest of the list in that
 				// case is a waste of time.
-				std::sort(ordered_partials, ordered_partials + num_ordered_partials
+				std::sort(ordered_partials.begin(), ordered_partials.begin() + num_ordered_partials
 					, std::bind(&piece_picker::partial_compare_rarest_first, this
 						, _1, _2));
 			}
@@ -2306,8 +2306,7 @@ get_out:
 			+ m_downloads[piece_pos::piece_full].size()));
 		if (partials_size == 0) return ret;
 
-		downloading_piece const** partials
-			= TORRENT_ALLOCA(downloading_piece const*, partials_size);
+		auto partials = TORRENT_ALLOCA(downloading_piece const*, partials_size);
 		int c = 0;
 
 #if TORRENT_USE_INVARIANT_CHECKS

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -134,21 +134,22 @@ namespace libtorrent
 		}
 	}
 
-	void advance_bufs(file::iovec_t*& bufs, int bytes)
+	span<file::iovec_t> advance_bufs(span<file::iovec_t> bufs, int bytes)
 	{
 		int size = 0;
 		for (;;)
 		{
-			size += int(bufs->iov_len);
+			size += int(bufs.front().iov_len);
 			if (size >= bytes)
 			{
-				bufs->iov_base = reinterpret_cast<char*>(bufs->iov_base)
-					+ bufs->iov_len - (size - bytes);
-				bufs->iov_len = size - bytes;
-				return;
+				bufs.front().iov_base = reinterpret_cast<char*>(bufs.front().iov_base)
+					+ bufs.front().iov_len - (size - bytes);
+				bufs.front().iov_len = size - bytes;
+				return bufs;
 			}
-			++bufs;
+			bufs = bufs.subspan(1);
 		}
+		return bufs;
 	}
 
 	void clear_bufs(file::iovec_t const* bufs, int num_bufs)
@@ -1148,11 +1149,11 @@ namespace libtorrent
 		// copy the iovec array so we can use it to keep track of our current
 		// location by updating the head base pointer and size. (see
 		// advance_bufs())
-		file::iovec_t* current_buf = TORRENT_ALLOCA(file::iovec_t, num_bufs);
-		copy_bufs(bufs, size, current_buf);
-		TORRENT_ASSERT(count_bufs(current_buf, size) == num_bufs);
+		span<file::iovec_t> current_buf = TORRENT_ALLOCA(file::iovec_t, num_bufs);
+		copy_bufs(bufs, size, current_buf.data());
+		TORRENT_ASSERT(count_bufs(current_buf.data(), size) == num_bufs);
 
-		file::iovec_t* tmp_buf = TORRENT_ALLOCA(file::iovec_t, num_bufs);
+		span<file::iovec_t> tmp_buf = TORRENT_ALLOCA(file::iovec_t, num_bufs);
 
 		// the number of bytes left to read in the current file (specified by
 		// file_index). This is the minimum of (file_size - file_offset) and
@@ -1184,18 +1185,18 @@ namespace libtorrent
 
 			// make a copy of the iovec array that _just_ covers the next
 			// file_bytes_left bytes, i.e. just this one operation
-			copy_bufs(current_buf, file_bytes_left, tmp_buf);
+			copy_bufs(current_buf.data(), file_bytes_left, tmp_buf.data());
 
 			int bytes_transferred = op.file_op(file_index, file_offset,
-				file_bytes_left, tmp_buf, ec);
+				file_bytes_left, tmp_buf.data(), ec);
 			if (ec) return -1;
 
 			// advance our position in the iovec array and the file offset.
-			advance_bufs(current_buf, bytes_transferred);
+			current_buf = advance_bufs(current_buf, bytes_transferred);
 			bytes_left -= bytes_transferred;
 			file_offset += bytes_transferred;
 
-			TORRENT_ASSERT(count_bufs(current_buf, bytes_left) <= num_bufs);
+			TORRENT_ASSERT(count_bufs(current_buf.data(), bytes_left) <= num_bufs);
 
 			// if the file operation returned 0, we've hit end-of-file. We're done
 			if (bytes_transferred == 0)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9604,7 +9604,7 @@ namespace libtorrent
 		// busy blocks we may pick
 		// first, figure out which blocks are eligible for picking
 		// in "busy-mode"
-		busy_block_t* busy_blocks
+		span<busy_block_t> busy_blocks
 			= TORRENT_ALLOCA(busy_block_t, blocks_in_piece);
 		int busy_count = 0;
 
@@ -9637,16 +9637,18 @@ namespace libtorrent
 		std::printf("\n");
 #endif
 
+		busy_blocks = busy_blocks.first(busy_count);
+
 		// then sort blocks by the number of peers with requests
 		// to the blocks (request the blocks with the fewest peers
 		// first)
-		std::sort(busy_blocks, busy_blocks + busy_count);
+		std::sort(busy_blocks.begin(), busy_blocks.end());
 
 		// then insert them into the interesting_blocks vector
-		for (int k = 0; k < busy_count; ++k)
+		for (auto block : busy_blocks)
 		{
 			interesting_blocks.push_back(
-				piece_block(piece, busy_blocks[k].index));
+				piece_block(piece, block.index));
 		}
 	}
 

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1866,7 +1866,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 			// correctly aligned memory. That's why we ask for 7 more bytes
 			// and adjust our pointer to be aligned later
 			p = reinterpret_cast<packet*>(TORRENT_ALLOCA(char, sizeof(packet) + packet_size
-				+ sizeof(packet*) - 1));
+				+ sizeof(packet*) - 1).data());
 			p = reinterpret_cast<packet*>(align_pointer(p));
 			UTP_LOGV("%8p: allocating %d bytes on the stack\n", static_cast<void*>(this), packet_size);
 			p->allocated = packet_size;

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -221,9 +221,9 @@ void send_bitfield(tcp::socket& s, char const* bits)
 
 	int num_pieces = int(strlen(bits));
 	int packet_size = (num_pieces+7)/8 + 5;
-	char* msg = (char*)TORRENT_ALLOCA(char, packet_size);
-	memset(msg, 0, packet_size);
-	char* ptr = msg;
+	span<char> msg = TORRENT_ALLOCA(char, packet_size);
+	std::fill(msg.begin(), msg.end(), 0);
+	char* ptr = msg.data();
 	write_int32(packet_size-4, ptr);
 	write_int8(5, ptr);
 	log("==> bitfield [%s]", bits);
@@ -232,7 +232,7 @@ void send_bitfield(tcp::socket& s, char const* bits)
 		ptr[i/8] |= (bits[i] == '1' ? 1 : 0) << i % 8;
 	}
 	error_code ec;
-	boost::asio::write(s, boost::asio::buffer(msg, packet_size)
+	boost::asio::write(s, boost::asio::buffer(msg.data(), msg.size())
 		, boost::asio::transfer_all(), ec);
 	if (ec) TEST_ERROR(ec.message());
 }

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -978,21 +978,20 @@ TORRENT_TEST(iovec_advance_bufs)
 
 	memcpy(iov2, iov1, sizeof(iov1));
 
-	file::iovec_t* iov = iov2;
-	file::iovec_t* end = iov2 + 10;
+	span<file::iovec_t> iov = iov2;
 
 	// advance iov 13 bytes. Make sure what's left fits pattern 1 shifted
 	// 13 bytes
-	advance_bufs(iov, 13);
+	iov = advance_bufs(iov, 13);
 
 	// make sure what's in
 	int counter = 13;
-	for (int i = 0; i < end - iov; ++i)
+	for (auto buf : iov)
 	{
-		unsigned char* buf = (unsigned char*)iov[i].iov_base;
-		for (int k = 0; k < int(iov[i].iov_len); ++k)
+		unsigned char* buf_base = (unsigned char*)buf.iov_base;
+		for (int k = 0; k < int(buf.iov_len); ++k)
 		{
-			TEST_EQUAL(int(buf[k]), (counter & 0xff));
+			TEST_EQUAL(int(buf_base[k]), (counter & 0xff));
 			++counter;
 		}
 	}


### PR DESCRIPTION
This causes double evaluation of the size parameter which is unfortunate
but unavoidable due to the spooky voodoo that is alloca.

Alternate hack if this one is just too ugly (the alternative isn't much prettier): https://github.com/ssiloti/libtorrent/commit/b760e68e2611c667f51251ae90fa5d31aba03903