### PR TITLE
fix frequent dealloc/alloc for utp socket lists

### DIFF
--- a/include/libtorrent/utp_socket_manager.hpp
+++ b/include/libtorrent/utp_socket_manager.hpp
@@ -138,6 +138,8 @@ namespace libtorrent
 		// an ack for every single packet
 		socket_vector_t m_deferred_acks;
 
+		bool m_in_socket_drained = false;
+
 		// sockets that have received or sent packets this
 		// round, may subscribe to the event of draining the
 		// UDP socket. At that point they may call the
@@ -149,6 +151,8 @@ namespace libtorrent
 		// underlying socket. They are notified when the socket
 		// becomes writable again
 		socket_vector_t m_stalled_sockets;
+
+		bool m_in_writable = false;
 
 		// the last socket we received a packet on
 		utp_socket_impl* m_last_socket = nullptr;

--- a/include/libtorrent/utp_socket_manager.hpp
+++ b/include/libtorrent/utp_socket_manager.hpp
@@ -130,23 +130,28 @@ namespace libtorrent
 		typedef std::multimap<std::uint16_t, utp_socket_impl*> socket_map_t;
 		socket_map_t m_utp_sockets;
 
+		typedef std::vector<utp_socket_impl*> socket_vector_t;
+
 		// this is a list of sockets that needs to send an ack.
 		// once the UDP socket is drained, all of these will
 		// have a chance to do that. This is to avoid sending
 		// an ack for every single packet
-		std::vector<utp_socket_impl*> m_deferred_acks;
+		socket_vector_t m_deferred_acks;
+		socket_vector_t m_deferred_acks_tock;
 
 		// sockets that have received or sent packets this
 		// round, may subscribe to the event of draining the
 		// UDP socket. At that point they may call the
 		// user callback function to indicate bytes have been
 		// sent or received.
-		std::vector<utp_socket_impl*> m_drained_event;
+		socket_vector_t m_drained_event;
+		socket_vector_t m_drained_event_tock;
 
 		// list of sockets that received EWOULDBLOCK from the
 		// underlying socket. They are notified when the socket
 		// becomes writable again
-		std::vector<utp_socket_impl*> m_stalled_sockets;
+		socket_vector_t m_stalled_sockets;
+		socket_vector_t m_stalled_sockets_tock;
 
 		// the last socket we received a packet on
 		utp_socket_impl* m_last_socket = nullptr;

--- a/include/libtorrent/utp_socket_manager.hpp
+++ b/include/libtorrent/utp_socket_manager.hpp
@@ -139,11 +139,8 @@ namespace libtorrent
 		socket_vector_t m_deferred_acks;
 
 		// storage used for saving cpu time on "push_back"
-		// by using already pre-allocated vectors
-		socket_vector_t m_socket_drained_temp;
-
-		// prevents reentrant loop
-		bool m_in_socket_drained = false;
+		// by using already pre-allocated vector
+		socket_vector_t m_temp_sockets;
 
 		// sockets that have received or sent packets this
 		// round, may subscribe to the event of draining the
@@ -156,9 +153,6 @@ namespace libtorrent
 		// underlying socket. They are notified when the socket
 		// becomes writable again
 		socket_vector_t m_stalled_sockets;
-
-		socket_vector_t m_writable_temp;
-		bool m_in_writable = false;
 
 		// the last socket we received a packet on
 		utp_socket_impl* m_last_socket = nullptr;

--- a/include/libtorrent/utp_socket_manager.hpp
+++ b/include/libtorrent/utp_socket_manager.hpp
@@ -130,14 +130,13 @@ namespace libtorrent
 		typedef std::multimap<std::uint16_t, utp_socket_impl*> socket_map_t;
 		socket_map_t m_utp_sockets;
 
-		typedef std::vector<utp_socket_impl*> socket_vector_t;
+		using socket_vector_t = std::vector<utp_socket_impl*>;
 
 		// this is a list of sockets that needs to send an ack.
 		// once the UDP socket is drained, all of these will
 		// have a chance to do that. This is to avoid sending
 		// an ack for every single packet
 		socket_vector_t m_deferred_acks;
-		socket_vector_t m_deferred_acks_tock;
 
 		// sockets that have received or sent packets this
 		// round, may subscribe to the event of draining the
@@ -145,13 +144,11 @@ namespace libtorrent
 		// user callback function to indicate bytes have been
 		// sent or received.
 		socket_vector_t m_drained_event;
-		socket_vector_t m_drained_event_tock;
 
 		// list of sockets that received EWOULDBLOCK from the
 		// underlying socket. They are notified when the socket
 		// becomes writable again
 		socket_vector_t m_stalled_sockets;
