### PR TITLE
Fix alerts zero allocation for RC_1_1

### DIFF
--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -62,6 +62,7 @@ namespace libtorrent { namespace aux
 		int copy_buffer(char const* buf, int size)
 		{
 			int ret = int(m_storage.size());
+			if (size == 0) return -1;
 			m_storage.resize(ret + size);
 			memcpy(&m_storage[ret], buf, size);
 			return ret;
@@ -69,6 +70,7 @@ namespace libtorrent { namespace aux
 
 		int allocate(int bytes)
 		{
+			if (bytes == 0) return -1;
 			int ret = int(m_storage.size());
 			m_storage.resize(ret + bytes);
 			return ret;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1855,7 +1855,7 @@ namespace libtorrent {
 
 	char const* dht_pkt_alert::pkt_buf() const
 	{
-		return m_alloc.ptr(m_msg_idx);
+		return m_size > 0 ? m_alloc.ptr(m_msg_idx) : nullptr;
 	}
 
 	int dht_pkt_alert::pkt_size() const

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1896,7 +1896,7 @@ namespace libtorrent {
 
 		m_peers_idx = alloc.allocate(total_size);
 
-		char *ptr = alloc.ptr(m_peers_idx);
+		char *ptr = m_num_peers > 0 ? alloc.ptr(m_peers_idx) : nullptr;
 		for (int i = 0; i < m_num_peers; i++) {
 			tcp::endpoint endp = peers[i];
 			std::size_t size = endp.size();
@@ -1931,7 +1931,7 @@ namespace libtorrent {
 	std::vector<tcp::endpoint> dht_get_peers_reply_alert::peers() const {
 		std::vector<tcp::endpoint> peers(m_num_peers);
 
-		const char *ptr = m_alloc.ptr(m_peers_idx);
+		const char *ptr = m_num_peers > 0 ? m_alloc.ptr(m_peers_idx) : nullptr;
 		for (int i = 0; i < m_num_peers; i++) {
 			std::size_t size = detail::read_uint8(ptr);
 			memcpy(peers[i].data(), ptr, size);

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1997,8 +1997,10 @@ namespace libtorrent {
 		std::vector<piece_block> ret;
 		ret.resize(m_num_blocks);
 
-		char const* start = m_alloc.ptr(m_array_idx);
-		memcpy(&ret[0], start, m_num_blocks * sizeof(piece_block));
+		if (m_num_blocks > 0) {
+			char const* start = m_alloc.ptr(m_array_idx);
+			memcpy(&ret[0], start, m_num_blocks * sizeof(piece_block));
+		}
 
 		return ret;
 	}


### PR DESCRIPTION
Implementing similar fixes addressed in: https://github.com/arvidn/libtorrent/pull/1331 to handle the 0 size allocations on the stack_allocator in the following alerts:

- picker_log_alert
- dht_get_peers_reply_alert
- dht_pkt_alert

And updating the stack_allocator::allocate and stack_allocator::copy_buffer methods to return -1 on zero allocation.