### PR TITLE
fixed gcc 6 va_list argument passing issue

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2101,8 +2101,7 @@ namespace libtorrent
 	struct TORRENT_EXPORT log_alert final : alert
 	{
 		// internal
-		log_alert(aux::stack_allocator& alloc, char const* log);
-		log_alert(aux::stack_allocator& alloc, char const* fmt, va_list v);
+		log_alert(aux::stack_allocator& alloc, string_view log);
 
 		TORRENT_DEFINE_ALERT(log_alert, 79)
 
@@ -2131,7 +2130,7 @@ namespace libtorrent
 	{
 		// internal
 		torrent_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, char const* fmt, va_list v);
+			, string_view log);
 
 		TORRENT_DEFINE_ALERT(torrent_log_alert, 80)
 
@@ -2172,7 +2171,7 @@ namespace libtorrent
 		peer_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, tcp::endpoint const& i, peer_id const& pi
 			, peer_log_alert::direction_t dir
-			, char const* event, char const* fmt, va_list v);
+			, char const* event, string_view log);
 
 		TORRENT_DEFINE_ALERT(peer_log_alert, 81)
 
@@ -2327,7 +2326,7 @@ namespace libtorrent
 		};
 
 		dht_log_alert(aux::stack_allocator& alloc
-			, dht_module_t m, char const* fmt, va_list v);
+			, dht_module_t m, string_view log);
 
 		static const int static_category = alert::dht_log_notification;
 		TORRENT_DEFINE_ALERT(dht_log_alert, 85)

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -67,27 +67,6 @@ namespace libtorrent { namespace aux
 			return ret;
 		}
 
-		int format_string(char const* fmt, va_list v)
-		{
-			int const ret = int(m_storage.size());
-			m_storage.resize(ret + 512);
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-			int const len = std::vsnprintf(m_storage.data() + ret, 512, fmt, v);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
-			if (len < 0) return copy_string("(format error)");
-
-			// +1 is to include the 0-terminator
-			m_storage.resize(ret + (len > 512 ? 512 : len) + 1);
-			return ret;
-		}
-
 		int copy_buffer(span<char const> buf)
 		{
 			int const ret = int(m_storage.size());

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1666,13 +1666,9 @@ namespace libtorrent {
 		return msg;
 	}
 
-	log_alert::log_alert(aux::stack_allocator& alloc, char const* log)
+	log_alert::log_alert(aux::stack_allocator& alloc, string_view log)
 		: m_alloc(alloc)
 		, m_str_idx(alloc.copy_string(log))
-	{}
-	log_alert::log_alert(aux::stack_allocator& alloc, char const* fmt, va_list v)
-		: m_alloc(alloc)
-		, m_str_idx(alloc.format_string(fmt, v))
 	{}
 
 	char const* log_alert::log_message() const
@@ -1693,9 +1689,9 @@ namespace libtorrent {
 	}
 
 	torrent_log_alert::torrent_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, char const* fmt, va_list v)
+		, string_view log)
 		: torrent_alert(alloc, h)
-		, m_str_idx(alloc.format_string(fmt, v))
+		, m_str_idx(alloc.copy_string(log))
 	{}
 
 	char const* torrent_log_alert::log_message() const
@@ -1719,11 +1715,11 @@ namespace libtorrent {
 		, torrent_handle const& h
 		, tcp::endpoint const& i, peer_id const& pi
 		, peer_log_alert::direction_t dir
-		, char const* event, char const* fmt, va_list v)
+		, char const* event, string_view log)
 		: peer_alert(alloc, h, i, pi)
 		, event_type(event)
 		, direction(dir)
-		, m_str_idx(alloc.format_string(fmt, v))
+		, m_str_idx(alloc.copy_string(log))
 	{}
 
 	char const* peer_log_alert::log_message() const
@@ -1896,10 +1892,10 @@ namespace libtorrent {
 	}
 
 	dht_log_alert::dht_log_alert(aux::stack_allocator& alloc
-		, dht_log_alert::dht_module_t m, const char* fmt, va_list v)
+		, dht_log_alert::dht_module_t m, string_view log)
 		: module(m)
 		, m_alloc(alloc)
-		, m_msg_idx(alloc.format_string(fmt, v))
+		, m_msg_idx(alloc.copy_string(log))
 	{}
 
 	char const* dht_log_alert::log_message() const

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -94,17 +94,17 @@ namespace libtorrent
 		va_start(v, fmt);
 
 		char usr[2048];
