### PR TITLE
added size and resize methods to aux::vector

### DIFF
--- a/include/libtorrent/aux_/vector.hpp
+++ b/include/libtorrent/aux_/vector.hpp
@@ -52,21 +52,38 @@ namespace libtorrent { namespace aux {
 		{
 			TORRENT_ASSERT(idx >= IndexType(0));
 			TORRENT_ASSERT(idx < end_index());
-			return this->base::operator[](static_cast<underlying_index>(idx));
+			return this->base::operator[](std::size_t(static_cast<underlying_index>(idx)));
 		}
 
 		auto operator[](IndexType idx) -> decltype(this->base::operator[](underlying_index()))
 		{
 			TORRENT_ASSERT(idx >= IndexType(0));
 			TORRENT_ASSERT(idx < end_index());
-			return this->base::operator[](static_cast<underlying_index>(idx));
+			return this->base::operator[](std::size_t(static_cast<underlying_index>(idx)));
 		}
 
 		IndexType end_index() const
-		{ return IndexType(static_cast<underlying_index>(this->size())); }
+		{ return IndexType(static_cast<underlying_index>(this->base::size())); }
+
+		underlying_index size() const
+		{ return static_cast<underlying_index>(this->base::size()); }
+
+		void resize(underlying_index s)
+		{
+			TORRENT_ASSERT(s >= 0);
+			TORRENT_ASSERT(s <= std::numeric_limits<underlying_index>::max());
+			TORRENT_ASSERT(std::size_t(s) <= std::numeric_limits<std::size_t>::max());
+			this->base::resize(std::size_t(s));
+		}
+		void resize(underlying_index s, T const& v)
+		{
+			TORRENT_ASSERT(s >= 0);
+			TORRENT_ASSERT(s <= std::numeric_limits<underlying_index>::max());
+			TORRENT_ASSERT(std::size_t(s) <= std::numeric_limits<std::size_t>::max());
+			this->base::resize(std::size_t(s), v);
+		}
 	};
 
 }}
 
 #endif
-

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -576,12 +576,12 @@ namespace libtorrent
 			std::set<const torrent_peer*> have_peers;
 #endif
 
-			enum : std::uint32_t
+			enum : std::int32_t
 			{
 				// index is set to this to indicate that we have the
 				// piece. There is no entry for the piece in the
 				// buckets if this is the case.
-				we_have_index = 0xffffffff,
+				we_have_index = 0x7fffffff,
 				// the priority value that means the piece is filtered
 				filter_priority = 0,
 				// the max number the peer count can hold


### PR DESCRIPTION
OK, this is mainly for your consideration. I find this a good way to express that the vector can't be expanded beyond the natural limit of the index and in the process, a lot of `sign-conversion` warnings should be eliminated.