### PR TITLE
fix torrent peer class index overflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix torrent connection index overflow, this fix several errors related to
+	  working with more then 256 torrents like resume data and connection handling
 	* don't load user_agent and peer_fingerprint from session_state
 	* fix file rename issue with name prefix matching torrent name
 	* fix division by zero when setting tick_interval > 1000

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,4 @@
-	* fix torrent connection index overflow, this fix several errors related to
-	  working with more then 256 torrents like resume data and connection handling
+	* fix per-torrent rate limits for >256 peer classes
 	* don't load user_agent and peer_fingerprint from session_state
 	* fix file rename issue with name prefix matching torrent name
 	* fix division by zero when setting tick_interval > 1000

--- a/include/libtorrent/peer_class.hpp
+++ b/include/libtorrent/peer_class.hpp
@@ -47,7 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
-	typedef boost::uint16_t peer_class_t;
+	typedef boost::uint32_t peer_class_t;
 
 	struct peer_class_info
 	{

--- a/include/libtorrent/peer_class.hpp
+++ b/include/libtorrent/peer_class.hpp
@@ -47,7 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
-	typedef boost::uint8_t peer_class_t;
+	typedef boost::uint16_t peer_class_t;
 
 	struct peer_class_info
 	{

--- a/src/peer_class.cpp
+++ b/src/peer_class.cpp
@@ -87,10 +87,11 @@ namespace libtorrent
 		}
 		else
 		{
-			TORRENT_ASSERT(m_peer_classes.size() < 0x10000);
+			TORRENT_ASSERT(m_peer_classes.size() < 0x100000000);
 			ret = m_peer_classes.size();
 			m_peer_classes.push_back(boost::shared_ptr<peer_class>());
 		}
+
 		TORRENT_ASSERT(m_peer_classes[ret].get() == 0);
 		m_peer_classes[ret] = boost::make_shared<peer_class>(label);
 		return ret;

--- a/src/peer_class.cpp
+++ b/src/peer_class.cpp
@@ -87,10 +87,10 @@ namespace libtorrent
 		}
 		else
 		{
+			TORRENT_ASSERT(m_peer_classes.size() < 0x10000);
 			ret = m_peer_classes.size();
 			m_peer_classes.push_back(boost::shared_ptr<peer_class>());
 		}
-
 		TORRENT_ASSERT(m_peer_classes[ret].get() == 0);
 		m_peer_classes[ret] = boost::make_shared<peer_class>(label);
 		return ret;


### PR DESCRIPTION
this resolves:
- session start fast resume assert
- fast resume data save error on session close
- throtteling accuracy get improved
