### PR TITLE
Cast cached_piece_info::kind to int.

### DIFF
--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -477,7 +477,7 @@ namespace
           d["piece"] = i->piece;
           d["last_use"] = total_milliseconds(now - i->last_use) / 1000.f;
           d["next_to_hash"] = i->next_to_hash;
-          d["kind"] = i->kind;
+          d["kind"] = static_cast<int>(i->kind);
           pieces.append(d);
        }
        return pieces;


### PR DESCRIPTION
Following up on previous commits: it turned out cached_piece_info::kind_t wouldn't automatically convert. I needed to cast it to int.

I'm open to suggestions on how I could test this in `test.py`.