### PR TITLE
- add windows guid listen_interfaces settings example

### DIFF
--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -194,6 +194,12 @@ namespace libtorrent
 			// ``[::]:0s`` - will accept SSL connections on a port chosen by the
 			// OS. And not accept non-SSL connections at all.
 			//
+			// Windows OS network adapter device name can be specified with GUID.
+			// It can be obtained from "netsh lan show interfaces" command output.
+			// GUID must be uppercased string embraced in curly brackets.
+			// ``{E4F0B674-0DFC-48BB-98A5-2AA730BDB6D6}::7777`` - will accept
+			// connections on port 7777 on adapter with this GUID.
+			//
 			// .. note::
 			//   The current support for opening arbitrary UDP sockets is limited.
 			//   In this version of libtorrent, there will only ever be two UDP

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -240,14 +240,14 @@ namespace libtorrent
 
 		// ``add_tracker()`` adds a tracker to the announce-list. The ``tier``
 		// determines the order in which the trackers are to be tried.
-		//
+		void add_tracker(std::string const& url, int tier = 0);
+
 		// The ``trackers()`` function will return a sorted vector of
 		// ``announce_entry``. Each announce entry contains a string, which is
 		// the tracker url, and a tier index. The tier index is the high-level
 		// priority. No matter which trackers that works or not, the ones with
 		// lower tier will always be tried before the one with higher tier
 		// number. For more information, see announce_entry_.
-		void add_tracker(std::string const& url, int tier = 0);
 		std::vector<announce_entry> const& trackers() const { return m_urls; }
 
 		// These two functions are related to BEP38_ (mutable torrents). The
@@ -418,15 +418,16 @@ namespace libtorrent
 		// to peers over anything other than the i2p network.
 		bool is_i2p() const { return (m_flags & i2p) != 0; }
 
+		// returns the piece size of file with ``index``. This will be the same as piece_length(),
+		// except for the last piece, which may be shorter.
 		int piece_size(piece_index_t index) const { return m_files.piece_size(index); }
 
 		// ``hash_for_piece()`` takes a piece-index and returns the 20-bytes
 		// sha1-hash for that piece and ``info_hash()`` returns the 20-bytes
 		// sha1-hash for the info-section of the torrent file.
-		sha1_hash hash_for_piece(piece_index_t index) const;
-
 		// ``hash_for_piece_ptr()`` returns a pointer to the 20 byte sha1 digest
 		// for the piece. Note that the string is not 0-terminated.
