### PR TITLE
using custom equal function in block_cache::cache_t

### DIFF
--- a/include/libtorrent/block_cache.hpp
+++ b/include/libtorrent/block_cache.hpp
@@ -339,11 +339,17 @@ namespace libtorrent
 			std::size_t operator()(cached_piece_entry const& p) const
 			{ return std::size_t(p.storage.get()) + std::size_t(p.piece); }
 		};
-		typedef std::unordered_set<cached_piece_entry, hash_value> cache_t;
+		struct equal_value
+		{
+			bool operator()(cached_piece_entry const& p1
+				, cached_piece_entry const& p2) const
+			{ return p1.storage.get() == p2.storage.get() && p1.piece == p2.piece; }
+		};
+		using cache_t = std::unordered_set<cached_piece_entry, hash_value, equal_value>;
 
 	public:
 
-		typedef cache_t::const_iterator const_iterator;
+		using const_iterator = cache_t::const_iterator;
 
 		// returns the number of blocks this job would cause to be read in
 		int pad_job(disk_io_job const* j, int blocks_in_piece


### PR DESCRIPTION
I expect this to fix the issue https://github.com/arvidn/libtorrent/issues/1225 (if not, well, need to keep looking).

The theory behind this is the following:

The custom hash is used to determine the internal bucket in the internal hash table. The `libc++` implementation of the `find`, lookup the bucket and iterate all the elements (it could be one) and test for equality of the value (default is the `==`). In this case, not providing a custom `equals` is a bug.

Why it hasn't happened before? Looking at the `boost::unordered_set` implementation, branch `RC_1_1`, in their `find` algorithm, they lookup the bucket and they "cleverly" returns if only one element is found. If the bucket contains more than one element (hash collision) then they iterate using the equality. In this case, not providing a custom `equals` is irrelevant, since by "definition", this is a set and hash values should not create a collision.