### PR TITLE
Clarify documentation

### DIFF
--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -347,7 +347,7 @@ namespace libtorrent
 		// and they have the same name.
 		bool m_multifile:1;
 
-		// this is true if the torrent is private. i.e., is should not
+		// this is true if the torrent is private. i.e., its interested peers should not
 		// be announced on the dht
 		bool m_private:1;
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -397,7 +397,7 @@ namespace libtorrent
 		// metadata resolved yet or not.
 		bool is_valid() const { return m_files.is_valid(); }
 
-		// returns true if this torrent is private. i.e., it should not be
+		// returns true if this torrent is private. i.e., its interested peers should not be
 		// distributed on the trackerless network (the kademlia DHT).
 		bool priv() const { return (m_flags & private_torrent) != 0; }
 


### PR DESCRIPTION
The current expression could mislead someone to think that the torrent is distributed (or announced) on Kademlia DHT.

The suggested expression should clarify, that Kademlia DHT, unless the torrent is private, distributes the its interested peers.
