### PR TITLE
Provide a pieces bitfield in a cache_flushed_alert.

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -209,6 +209,17 @@ list dht_get_peers_reply_alert_peers(dht_get_peers_reply_alert const& a)
     return result;
 }
 
+static object bitfield_to_list(bitfield const& bf)
+{
+    list ret;
+
+    for (bitfield::const_iterator i(bf.begin()), e(bf.end()); i != e; ++i)
+        ret.append(*i);
+    return ret;
+}
+
+object cache_flushed_alert_pieces(cache_flushed_alert const& a) { return bitfield_to_list(a.pieces); }
+
 void bind_alert()
 {
     using boost::noncopyable;
@@ -675,6 +686,7 @@ void bind_alert()
 
     class_<cache_flushed_alert, bases<torrent_alert>, noncopyable>(
         "cache_flushed_alert", no_init)
+        .add_property("pieces", &cache_flushed_alert_pieces)
     ;
 
     class_<anonymous_mode_alert, bases<torrent_alert>, noncopyable>(

--- a/bindings/python/src/torrent_status.cpp
+++ b/bindings/python/src/torrent_status.cpp
@@ -10,7 +10,7 @@
 using namespace boost::python;
 using namespace libtorrent;
 
-object bitfield_to_list(bitfield const& bf)
+static object bitfield_to_list(bitfield const& bf)
 {
 	list ret;
 

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1614,11 +1614,13 @@ namespace libtorrent
 	struct TORRENT_EXPORT cache_flushed_alert TORRENT_FINAL : torrent_alert
 	{
 		// internal
-		cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h, bitfield const& pieces);
 
 		TORRENT_DEFINE_ALERT(cache_flushed_alert, 58)
 
 		static const int static_category = alert::storage_notification;
+
+		bitfield pieces;
 	};
 
 	// This alert is posted when a bittorrent feature is blocked because of the

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -543,6 +543,8 @@ namespace libtorrent
 
 		void status(torrent_status* st, boost::uint32_t flags);
 
+		void fill_pieces(bitfield* pieces, bool complete);
+
 		// this torrent changed state, if the user is subscribing to
 		// it, add it to the m_state_updates list in session_impl
 		void state_updated();
@@ -1152,7 +1154,7 @@ namespace libtorrent
 		void on_storage_moved(disk_io_job const* j);
 		void on_save_resume_data(disk_io_job const* j);
 		void on_file_renamed(disk_io_job const* j);
-		void on_cache_flushed(disk_io_job const* j);
+		void on_cache_flushed(disk_io_job const* j, boost::shared_ptr<bitfield> pieces);
 
 		// upload and download rate limits for the torrent
 		void set_limit_impl(int limit, int channel, bool state_update = true);

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1137,8 +1137,10 @@ namespace libtorrent {
 	}
 
 	cache_flushed_alert::cache_flushed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h) {}
+		, torrent_handle const& h, bitfield const& p)
+		: torrent_alert(alloc, h)
+		, pieces(p)
+		{}
 
 	anonymous_mode_alert::anonymous_mode_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, int k, std::string const& s)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4974,14 +4974,20 @@ namespace libtorrent
 		if (m_storage.get())
 		{
 			inc_refcount("release_files");
+			boost::shared_ptr<bitfield> pieces(new bitfield);
+			fill_pieces(pieces.get(), true);
 			m_ses.disk_thread().async_stop_torrent(m_storage.get()
-				, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1));
+				, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1, pieces));
 		}
 		else
 		{
 			TORRENT_ASSERT(m_abort);
 			if (alerts().should_post<cache_flushed_alert>())
-				alerts().emplace_alert<cache_flushed_alert>(get_handle());
+			{
+				bitfield pieces;
+				pieces.resize(m_torrent_file->num_pieces(), false);
+				alerts().emplace_alert<cache_flushed_alert>(get_handle(), pieces);
+			}
 		}
 
 		m_storage.reset();
