### PR TITLE
compact block_cache_reference

### DIFF
--- a/include/libtorrent/aux_/block_cache_reference.hpp
+++ b/include/libtorrent/aux_/block_cache_reference.hpp
@@ -34,15 +34,19 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_BLOCK_CACHE_REFERENCE_HPP
 
 #include "libtorrent/units.hpp"
+#include "libtorrent/storage_defs.hpp"
 
 namespace libtorrent {
 namespace aux {
 
 	struct block_cache_reference
 	{
-		void* storage;
-		piece_index_t piece;
-		int block;
+		storage_index_t storage;
+		std::uint32_t cookie;
+
+		// if the cookie is set to this value, it doesn't refer to anything in the
+		// cache (and the buffer is mutable)
+		static std::uint32_t const none = 0xffffffffu;
 	};
 
 }

--- a/include/libtorrent/block_cache.hpp
+++ b/include/libtorrent/block_cache.hpp
@@ -344,7 +344,7 @@ namespace libtorrent
 		int pad_job(disk_io_job const* j, int blocks_in_piece
 			, int read_ahead) const;
 
-		void reclaim_block(aux::block_cache_reference const& ref);
+		void reclaim_block(storage_interface* st, aux::block_cache_reference const& ref);
 
 		// returns a range of all pieces. This might be a very
 		// long list, use carefully
@@ -406,7 +406,6 @@ namespace libtorrent
 
 		// looks for this piece in the cache. If it's there, returns a pointer
 		// to it, otherwise 0.
-		cached_piece_entry* find_piece(aux::block_cache_reference const& ref);
 		cached_piece_entry* find_piece(disk_io_job const* j);
 		cached_piece_entry* find_piece(storage_interface* st, piece_index_t piece);
 

--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -111,7 +111,7 @@ namespace libtorrent
 #if TORRENT_CPP98_DEQUE
 			move_construct_holder_fun move_holder;
 #endif
-			std::aligned_storage<32>::type holder;
+			std::aligned_storage<24>::type holder;
 			char* buf; // the first byte of the buffer
 			int size; // the total size of the buffer
 			int used_size; // this is the number of bytes to send/receive

--- a/include/libtorrent/disk_buffer_holder.hpp
+++ b/include/libtorrent/disk_buffer_holder.hpp
@@ -103,7 +103,7 @@ namespace libtorrent
 		}
 
 		// if this returns true, the buffer may not be modified in place
-		bool is_mutable() const noexcept { return m_ref.storage == nullptr; }
+		bool is_mutable() const noexcept { return m_ref.cookie == aux::block_cache_reference::none; }
 
 		// implicitly convertible to true if the object is currently holding a
 		// buffer

--- a/src/disk_io_job.cpp
+++ b/src/disk_io_job.cpp
@@ -105,9 +105,8 @@ namespace libtorrent
 		buffer.disk_block = nullptr;
 		d.io.offset = 0;
 		d.io.buffer_size = 0;
-		d.io.ref.storage = nullptr;
-		d.io.ref.piece = piece_index_t{0};
-		d.io.ref.block = 0;
+		d.io.ref.storage = storage_index_t{0};
+		d.io.ref.cookie = aux::block_cache_reference::none;
 	}
 
 	disk_io_job::~disk_io_job()

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1477,10 +1477,7 @@ namespace libtorrent
 
 	// ====== disk_job_fence implementation ========
 
-	disk_job_fence::disk_job_fence()
-		: m_has_fence(0)
-		, m_outstanding_jobs(0)
-	{}
+	disk_job_fence::disk_job_fence() {}
 
 	int disk_job_fence::job_complete(disk_io_job* j, tailqueue<disk_io_job>& jobs)
 	{

--- a/test/test_block_cache.cpp
+++ b/test/test_block_cache.cpp
@@ -134,9 +134,9 @@ static void nop() {}
 	ret = bc.try_read(&rj)
 
 #define RETURN_BUFFER \
-	if (rj.d.io.ref.storage) bc.reclaim_block(rj.d.io.ref); \
+	if (rj.d.io.ref.cookie != aux::block_cache_reference::none) bc.reclaim_block(pm.get(), rj.d.io.ref); \
 	else if (rj.buffer.disk_block) bc.free_buffer(rj.buffer.disk_block); \
-	rj.d.io.ref.storage = 0
+	rj.d.io.ref.cookie = aux::block_cache_reference::none
 
 #define FLUSH(flushing) \
 	for (int i = 0; i < int(sizeof(flushing)/sizeof((flushing)[0])); ++i) \


### PR DESCRIPTION
 by using storage_index_t instead of pointer. make sure storage object is kept alive by block_cache_references