### PR TITLE
Add  web seed name lookup retry minutes to session_settings

### DIFF
--- a/include/libtorrent/session_settings.hpp
+++ b/include/libtorrent/session_settings.hpp
@@ -229,6 +229,9 @@ namespace libtorrent
 		// time to wait until a new retry takes place
 		int urlseed_wait_retry;
 		
+		// if unavailable, retry in these minutes
+		int web_seed_name_lookup_retry_minutes;
+		
 		// sets the upper limit on the total number of files this session will
 		// keep open. The reason why files are left open at all is that some anti
 		// virus software hooks on every file close, and scans the file for

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1253,6 +1253,7 @@ namespace libtorrent
 		, urlseed_timeout(20)
 		, urlseed_pipeline_size(5)
 		, urlseed_wait_retry(30)
+		, web_seed_name_lookup_retry_minutes(30)
 		, file_pool_size(40)
 		, allow_multiple_connections_per_ip(false)
 		, max_failcount(3)

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -307,6 +307,7 @@ namespace aux {
 		TORRENT_SETTING(integer, urlseed_timeout)
 		TORRENT_SETTING(integer, urlseed_pipeline_size)
 		TORRENT_SETTING(integer, urlseed_wait_retry)
+		TORRENT_SETTING(integer, web_seed_name_lookup_retry_minutes)
 		TORRENT_SETTING(integer, file_pool_size)
 		TORRENT_SETTING(boolean, allow_multiple_connections_per_ip)
 		TORRENT_SETTING(integer, max_failcount)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4974,8 +4974,8 @@ namespace libtorrent
 				, web->url.c_str(), e.value(), e.message().c_str());
 #endif
 
-			// unavailable, retry in 30 minutes
-			web->retry = time_now() + minutes(30);
+			// unavailable, retry in `m_ses.settings().web_seed_name_lookup_retry_minutes` minutes
+			web->retry = time_now() + minutes(m_ses.settings().web_seed_name_lookup_retry_minutes);
 			return;
 		}
 


### PR DESCRIPTION
It will take 30 minutes to retry name lookup when web seed name lookup
failed default. You can restart libtorrent client to retry but it is not
convenient, so just add a setting to session_settings to control it is a
good idea.