### PR TITLE
[RC_1_0] Update ax_boost_system.m4

### DIFF
--- a/m4/ax_boost_system.m4
+++ b/m4/ax_boost_system.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#         http://www.nongnu.org/autoconf-archive/ax_boost_system.html
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_system.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -28,7 +28,10 @@
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
-#   and this notice are preserved.
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 18
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
@@ -37,14 +40,14 @@ AC_DEFUN([AX_BOOST_SYSTEM],
                    [use the System library from boost - it is possible to specify a certain library for the linker
                         e.g. --with-boost-system=boost_system-gcc-mt ]),
         [
-        if test "x$withval" = "xno"; then
+        if test "$withval" = "no"; then
 			want_boost="no"
-        elif test "x$withval" = "xyes"; then
+        elif test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_system_lib=""
         else
 		    want_boost="yes"
-        	ax_boost_user_system_lib="$withval"
+		ax_boost_user_system_lib="$withval"
 		fi
         ],
         [want_boost="yes"]
@@ -65,9 +68,10 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 					   ax_cv_boost_system,
         [AC_LANG_PUSH([C++])
 			 CXXFLAGS_SAVE=$CXXFLAGS
+			 CXXFLAGS=
 
-			 AC_COMPILE_IFELSE(AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
-                                   [[boost::system::system_category]]),
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
+				    [[boost::system::error_category *a = 0;]])],
                    ax_cv_boost_system=yes, ax_cv_boost_system=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
@@ -75,24 +79,24 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 		if test "x$ax_cv_boost_system" = "xyes"; then
 			AC_SUBST(BOOST_CPPFLAGS)
 
-			AC_DEFINE(HAVE_BOOST_SYSTEM,[1],[define if the Boost::System library is available])
+			AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_system_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_system*.{so,dylib,a}* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.so.*$;\1;' -e 's;^lib\(boost_system.*\)\.a*$;\1;' -e 's;^lib\(boost_system.*\)\.dylib$;\1;'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
-  				done
+				done
                 if test "x$link_system" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_system*.{dll,a}* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.dll.*$;\1;' -e 's;^\(boost_system.*\)\.a*$;\1;'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
-  				done
+				done
                 fi
 
             else
@@ -103,12 +107,15 @@ AC_DEFUN([AX_BOOST_SYSTEM],
                   done
 
             fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
 			if test "x$link_system" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi
 
 		CPPFLAGS="$CPPFLAGS_SAVED"
-    	LDFLAGS="$LDFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
 	fi
 ])


### PR DESCRIPTION
I met this problem when doing `configure`:
```
Checking for boost libraries:
checking for boostlib >= 1.36... yes
checking whether the Boost::System library is available... yes
configure: error: Boost.System library not found. Try using --with-boost-system=lib
```
was building with boost 1.62, gcc 6.2.1 on Arch linux.

Updating ax_boost_system.m4 resolves the problem. 
maybe master branch could use the update too.