### PR TITLE
fix windows-version=xp build

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -343,6 +343,12 @@ rule building ( properties * )
 		}
 	}
 
+	if <target-os>windows in $(properties)
+		&& <windows-version>xp in $(properties)
+	{
+		result += <source>src/sha512.cpp ;
+	}
+
 	if ( <toolset>darwin in $(properties)
 		|| <toolset>gcc in $(properties)
 		|| <toolset>clang in $(properties)

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -237,6 +237,17 @@ POSSIBILITY OF SUCH DAMAGE.
 // unless some other crypto library has been specified, default to the native
 // windows CryptoAPI
 #define TORRENT_USE_CRYPTOAPI 1
+
+#ifdef NTDDI_VERSION
+# if (NTDDI_VERSION > NTDDI_WINXPSP2)
+#  define TORRENT_USE_CRYPTOAPI_SHA_512 1
+# endif
+#else // NTDDI_VERSION not defined so use simple _WIN32_WINNT check
+# if _WIN32_WINNT >= 0x0600
+#  define TORRENT_USE_CRYPTOAPI_SHA_512 1
+# endif
+#endif
+
 #endif
 
 #define TORRENT_USE_GETADAPTERSADDRESSES 1
@@ -396,6 +407,10 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef TORRENT_USE_CRYPTOAPI
 #define TORRENT_USE_CRYPTOAPI 0
+#endif
+
+#ifndef TORRENT_USE_CRYPTOAPI_SHA_512
+#define TORRENT_USE_CRYPTOAPI_SHA_512 0
 #endif
 
 #ifndef TORRENT_HAVE_MMAP

--- a/include/libtorrent/hasher512.hpp
+++ b/include/libtorrent/hasher512.hpp
@@ -46,16 +46,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #elif TORRENT_USE_COMMONCRYPTO
 #include <CommonCrypto/CommonDigest.h>
 
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 #include <windows.h>
-#include <wincrypt.h> // CALG_SHA_512 conditionally defined here
-
-#ifdef CALG_SHA_512
-#define TORRENT_USE_CRYPTOAPI_SHA_512 1
-#else
-// fallback to built-in
-#include "libtorrent/sha512.hpp"
-#endif
+#include <wincrypt.h>
 
 #elif defined TORRENT_USE_LIBCRYPTO
 
@@ -65,10 +58,6 @@ extern "C" {
 
 #else
 #include "libtorrent/sha512.hpp"
-#endif
-
-#ifndef TORRENT_USE_CRYPTOAPI_SHA_512
-#define TORRENT_USE_CRYPTOAPI_SHA_512 0
 #endif
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"

--- a/include/libtorrent/hasher512.hpp
+++ b/include/libtorrent/hasher512.hpp
@@ -48,10 +48,12 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #elif TORRENT_USE_CRYPTOAPI
 #include <windows.h>
-#include <wincrypt.h>
+#include <wincrypt.h> // CALG_SHA_512 conditionally defined here
 
+#ifdef CALG_SHA_512
+#define TORRENT_USE_CRYPTOAPI_SHA_512 1
+#else
 // fallback to built-in
-#ifndef CALG_SHA_512
 #include "libtorrent/sha512.hpp"
 #endif
 
@@ -117,7 +119,7 @@ namespace libtorrent
 		gcry_md_hd_t m_context;
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_CTX m_context;
-#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 		HCRYPTHASH m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
 		SHA512_CTX m_context;

--- a/include/libtorrent/hasher512.hpp
+++ b/include/libtorrent/hasher512.hpp
@@ -50,6 +50,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <windows.h>
 #include <wincrypt.h>
 
+// fallback to built-in
+#ifndef CALG_SHA_512
+#include "libtorrent/sha512.hpp"
+#endif
+
 #elif defined TORRENT_USE_LIBCRYPTO
 
 extern "C" {
@@ -112,7 +117,7 @@ namespace libtorrent
 		gcry_md_hd_t m_context;
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_CTX m_context;
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 		HCRYPTHASH m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
 		SHA512_CTX m_context;

--- a/include/libtorrent/hasher512.hpp
+++ b/include/libtorrent/hasher512.hpp
@@ -66,6 +66,11 @@ extern "C" {
 #else
 #include "libtorrent/sha512.hpp"
 #endif
+
+#ifndef TORRENT_USE_CRYPTOAPI_SHA_512
+#define TORRENT_USE_CRYPTOAPI_SHA_512 0
+#endif
+
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 namespace libtorrent

--- a/src/hasher512.cpp
+++ b/src/hasher512.cpp
@@ -35,7 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/openssl.hpp"
 
-#if TORRENT_USE_CRYPTOAPI
+#if TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+ 
 namespace
 {
 	HCRYPTPROV make_crypt_provider()
@@ -76,7 +77,7 @@ namespace libtorrent
 		gcry_md_open(&m_context, GCRY_MD_SHA512, 0);
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Init(&m_context);
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 		if (CryptCreateHash(get_crypt_provider(), CALG_SHA_512, 0, 0, &m_context) == false)
 		{
 #ifndef BOOST_NO_EXCEPTIONS
@@ -111,7 +112,7 @@ namespace libtorrent
 		gcry_md_copy(&m_context, h.m_context);
 		return *this;
 	}
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 	hasher512::hasher512(hasher512 const& h)
 	{
 		if (CryptDuplicateHash(h.m_context, 0, 0, &m_context) == false)
@@ -150,7 +151,7 @@ namespace libtorrent
 		gcry_md_write(m_context, data.data(), data.size());
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data()), data.size());
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 		if (CryptHashData(m_context, reinterpret_cast<BYTE const*>(data.data()), int(data.size()), 0) == false)
 		{
 #ifndef BOOST_NO_EXCEPTIONS
@@ -175,7 +176,7 @@ namespace libtorrent
 		digest.assign((char const*)gcry_md_read(m_context, 0));
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 
 		DWORD size = DWORD(digest.size());
 		if (CryptGetHashParam(m_context, HP_HASHVAL
@@ -202,7 +203,7 @@ namespace libtorrent
 		gcry_md_reset(m_context);
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Init(&m_context);
-#elif TORRENT_USE_CRYPTOAPI
+#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 		CryptDestroyHash(m_context);
 		if (CryptCreateHash(get_crypt_provider(), CALG_SHA_512, 0, 0, &m_context) == false)
 		{
@@ -221,7 +222,7 @@ namespace libtorrent
 
 	hasher512::~hasher512()
 	{
-#if TORRENT_USE_CRYPTOAPI
+#if TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
 		CryptDestroyHash(m_context);
 #elif defined TORRENT_USE_LIBGCRYPT
 		gcry_md_close(m_context);

--- a/src/hasher512.cpp
+++ b/src/hasher512.cpp
@@ -36,7 +36,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/openssl.hpp"
 
 #if TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
- 
 namespace
 {
 	HCRYPTPROV make_crypt_provider()

--- a/src/hasher512.cpp
+++ b/src/hasher512.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/openssl.hpp"
 
-#if TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#if TORRENT_USE_CRYPTOAPI_SHA_512
 namespace
 {
 	HCRYPTPROV make_crypt_provider()
@@ -76,7 +76,7 @@ namespace libtorrent
 		gcry_md_open(&m_context, GCRY_MD_SHA512, 0);
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Init(&m_context);
-#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 		if (CryptCreateHash(get_crypt_provider(), CALG_SHA_512, 0, 0, &m_context) == false)
 		{
 #ifndef BOOST_NO_EXCEPTIONS
@@ -111,7 +111,7 @@ namespace libtorrent
 		gcry_md_copy(&m_context, h.m_context);
 		return *this;
 	}
-#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 	hasher512::hasher512(hasher512 const& h)
 	{
 		if (CryptDuplicateHash(h.m_context, 0, 0, &m_context) == false)
@@ -150,7 +150,7 @@ namespace libtorrent
 		gcry_md_write(m_context, data.data(), data.size());
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data()), data.size());
-#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 		if (CryptHashData(m_context, reinterpret_cast<BYTE const*>(data.data()), int(data.size()), 0) == false)
 		{
 #ifndef BOOST_NO_EXCEPTIONS
@@ -175,7 +175,7 @@ namespace libtorrent
 		digest.assign((char const*)gcry_md_read(m_context, 0));
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
-#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 
 		DWORD size = DWORD(digest.size());
 		if (CryptGetHashParam(m_context, HP_HASHVAL
@@ -202,7 +202,7 @@ namespace libtorrent
 		gcry_md_reset(m_context);
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Init(&m_context);
-#elif TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#elif TORRENT_USE_CRYPTOAPI_SHA_512
 		CryptDestroyHash(m_context);
 		if (CryptCreateHash(get_crypt_provider(), CALG_SHA_512, 0, 0, &m_context) == false)
 		{
@@ -221,7 +221,7 @@ namespace libtorrent
 
 	hasher512::~hasher512()
 	{
-#if TORRENT_USE_CRYPTOAPI && defined(CALG_SHA_512)
+#if TORRENT_USE_CRYPTOAPI_SHA_512
 		CryptDestroyHash(m_context);
 #elif defined TORRENT_USE_LIBGCRYPT
 		gcry_md_close(m_context);


### PR DESCRIPTION
window xp build may fail due CALG_SHA_512 definition absence. let's fallback to built-in hash routine.