### PR TITLE
1.1.2 set queue position by number

### DIFF
--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -833,9 +833,13 @@ namespace libtorrent
 		int queue_position() const;
 		void queue_position_up() const;
 		void queue_position_down() const;
-		void queue_position_set(uint p) const;
 		void queue_position_top() const;
 		void queue_position_bottom() const;
+		// set the new position in queue starting by 0. If given position does
+		// already exist your torrent will be set on top of it and remaining once
+		// get posion + 1. If the given position is greater then queue it will be
+		// added on bottom
+		void queue_position_set(uint p) const;
 
 #ifndef TORRENT_NO_DEPRECATE
 		// deprecated in 1.1

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -835,6 +835,7 @@ namespace libtorrent
 		void queue_position_down() const;
 		void queue_position_top() const;
 		void queue_position_bottom() const;
+
 		// set the new position in queue starting by 0. If given position does
 		// already exist your torrent will be set on top of it and remaining once
 		// get posion + 1. If the given position is greater then queue it will be

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -840,7 +840,7 @@ namespace libtorrent
 		// already exist your torrent will be set on top of it and remaining once
 		// get posion + 1. If the given position is greater then queue it will be
 		// added on bottom
-		void queue_position_set(uint p) const;
+		void queue_position_set(int p) const;
 
 #ifndef TORRENT_NO_DEPRECATE
 		// deprecated in 1.1

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -833,6 +833,7 @@ namespace libtorrent
 		int queue_position() const;
 		void queue_position_up() const;
 		void queue_position_down() const;
+		void queue_position_set(uint p) const;
 		void queue_position_top() const;
 		void queue_position_bottom() const;
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -836,10 +836,9 @@ namespace libtorrent
 		void queue_position_top() const;
 		void queue_position_bottom() const;
 
-		// set the new position in queue starting by 0. If given position does
-		// already exist your torrent will be set on top of it and remaining once
-		// get posion + 1. If the given position is greater then queue it will be
-		// added on bottom
+		// updates the position in the queue for this torrent. The relative order
+		// of all other torrents remain intact but their numerical queue position
+		// shifts to make space for this torrent's new position
 		void queue_position_set(int p) const;
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9239,13 +9239,13 @@ namespace libtorrent
 	void torrent::set_queue_position(int p)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		TORRENT_ASSERT((p == -1) == is_finished()
-			|| (!m_auto_managed && p == -1)
-			|| (m_abort && p == -1));
-		if (is_finished() && p != -1) return;
+		if(is_finished() || is_seed() || !m_auto_managed || m_abort)
+		{
+			p = -1;
+		} else {
+			p = p < 0 ? 0 : p;
+		}
 		if (p == m_sequence_number) return;
