### PR TITLE
added support for enumerating the internal DHT live nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* added support for retrieval of DHT live nodes
 	* complete UNC path support
 	* add packets pool allocator
 	* fix last_upload and last_download overflow after 9 hours in past

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2510,11 +2510,33 @@ namespace libtorrent
 		aux::allocation_slot const m_msg_idx;
 	};
 
+	struct TORRENT_EXPORT dht_live_nodes_alert final : alert
+	{
+		dht_live_nodes_alert(aux::stack_allocator& alloc
+			, sha1_hash const& nid
+			, std::vector<std::pair<sha1_hash, udp::endpoint>> const& nodes);
+
+		TORRENT_DEFINE_ALERT(dht_live_nodes_alert, 91)
+
+		static const int static_category = alert::dht_notification;
+		virtual std::string message() const override;
+
+		sha1_hash const node_id;
+
+		int num_nodes() const;
+		std::vector<std::pair<sha1_hash, udp::endpoint>> nodes() const;
+
+	private:
+		std::reference_wrapper<aux::stack_allocator> m_alloc;
+		int const m_num_nodes;
+		aux::allocation_slot m_nodes_idx;
+	};
+
 #undef TORRENT_DEFINE_ALERT_IMPL
 #undef TORRENT_DEFINE_ALERT
 #undef TORRENT_DEFINE_ALERT_PRIO
 
-	enum { num_alert_types = 91 }; // this enum represents "max_alert_index" + 1
+	enum { num_alert_types = 92 }; // this enum represents "max_alert_index" + 1
 }
 
 #endif

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2528,8 +2528,10 @@ namespace libtorrent
 
 	private:
 		std::reference_wrapper<aux::stack_allocator> m_alloc;
-		int const m_num_nodes;
-		aux::allocation_slot m_nodes_idx;
+		int m_v4_num_nodes = 0;
+		int m_v6_num_nodes = 0;
+		aux::allocation_slot m_v4_nodes_idx;
+		aux::allocation_slot m_v6_nodes_idx;
 	};
 
 #undef TORRENT_DEFINE_ALERT_IMPL

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -394,6 +394,9 @@ namespace libtorrent
 			void dht_get_peers(sha1_hash const& info_hash);
 			void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
+			void dht_live_nodes(sha1_hash const& nid
+				, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb);
+
 			void dht_direct_request(udp::endpoint ep, entry& e
 				, void* userdata = nullptr);
 

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -394,8 +394,7 @@ namespace libtorrent
 			void dht_get_peers(sha1_hash const& info_hash);
 			void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