-		int len = vsnprintf(usr, sizeof(usr), fmt, v);
+		int len = std::vsnprintf(usr, sizeof(usr), fmt, v);
+		va_end(v);
 
 		static bool prepend_time = true;
 		if (!prepend_time)
 		{
-			prepend_time = (usr[len-1] == '\n');
+			prepend_time = (usr[len - 1] == '\n');
 			std::unique_lock<std::mutex> l(log_mutex);
 			fputs(usr, stderr);
 			return;
 		}
-		va_end(v);
 		char buf[2300];
 		int t = total_milliseconds(clock_type::now() - start);
 		std::snprintf(buf, sizeof(buf), "%05d: [%p] %s", t, pthread_self(), usr);

--- a/src/lsd.cpp
+++ b/src/lsd.cpp
@@ -94,7 +94,7 @@ void lsd::debug_log(char const* fmt, ...) const
 	va_start(v, fmt);
 
 	char buf[1024];
-	vsnprintf(buf, sizeof(buf), fmt, v);
+	std::vsnprintf(buf, sizeof(buf), fmt, v);
 	va_end(v);
 	m_callback.log_lsd(buf);
 }

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -494,18 +494,18 @@ namespace libtorrent
 
 		if (!m_ses.alerts().should_post<peer_log_alert>()) return;
 
+		char msg[512];
 		va_list v;
 		va_start(v, fmt);
