### PR TITLE
don't indicate interest in peers when in upload only mode

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1929,7 +1929,7 @@ namespace libtorrent
 		// calling disconnect_if_redundant, otherwise we may disconnect even if
 		// we are interested
 		if (!t->has_piece_passed(index)
-			&& !t->is_seed()
+			&& !t->is_upload_only()
 			&& !is_interesting()
 			&& (!t->has_picker() || t->picker().piece_priority(index) != 0))
 			t->peer_is_interesting(*this);


### PR DESCRIPTION
If the torrent is paused we don't want to mark peers as interesting
even if the torrent has not finished downloading.