### PR TITLE
fix bug: urlseed never timeout

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -6518,7 +6518,7 @@ namespace libtorrent
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::outgoing_message, "KEEPALIVE");
 #endif
- 
+
 		write_keepalive();
 	}
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5555,6 +5555,7 @@ namespace libtorrent
 			&peer_connection::on_send_data, self(), _1, _2)));
 
 		m_channel_state[upload_channel] |= peer_info::bw_network;
+		m_last_sent = aux::time_now();
 	}
 
 	void peer_connection::on_disk()
@@ -6517,8 +6518,7 @@ namespace libtorrent
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::outgoing_message, "KEEPALIVE");
 #endif
-
-		m_last_sent = aux::time_now();
+ 
 		write_keepalive();
 	}
 


### PR DESCRIPTION
updates `m_last_sent` in `peer_connection::setup_send()` instand of `peer_connection::keep_alive()`