### PR TITLE
fix bug: urlseed never timeout

### DIFF
--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -242,7 +242,7 @@ namespace libtorrent
 		void write_have(int index) override;
 		void write_dont_have(int index) override;
 		void write_piece(peer_request const& r, disk_buffer_holder buffer) override;
-		void write_keepalive() override;
+		bool write_keepalive() override;
 		void write_handshake();
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		void write_extensions();

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -700,7 +700,7 @@ namespace libtorrent
 		virtual void write_cancel(peer_request const& r) = 0;
 		virtual void write_have(int index) = 0;
 		virtual void write_dont_have(int index) = 0;
-		virtual void write_keepalive() = 0;
+		virtual bool write_keepalive() = 0;
 		virtual void write_piece(peer_request const& r, disk_buffer_holder buffer) = 0;
 		virtual void write_suggest(int piece) = 0;
 		virtual void write_bitfield() = 0;

--- a/include/libtorrent/web_connection_base.hpp
+++ b/include/libtorrent/web_connection_base.hpp
@@ -87,7 +87,7 @@ namespace libtorrent
 		void write_dont_have(int) {}
 		void write_piece(peer_request const&, disk_buffer_holder)
 		{ TORRENT_ASSERT_FAIL(); }
-		void write_keepalive() {}
+		bool write_keepalive() { return false; }
 		void on_connected();
 		void write_reject_request(peer_request const&) {}
 		void write_allow_fast(int) {}

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2041,7 +2041,7 @@ namespace libtorrent
 	}
 #endif
 
-	void bt_peer_connection::write_keepalive()
+	bool bt_peer_connection::write_keepalive()
 	{
 		INVARIANT_CHECK;
 
@@ -2055,6 +2055,7 @@ namespace libtorrent
 
 		char msg[] = {0,0,0,0};
 		send_buffer(msg, sizeof(msg));
+		return true;
 	}
 
 	void bt_peer_connection::write_cancel(peer_request const& r)

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -6518,7 +6518,6 @@ namespace libtorrent
 		peer_log(peer_log_alert::outgoing_message, "KEEPALIVE");
 #endif
 
-		m_last_sent = aux::time_now();
 		write_keepalive();
 	}
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -6518,7 +6518,9 @@ namespace libtorrent
 		peer_log(peer_log_alert::outgoing_message, "KEEPALIVE");
 #endif
 
-		write_keepalive();
+		if (write_keepalive()) {
+			m_last_sent = aux::time_now();
+		}
 	}
 
 	bool peer_connection::is_seed() const


### PR DESCRIPTION

`m_last_sent` has updated in `peer_connection::on_send_data` function,  update in `peer_connection::keep_alive()` will case `web_connection_base` never timeout.