-		socket_vector_t m_stalled_sockets_tock;
 
 		// the last socket we received a packet on
 		utp_socket_impl* m_last_socket = nullptr;

--- a/include/libtorrent/utp_socket_manager.hpp
+++ b/include/libtorrent/utp_socket_manager.hpp
@@ -138,6 +138,11 @@ namespace libtorrent
 		// an ack for every single packet
 		socket_vector_t m_deferred_acks;
 
+		// storage used for saving cpu time on "push_back"
+		// by using already pre-allocated vectors
+		socket_vector_t m_socket_drained_temp;
+
+		// prevents reentrant loop
 		bool m_in_socket_drained = false;
 
 		// sockets that have received or sent packets this
@@ -152,6 +157,7 @@ namespace libtorrent
 		// becomes writable again
 		socket_vector_t m_stalled_sockets;
 
+		socket_vector_t m_writable_temp;
 		bool m_in_writable = false;
 
 		// the last socket we received a packet on

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -255,12 +255,11 @@ namespace libtorrent
 
 	void utp_socket_manager::writable()
 	{
-		m_stalled_sockets_tock.clear();
-		m_stalled_sockets.swap(m_stalled_sockets_tock);
-		for (socket_vector_t::iterator i = m_stalled_sockets_tock.begin()
-			, end(m_stalled_sockets_tock.end()); i != end; ++i)
+		static socket_vector_t stalled_sockets;
+		stalled_sockets.clear();
+		m_stalled_sockets.swap(stalled_sockets);
+		for (auto const &s : stalled_sockets)
 		{
-			utp_socket_impl* s = *i;
 			utp_writable(s);
 		}
 	}
