### PR TITLE
submit disk jobs from read_piece right away

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1028,6 +1028,8 @@ namespace libtorrent
 				get_handle(), r.piece, rp->piece_data, 0);
 			return;
 		}
+
+		m_ses.deferred_submit_jobs();
 		for (int i = 0; i < blocks_in_piece; ++i, r.start += block_size())
 		{
 			r.length = (std::min)(piece_size - r.start, block_size());


### PR DESCRIPTION
Without this the jobs get submitted on the next tick which may take a while.