### PR TITLE
add web_seed_name_lookup_retry to session_settings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* add web_seed_name_lookup_retry to session_settings
 	* slightly improve proxy settings backwards compatibility
 	* add function to get default settings
 	* updating super seeding would include the torrent in state_update_alert

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -795,8 +795,7 @@ namespace libtorrent
 			// time to wait until a new retry of a web seed takes place
 			urlseed_wait_retry,
 			
-			// time to wait until a new retry of a web seed name lookup. Default
-			// is 1800 seconds
+			// time to wait until a new retry of a web seed name lookup
 			web_seed_name_lookup_retry,
 			
 			// sets the upper limit on the total number of files this session will

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -794,7 +794,11 @@ namespace libtorrent
 
 			// time to wait until a new retry of a web seed takes place
 			urlseed_wait_retry,
-
+			
+			// time to wait until a new retry of a web seed name lookup. Default
+			// is 1800 seconds
+			web_seed_name_lookup_retry,
+			
 			// sets the upper limit on the total number of files this session will
 			// keep open. The reason why files are left open at all is that some
 			// anti virus software hooks on every file close, and scans the file

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -236,6 +236,7 @@ namespace libtorrent
 		SET(urlseed_pipeline_size, 5, 0),
 		SET_NOPREV(urlseed_max_request_bytes, 16 * 1024 * 1024, 0),
 		SET(urlseed_wait_retry, 30, 0),
+		SET_NOPREV(web_seed_name_lookup_retry, 1800, 0),		
 		SET(file_pool_size, 40, 0),
 		SET(max_failcount, 3, &session_impl::update_max_failcount),
 		SET(min_reconnect_time, 60, 0),

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6511,8 +6511,8 @@ namespace libtorrent
 				, web->url.c_str(), e.value(), e.message().c_str());
 #endif
 
-			// unavailable, retry in 30 minutes
-			web->retry = aux::time_now() + minutes(30);
+			// unavailable, retry in `settings_pack::web_seed_name_lookup_retry` seconds
+			web->retry = aux::time_now() + seconds(settings().get_int(settings_pack::web_seed_name_lookup_retry));
 			return;
 		}
 


### PR DESCRIPTION
add web_seed_name_lookup_retry to session_settings to control web seed
name lookup retry in seconds, default is 1800 seconds.