### PR TITLE
fix missing include in dht_rate_limit test

### DIFF
--- a/simulation/test_dht_rate_limit.cpp
+++ b/simulation/test_dht_rate_limit.cpp
@@ -45,6 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <functional>
 #include <cstdarg>
+#include <cmath>
 
 using namespace libtorrent;
 namespace lt = libtorrent;


### PR DESCRIPTION
cmath is needed for abs(float)