### PR TITLE
return vector of correct size if internal file_progress is empty

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10220,7 +10220,7 @@ namespace libtorrent
 			return;
 		}
 
-		if (num_have() == 0)
+		if (num_have() == 0 || m_file_progress.empty())
 		{
 			// if we don't have any pieces, just return zeroes
 			fp.clear();


### PR DESCRIPTION
Fix issue https://github.com/frostwire/frostwire-jlibtorrent/issues/148