+		std::vsnprintf(msg, sizeof(msg), fmt, v);
+		va_end(v);
 
 		torrent_handle h;
 		std::shared_ptr<torrent> t = m_torrent.lock();
 		if (t) h = t->get_handle();
 
 		m_ses.alerts().emplace_alert<peer_log_alert>(
-			h, m_remote, m_peer_id, direction, event, fmt, v);
-
-		va_end(v);
-
+			h, m_remote, m_peer_id, direction, event, msg);
 	}
 #endif
 

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -231,7 +231,6 @@ void peer_connection_handle::peer_log(peer_log_alert::direction_t direction
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
-#pragma clang diagnostic ignored "-Wclass-varargs"
 #endif
 	pc->peer_log(direction, event, fmt, v);
 #ifdef __clang__

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4372,10 +4372,12 @@ namespace aux {
 	{
 		if (!m_alerts.should_post<log_alert>()) return;
 
+		char msg[512];
 		va_list v;
 		va_start(v, fmt);
-		m_alerts.emplace_alert<log_alert>(fmt, v);
+		std::vsnprintf(msg, sizeof(msg), fmt, v);
 		va_end(v);
+		m_alerts.emplace_alert<log_alert>(msg);
 	}
 #endif
 
@@ -6483,11 +6485,13 @@ namespace aux {
 	{
 		if (!m_alerts.should_post<dht_log_alert>()) return;
 
+		char msg[512];
 		va_list v;
 		va_start(v, fmt);
-		m_alerts.emplace_alert<dht_log_alert>(
-			static_cast<dht_log_alert::dht_module_t>(m), fmt, v);
+		std::vsnprintf(msg, sizeof(msg), fmt, v);
 		va_end(v);
+		m_alerts.emplace_alert<dht_log_alert>(
+			static_cast<dht_log_alert::dht_module_t>(m), msg);
 	}
 
 	void session_impl::log_packet(message_direction_t dir, span<char const> pkt
@@ -6849,14 +6853,17 @@ namespace aux {
 			return m_ses.alerts().should_post<log_alert>();
 		}
 
+		TORRENT_FORMAT(2, 3)
 		void tracker_logger::debug_log(const char* fmt, ...) const
 		{
 			if (!m_ses.alerts().should_post<log_alert>()) return;
 
+			char msg[512];
 			va_list v;
 			va_start(v, fmt);
-			m_ses.alerts().emplace_alert<log_alert>(fmt, v);
+			std::vsnprintf(msg, sizeof(msg), fmt, v);
 			va_end(v);
+			m_ses.alerts().emplace_alert<log_alert>(msg);
 		}
 #endif // TORRENT_DISABLE_LOGGING
 }}

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -11045,11 +11045,13 @@ namespace libtorrent
 	{
 		if (!alerts().should_post<torrent_log_alert>()) return;
 
+		char msg[512];
 		va_list v;
 		va_start(v, fmt);
-		alerts().emplace_alert<torrent_log_alert>(
-			const_cast<torrent*>(this)->get_handle(), fmt, v);
+		std::vsnprintf(msg, sizeof(msg), fmt, v);
 		va_end(v);
+		alerts().emplace_alert<torrent_log_alert>(
+			const_cast<torrent*>(this)->get_handle(), msg);
 	}
 #endif
 

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -83,7 +83,7 @@ void utp_log(char const* fmt, ...)
 	std::fprintf(log_file_holder.utp_log_file, "[%012" PRId64 "] ", total_microseconds(clock_type::now() - start));
 	va_list l;
 	va_start(l, fmt);
-	vfprintf(log_file_holder.utp_log_file, fmt, l);
+	std::vfprintf(log_file_holder.utp_log_file, fmt, l);
 	va_end(l);
 }
 

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -489,7 +489,7 @@ struct obs : dht::dht_observer
 		va_list v;
 		va_start(v, fmt);
 		char buf[1024];
-		vsnprintf(buf, sizeof(buf), fmt, v);
+		std::vsnprintf(buf, sizeof(buf), fmt, v);
 		va_end(v);
 		std::printf("%s\n", buf);
 		m_log.push_back(buf);

--- a/test/test_dos_blocker.cpp
+++ b/test/test_dos_blocker.cpp
@@ -52,7 +52,7 @@ struct log_t : libtorrent::dht::dht_logger
 	{
 		va_list v;
 		va_start(v, fmt);
-		vfprintf(stderr, fmt, v);
+		std::vfprintf(stderr, fmt, v);
 		va_end(v);
 	}
 

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -59,7 +59,7 @@ void log(char const* fmt, ...)
 	va_start(v, fmt);
 
 	char buf[1024];
-	vsnprintf(buf, sizeof(buf), fmt, v);
+	std::vsnprintf(buf, sizeof(buf), fmt, v);
 	va_end(v);
 
 	std::printf("\x1b[1m\x1b[36m%s: %s\x1b[0m\n"

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -78,7 +78,7 @@ struct mock_peer_connection
 	{
 		va_list v;
 		va_start(v, fmt);
-		vprintf(fmt, v);
+		std::vprintf(fmt, v);
 		va_end(v);
 	}
 #endif
@@ -136,7 +136,7 @@ struct mock_torrent
 	{
 		va_list v;
 		va_start(v, fmt);
-		vprintf(fmt, v);
+		std::vprintf(fmt, v);
 		va_end(v);
 	}
 #endif


### PR DESCRIPTION
Experimenting with GCC 6 and getting errors like this:
```
/home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/src/session_impl.cpp: In member function ‘virtual void libtorrent::aux::session_impl::session_log(const char*, ...) const’:
/home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/src/session_impl.cpp:4377:43: error: no matching function for call to ‘libtorrent::alert_manager::emplace_alert(const char*&, va_list)’
   m_alerts.emplace_alert<log_alert>(fmt, v);
                                           ^
In file included from /home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/include/libtorrent/aux_/session_impl.hpp:67:0,
                 from /home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/src/session_impl.cpp:77:
/home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/include/libtorrent/alert_manager.hpp:62:8: note: candidate: void libtorrent::alert_manager::emplace_alert(Args&& ...) [with T = libtorrent::log_alert; Args = {const char*&, __va_list_tag (&)[1]}]
   void emplace_alert(Args&&... args)
        ^~~~~~~~~~~~~
/home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/include/libtorrent/alert_manager.hpp:62:8: note:   no known conversion for argument 2 from ‘va_list {aka __va_list_tag [1]}’ to ‘__va_list_tag (&)[1]’
/home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/src/session_impl.cpp: In member function ‘virtual void libtorrent::aux::session_impl::log(libtorrent::dht::dht_logger::module_t, const char*, ...)’:
/home/travis/build/aldenml/frostwire-jlibtorrent/libtorrent/src/session_impl.cpp:6489:55: error: no matching function for call to ‘libtorrent::alert_manager::emplace_alert(libtorrent::dht_log_alert::dht_module_t, const char*&, va_list)’
    static_cast<dht_log_alert::dht_module_t>(m), fmt, v);
```