### PR TITLE
keep old listen sockets if they're still valid

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -138,6 +138,10 @@ namespace libtorrent
 		// this is a cached local endpoint for the listen TCP socket
 		tcp::endpoint local_endpoint;
 
+		// the name of the device the socket is bound to, may be empty
+		// if the socket is not bound to a device
+		std::string device;
+
 		// this is typically set to the same as the local
 		// listen port. In case a NAT port forward was
 		// successfully opened, this will be set to the

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -142,6 +142,11 @@ namespace libtorrent
 		// if the socket is not bound to a device
 		std::string device;
 
+		// this is the port that was originally specified to listen on
+		// it may be different from local_endpoint.port() if we could
+		// had to retry binding with a higher port
+		int original_port;
+
 		// this is typically set to the same as the local
 		// listen port. In case a NAT port forward was
 		// successfully opened, this will be set to the
@@ -187,6 +192,26 @@ namespace libtorrent
 		TORRENT_EXTRA_EXPORT dht_settings read_dht_settings(bdecode_node const& e);
 		TORRENT_EXTRA_EXPORT entry save_dht_settings(dht_settings const& settings);
 #endif
+
+		struct TORRENT_EXTRA_EXPORT listen_endpoint_t
+		{
+			listen_endpoint_t(address adr, int p, std::string dev, bool s)
+				: addr(adr), port(p), device(dev), ssl(s) {}
+
+			address addr;
+			int port;
+			std::string device;
+			bool ssl;
+		};
+
+		// partitions sockets based on whether they match one of the given endpoints
+		// all matched sockets are ordered before unmatched sockets
+		// matched endpoints are removed from the vector
+		// returns an iterator to the first unmatched socket
+		TORRENT_EXTRA_EXPORT std::list<listen_socket_t>::iterator
+		partition_listen_sockets(
+			std::vector<listen_endpoint_t>& eps
+			, std::list<listen_socket_t>& sockets);
 
 		// this is the link between the main thread and the
 		// thread started to run the main downloader loop

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -103,7 +103,7 @@ namespace libtorrent { namespace
 {
 
 #if !defined TORRENT_BUILD_SIMULATOR
-	address inaddr_to_address(in_addr const* ina, int len = 4)
+	address_v4 inaddr_to_address(in_addr const* ina, int len = 4)
 	{
 		typedef boost::asio::ip::address_v4::bytes_type bytes_t;
 		bytes_t b;
@@ -113,7 +113,7 @@ namespace libtorrent { namespace
 	}
 
 #if TORRENT_USE_IPV6
-	address inaddr6_to_address(in6_addr const* ina6, int len = 16)
+	address_v6 inaddr6_to_address(in6_addr const* ina6, int len = 16)
 	{
 		typedef boost::asio::ip::address_v6::bytes_type bytes_t;
 		bytes_t b;
@@ -139,8 +139,13 @@ namespace libtorrent { namespace
 				, sockaddr_len(sin) - offsetof(sockaddr, sa_data));
 #if TORRENT_USE_IPV6
 		else if (sin->sa_family == AF_INET6 || assume_family == AF_INET6)
-			return inaddr6_to_address(&reinterpret_cast<sockaddr_in6 const*>(sin)->sin6_addr
+		{
+			auto saddr = reinterpret_cast<sockaddr_in6 const*>(sin);
+			auto ret = inaddr6_to_address(&saddr->sin6_addr
 				, sockaddr_len(sin) - offsetof(sockaddr, sa_data));
+			ret.scope_id(saddr->sin6_scope_id);
+			return ret;
+		}
 #endif
 		return address();
 	}

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -146,6 +146,7 @@ test-suite libtorrent :
 		test_enum_net.cpp
 		test_linked_list.cpp
 		test_stack_allocator.cpp
+		test_listen_socket.cpp
 		test_file_progress.cpp ]
 
 	[ run test_piece_picker.cpp ]

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -155,6 +155,7 @@ test_primitives_SOURCES = \
   test_resolve_links.cpp \
   test_crc32.cpp \
   test_heterogeneous_queue.cpp \
+  test_listen_socket.cpp \
   test_ip_voter.cpp \
   test_sliding_average.cpp \
   test_socket_io.cpp \

--- a/test/test_listen_socket.cpp
+++ b/test/test_listen_socket.cpp
@@ -1,0 +1,201 @@
+/*
+
+Copyright (c) 2016, Steven Siloti
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+* Neither the name of the author nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "test.hpp"
+#include "libtorrent/aux_/session_impl.hpp"
+
+using namespace libtorrent;
+
+namespace
+{
+	void test_equal(listen_socket_t const& s, address addr, int port, std::string dev, bool ssl)
+	{
+		TEST_EQUAL(s.ssl, ssl);
+		TEST_EQUAL(s.local_endpoint.address(), addr);
+		TEST_EQUAL(s.original_port, port);
+		TEST_EQUAL(s.device, dev);
+	}
+
+	void test_equal(aux::listen_endpoint_t const& e1, address addr, int port, std::string dev, bool ssl)
+	{
+		TEST_EQUAL(e1.ssl, ssl);
+		TEST_EQUAL(e1.port, port);
+		TEST_EQUAL(e1.addr, addr);
+		TEST_EQUAL(e1.device, dev);
+	}
+}
+
+TORRENT_TEST(partition_listen_sockets)
+{
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(tcp::v4(), 6881);
+		s.original_port = 6881;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(tcp::v6(), 6881);
+		sockets.push_back(s);
+
+		// remove the wildcard v6 socket and replace it with a specific global IP
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v4(), 6881, "", false);
+		eps.emplace_back(address_v6::from_string("2001::1"), 6881, "", false);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_EQUAL(eps.size(), 1);
+		TEST_EQUAL(std::distance(sockets.begin(), remove_iter), 1);
+		TEST_EQUAL(std::distance(remove_iter, sockets.end()), 1);
+		test_equal(sockets.front(), address_v4(), 6881, "", false);
+		test_equal(sockets.back(), address_v6(), 6881, "", false);
+		test_equal(eps.front(), address_v6::from_string("2001::1"), 6881, "", false);
+	}
+
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(tcp::v4(), 6881);
+		s.original_port = 6881;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(tcp::v6(), 6881);
+		sockets.push_back(s);
+
+		// change the ports
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v4(), 6882, "", false);
+		eps.emplace_back(address_v6(), 6882, "", false);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_CHECK(sockets.begin() == remove_iter);
+		TEST_EQUAL(eps.size(), 2);
+	}
+
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(address_v6::from_string("2001::1"), 6881);
+		s.original_port = 6881;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(tcp::v4(), 6881);
+		sockets.push_back(s);
+
+
+		// replace the IPv6 socket with a pair of device bound sockets
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v4(), 6881, "", false);
+		eps.emplace_back(address_v6::from_string("2001::1"), 6881, "eth1", false);
+		eps.emplace_back(address_v6::from_string("2001::2"), 6881, "eth1", false);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_EQUAL(std::distance(sockets.begin(), remove_iter), 1);
+		TEST_EQUAL(std::distance(remove_iter, sockets.end()), 1);
+		test_equal(sockets.front(), address_v4(), 6881, "", false);
+		test_equal(sockets.back(), address_v6::from_string("2001::1"), 6881, "", false);
+		TEST_EQUAL(eps.size(), 2);
+	}
+
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(address_v6::from_string("fe80::d250:99ff:fe0c:9b74"), 6881);
+		s.device = "enp3s0";
+		s.original_port = 6881;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(address_v6::from_string("2001::1"), 6881);
+		sockets.push_back(s);
+
+		// change the global IP of a device bound socket
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v6::from_string("fe80::d250:99ff:fe0c:9b74"), 6881, "enp3s0", false);
+		eps.emplace_back(address_v6::from_string("2001::2"), 6881, "enp3s0", false);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_EQUAL(std::distance(sockets.begin(), remove_iter), 1);
+		TEST_EQUAL(std::distance(remove_iter, sockets.end()), 1);
+		test_equal(sockets.front(), address_v6::from_string("fe80::d250:99ff:fe0c:9b74"), 6881, "enp3s0", false);
+		test_equal(sockets.back(), address_v6::from_string("2001::1"), 6881, "enp3s0", false);
+		TEST_EQUAL(eps.size(), 1);
+		test_equal(eps.front(), address_v6::from_string("2001::2"), 6881, "enp3s0", false);
+	}
+
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(tcp::v4(), 6883);
+		s.original_port = 6881;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(tcp::v6(), 6883);
+		sockets.push_back(s);
+
+		// make sure all sockets are kept when the actual port is different from the original
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v4(), 6881, "", false);
+		eps.emplace_back(address_v6(), 6881, "", false);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_CHECK(remove_iter == sockets.end());
+		TEST_CHECK(eps.empty());
+	}
+
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(tcp::v4(), 6881);
+		s.original_port = 6881;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(tcp::v6(), 6881);
+		sockets.push_back(s);
+
+		// add ssl sockets
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v4(), 6881, "", false);
+		eps.emplace_back(address_v6(), 6881, "", false);
+		eps.emplace_back(address_v4(), 6881, "", true);
+		eps.emplace_back(address_v6(), 6881, "", true);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_CHECK(remove_iter == sockets.end());
+		TEST_EQUAL(eps.size(), 2);
+	}
+
+	{
+		std::list<listen_socket_t> sockets;
+		listen_socket_t s;
+		s.local_endpoint = tcp::endpoint(tcp::v4(), 6881);
+		s.original_port = 0;
+		sockets.push_back(s);
+		s.local_endpoint = tcp::endpoint(tcp::v6(), 6881);
+		sockets.push_back(s);
+
+		// replace OS assigned ports with explicit ports
+		std::vector<aux::listen_endpoint_t> eps;
+		eps.emplace_back(address_v4(), 6882, "", false);
+		eps.emplace_back(address_v6(), 6882, "", false);
+		auto remove_iter = aux::partition_listen_sockets(eps, sockets);
+		TEST_CHECK(remove_iter == sockets.begin());
+		TEST_EQUAL(eps.size(), 2);
+	}
+
+}

--- a/test/test_listen_socket.cpp
+++ b/test/test_listen_socket.cpp
@@ -30,6 +30,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#if TORRENT_USE_IPV6
+
 #include "test.hpp"
 #include "libtorrent/aux_/session_impl.hpp"
 
@@ -199,3 +201,5 @@ TORRENT_TEST(partition_listen_sockets)
 	}
 
 }
+
+#endif


### PR DESCRIPTION
This is to support multi-home. We need to be able to keep track of which socket
a DHT node or UTP connection should use. We also need to generate notifications
when local endpoints come and go so that the DHT tracker knows when to create
or delete nodes. The easiest way to do this is to keep the same socket for as
long as its local endpoint is valid. This way the nodes and connections can
simply reference the socket itself and generating notifications is trivial.