### PR TITLE
simplify disk_io_thread interface

### DIFF
--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -283,7 +283,6 @@ namespace libtorrent
 		~disk_io_thread();
 
 		void set_settings(settings_pack const* sett, alert_manager& alerts);
-		void set_num_threads(int i);
 
 		void abort(bool wait);
 
@@ -357,9 +356,10 @@ namespace libtorrent
 		{ return m_disk_cache.is_disk_buffer(buffer); }
 #endif
 
-		enum thread_type_t {
-			generic_thread,
-			hasher_thread
+		enum class thread_type_t : std::uint8_t
+		{
+			generic,
+			hasher
 		};
 
 		void thread_fun(thread_type_t type, io_service::work w);

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -266,7 +266,6 @@ namespace libtorrent
 		std::shared_ptr<char> dummy;
 		counters cnt;
 		disk_io_thread disk_thread(ios, cnt);
-		disk_thread.set_num_threads(1);
 
 		storage_params params;
 		params.files = &t.files();
@@ -282,7 +281,7 @@ namespace libtorrent
 
 		settings_pack sett;
 		sett.set_int(settings_pack::cache_size, 0);
-		sett.set_int(settings_pack::aio_threads, 2);
+		sett.set_int(settings_pack::aio_threads, 1);
 
 		// TODO: this should probably be optional
 		alert_manager dummy2(0, 0);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1321,7 +1321,8 @@ namespace aux {
 		m_disk_thread.set_settings(&pack, m_alerts);
 
 		if (init && !reopen_listen_port)
-		{	// no need to call this if reopen_listen_port is true
+		{
+			// no need to call this if reopen_listen_port is true
 			// since the apply_pack will do it
 			update_listen_interfaces();
 		}
@@ -5956,8 +5957,6 @@ namespace aux {
 		if (m_settings.get_int(settings_pack::aio_threads) > 1)
 			m_settings.set_int(settings_pack::aio_threads, 1);
 #endif
-
-		m_disk_thread.set_num_threads(m_settings.get_int(settings_pack::aio_threads));
 	}
 
 	void session_impl::update_cache_buffer_chunk_size()

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -451,7 +451,12 @@ void test_check_files(std::string const& test_path
 	boost::asio::io_service ios;
 	counters cnt;
 	disk_io_thread io(ios, cnt);
-	io.set_num_threads(1);
+	settings_pack sett;
+	sett.set_int(settings_pack::aio_threads, 1);
+	// TODO: this should probably be optional
+	alert_manager dummy2(0, 0);
+	io.set_settings(&sett, dummy2);
+
 	disk_buffer_pool dp(16 * 1024, ios, std::bind(&nop));
 	storage_params p;
 	p.files = &fs;


### PR DESCRIPTION
 by setting the number of threads via settings rather than a separate function