+		sha1_hash hash_for_piece(piece_index_t index) const;
 		char const* hash_for_piece_ptr(piece_index_t const index) const
 		{
 			TORRENT_ASSERT(index >= piece_index_t(0));
@@ -465,7 +466,7 @@ namespace libtorrent
 		{ TORRENT_ASSERT(h.size() == m_merkle_tree.size() ); m_merkle_tree.swap(h); }
 
 		// ``name()`` returns the name of the torrent.
-		// Both the name and the comment is UTF-8 encoded strings.
+		// name contains UTF-8 encoded string.
 		const std::string& name() const { return m_files.name(); }
 
 		// ``creation_date()`` returns the creation date of the torrent as time_t
@@ -482,6 +483,7 @@ namespace libtorrent
 
 		// ``comment()`` returns the comment associated with the torrent. If
 		// there's no comment, it will return an empty string.
+		// comment contains UTF-8 encoded string.
 		const std::string& comment() const
 		{ return m_comment; }
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -418,13 +418,15 @@ namespace libtorrent
 		// to peers over anything other than the i2p network.
 		bool is_i2p() const { return (m_flags & i2p) != 0; }
 
+		int piece_size(piece_index_t index) const { return m_files.piece_size(index); }
+
 		// ``hash_for_piece()`` takes a piece-index and returns the 20-bytes
 		// sha1-hash for that piece and ``info_hash()`` returns the 20-bytes
 		// sha1-hash for the info-section of the torrent file.
+		sha1_hash hash_for_piece(piece_index_t index) const;
+
 		// ``hash_for_piece_ptr()`` returns a pointer to the 20 byte sha1 digest
 		// for the piece. Note that the string is not 0-terminated.
-		int piece_size(piece_index_t index) const { return m_files.piece_size(index); }
-		sha1_hash hash_for_piece(piece_index_t index) const;
 		char const* hash_for_piece_ptr(piece_index_t const index) const
 		{
 			TORRENT_ASSERT(index >= piece_index_t(0));
@@ -450,7 +452,8 @@ namespace libtorrent
 
 		// ``merkle_tree()`` returns a reference to the merkle tree for this
 		// torrent, if any.
-		//
+		std::vector<sha1_hash> const& merkle_tree() const { return m_merkle_tree; }
+
 		// ``set_merkle_tree()`` moves the passed in merkle tree into the
 		// torrent_info object. i.e. ``h`` will not be identical after the call.
 		// You need to set the merkle tree for a torrent that you've just created
@@ -458,29 +461,27 @@ namespace libtorrent
 		// ``create_torrent::merkle_tree()`` function, and need to be saved
 		// separately from the torrent file itself. Once it's added to
 		// libtorrent, the merkle tree will be persisted in the resume data.
-		std::vector<sha1_hash> const& merkle_tree() const { return m_merkle_tree; }
 		void set_merkle_tree(std::vector<sha1_hash>& h)
 		{ TORRENT_ASSERT(h.size() == m_merkle_tree.size() ); m_merkle_tree.swap(h); }
 
 		// ``name()`` returns the name of the torrent.
-		//
-		// ``comment()`` returns the comment associated with the torrent. If
-		// there's no comment, it will return an empty string.
+		// Both the name and the comment is UTF-8 encoded strings.
+		const std::string& name() const { return m_files.name(); }
+
 		// ``creation_date()`` returns the creation date of the torrent as time_t
 		// (`posix time`_). If there's no time stamp in the torrent file, the
 		// optional object will be uninitialized.
-		//
-		// Both the name and the comment is UTF-8 encoded strings.
-		//
-		// ``creator()`` returns the creator string in the torrent. If there is
-		// no creator string it will return an empty string.
-		//
 		// .. _`posix time`: http://www.opengroup.org/onlinepubs/009695399/functions/time.html
-		const std::string& name() const { return m_files.name(); }
 		time_t creation_date() const
 		{ return m_creation_date; }
+
+		// ``creator()`` returns the creator string in the torrent. If there is
+		// no creator string it will return an empty string.
 		const std::string& creator() const
 		{ return m_created_by; }
+
+		// ``comment()`` returns the comment associated with the torrent. If
+		// there's no comment, it will return an empty string.
 		const std::string& comment() const
 		{ return m_comment; }
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -240,14 +240,13 @@ namespace libtorrent
 
 		// ``add_tracker()`` adds a tracker to the announce-list. The ``tier``
 		// determines the order in which the trackers are to be tried.
-		void add_tracker(std::string const& url, int tier = 0);
-
 		// The ``trackers()`` function will return a sorted vector of
 		// ``announce_entry``. Each announce entry contains a string, which is
 		// the tracker url, and a tier index. The tier index is the high-level
 		// priority. No matter which trackers that works or not, the ones with
 		// lower tier will always be tried before the one with higher tier
 		// number. For more information, see announce_entry_.
+		void add_tracker(std::string const& url, int tier = 0);
 		std::vector<announce_entry> const& trackers() const { return m_urls; }
 
 		// These two functions are related to BEP38_ (mutable torrents). The
@@ -453,8 +452,6 @@ namespace libtorrent
 
 		// ``merkle_tree()`` returns a reference to the merkle tree for this
 		// torrent, if any.
-		std::vector<sha1_hash> const& merkle_tree() const { return m_merkle_tree; }
-
 		// ``set_merkle_tree()`` moves the passed in merkle tree into the
 		// torrent_info object. i.e. ``h`` will not be identical after the call.
 		// You need to set the merkle tree for a torrent that you've just created
@@ -462,6 +459,7 @@ namespace libtorrent
 		// ``create_torrent::merkle_tree()`` function, and need to be saved
 		// separately from the torrent file itself. Once it's added to
 		// libtorrent, the merkle tree will be persisted in the resume data.
+		std::vector<sha1_hash> const& merkle_tree() const { return m_merkle_tree; }
 		void set_merkle_tree(std::vector<sha1_hash>& h)
 		{ TORRENT_ASSERT(h.size() == m_merkle_tree.size() ); m_merkle_tree.swap(h); }
 


### PR DESCRIPTION
- rearrange comments for corresponding methods

@arvidn  is it ok to toss comment closer to its method so IDE will show appropriate method hint?