### PR TITLE
moved alloca.hpp to private aux_ and size refactor

### DIFF
--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -6,7 +6,6 @@ nobase_include_HEADERS = \
   alert.hpp                    \
   alert_manager.hpp            \
   alert_types.hpp              \
-  alloca.hpp                   \
   allocator.hpp                \
   announce_entry.hpp           \
   assert.hpp                   \
@@ -196,6 +195,7 @@ nobase_include_HEADERS = \
   aux_/storage_utils.hpp            \
   aux_/numeric_cast.hpp             \
   aux_/unique_ptr.hpp               \
+  aux_/alloca.hpp                   \
   \
   extensions/smart_ban.hpp          \
   extensions/ut_metadata.hpp        \

--- a/include/libtorrent/aux_/alloca.hpp
+++ b/include/libtorrent/aux_/alloca.hpp
@@ -40,7 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <malloc.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	std::size_t TORRENT_ALLOCA_size = aux::numeric_cast<std::size_t>(n); \
+	std::size_t TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::size_t>(n); \
 	t* TORRENT_ALLOCA_tmp = static_cast<t*>(_alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
 	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); }
 
@@ -48,7 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	std::size_t TORRENT_ALLOCA_size = aux::numeric_cast<std::size_t>(n); \
+	std::size_t TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::size_t>(n); \
 	t* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
 	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); }
 
@@ -56,7 +56,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <alloca.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	std::size_t TORRENT_ALLOCA_size = aux::numeric_cast<std::size_t>(n); \
+	std::size_t TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::size_t>(n); \
 	t* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
 	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); }
 

--- a/include/libtorrent/aux_/alloca.hpp
+++ b/include/libtorrent/aux_/alloca.hpp
@@ -34,27 +34,31 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/span.hpp"
+#include "libtorrent/aux_/numeric_cast.hpp"
 
 #if defined TORRENT_WINDOWS || defined TORRENT_MINGW
 
 #include <malloc.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	t* TORRENT_ALLOCA_tmp = static_cast<t*>(_alloca(sizeof(t) * (std::size_t(n)))); \
-	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, std::size_t(n)); }
+	std::size_t TORRENT_ALLOCA_size = aux::numeric_cast<std::size_t>(n); \
+	t* TORRENT_ALLOCA_tmp = static_cast<t*>(_alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
+	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); }
 
 #elif defined TORRENT_BSD
 
 #include <stdlib.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	t* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * (std::size_t(n)))); \
-	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, std::size_t(n)); }
+	std::size_t TORRENT_ALLOCA_size = aux::numeric_cast<std::size_t>(n); \
+	t* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
+	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); }
 
 #else
 
 #include <alloca.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	t* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * (std::size_t(n)))); \
-	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, std::size_t(n)); }
+	std::size_t TORRENT_ALLOCA_size = aux::numeric_cast<std::size_t>(n); \
+	t* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
+	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); }
 
 #endif
 

--- a/include/libtorrent/aux_/numeric_cast.hpp
+++ b/include/libtorrent/aux_/numeric_cast.hpp
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_NUMERIC_CAST_HPP
 
 #include <type_traits>
+#include <limits>
 
 #include "libtorrent/assert.hpp"
 

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/bdecode.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include <limits>
 #include <cstring> // for memset

--- a/src/block_cache.cpp
+++ b/src/block_cache.cpp
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error.hpp"
 #include "libtorrent/disk_io_thread.hpp" // disk_operation_failed
 #include "libtorrent/invariant_check.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/performance_counters.hpp"
 #include "libtorrent/aux_/time.hpp"
 #include "libtorrent/aux_/block_cache_reference.hpp"

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -64,7 +64,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/broadcast_socket.hpp"
 #include "libtorrent/peer_info.hpp"
 #include "libtorrent/random.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/socket_type.hpp"
 #include "libtorrent/performance_counters.hpp" // for counters
 

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/disk_io_thread.hpp"
 #include "libtorrent/string_util.hpp" // for allocate_string_copy
 #include "libtorrent/disk_buffer_holder.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/error.hpp"
 #include "libtorrent/file_pool.hpp"

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -67,7 +67,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include "libtorrent/config.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/file.hpp"
 #include "libtorrent/string_util.hpp"
 #include "libtorrent/aux_/max_path.hpp" // for TORRENT_MAX_PATH

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -50,7 +50,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include "libtorrent/random.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/pe_crypto.hpp"
 #include "libtorrent/hasher.hpp"
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -52,7 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/peer_info.hpp"
 #include "libtorrent/bt_peer_connection.hpp"
 #include "libtorrent/error.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/disk_interface.hpp"
 #include "libtorrent/bandwidth_manager.hpp"
 #include "libtorrent/request_blocks.hpp" // for request_a_block

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/piece_picker.hpp"
 #include "libtorrent/bitfield.hpp"
 #include "libtorrent/random.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/range.hpp"
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/alert_types.hpp" // for picker_log_alert

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -32,7 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/storage_utils.hpp"
 #include "libtorrent/file_storage.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/file.hpp" // for count_bufs
 #include "libtorrent/part_file.hpp"
 #include "libtorrent/session.hpp" // for session::delete_files

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -86,7 +86,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/request_blocks.hpp"
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/resolver_interface.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/resolve_links.hpp"
 #include "libtorrent/aux_/file_progress.hpp"
 #include "libtorrent/aux_/has_block.hpp"

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/utp_stream.hpp"
 #include "libtorrent/sliding_average.hpp"
 #include "libtorrent/utp_socket_manager.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/timestamp_history.hpp"
 #include "libtorrent/error.hpp"
 #include "libtorrent/random.hpp"

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -36,7 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/socket.hpp"
 #include "libtorrent/io.hpp"
-#include "libtorrent/alloca.hpp"
+#include "libtorrent/aux_/alloca.hpp" // for use of private TORRENT_ALLOCA
 #include "libtorrent/time.hpp"
 #include "libtorrent/peer_info.hpp"
 #include "libtorrent/bdecode.hpp"


### PR DESCRIPTION
The context for this is that I want to use private api `aux::numeric_cast` and an eventual `aux::typed_span`