### PR TITLE
test fail related to bt_peer_connection::on_suggest_piece

### DIFF
--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -1335,7 +1335,7 @@ namespace libtorrent
 		span<char const> recv_buffer = m_recv_buffer.get();
 
 		const char* ptr = recv_buffer.begin() + 1;
-		piece_index_t const piece(detail::read_uint32(ptr));
+		piece_index_t const piece(aux::numeric_cast<int>(detail::read_uint32(ptr)));
 		incoming_suggest(piece);
 	}
 


### PR DESCRIPTION
Hi @arvidn, this simple numeric cast makes `[test_fast_extension.cpp.invalid_suggest]` fail. I'm not very familiar with this part of the code, what do you think it could be?