### PR TITLE
Fix ar 'modifier ignored' build warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,9 @@ AC_CONFIG_MACRO_DIR([m4])
 # Silencing build output (automake-1.11)
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
+# Change ar argument to 'rc' to silence the warning:
+#     ar: `u' modifier ignored since `D' is the default (see `U')
+m4_divert_text([DEFAULTS], [: "${AR_FLAGS=rc}"])
 
 ###############################################################################
 dnl ---------------------------------------------------------------------------


### PR DESCRIPTION
Another trivial fix but nice to squash the random build warnings :stuck_out_tongue: 

 * This only applies to AR_FLAGS and not ARFLAGS.
 * afaik ARFLAGS is the new convention and this warning is fixed
   upstream in libtool but may be a while before OSes catchup.