-
-		TORRENT_ASSERT(p >= -1);
 
 		state_updated();
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9227,7 +9227,7 @@ namespace libtorrent
 
 	void torrent::queue_up()
 	{
-		// fix async position change calls for race conditions on changed torrents
+		// fix race conditions on async position change calls (from handler)
 		if(!m_auto_managed || m_abort || is_finished()) return;
 
 		set_queue_position(queue_position() == 0
@@ -9236,9 +9236,6 @@ namespace libtorrent
 
 	void torrent::queue_down()
 	{
-		// fix async position change calls for race conditions on changed torrents
-		if(!m_auto_managed || m_abort || is_finished()) return;
-
 		set_queue_position(queue_position() + 1);
 	}
 
@@ -9246,7 +9243,7 @@ namespace libtorrent
 	{
 		TORRENT_ASSERT(is_single_thread());
 
-		// fix async position change calls for race conditions on changed torrents
+		// fix race conditions on async position change calls (from handler)
 		if ((!m_auto_managed || m_abort || is_finished()) && p != -1) return;
 
 		TORRENT_ASSERT((p == -1) == is_finished()

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -363,7 +363,7 @@ namespace libtorrent
 
 	void torrent_handle::queue_position_set(int p) const
 	{
-		TORRENT_ASYNC_CALL1(set_queue_position, p);
+		TORRENT_ASYNC_CALL1(set_queue_position, p < 0 ? 0 : p);
 	}
 
 	void torrent_handle::queue_position_top() const

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -363,6 +363,7 @@ namespace libtorrent
 
 	void torrent_handle::queue_position_set(int p) const
 	{
+		TORRENT_ASSERT_PRECOND(p >= 0);
 		TORRENT_ASYNC_CALL1(set_queue_position, p);
 	}
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -361,6 +361,11 @@ namespace libtorrent
 		TORRENT_ASYNC_CALL(queue_down);
 	}
 
+	void torrent_handle::queue_position_set(uint p) const
+	{
+		TORRENT_ASYNC_CALL1(set_queue_position, p);
+	}
+
 	void torrent_handle::queue_position_top() const
 	{
 		TORRENT_ASYNC_CALL1(set_queue_position, 0);

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -363,7 +363,7 @@ namespace libtorrent
 
 	void torrent_handle::queue_position_set(int p) const
 	{
-		TORRENT_ASYNC_CALL1(set_queue_position, p < 0 ? 0 : p);
+		TORRENT_ASYNC_CALL1(set_queue_position, p);
 	}
 
 	void torrent_handle::queue_position_top() const

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -364,6 +364,7 @@ namespace libtorrent
 	void torrent_handle::queue_position_set(int p) const
 	{
 		TORRENT_ASSERT_PRECOND(p >= 0);
+		if (p < 0) return;
 		TORRENT_ASYNC_CALL1(set_queue_position, p);
 	}
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -361,7 +361,7 @@ namespace libtorrent
 		TORRENT_ASYNC_CALL(queue_down);
 	}
 
-	void torrent_handle::queue_position_set(uint p) const
+	void torrent_handle::queue_position_set(int p) const
 	{
 		TORRENT_ASYNC_CALL1(set_queue_position, p);
 	}

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -443,12 +443,41 @@ TORRENT_TEST(queue)
 	TEST_EQUAL(torrents[3].queue_position(), 3);
 	TEST_EQUAL(torrents[4].queue_position(), 4);
 
-	// test set pos on not existing pos
-	torrents[3].queue_position_set(10);
+	//test strange up and down commands
+	torrents[0].queue_position_up();
+	torrents[4].queue_position_down();
 
 	TEST_EQUAL(torrents[0].queue_position(), 0);
 	TEST_EQUAL(torrents[1].queue_position(), 1);
 	TEST_EQUAL(torrents[2].queue_position(), 2);
+	TEST_EQUAL(torrents[3].queue_position(), 3);
+	TEST_EQUAL(torrents[4].queue_position(), 4);
+
+	torrents[1].queue_position_up();
+	torrents[3].queue_position_down();
+
+	TEST_EQUAL(torrents[1].queue_position(), 0);
+	TEST_EQUAL(torrents[0].queue_position(), 1);
+	TEST_EQUAL(torrents[2].queue_position(), 2);
+	TEST_EQUAL(torrents[4].queue_position(), 3);
+	TEST_EQUAL(torrents[3].queue_position(), 4);
+
+	torrents[1].queue_position_down();
+	torrents[3].queue_position_up();
+
+	TEST_EQUAL(torrents[0].queue_position(), 0);
+	TEST_EQUAL(torrents[1].queue_position(), 1);
+	TEST_EQUAL(torrents[2].queue_position(), 2);
+	TEST_EQUAL(torrents[3].queue_position(), 3);
+	TEST_EQUAL(torrents[4].queue_position(), 4);
+
+	// test set pos on not existing pos
+	torrents[3].queue_position_set(10);
+	torrents[2].queue_position_set(-10);
+
+	TEST_EQUAL(torrents[2].queue_position(), 0);
+	TEST_EQUAL(torrents[0].queue_position(), 1);
+	TEST_EQUAL(torrents[1].queue_position(), 2);
 	TEST_EQUAL(torrents[4].queue_position(), 3);
 	TEST_EQUAL(torrents[3].queue_position(), 4);
 }

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -399,7 +399,7 @@ TORRENT_TEST(queue)
 	pack.set_bool(settings_pack::disable_hash_checks, true);
 	lt::session ses(pack);
 
-	torrent_handle torrents[6];
+	std::vector<torrent_handle> torrents;
 	for(int i = 0; i < 6; i++)
 	{
 		file_storage fs;
@@ -412,7 +412,7 @@ TORRENT_TEST(queue)
 		add_torrent_params p;
 		p.ti = ti;
 		p.save_path = ".";
-		torrents[i] = ses.add_torrent(p);
+		torrents.push_back(ses.add_torrent(p));
 	}
 
 	std::vector<int> pieces = torrents[5].piece_priorities();
@@ -490,13 +490,12 @@ TORRENT_TEST(queue)
 
 	// test set pos on not existing pos
 	torrents[3].queue_position_set(10);
-	torrents[2].queue_position_set(-10);
-	finished.queue_position_set(-10);
+	finished.queue_position_set(10);
 
 	TEST_EQUAL(finished.queue_position(), -1);
-	TEST_EQUAL(torrents[2].queue_position(), 0);
-	TEST_EQUAL(torrents[0].queue_position(), 1);
-	TEST_EQUAL(torrents[1].queue_position(), 2);
+	TEST_EQUAL(torrents[0].queue_position(), 0);
+	TEST_EQUAL(torrents[1].queue_position(), 1);
+	TEST_EQUAL(torrents[2].queue_position(), 2);
 	TEST_EQUAL(torrents[4].queue_position(), 3);
 	TEST_EQUAL(torrents[3].queue_position(), 4);
 }

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -403,7 +403,9 @@ TORRENT_TEST(queue)
 	for(int i = 0; i < 6; i++)
 	{
 		file_storage fs;
-		fs.add_file("test_torrent_dir4/queue" + std::to_string(i), 1024);
+		std::stringstream file_path;
+		file_path << "test_torrent_dir4/queue" << i;
+		fs.add_file(file_path.str(), 1024);
 		libtorrent::create_torrent t(fs, 128 * 1024, 6);
 
 		std::vector<char> buf;

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -399,8 +399,8 @@ TORRENT_TEST(queue)
 	pack.set_bool(settings_pack::disable_hash_checks, true);
 	lt::session ses(pack);
 
-	torrent_handle torrents[5];
-	for(int i = 0; i < 5; i++)
+	torrent_handle torrents[6];
+	for(int i = 0; i < 6; i++)
 	{
 		file_storage fs;
 		fs.add_file("test_torrent_dir4/queue" + std::to_string(i), 1024);
@@ -415,7 +415,16 @@ TORRENT_TEST(queue)
 		torrents[i] = ses.add_torrent(p);
 	}
 
+	std::vector<int> pieces = torrents[5].piece_priorities();
+	std::vector<std::pair<int, int> > piece_prios;
+	for (int i = 0; i < int(pieces.size()); ++i) {
+		piece_prios.push_back(std::make_pair(i,0));
+	}
+	torrents[5].prioritize_pieces(piece_prios);
+	torrent_handle finished = torrents[5];
+
 	// add_torrent should be ordered
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[0].queue_position(), 0);
 	TEST_EQUAL(torrents[1].queue_position(), 1);
 	TEST_EQUAL(torrents[2].queue_position(), 2);
@@ -426,6 +435,7 @@ TORRENT_TEST(queue)
 	torrents[2].queue_position_top();
 	torrents[1].queue_position_bottom();
 
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[2].queue_position(), 0);
 	TEST_EQUAL(torrents[0].queue_position(), 1);
 	TEST_EQUAL(torrents[3].queue_position(), 2);
