### PR TITLE
update stack_allocator to support 0 size allocations

### DIFF
--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -90,8 +90,9 @@ namespace libtorrent { namespace aux
 
 		int copy_buffer(span<char const> buf)
 		{
-			int const ret = int(m_storage.size());
 			int const size = int(buf.size());
+			if (size == 0) return -1;
+			int const ret = int(m_storage.size());
 			m_storage.resize(ret + size);
 			std::memcpy(&m_storage[ret], buf.data(), size);
 			return ret;
@@ -99,7 +100,7 @@ namespace libtorrent { namespace aux
 
 		int allocate(int const bytes)
 		{
-			TORRENT_ASSERT(bytes >= 0);
+			if (bytes < 1) return -1;
 			int const ret = int(m_storage.size());
 			m_storage.resize(ret + bytes);
 			return ret;
@@ -107,15 +108,15 @@ namespace libtorrent { namespace aux
 
 		char* ptr(int const idx)
 		{
-			TORRENT_ASSERT(idx >= 0);
-			TORRENT_ASSERT(idx < int(m_storage.size()));
+			if(idx < 0) return nullptr;
+			if(idx >= int(m_storage.size())) return nullptr;
 			return &m_storage[idx];
 		}
 
 		char const* ptr(int const idx) const
 		{
-			TORRENT_ASSERT(idx >= 0);
-			TORRENT_ASSERT(idx < int(m_storage.size()));
+			if(idx < 0) return nullptr;
+			if(idx >= int(m_storage.size())) return nullptr;
 			return &m_storage[idx];
 		}
 


### PR DESCRIPTION
This fix handles the case when the session emplaces the `dht_get_peers_reply_alert` with zero peers.

The issue is that the `dht_get_peers_reply_alert` constructor doesn't handle the case when zero peers found, resulting in the allocation of 0 bytes in the stack_allocator followed by attempting to ~~access memory~~ get a pointer to location beyond the allocated storage. A `TORRENT_ASSERT` statement in `stack_allocator::ptr(int)` catches this condition and produces:

```
version: 1.1.0.0-044ee0f

file: 'include/libtorrent/stack_allocator.hpp'
line: 80
function: char *libtorrent::aux::stack_allocator::ptr(int)
expression: idx < int(m_storage.size())

stack:
1: assert_fail(char const*, int, char const*, char const*, char const*, int)
2: libtorrent::aux::stack_allocator::ptr(int)
3: libtorrent::dht_get_peers_reply_alert::dht_get_peers_reply_alert(libtorrent::aux::stack_allocator&, libtorrent::sha1_hash const&, std::__1::vector<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, std::__1::allocator<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> > > const&)
4: libtorrent::dht_get_peers_reply_alert::dht_get_peers_reply_alert(libtorrent::aux::stack_allocator&, libtorrent::sha1_hash const&, std::__1::vector<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, std::__1::allocator<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> > > const&)
5: void libtorrent::alert_manager::emplace_alert<libtorrent::dht_get_peers_reply_alert, libtorrent::sha1_hash&, std::__1::vector<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, std::__1::allocator<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> > > const&>(libtorrent::sha1_hash&&&, std::__1::vector<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, std::__1::allocator<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> > > const&&&)
.
.
```

