### PR TITLE
[#1520] Add AM_MAINTAINER_MODE macro to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AC_CANONICAL_TARGET
 AS_ECHO
 AS_ECHO "Initializing Automake:"
 AM_INIT_AUTOMAKE([1.11 foreign])
-
+AM_MAINTAINER_MODE([enable])
 
 AS_ECHO
 AS_ECHO "Initializing Libtool:"
@@ -653,7 +653,7 @@ OpenSSL library:
   OpenSSL Libs:         ${OPENSSL_LIBS}
   OpenSSL LDFlags:      ${OPENSSL_LDFLAGS}
   OpenSSL Includes:     ${OPENSSL_INCLUDES}
-END 
+END
 ])
 
 cat config.report


### PR DESCRIPTION
 * '--disable-maintainer-mode' option is now available for configure.
 * This fixes the warning 'unrecognized options: --disable-maintainer-mode' from debian pkg builds.
 * Setting the macro to 'enable' as default is equivalent to no macro call so no change in default functionality.

Could this also be applied to RC_1_1, thanks!