@@ -8553,8 +8559,10 @@ namespace libtorrent
 		{
 			// we need to keep the object alive during this operation
 			inc_refcount("release_files");
+			boost::shared_ptr<bitfield> pieces(new bitfield);
+			fill_pieces(pieces.get(), true);
 			m_ses.disk_thread().async_release_files(m_storage.get()
-				, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1));
+				, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1, pieces));
 		}
 
 		// this torrent just completed downloads, which means it will fall
@@ -9713,12 +9721,14 @@ namespace libtorrent
 			TORRENT_ASSERT(m_abort);
 			return;
 		}
+		boost::shared_ptr<bitfield> pieces(new bitfield);
+		fill_pieces(pieces.get(), true);
 		inc_refcount("release_files");
 		m_ses.disk_thread().async_release_files(m_storage.get()
-			, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1));
+			, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1, pieces));
 	}
 
-	void torrent::on_cache_flushed(disk_io_job const*)
+	void torrent::on_cache_flushed(disk_io_job const*, boost::shared_ptr<bitfield> pieces)
 	{
 		dec_refcount("release_files");
 		TORRENT_ASSERT(is_single_thread());
@@ -9726,7 +9736,7 @@ namespace libtorrent
 		if (m_ses.is_aborted()) return;
 
 		if (alerts().should_post<cache_flushed_alert>())
-			alerts().emplace_alert<cache_flushed_alert>(get_handle());
+			alerts().emplace_alert<cache_flushed_alert>(get_handle(), *pieces);
 	}
 
 	bool torrent::is_paused() const
@@ -12167,21 +12177,7 @@ namespace libtorrent
 #endif
 		}
 
-		int num_pieces = m_torrent_file->num_pieces();
-		if (has_picker() && (flags & torrent_handle::query_pieces))
-		{
-			st->pieces.resize(num_pieces, false);
-			for (int i = 0; i < num_pieces; ++i)
-				if (m_picker->has_piece_passed(i)) st->pieces.set_bit(i);
-		}
-		else if (m_have_all)
-		{
-			st->pieces.resize(num_pieces, true);
-		}
-		else
-		{
-			st->pieces.resize(num_pieces, false);
-		}
+		fill_pieces(&st->pieces, flags & torrent_handle::query_pieces);
 		st->num_pieces = num_have();
 		st->num_seeds = num_seeds();
 		if ((flags & torrent_handle::query_distributed_copies) && m_picker.get())
@@ -12203,6 +12199,25 @@ namespace libtorrent
 		}
 
 		st->last_seen_complete = m_swarm_last_seen_complete;
+	}
+
+	void torrent::fill_pieces(bitfield* pieces, bool complete)
+	{
+		int num_pieces = m_torrent_file->num_pieces();
+		if (has_picker() && complete)
+		{
+			pieces->resize(num_pieces, false);
+			for (int i = 0; i < num_pieces; ++i)
+				if (m_picker->has_piece_passed(i)) pieces->set_bit(i);
+		}
+		else if (m_have_all)
+		{
+			pieces->resize(num_pieces, true);
+		}
+		else
+		{
+			pieces->resize(num_pieces, false);
+		}
 	}
 
 	void torrent::add_redundant_bytes(int b, torrent::wasted_reason_t reason)


### PR DESCRIPTION
This is continuing my earlier project.

For some background: I need to read completed pieces directly from disk (deluge can't really make use of read_piece_alert, since it only polls for new alerts every 1s, which murders performance). You can see the deluge plugin I've written for RPC access at: https://github.com/AllSeeingEyeTolledEweSew/Deluge-PieceIO-Plugin

The trouble is that there's no way to figure out which pieces have actually been flushed to disk. I can query the completed pieces then call flush_cache and hope that those were the pieces that got flushed, however I don't know if the resulting cache_flushed_alert was triggered by my flush_cache, or something else (e.g. another client). So I might think a piece has been flushed when it hasn't.

I propose that libtorrent include a list of pieces in cache_flushed_alert, indicating which pieces are known to have been flushed.