@@ -437,6 +447,7 @@ TORRENT_TEST(queue)
 	torrents[1].queue_position_set(1);
 	// torrent 2 should be get moved down by 0 and 1 to pos 2
 
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[0].queue_position(), 0);
 	TEST_EQUAL(torrents[1].queue_position(), 1);
 	TEST_EQUAL(torrents[2].queue_position(), 2);
@@ -447,6 +458,7 @@ TORRENT_TEST(queue)
 	torrents[0].queue_position_up();
 	torrents[4].queue_position_down();
 
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[0].queue_position(), 0);
 	TEST_EQUAL(torrents[1].queue_position(), 1);
 	TEST_EQUAL(torrents[2].queue_position(), 2);
@@ -455,7 +467,9 @@ TORRENT_TEST(queue)
 
 	torrents[1].queue_position_up();
 	torrents[3].queue_position_down();
+	finished.queue_position_up();
 
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[1].queue_position(), 0);
 	TEST_EQUAL(torrents[0].queue_position(), 1);
 	TEST_EQUAL(torrents[2].queue_position(), 2);
@@ -464,7 +478,10 @@ TORRENT_TEST(queue)
 
 	torrents[1].queue_position_down();
 	torrents[3].queue_position_up();
+	finished.queue_position_down();
 
+
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[0].queue_position(), 0);
 	TEST_EQUAL(torrents[1].queue_position(), 1);
 	TEST_EQUAL(torrents[2].queue_position(), 2);
@@ -474,7 +491,9 @@ TORRENT_TEST(queue)
 	// test set pos on not existing pos
 	torrents[3].queue_position_set(10);
 	torrents[2].queue_position_set(-10);
+	finished.queue_position_set(-10);
 
+	TEST_EQUAL(finished.queue_position(), -1);
 	TEST_EQUAL(torrents[2].queue_position(), 0);
 	TEST_EQUAL(torrents[0].queue_position(), 1);
 	TEST_EQUAL(torrents[1].queue_position(), 2);


### PR DESCRIPTION
Something of my local extensions.

If you like it I will create a test for it.

This is needed to sort queue without dropping connections. Currently I use queue top which will drop connections because I have to set queue top for all entries starting at lowest priority. The low entries queue top calls kicks active entries out of active range.

Offtopic
These connection drops cased by moving queue entries every 10 minutes does maybe cause the illegal torrent piece state, but we will see it after we found the illegal state description.