@@ -269,21 +268,19 @@ namespace libtorrent
 	{
 		// flush all deferred acks
 
-		m_deferred_acks_tock.clear();
-		m_deferred_acks.swap(m_deferred_acks_tock);
-		for (socket_vector_t::iterator i = m_deferred_acks_tock.begin()
-			, end(m_deferred_acks_tock.end()); i != end; ++i)
+		static socket_vector_t deferred_acks;
+		deferred_acks.clear();
+		m_deferred_acks.swap(deferred_acks);
+		for (auto const &s : deferred_acks)
 		{
-			utp_socket_impl* s = *i;
 			utp_send_ack(s);
 		}
 
-		m_drained_event_tock.clear();
-		m_drained_event.swap(m_drained_event_tock);
-		for (socket_vector_t::iterator i = m_drained_event_tock.begin()
-			, end(m_drained_event_tock.end()); i != end; ++i)
+		static socket_vector_t drained_event;
+		drained_event.clear();
+		m_drained_event.swap(drained_event);
+		for (auto const &s : drained_event)
 		{
-			utp_socket_impl* s = *i;
 			utp_socket_drained(s);
 		}
 	}

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -270,10 +270,9 @@ namespace libtorrent
 	{
 		// flush all deferred acks
 
-		static socket_vector_t temp_sockets;
-
 		if (!m_deferred_acks.empty())
 		{
+			static socket_vector_t temp_sockets;
 			temp_sockets.clear();
 			m_deferred_acks.swap(temp_sockets);
 			for (auto const &s : temp_sockets)
@@ -284,6 +283,7 @@ namespace libtorrent
 
 		if (!m_drained_event.empty())
 		{
+			static socket_vector_t temp_sockets;
 			temp_sockets.clear();
 			m_drained_event.swap(temp_sockets);
 			for (auto const &s : temp_sockets)

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -255,48 +255,40 @@ namespace libtorrent
 
 	void utp_socket_manager::writable()
 	{
-		if (m_in_writable) return;
-		m_in_writable = true;
-
-		while (!m_stalled_sockets.empty())
+		if (!m_stalled_sockets.empty())
 		{
-			m_writable_temp.clear();
-			m_stalled_sockets.swap(m_writable_temp);
-			for (auto const &s : m_writable_temp)
+			m_temp_sockets.clear();
+			m_stalled_sockets.swap(m_temp_sockets);
+			for (auto const &s : m_temp_sockets)
 			{
 				utp_writable(s);
 			}
 		}
-		m_in_writable = false;
 	}
 
 	void utp_socket_manager::socket_drained()
 	{
-		if (m_in_socket_drained) return;
-		m_in_socket_drained = true;
-
 		// flush all deferred acks
 
-		while (!m_deferred_acks.empty())
+		if (!m_deferred_acks.empty())
 		{
-			m_socket_drained_temp.clear();
-			m_deferred_acks.swap(m_socket_drained_temp);
-			for (auto const &s : m_socket_drained_temp)
+			m_temp_sockets.clear();
+			m_deferred_acks.swap(m_temp_sockets);
+			for (auto const &s : m_temp_sockets)
 			{
 				utp_send_ack(s);
 			}
 		}
 
-		while (!m_drained_event.empty())
+		if (!m_drained_event.empty())
 		{
-			m_socket_drained_temp.clear();
-			m_drained_event.swap(m_socket_drained_temp);
-			for (auto const &s : m_socket_drained_temp)
+			m_temp_sockets.clear();
+			m_drained_event.swap(m_temp_sockets);
+			for (auto const &s : m_temp_sockets)
 			{
 				utp_socket_drained(s);
 			}
 		}
-		m_in_socket_drained = false;
 	}
 
 	void utp_socket_manager::defer_ack(utp_socket_impl* s)

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -260,13 +260,9 @@ namespace libtorrent
 
 		while (!m_stalled_sockets.empty())
 		{
-			// static storage used for saving cpu time on "push_back"
-			// by using already pre-allocated vectors
-			static socket_vector_t stalled_sockets;
-
-			stalled_sockets.clear();
-			m_stalled_sockets.swap(stalled_sockets);
-			for (auto const &s : stalled_sockets)
+			m_writable_temp.clear();
+			m_stalled_sockets.swap(m_writable_temp);
+			for (auto const &s : m_writable_temp)
 			{
 				utp_writable(s);
 			}
@@ -281,15 +277,11 @@ namespace libtorrent
 
 		// flush all deferred acks
 
-		// static storage used for saving cpu time on "push_back"
-		// by using already pre-allocated vectors
-		static socket_vector_t temp_sockets;
-
 		while (!m_deferred_acks.empty())
 		{
-			temp_sockets.clear();
-			m_deferred_acks.swap(temp_sockets);
-			for (auto const &s : temp_sockets)
+			m_socket_drained_temp.clear();
+			m_deferred_acks.swap(m_socket_drained_temp);
+			for (auto const &s : m_socket_drained_temp)
 			{
 				utp_send_ack(s);
 			}
@@ -297,9 +289,9 @@ namespace libtorrent
 
 		while (!m_drained_event.empty())
 		{
-			temp_sockets.clear();
-			m_drained_event.swap(temp_sockets);
-			for (auto const &s : temp_sockets)
+			m_socket_drained_temp.clear();
+			m_drained_event.swap(m_socket_drained_temp);
+			for (auto const &s : m_socket_drained_temp)
 			{
 				utp_socket_drained(s);
 			}

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -255,10 +255,10 @@ namespace libtorrent
 
 	void utp_socket_manager::writable()
 	{
-		std::vector<utp_socket_impl*> stalled_sockets;
-		m_stalled_sockets.swap(stalled_sockets);
-		for (std::vector<utp_socket_impl*>::iterator i = stalled_sockets.begin()
-			, end(stalled_sockets.end()); i != end; ++i)
+		m_stalled_sockets_tock.clear();
+		m_stalled_sockets.swap(m_stalled_sockets_tock);
+		for (socket_vector_t::iterator i = m_stalled_sockets_tock.begin()
+			, end(m_stalled_sockets_tock.end()); i != end; ++i)
 		{
 			utp_socket_impl* s = *i;
 			utp_writable(s);
@@ -269,19 +269,19 @@ namespace libtorrent
 	{
 		// flush all deferred acks
 
-		std::vector<utp_socket_impl*> deferred_acks;
-		m_deferred_acks.swap(deferred_acks);
-		for (std::vector<utp_socket_impl*>::iterator i = deferred_acks.begin()
-			, end(deferred_acks.end()); i != end; ++i)
+		m_deferred_acks_tock.clear();
+		m_deferred_acks.swap(m_deferred_acks_tock);
+		for (socket_vector_t::iterator i = m_deferred_acks_tock.begin()
+			, end(m_deferred_acks_tock.end()); i != end; ++i)
 		{
 			utp_socket_impl* s = *i;
 			utp_send_ack(s);
 		}
 
-		std::vector<utp_socket_impl*> drained_event;
-		m_drained_event.swap(drained_event);
-		for (std::vector<utp_socket_impl*>::iterator i = drained_event.begin()
-			, end(drained_event.end()); i != end; ++i)
+		m_drained_event_tock.clear();
+		m_drained_event.swap(m_drained_event_tock);
+		for (socket_vector_t::iterator i = m_drained_event_tock.begin()
+			, end(m_drained_event_tock.end()); i != end; ++i)
 		{
 			utp_socket_impl* s = *i;
 			utp_socket_drained(s);


### PR DESCRIPTION
old implementation spent too much cpu time at std::allocator<libtorrent::utp_socket_impl * >: *