### PR TITLE
fix disabled "close_redundant_connections" web_seed disconnect exception

### DIFF
--- a/simulation/test_web_seed.cpp
+++ b/simulation/test_web_seed.cpp
@@ -520,7 +520,7 @@ TORRENT_TEST(no_close_redudant_webseed)
 
 				return sim::send_response(206, "Partial Content", 1, extra_headers).
 					append("A").
-					append(sim::send_response(408, "REQUEST TIMEOUT", 0)); 
+					append(sim::send_response(408, "REQUEST TIMEOUT", 0));
 			});
 
 			sim.run();

--- a/simulation/test_web_seed.cpp
+++ b/simulation/test_web_seed.cpp
@@ -518,7 +518,9 @@ TORRENT_TEST(no_close_redudant_webseed)
 				expected = true;
 				char const* extra_headers[4] = { "Content-Range: bytes 0-0/1\r\n", "", "", ""};
 
-				return sim::send_response(206, "Partial Content", 1, extra_headers).append("A").append(sim::send_response(408, "REQUEST TIMEOUT", 0));
+				return sim::send_response(206, "Partial Content", 1, extra_headers).
+					append("A").
+					append(sim::send_response(408, "REQUEST TIMEOUT", 0)); 
 			});
 
 			sim.run();

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -792,7 +792,6 @@ void web_peer_connection::on_receive(error_code const& error
 				if (!m_file_requests.empty())
 				{
 					file_request_t const& file_req = m_file_requests.front();
-					m_web->have_files.resize(t->torrent_file().num_files(), true);
 					m_web->have_files.clear_bit(file_req.file_index);
 				}
 				handle_error(int(recv_buffer.size()));

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -792,6 +792,7 @@ void web_peer_connection::on_receive(error_code const& error
 				if (!m_file_requests.empty())
 				{
 					file_request_t const& file_req = m_file_requests.front();
+					m_web->have_files.resize(t->torrent_file().num_files(), true);
 					m_web->have_files.clear_bit(file_req.file_index);
 				}
 				handle_error(int(recv_buffer.size()));

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -789,9 +789,12 @@ void web_peer_connection::on_receive(error_code const& error
 			// if the status code is not one of the accepted ones, abort
 			if (!is_ok_status(m_parser.status_code()))
 			{
-				file_request_t const& file_req = m_file_requests.front();
-				m_web->have_files.resize(t->torrent_file().num_files(), true);
-				m_web->have_files.clear_bit(file_req.file_index);
+				if (!m_file_requests.empty())
+				{
+					file_request_t const& file_req = m_file_requests.front();
+					m_web->have_files.resize(t->torrent_file().num_files(), true);
+					m_web->have_files.clear_bit(file_req.file_index);
+				}
 				handle_error(int(recv_buffer.size()));
 				return;
 			}


### PR DESCRIPTION
with  disabled "close_redundant_connections" web_seed disconnect may occure by unexpected http response which raise exception:
````c++
 0: 0155BDC5 std::_Debug_message +37   f:\dd\vctools\crt\crtw32\stdcpp\stdthrow.cpp:17
 1: 014C8ED0 std::_Deque_const_iterator<std::_Deque_val<std::_Deque_simple_types<libtorrent::web_peer_connection::file_request_t> > >::operator* +80   c:\program files (x86)\microsoft visual studio 14.0\vc\include\deque:329
 2: 014C904F std::_Deque_iterator<std::_Deque_val<std::_Deque_simple_types<libtorrent::web_peer_connection::file_request_t> > >::operator* +15   c:\program files (x86)\microsoft visual studio 14.0\vc\include\deque:591
 3: 014CA92C std::deque<libtorrent::web_peer_connection::file_request_t,std::allocator<libtorrent::web_peer_connection::file_request_t> >::front +76   c:\program files (x86)\microsoft visual studio 14.0\vc\include\deque:1438
 4: 014C2825 libtorrent::web_peer_connection::on_receive +1861 libtorrent\src\web_peer_connection.cpp:792
 5: 013CF311 libtorrent::peer_connection::on_receive_data +2273 libtorrent\src\peer_connection.cpp:5850
````
commit adds fix and simulation test