-			void dht_live_nodes(sha1_hash const& nid
-				, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb);
+			void dht_live_nodes(sha1_hash const& nid);
 
 			void dht_direct_request(udp::endpoint ep, entry& e
 				, void* userdata = nullptr);

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -125,8 +125,7 @@ namespace libtorrent { namespace dht
 		void incoming_error(error_code const& ec, udp::endpoint const& ep);
 		bool incoming_packet(udp::endpoint const& ep, span<char const> buf);
 
-		std::vector<std::pair<node_id, udp::endpoint>> live_nodes(node_id const& nid
-			, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb);
+		std::vector<std::pair<node_id, udp::endpoint>> live_nodes(node_id const& nid);
 
 	private:
 

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -125,6 +125,9 @@ namespace libtorrent { namespace dht
 		void incoming_error(error_code const& ec, udp::endpoint const& ep);
 		bool incoming_packet(udp::endpoint const& ep, span<char const> buf);
 
+		std::vector<std::pair<node_id, udp::endpoint>> live_nodes(node_id const& nid
+			, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb);
+
 	private:
 
 		std::shared_ptr<dht_tracker> self()

--- a/include/libtorrent/kademlia/routing_table.hpp
+++ b/include/libtorrent/kademlia/routing_table.hpp
@@ -224,14 +224,8 @@ public:
 		return int(i->live_nodes.size());
 	}
 
-	template <typename F>
-	void for_each_node(F f)
-	{
-		for_each_node(&impl::forwarder<F>, &impl::forwarder<F>, reinterpret_cast<void*>(&f));
-	}
-
-	void for_each_node(void (*)(void*, node_entry const&)
-		, void (*)(void*, node_entry const&), void* userdata) const;
+	void for_each_node(std::function<void(node_entry const&)> live_cb
+		, std::function<void(node_entry const&)> replacements_cb) const;
 
 	int bucket_size() const { return m_bucket_size; }
 

--- a/include/libtorrent/kademlia/routing_table.hpp
+++ b/include/libtorrent/kademlia/routing_table.hpp
@@ -227,6 +227,9 @@ public:
 	void for_each_node(std::function<void(node_entry const&)> live_cb
 		, std::function<void(node_entry const&)> replacements_cb) const;
 
+	void for_each_node(std::function<void(node_entry const&)> f) const
+	{ for_each_node(f, f); }
+
 	int bucket_size() const { return m_bucket_size; }
 
 	// returns the number of nodes in the main buckets, number of nodes in the

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -442,6 +442,19 @@ namespace libtorrent
 		void dht_get_peers(sha1_hash const& info_hash);
 		void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
+		// Iterate all the live DHT (identified by ``nid``) nodes and pass the
+		// nodes id and endpoint to the callback ``cb``. If the callback function
+		// returns true, the pair will be returned in the list of nodes in the
+		// alert ``dht_live_nodes_alert``.
+		// Since this alert is a response to an explicit call, it will always be
+		// posted, regardless of the alert mask.
+		//
+		// Given that the function is called from an internal thread of libtorrent,
+		// it's important to not stall or make calls to the public API
+		// that can result in race conditions.
+		void dht_live_nodes(sha1_hash const& nid
+			, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb);
+
 		// Send an arbitrary DHT request directly to the specified endpoint. This
 		// function is intended for use by plugins. When a response is received
 		// or the request times out, a dht_direct_response_alert will be posted

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -442,18 +442,12 @@ namespace libtorrent
 		void dht_get_peers(sha1_hash const& info_hash);
 		void dht_announce(sha1_hash const& info_hash, int port = 0, int flags = 0);
 
-		// Iterate all the live DHT (identified by ``nid``) nodes and pass the
-		// nodes id and endpoint to the callback ``cb``. If the callback function
-		// returns true, the pair will be returned in the list of nodes in the
+		// Retrieve all the live DHT (identified by ``nid``) nodes. All the
+		// nodes id and endpoint will be returned in the list of nodes in the
 		// alert ``dht_live_nodes_alert``.
 		// Since this alert is a response to an explicit call, it will always be
 		// posted, regardless of the alert mask.
-		//
-		// Given that the function is called from an internal thread of libtorrent,
-		// it's important to not stall or make calls to the public API
-		// that can result in race conditions.
-		void dht_live_nodes(sha1_hash const& nid
-			, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb);
+		void dht_live_nodes(sha1_hash const& nid);
 
 		// Send an arbitrary DHT request directly to the specified endpoint. This
 		// function is intended for use by plugins. When a response is received

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -536,8 +536,7 @@ namespace libtorrent { namespace dht
 		return true;
 	}
 
-	std::vector<std::pair<node_id, udp::endpoint>> dht_tracker::live_nodes(node_id const& nid
-		, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb)
+	std::vector<std::pair<node_id, udp::endpoint>> dht_tracker::live_nodes(node_id const& nid)
 	{
 		std::vector<std::pair<node_id, udp::endpoint>> ret;
 
@@ -551,11 +550,8 @@ namespace libtorrent { namespace dht
 
 		if (dht == nullptr) return ret;
 
-		dht->m_table.for_each_node([&cb, &ret](node_entry const& e)
-		{
-			udp::endpoint const endp = e.endpoint;
-			if (cb(e.id, endp)) ret.emplace_back(e.id, endp);
-		}, nullptr);
+		dht->m_table.for_each_node([&ret](node_entry const& e)
+		{ ret.emplace_back(e.id, e.endpoint); }, nullptr);
 
 		return ret;
 	}
@@ -566,9 +562,9 @@ namespace libtorrent { namespace dht
 	{
 		std::vector<udp::endpoint> ret;
 
-		auto cb = [&ret](node_entry const& e) { ret.push_back(e.ep()); };
+		dht.m_table.for_each_node([&ret](node_entry const& e)
+		{ ret.push_back(e.ep()); });
 
-		dht.m_table.for_each_node(cb, cb);
 		return ret;
 	}
 

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -536,19 +536,39 @@ namespace libtorrent { namespace dht
 		return true;
 	}
 
-	namespace {
-
-	void add_node_fun(void* userdata, node_entry const& e)
+	std::vector<std::pair<node_id, udp::endpoint>> dht_tracker::live_nodes(node_id const& nid
+		, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb)
 	{
-		auto v = static_cast<std::vector<udp::endpoint>*>(userdata);
-		v->push_back(e.ep());
+		std::vector<std::pair<node_id, udp::endpoint>> ret;
+
+		// TODO: figure out a better solution when multi-home is implemented
+		node const* dht = m_dht.nid() == nid ? &m_dht
+#if TORRENT_USE_IPV6
+			: m_dht6.nid() == nid ? &m_dht6 : nullptr;
+#else
+			: nullptr
+#endif
+
+		if (dht == nullptr) return ret;
+
+		dht->m_table.for_each_node([&cb, &ret](node_entry const& e)
+		{
+			udp::endpoint const endp = e.endpoint;
+			if (cb(e.id, endp)) ret.emplace_back(e.id, endp);
+		}, nullptr);
+
+		return ret;
 	}
+
+	namespace {
 
 	std::vector<udp::endpoint> save_nodes(node const& dht)
 	{
 		std::vector<udp::endpoint> ret;
-		// TODO: refactor for more use of lambda
-		dht.m_table.for_each_node(&add_node_fun, &add_node_fun, &ret);
+
+		auto cb = [&ret](node_entry const& e) { ret.push_back(e.ep()); };
+
+		dht.m_table.for_each_node(cb, cb);
 		return ret;
 	}
 

--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -946,22 +946,20 @@ void routing_table::update_node_id(node_id const& id)
 			add_node(n);
 }
 
-void routing_table::for_each_node(
-	void (*fun1)(void*, node_entry const&)
-	, void (*fun2)(void*, node_entry const&)
-	, void* userdata) const
+void routing_table::for_each_node(std::function<void(node_entry const&)> live_cb
+	, std::function<void(node_entry const&)> replacements_cb) const
 {
 	for (auto const& i : m_buckets)
 	{
-		if (fun1)
+		if (live_cb)
 		{
 			for (auto const& j : i.live_nodes)
-				fun1(userdata, j);
+				live_cb(j);
 		}
-		if (fun2)
+		if (replacements_cb)
 		{
 			for (auto const& j : i.replacements)
-				fun2(userdata, j);
+				replacements_cb(j);
 		}
 	}
 }

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -601,14 +601,12 @@ namespace libtorrent
 #endif
 	}
 
-	void session_handle::dht_live_nodes(sha1_hash const& nid
-		, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb)
+	void session_handle::dht_live_nodes(sha1_hash const& nid)
 	{
 #ifndef TORRENT_DISABLE_DHT
-		async_call(&session_impl::dht_live_nodes, nid, std::move(cb));
+		async_call(&session_impl::dht_live_nodes, nid);
 #else
 		TORRENT_UNUSED(nid);
-		TORRENT_UNUSED(cb);
 #endif
 	}
 

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -601,6 +601,17 @@ namespace libtorrent
 #endif
 	}
 
+	void session_handle::dht_live_nodes(sha1_hash const& nid
+		, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb)
+	{
+#ifndef TORRENT_DISABLE_DHT
+		async_call(&session_impl::dht_live_nodes, nid, std::move(cb));
+#else
+		TORRENT_UNUSED(nid);
+		TORRENT_UNUSED(cb);
+#endif
+	}
+
 	void session_handle::dht_direct_request(udp::endpoint ep, entry const& e, void* userdata)
 	{
 #ifndef TORRENT_DISABLE_DHT

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5831,11 +5831,10 @@ namespace aux {
 		m_dht->announce(info_hash, port, flags, std::bind(&on_dht_get_peers, std::ref(m_alerts), info_hash, _1));
 	}
 
-	void session_impl::dht_live_nodes(sha1_hash const& nid
-		, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb)
+	void session_impl::dht_live_nodes(sha1_hash const& nid)
 	{
 		if (!m_dht) return;
-		auto nodes = m_dht->live_nodes(nid, cb);
+		auto nodes = m_dht->live_nodes(nid);
 		m_alerts.emplace_alert<dht_live_nodes_alert>(nid, nodes);
 	}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5831,6 +5831,14 @@ namespace aux {
 		m_dht->announce(info_hash, port, flags, std::bind(&on_dht_get_peers, std::ref(m_alerts), info_hash, _1));
 	}
 
+	void session_impl::dht_live_nodes(sha1_hash const& nid
+		, std::function<bool(sha1_hash const&, udp::endpoint const&)> cb)
+	{
+		if (!m_dht) return;
+		auto nodes = m_dht->live_nodes(nid, cb);
+		m_alerts.emplace_alert<dht_live_nodes_alert>(nid, nodes);
+	}
+
 	void session_impl::dht_direct_request(udp::endpoint ep, entry& e, void* userdata)
 	{
 		if (!m_dht) return;

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -88,21 +88,19 @@ sequence_number next_seq(sequence_number s)
 	return sequence_number(s.value + 1);
 }
 
-void add_and_replace(libtorrent::dht::node_id& dst, libtorrent::dht::node_id const& add)
+void add_and_replace(node_id& dst, node_id const& add)
 {
 	bool carry = false;
 	for (int k = 19; k >= 0; --k)
 	{
-		int sum = dst[k] + add[k] + (carry?1:0);
+		int sum = dst[k] + add[k] + (carry ? 1 : 0);
 		dst[k] = sum & 255;
 		carry = sum > 255;
 	}
 }
 
-void node_push_back(void* userdata, libtorrent::dht::node_entry const& n)
+void node_push_back(std::vector<node_entry>* nv, node_entry const& n)
 {
-	using namespace libtorrent::dht;
-	std::vector<node_entry>* nv = (std::vector<node_entry>*)userdata;
 	nv->push_back(n);
 }
 
@@ -1677,8 +1675,6 @@ void test_routing_table(address(&rand_addr)())
 		}
 	}
 
-	using namespace libtorrent::dht;
-
 	char const* ips[] = {
 		"124.31.75.21",
 		"21.75.31.124",
@@ -2914,8 +2910,7 @@ TORRENT_TEST(routing_table_set_id)
 	TEST_EQUAL(tbl.num_active_buckets(), 6);
 
 	std::set<node_id> original_nodes;
-	tbl.for_each_node(std::bind(&inserter, &original_nodes, _1)
-		, std::bind(&inserter, &original_nodes, _1));
+	tbl.for_each_node(std::bind(&inserter, &original_nodes, _1));
 
 	print_state(std::cout, tbl);
 
@@ -2925,8 +2920,7 @@ TORRENT_TEST(routing_table_set_id)
 
 	TEST_CHECK(tbl.num_active_buckets() <= 4);
 	std::set<node_id> remaining_nodes;
-	tbl.for_each_node(std::bind(&inserter, &remaining_nodes, _1)
-		, std::bind(&inserter, &remaining_nodes, _1));
+	tbl.for_each_node(std::bind(&inserter, &remaining_nodes, _1));
 
 	std::set<node_id> intersection;
 	std::set_intersection(remaining_nodes.begin(), remaining_nodes.end()
@@ -2976,7 +2970,7 @@ TORRENT_TEST(routing_table_for_each)
 	tbl.for_each_node(nullptr, std::bind(node_push_back, &v, _1));
 	TEST_EQUAL(v.size(), 2);
 	v.clear();
-	tbl.for_each_node(std::bind(node_push_back, &v, _1), std::bind(node_push_back, &v, _1));
+	tbl.for_each_node(std::bind(node_push_back, &v, _1));
 	TEST_EQUAL(v.size(), 4);
 }
 
@@ -3301,9 +3295,6 @@ TORRENT_TEST(dht_verify_node_address)
 
 TORRENT_TEST(generate_prefix_mask)
 {
-	// test node-id functions
-	using namespace libtorrent::dht;
-
 	std::vector<std::pair<int, char const*>> const test = {
 		{   0, "0000000000000000000000000000000000000000" },
 		{   1, "8000000000000000000000000000000000000000" },


### PR DESCRIPTION
Before going any further with tests (and some details), I would like to have some feedback in this public API addition. The context is be able to access internal DHT nodes information in order to use in https://github.com/arvidn/libtorrent/pull/1652.

I believe that this approach allows for a flexible collection (and recreation) of relevant data of nodes. One interesting trick is that if one wants to avoid a big alert in the queue, a crafted "callback" function could be used.