### PR TITLE
make buffer_allocator_interface an implementation detail of the disk_io_thread

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -613,17 +613,12 @@ namespace libtorrent
 
 			void deferred_submit_jobs() override;
 
-			char* allocate_buffer() override;
+			ses_buffer_holder allocate_buffer() override;
 			torrent_peer* allocate_peer_entry(int type);
 			void free_peer_entry(torrent_peer* p);
 
 			void free_buffer(char* buf) override;
 			int send_buffer_size() const override { return send_buffer_size_impl; }
-
-			// implements buffer_allocator_interface
-			void free_disk_buffer(char* buf) override;
-			void reclaim_blocks(span<block_cache_reference> refs) override;
-			void do_reclaim_blocks();
 
 			// implements dht_observer
 			virtual void set_external_address(address const& ip
@@ -1138,12 +1133,6 @@ namespace libtorrent
 			// within the LSD announce interval (which defaults to
 			// 5 minutes)
 			torrent_map::iterator m_next_lsd_torrent;
-
-			// we try to return disk buffers to the disk thread in batches, to
-			// avoid hammering its mutex. We accrue blocks here and defer returning
-			// them in a function we post to the io_service
-			std::vector<block_cache_reference> m_blocks_to_reclaim;
-			bool m_pending_block_reclaim = false;
 
 #ifndef TORRENT_DISABLE_DHT
 			// torrents are announced on the DHT in a

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -118,13 +118,14 @@ namespace libtorrent { namespace aux
 	};
 #endif // TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
 
+	struct ses_buffer_holder;
+
 	// TODO: 2 make this interface a lot smaller. It could be split up into
 	// several smaller interfaces. Each subsystem could then limit the size
 	// of the mock object to test it.
 	struct TORRENT_EXTRA_EXPORT session_interface
-		: buffer_allocator_interface
 #if !defined TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
-		, session_logger
+		: session_logger
 #endif
 	{
 		// TODO: 2 the IP voting mechanism should be factored out
@@ -193,7 +194,7 @@ namespace libtorrent { namespace aux
 		virtual void close_connection(peer_connection* p, error_code const& ec) = 0;
 		virtual int num_connections() const = 0;
 
-		virtual char* allocate_buffer() = 0;
+		virtual ses_buffer_holder allocate_buffer() = 0;
 		virtual void free_buffer(char* buf) = 0;
 		virtual int send_buffer_size() const = 0;
 
@@ -320,6 +321,29 @@ namespace libtorrent { namespace aux
 		virtual void sent_buffer(int size) = 0;
 	protected:
 		~session_interface() {}
+	};
+
+	struct ses_buffer_holder
+	{
+		ses_buffer_holder(session_interface& ses, char* buf)
+			: m_ses(&ses), m_buf(buf) {}
+		~ses_buffer_holder() { if (m_buf) m_ses->free_buffer(m_buf); }
+		ses_buffer_holder(ses_buffer_holder const&) = delete;
+		ses_buffer_holder& operator=(ses_buffer_holder const&) = delete;
+		ses_buffer_holder(ses_buffer_holder&& rhs)
+			: m_ses(rhs.m_ses), m_buf(rhs.m_buf) { rhs.m_buf = nullptr; }
+		ses_buffer_holder& operator=(ses_buffer_holder&& rhs)
+		{
+			if (m_buf) m_ses->free_buffer(m_buf);
+			m_buf = rhs.m_buf;
+			m_ses = rhs.m_ses;
+			rhs.m_buf = nullptr;
+			return *this;
+		}
+		char* get() const { return m_buf; }
+		private:
+		session_interface* m_ses;
+		char* m_buf;
 	};
 }}
 

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -330,9 +330,9 @@ namespace libtorrent { namespace aux
 		~ses_buffer_holder() { if (m_buf) m_ses->free_buffer(m_buf); }
 		ses_buffer_holder(ses_buffer_holder const&) = delete;
 		ses_buffer_holder& operator=(ses_buffer_holder const&) = delete;
-		ses_buffer_holder(ses_buffer_holder&& rhs)
+		ses_buffer_holder(ses_buffer_holder&& rhs) noexcept
 			: m_ses(rhs.m_ses), m_buf(rhs.m_buf) { rhs.m_buf = nullptr; }
-		ses_buffer_holder& operator=(ses_buffer_holder&& rhs)
+		ses_buffer_holder& operator=(ses_buffer_holder&& rhs) noexcept
 		{
 			if (m_buf) m_ses->free_buffer(m_buf);
 			m_buf = rhs.m_buf;
@@ -340,8 +340,8 @@ namespace libtorrent { namespace aux
 			rhs.m_buf = nullptr;
 			return *this;
 		}
-		char* get() const { return m_buf; }
-		private:
+		char* get() const noexcept { return m_buf; }
+	private:
 		session_interface* m_ses;
 		char* m_buf;
 	};

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -314,10 +314,24 @@ public:
 		// these functions encrypt the send buffer if m_rc4_encrypted
 		// is true, otherwise it passes the call to the
 		// peer_connection functions of the same names
-		virtual void append_const_send_buffer(char const* buffer, int size
-			, chained_buffer::free_buffer_fun destructor = &nop
-			, void* userdata = nullptr, aux::block_cache_reference ref
-			= aux::block_cache_reference()) override;
+		template <typename Holder>
+		void append_const_send_buffer(char const* buffer, int size, Holder h)
+		{
+#if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
+			if (!m_enc_handler.is_send_plaintext())
+			{
+				// if we're encrypting this buffer, we need to make a copy
+				// since we'll mutate it
+				std::unique_ptr<char[]> buf(new char[size]);
+				std::memcpy(buf.get(), buffer, size);
+				append_send_buffer(buf.get(), size, std::move(buf));
+			}
+			else
+#endif
+			{
+				append_send_buffer(const_cast<char*>(buffer), size, std::move(h));
+			}
+		}
 
 private:
 

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -309,13 +309,13 @@ namespace libtorrent
 		void rc4_decrypt(span<char> buf);
 #endif
 
-public:
+	public:
 
 		// these functions encrypt the send buffer if m_rc4_encrypted
 		// is true, otherwise it passes the call to the
 		// peer_connection functions of the same names
 		template <typename Holder>
-		void append_const_send_buffer(char const* buffer, int size, Holder h)
+		void append_const_send_buffer(Holder buffer, int size)
 		{
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 			if (!m_enc_handler.is_send_plaintext())
@@ -323,17 +323,17 @@ public:
 				// if we're encrypting this buffer, we need to make a copy
 				// since we'll mutate it
 				std::unique_ptr<char[]> buf(new char[size]);
-				std::memcpy(buf.get(), buffer, size);
-				append_send_buffer(buf.get(), size, std::move(buf));
+				std::memcpy(buf.get(), buffer.get(), size);
+				append_send_buffer(std::move(buf), size);
 			}
 			else
 #endif
 			{
-				append_send_buffer(const_cast<char*>(buffer), size, std::move(h));
+				append_send_buffer(std::move(buffer), size);
 			}
 		}
 
-private:
+	private:
 
 		enum class state_t : std::uint8_t
 		{

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -45,11 +45,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/asio/buffer.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
-//#ifdef _MSC_VER
+#ifdef _MSC_VER
 // visual studio requires the value in a deque to be copyable or movable. C++11
 // only requires that when calling functions with those requirements
 #define TORRENT_CPP98_DEQUE 1
-//#endif
+#else
+#define TORRENT_CPP98_DEQUE 0
+#endif
 
 namespace libtorrent
 {
@@ -96,12 +98,16 @@ namespace libtorrent
 				move_holder(&holder, &rhs.holder);
 				return *this;
 			}
+			buffer_t(buffer_t const& rhs) noexcept
+				: buffer_t(std::move(const_cast<buffer_t&>(rhs))) {}
+			buffer_t& operator=(buffer_t const& rhs) noexcept
+			{ return this->operator=(std::move(const_cast<buffer_t&>(rhs))); }
 #else
 			buffer_t(buffer_t&&) = delete;
 			buffer_t& operator=(buffer_t&&) = delete;
-#endif
 			buffer_t(buffer_t const&) = delete;
 			buffer_t& operator=(buffer_t const&) = delete;
+#endif
 
 			destruct_holder_fun destruct_holder;
 #if TORRENT_CPP98_DEQUE

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -74,7 +74,7 @@ namespace libtorrent
 		{
 			buffer_t() {}
 #if TORRENT_CPP98_DEQUE
-			buffer_t(buffer_t&& rhs)
+			buffer_t(buffer_t&& rhs) noexcept
 			{
 				destruct_holder = rhs.destruct_holder;
 				move_holder = rhs.move_holder;
@@ -84,7 +84,7 @@ namespace libtorrent
 				used_size = rhs.used_size;
 				move_holder(&holder, &rhs.holder);
 			}
-			buffer_t& operator=(buffer_t&& rhs)
+			buffer_t& operator=(buffer_t&& rhs) noexcept
 			{
 				destruct_holder(&holder);
 				destruct_holder = rhs.destruct_holder;

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -90,8 +90,19 @@ namespace libtorrent
 			buffer_t& b = m_vec.back();
 
 			static_assert(sizeof(Holder) <= sizeof(b.holder), "buffer holder too large");
+
+#ifdef _MSC_VER
+// this appears to be a false positive msvc warning
+#pragma warning(push, 1)
+#pragma warning(disable : 4100)
+#endif
 			b.destruct_holder = [](void* holder)
 			{ reinterpret_cast<Holder*>(holder)->~Holder(); };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 			new (&b.holder) Holder(std::move(h));
 			b.buf = buffer;
 			b.size = s;
@@ -112,8 +123,19 @@ namespace libtorrent
 			buffer_t& b = m_vec.front();
 
 			static_assert(sizeof(Holder) <= sizeof(b.holder), "buffer holder too large");
+
+#ifdef _MSC_VER
+// this appears to be a false positive msvc warning
+#pragma warning(push, 1)
+#pragma warning(disable : 4100)
+#endif
 			b.destruct_holder = [](void* holder)
 			{ reinterpret_cast<Holder*>(holder)->~Holder(); };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 			new (&b.holder) Holder(std::move(h));
 			b.buf = buffer;
 			b.size = s;

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -63,6 +63,12 @@ namespace libtorrent
 
 		struct buffer_t
 		{
+			buffer_t() {}
+			buffer_t(buffer_t&&) = delete;
+			buffer_t(buffer_t const&) = delete;
+			buffer_t& operator=(buffer_t&&) = delete;
+			buffer_t& operator=(buffer_t const&) = delete;
+
 			free_buffer_fun destruct_holder;
 			std::aligned_storage<32>::type holder;
 			// TODO: 2 the pointers here should probably be const, since
@@ -86,7 +92,7 @@ namespace libtorrent
 		{
 			TORRENT_ASSERT(is_single_thread());
 			TORRENT_ASSERT(s >= used_size);
-			m_vec.push_back(buffer_t());
+			m_vec.emplace_back();
 			buffer_t& b = m_vec.back();
 
 			static_assert(sizeof(Holder) <= sizeof(b.holder), "buffer holder too large");
@@ -119,7 +125,7 @@ namespace libtorrent
 		{
 			TORRENT_ASSERT(is_single_thread());
 			TORRENT_ASSERT(s >= used_size);
-			m_vec.push_front(buffer_t());
+			m_vec.emplace_front();
 			buffer_t& b = m_vec.front();
 
 			static_assert(sizeof(Holder) <= sizeof(b.holder), "buffer holder too large");

--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -39,7 +39,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 #include "libtorrent/units.hpp"
+#include "libtorrent/disk_buffer_holder.hpp"
 #include "libtorrent/aux_/vector.hpp"
+#include "libtorrent/export.hpp"
 
 namespace libtorrent
 {
@@ -51,6 +53,9 @@ namespace libtorrent
 	struct cache_status;
 	struct disk_buffer_holder;
 	struct counters;
+	struct settings_pack;
+	struct storage_params;
+	class file_storage;
 
 	enum class status_t : std::uint8_t
 	{
@@ -76,8 +81,8 @@ namespace libtorrent
 		};
 
 		virtual void async_read(storage_interface* storage, peer_request const& r
-			, std::function<void(aux::block_cache_reference ref, char* block
-				, int flags, storage_error const& se)> handler, void* requester, std::uint8_t flags = 0) = 0;
+			, std::function<void(disk_buffer_holder block, int flags, storage_error const& se)> handler
+			, void* requester, std::uint8_t flags = 0) = 0;
 		virtual bool async_write(storage_interface* storage, peer_request const& r
 			, char const* buf, std::shared_ptr<disk_observer> o
 			, std::function<void(storage_error const&)> handler

--- a/include/libtorrent/disk_io_job.hpp
+++ b/include/libtorrent/disk_io_job.hpp
@@ -57,6 +57,7 @@ namespace libtorrent
 	struct cached_piece_entry;
 	class torrent_info;
 	struct add_torrent_params;
+	struct buffer_allocator_interface;
 
 	// disk_io_jobs are allocated in a pool allocator in disk_io_thread
 	// they are always allocated from the network thread, posted
@@ -77,7 +78,7 @@ namespace libtorrent
 		disk_io_job(disk_io_job const&) = delete;
 		disk_io_job& operator=(disk_io_job const&) = delete;
 
-		void call_callback();
+		void call_callback(buffer_allocator_interface&);
 
 		enum action_t : std::uint8_t
 		{
@@ -146,8 +147,7 @@ namespace libtorrent
 
 		// this is called when operation completes
 
-		using read_handler = std::function<void(aux::block_cache_reference ref
-			, char* block, int flags, storage_error const& se)>;
+		using read_handler = std::function<void(disk_buffer_holder block, int flags, storage_error const& se)>;
 		using write_handler = std::function<void(storage_error const&)>;
 		using hash_handler = std::function<void(piece_index_t, sha1_hash const&, storage_error const&)>;
 		using move_handler = std::function<void(status_t, std::string const&, storage_error const&)>;

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -292,7 +292,7 @@ namespace libtorrent
 		void abort(bool wait);
 
 		void async_read(storage_interface* storage, peer_request const& r
-			, std::function<void(aux::block_cache_reference ref, char* block
+			, std::function<void(disk_buffer_holder block
 				, int flags, storage_error const& se)> handler, void* requester, std::uint8_t flags = 0) override;
 		bool async_write(storage_interface* storage, peer_request const& r
 			, char const* buf, std::shared_ptr<disk_observer> o

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -137,7 +137,6 @@ namespace libtorrent
 		aux::session_interface* ses;
 		aux::session_settings const* sett;
 		counters* stats_counters;
-		buffer_allocator_interface* allocator;
 		disk_interface* disk_thread;
 		io_service* ios;
 		std::weak_ptr<torrent> tor;
@@ -147,7 +146,7 @@ namespace libtorrent
 	};
 
 	// internal
-	inline void nop(char*, void*, aux::block_cache_reference) {}
+	struct nop {};
 
 	struct TORRENT_EXTRA_EXPORT peer_connection_hot_members
 	{
@@ -626,15 +625,12 @@ namespace libtorrent
 		void send_buffer(char const* begin, int size, int flags = 0);
 		void setup_send();
 
-		void append_send_buffer(char* buffer, int size
-			, chained_buffer::free_buffer_fun destructor = &nop
-			, void* userdata = nullptr, aux::block_cache_reference ref
-			= aux::block_cache_reference());
-
-		virtual void append_const_send_buffer(char const* buffer, int size
-			, chained_buffer::free_buffer_fun destructor = &nop
-			, void* userdata = nullptr, aux::block_cache_reference ref
-			= aux::block_cache_reference());
+		template <typename Holder>
+		void append_send_buffer(char* buffer, int size, Holder h)
+		{
+			TORRENT_ASSERT(is_single_thread());
+			m_send_buffer.append_buffer(buffer, size, size, std::move(h));
+		}
 
 		int outstanding_bytes() const { return m_outstanding_bytes; }
 
@@ -758,9 +754,8 @@ namespace libtorrent
 
 		void do_update_interest();
 		void fill_send_buffer();
-		void on_disk_read_complete(aux::block_cache_reference ref
-			, char* disk_block, int flags, storage_error const& error, peer_request r
-			, time_point issue_time);
+		void on_disk_read_complete(disk_buffer_holder disk_block, int flags
+			, storage_error const& error, peer_request r, time_point issue_time);
 		void on_disk_write_complete(storage_error const& error
 			, peer_request r, std::shared_ptr<torrent> t);
 		void on_seed_mode_hashed(piece_index_t piece
@@ -831,10 +826,6 @@ namespace libtorrent
 
 		// the disk thread to use to issue disk jobs to
 		disk_interface& m_disk_thread;
-
-	public:
-		buffer_allocator_interface& m_allocator;
-	private:
 
 		// io service
 		io_service& m_ios;

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -146,7 +146,13 @@ namespace libtorrent
 	};
 
 	// internal
-	struct nop {};
+	struct nop
+	{
+		nop(char* b) : m_buf(b) {}
+		char* get() const { return m_buf; }
+	private:
+		char* m_buf;
+	};
 
 	struct TORRENT_EXTRA_EXPORT peer_connection_hot_members
 	{
@@ -626,10 +632,10 @@ namespace libtorrent
 		void setup_send();
 
 		template <typename Holder>
-		void append_send_buffer(char* buffer, int size, Holder h)
+		void append_send_buffer(Holder buffer, int size)
 		{
 			TORRENT_ASSERT(is_single_thread());
-			m_send_buffer.append_buffer(buffer, size, size, std::move(h));
+			m_send_buffer.append_buffer(std::move(buffer), size, size);
 		}
 
 		int outstanding_bytes() const { return m_outstanding_bytes; }

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -148,7 +148,7 @@ namespace libtorrent
 	// internal
 	struct nop
 	{
-		nop(char* b) : m_buf(b) {}
+		explicit nop(char* b) : m_buf(b) {}
 		char* get() const { return m_buf; }
 	private:
 		char* m_buf;

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -392,8 +392,7 @@ namespace libtorrent
 			error_code error;
 		};
 		void read_piece(piece_index_t piece);
-		void on_disk_read_complete(aux::block_cache_reference ref
-			, char* block, int flags, storage_error const& se
+		void on_disk_read_complete(disk_buffer_holder block, int flags, storage_error const& se
 			, peer_request r, std::shared_ptr<read_piece_struct> rp);
 
 		storage_mode_t storage_mode() const;

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2465,11 +2465,11 @@ namespace libtorrent
 
 		if (buffer.ref().storage == nullptr)
 		{
-			append_send_buffer(buffer.get(), r.length, std::move(buffer));
+			append_send_buffer(std::move(buffer), r.length);
 		}
 		else
 		{
-			append_const_send_buffer(buffer.get(), r.length, std::move(buffer));
+			append_const_send_buffer(std::move(buffer), r.length);
 		}
 
 		m_payloads.push_back(range(send_buffer_size() - r.length, r.length));

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2471,7 +2471,6 @@ namespace libtorrent
 		{
 			append_const_send_buffer(buffer.get(), r.length, std::move(buffer));
 		}
-		buffer.release();
 
 		m_payloads.push_back(range(send_buffer_size() - r.length, r.length));
 		setup_send();

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -733,14 +733,6 @@ namespace libtorrent
 		m_rc4->decrypt(buf);
 	}
 
-	namespace {
-		void regular_c_free(char* buf, void* /* userdata */
-			, aux::block_cache_reference /* ref */)
-		{
-			std::free(buf);
-		}
-	}
-
 #endif // #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)
 
 	void bt_peer_connection::write_handshake()

--- a/src/chained_buffer.cpp
+++ b/src/chained_buffer.cpp
@@ -40,6 +40,7 @@ namespace libtorrent
 	void chained_buffer::pop_front(int bytes_to_pop)
 	{
 		TORRENT_ASSERT(is_single_thread());
+		TORRENT_ASSERT(!m_destructed);
 		TORRENT_ASSERT(bytes_to_pop <= m_bytes);
 		while (bytes_to_pop > 0 && !m_vec.empty())
 		{
@@ -71,8 +72,11 @@ namespace libtorrent
 	int chained_buffer::space_in_last_buffer()
 	{
 		TORRENT_ASSERT(is_single_thread());
+		TORRENT_ASSERT(!m_destructed);
 		if (m_vec.empty()) return 0;
 		buffer_t& b = m_vec.back();
+		TORRENT_ASSERT(b.start != nullptr);
+		TORRENT_ASSERT(b.buf != nullptr);
 		return b.size - b.used_size - int(b.start - b.buf);
 	}
 
@@ -82,7 +86,8 @@ namespace libtorrent
 	char* chained_buffer::append(char const* buf, int s)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		char* insert = allocate_appendix(s);
+		TORRENT_ASSERT(!m_destructed);
+		char* const insert = allocate_appendix(s);
 		if (insert == nullptr) return nullptr;
 		std::memcpy(insert, buf, s);
 		return insert;
@@ -94,9 +99,12 @@ namespace libtorrent
 	char* chained_buffer::allocate_appendix(int s)
 	{
 		TORRENT_ASSERT(is_single_thread());
+		TORRENT_ASSERT(!m_destructed);
 		if (m_vec.empty()) return nullptr;
 		buffer_t& b = m_vec.back();
-		char* insert = b.start + b.used_size;
+		TORRENT_ASSERT(b.start != nullptr);
+		TORRENT_ASSERT(b.buf != nullptr);
+		char* const insert = b.start + b.used_size;
 		if (insert + s > b.buf + b.size) return nullptr;
 		b.used_size += s;
 		m_bytes += s;
@@ -107,6 +115,7 @@ namespace libtorrent
 	std::vector<boost::asio::const_buffer> const& chained_buffer::build_iovec(int to_send)
 	{
 		TORRENT_ASSERT(is_single_thread());
+		TORRENT_ASSERT(!m_destructed);
 		m_tmp_vec.clear();
 		build_vec(to_send, m_tmp_vec);
 		return m_tmp_vec;
@@ -114,14 +123,18 @@ namespace libtorrent
 
 	void chained_buffer::build_mutable_iovec(int bytes, std::vector<span<char>> &vec)
 	{
+		TORRENT_ASSERT(!m_destructed);
 		build_vec(bytes, vec);
 	}
 
 	template <typename Buffer>
 	void chained_buffer::build_vec(int bytes, std::vector<Buffer>& vec)
 	{
+		TORRENT_ASSERT(!m_destructed);
 		for (auto i = m_vec.begin(), end(m_vec.end()); bytes > 0 && i != end; ++i)
 		{
+			TORRENT_ASSERT(i->start != nullptr);
+			TORRENT_ASSERT(i->buf != nullptr);
 			if (i->used_size > bytes)
 			{
 				TORRENT_ASSERT(bytes > 0);
@@ -136,6 +149,7 @@ namespace libtorrent
 
 	void chained_buffer::clear()
 	{
+		TORRENT_ASSERT(!m_destructed);
 		for (auto& b : m_vec)
 			b.destruct_holder(static_cast<void*>(&b.holder));
 		m_bytes = 0;
@@ -145,14 +159,14 @@ namespace libtorrent
 
 	chained_buffer::~chained_buffer()
 	{
-#if TORRENT_USE_ASSERTS
 		TORRENT_ASSERT(!m_destructed);
-		m_destructed = true;
-#endif
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(m_bytes >= 0);
 		TORRENT_ASSERT(m_capacity >= 0);
 		clear();
+#if TORRENT_USE_ASSERTS
+		m_destructed = true;
+#endif
 	}
 
 }

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -1514,8 +1514,8 @@ namespace libtorrent
 	}
 
 	void disk_io_thread::async_read(storage_interface* storage, peer_request const& r
-		, std::function<void(aux::block_cache_reference ref, char* block
-		, int flags, storage_error const& se)> handler, void* requester, std::uint8_t const flags)
+		, std::function<void(disk_buffer_holder block, int flags, storage_error const& se)> handler
+		, void* requester, std::uint8_t const flags)
 	{
 		TORRENT_ASSERT(r.length <= m_disk_cache.block_size());
 		TORRENT_ASSERT(r.length <= 16 * 1024);
@@ -1540,7 +1540,7 @@ namespace libtorrent
 		switch (ret)
 		{
 			case 0:
-				j->call_callback();
+				j->call_callback(*this);
 				free_job(j);
 				break;
 			case 1:
@@ -1765,7 +1765,7 @@ namespace libtorrent
 #endif
 
 			l.unlock();
-			j->call_callback();
+			j->call_callback(*this);
 			free_job(j);
 			return;
 		}
@@ -1919,7 +1919,7 @@ namespace libtorrent
 		if (m_abort)
 		{
 			j->error.ec = boost::asio::error::operation_aborted;
-			j->call_callback();
+			j->call_callback(*this);
 			free_job(j);
 			return;
 		}
@@ -3384,7 +3384,7 @@ namespace libtorrent
 #if TORRENT_USE_ASSERTS
 			j->callback_called = true;
 #endif
-			j->call_callback();
+			j->call_callback(*this);
 			to_delete[cnt++] = j;
 			j = next;
 			if (cnt == int(to_delete.size()))

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5447,7 +5447,7 @@ namespace libtorrent
 				// this const_cast is a here because chained_buffer need to be
 				// fixed.
 				char* ptr = const_cast<char*>(i->data());
-				m_send_buffer.prepend_buffer(ptr, size, size, nop());
+				m_send_buffer.prepend_buffer(nop(ptr), size, size);
 			}
 			set_send_barrier(next_barrier);
 		}
@@ -5671,15 +5671,14 @@ namespace libtorrent
 		int i = 0;
 		while (size > 0)
 		{
-			auto session_buf = m_ses.allocate_buffer();
+			aux::ses_buffer_holder session_buf = m_ses.allocate_buffer();
 
 			int const alloc_buf_size = m_ses.send_buffer_size();
-			int buf_size = std::min(alloc_buf_size, size);
+			int const buf_size = std::min(alloc_buf_size, size);
 			std::memcpy(session_buf.get(), buf, buf_size);
 			buf += buf_size;
 			size -= buf_size;
-			m_send_buffer.append_buffer(session_buf.get(), alloc_buf_size, buf_size
-				, std::move(session_buf));
+			m_send_buffer.append_buffer(std::move(session_buf), alloc_buf_size, buf_size);
 			++i;
 		}
 		setup_send();

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5673,7 +5673,7 @@ namespace libtorrent
 		{
 			auto session_buf = m_ses.allocate_buffer();
 
-			const int alloc_buf_size = m_ses.send_buffer_size();
+			int const alloc_buf_size = m_ses.send_buffer_size();
 			int buf_size = std::min(alloc_buf_size, size);
 			std::memcpy(session_buf.get(), buf, buf_size);
 			buf += buf_size;

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5648,14 +5648,6 @@ namespace libtorrent
 		return piece_block_progress();
 	}
 
-	namespace {
-		void session_free_buffer(char* buffer, void* userdata, aux::block_cache_reference)
-		{
-			aux::session_interface* ses = static_cast<aux::session_interface*>(userdata);
-			ses->free_buffer(buffer);
-		}
-	}
-
 	void peer_connection::send_buffer(char const* buf, int size, int flags)
 	{
 		TORRENT_ASSERT(is_single_thread());

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -280,7 +280,7 @@ namespace libtorrent { namespace
 			// TODO: we really need to increment the refcounter on the torrent
 			// while this buffer is still in the peer's send buffer
 			if (metadata_piece_size) m_pc.append_const_send_buffer(
-				metadata, metadata_piece_size, nop());
+				nop(const_cast<char*>(metadata)), metadata_piece_size);
 
 			m_pc.stats_counters().inc_stats_counter(counters::num_outgoing_extended);
 			m_pc.stats_counters().inc_stats_counter(counters::num_outgoing_metadata);

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -280,7 +280,7 @@ namespace libtorrent { namespace
 			// TODO: we really need to increment the refcounter on the torrent
 			// while this buffer is still in the peer's send buffer
 			if (metadata_piece_size) m_pc.append_const_send_buffer(
-				metadata, metadata_piece_size);
+				metadata, metadata_piece_size, nop());
 
 			m_pc.stats_counters().inc_stats_counter(counters::num_outgoing_extended);
 			m_pc.stats_counters().inc_stats_counter(counters::num_outgoing_metadata);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -71,7 +71,7 @@ using namespace libtorrent;
 int old_stdout = -1;
 int old_stderr = -1;
 bool redirect_stdout = true;
-bool redirect_stderr = true;
+bool redirect_stderr = false; // TEMPORARY!
 bool keep_files = false;
 
 extern int _g_test_idx;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -71,7 +71,7 @@ using namespace libtorrent;
 int old_stdout = -1;
 int old_stderr = -1;
 bool redirect_stdout = true;
-bool redirect_stderr = false; // TEMPORARY!
+bool redirect_stderr = true;
 bool keep_files = false;
 
 extern int _g_test_idx;

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -194,6 +194,7 @@ struct holder
 		rhs.m_buf = nullptr;
 		return *this;
 	}
+	char* get() const { return m_buf; }
 private:
 	char* m_buf;
 };
@@ -216,7 +217,7 @@ TORRENT_TEST(chained_buffer)
 
 		char* b1 = allocate_buffer(512);
 		std::memcpy(b1, data, 6);
-		b.append_buffer(b1, 512, 6, holder(b1));
+		b.append_buffer(holder(b1), 512, 6);
 		TEST_EQUAL(buffer_list.size(), 1);
 
 		TEST_CHECK(b.capacity() == 512);
@@ -246,12 +247,12 @@ TORRENT_TEST(chained_buffer)
 
 		char* b2 = allocate_buffer(512);
 		std::memcpy(b2, data, 6);
-		b.append_buffer(b2, 512, 6, holder(b2));
+		b.append_buffer(holder(b2), 512, 6);
 		TEST_CHECK(buffer_list.size() == 2);
 
 		char* b3 = allocate_buffer(512);
 		std::memcpy(b3, data, 6);
-		b.append_buffer(b3, 512, 6, holder(b3));
+		b.append_buffer(holder(b3), 512, 6);
 		TEST_CHECK(buffer_list.size() == 3);
 
 		TEST_CHECK(b.capacity() == 512 * 3);
@@ -286,7 +287,7 @@ TORRENT_TEST(chained_buffer)
 		char* b4 = allocate_buffer(20);
 		std::memcpy(b4, data, 6);
 		std::memcpy(b4 + 6, data, 6);
-		b.append_buffer(b4, 20, 12, holder(b4));
+		b.append_buffer(holder(b4), 20, 12);
 		TEST_CHECK(b.space_in_last_buffer() == 8);
 
 		ret = b.append(data, 6) != nullptr;
@@ -300,7 +301,7 @@ TORRENT_TEST(chained_buffer)
 
 		char* b5 = allocate_buffer(20);
 		std::memcpy(b5, data, 6);
-		b.append_buffer(b5, 20, 6, holder(b5));
+		b.append_buffer(holder(b5), 20, 6);
 
 		b.pop_front(22);
 		TEST_CHECK(b.size() == 5);

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -140,9 +140,8 @@ TORRENT_TEST(buffer_move_assign)
 
 std::set<char*> buffer_list;
 
-void free_buffer(char* m, void* userdata, aux::block_cache_reference ref)
+void free_buffer(char* m)
 {
-	TEST_CHECK(userdata == (void*)0x1337);
 	std::set<char*>::iterator i = buffer_list.find(m);
 	TEST_CHECK(i != buffer_list.end());
 
@@ -181,6 +180,24 @@ bool compare_chained_buffer(chained_buffer& b, char const* mem, int size)
 	return std::memcmp(&flat[0], mem, size) == 0;
 }
 
+struct holder
+{
+	explicit holder(char* buf) : m_buf(buf) {}
+	~holder() { if (m_buf) free_buffer(m_buf); }
+	holder(holder const&) = delete;
+	holder& operator=(holder const&) = delete;
+	holder(holder&& rhs) : m_buf(rhs.m_buf) { rhs.m_buf = nullptr; }
+	holder& operator=(holder&& rhs)
+	{
+		if (m_buf) free_buffer(m_buf);
+		m_buf = rhs.m_buf;
+		rhs.m_buf = nullptr;
+		return *this;
+	}
+private:
+	char* m_buf;
+};
+
 TORRENT_TEST(chained_buffer)
 {
 	char data[] = "foobar";
@@ -199,7 +216,7 @@ TORRENT_TEST(chained_buffer)
 
 		char* b1 = allocate_buffer(512);
 		std::memcpy(b1, data, 6);
-		b.append_buffer(b1, 512, 6, &free_buffer, (void*)0x1337);
+		b.append_buffer(b1, 512, 6, holder(b1));
 		TEST_EQUAL(buffer_list.size(), 1);
 
 		TEST_CHECK(b.capacity() == 512);
@@ -229,12 +246,12 @@ TORRENT_TEST(chained_buffer)
 
 		char* b2 = allocate_buffer(512);
 		std::memcpy(b2, data, 6);
-		b.append_buffer(b2, 512, 6, free_buffer, (void*)0x1337);
+		b.append_buffer(b2, 512, 6, holder(b2));
 		TEST_CHECK(buffer_list.size() == 2);
 
 		char* b3 = allocate_buffer(512);
 		std::memcpy(b3, data, 6);
-		b.append_buffer(b3, 512, 6, &free_buffer, (void*)0x1337);
+		b.append_buffer(b3, 512, 6, holder(b3));
 		TEST_CHECK(buffer_list.size() == 3);
 
 		TEST_CHECK(b.capacity() == 512 * 3);
@@ -269,7 +286,7 @@ TORRENT_TEST(chained_buffer)
 		char* b4 = allocate_buffer(20);
 		std::memcpy(b4, data, 6);
 		std::memcpy(b4 + 6, data, 6);
-		b.append_buffer(b4, 20, 12, &free_buffer, (void*)0x1337);
+		b.append_buffer(b4, 20, 12, holder(b4));
 		TEST_CHECK(b.space_in_last_buffer() == 8);
 
 		ret = b.append(data, 6) != nullptr;
@@ -282,8 +299,8 @@ TORRENT_TEST(chained_buffer)
 		std::cout << b.space_in_last_buffer() << std::endl;
 
 		char* b5 = allocate_buffer(20);
-		std::memcpy(b4, data, 6);
-		b.append_buffer(b5, 20, 6, &free_buffer, (void*)0x1337);
+		std::memcpy(b5, data, 6);
+		b.append_buffer(b5, 20, 6, holder(b5));
 
 		b.pop_front(22);
 		TEST_CHECK(b.size() == 5);


### PR DESCRIPTION
use disk_buffer_holder in the disk interface. make chaned_buffer use holder objects instead of free deleter function and userdata, to support putting disk_buffer_holder objects in there. Also make the session buffers be held by holders for the same reason.