### PR TITLE
fix build from RC_1_1 merge

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -1194,7 +1194,7 @@ namespace libtorrent
 			// this keeps the timers more accurate over time
 			// as a kind of "leap second" to adjust for the
 			// accumulated error
-			std::uint16_t m_tick_residual = 0;
+			std::int16_t m_tick_residual = 0;
 
 #ifndef TORRENT_DISABLE_LOGGING
 			virtual bool should_log() const override;

--- a/include/libtorrent/io.hpp
+++ b/include/libtorrent/io.hpp
@@ -80,14 +80,18 @@ namespace libtorrent
 				|| std::is_enum<In>::value>::type>
 		inline void write_impl(In data, OutIt& start)
 		{
-			T val = T(data);
-			TORRENT_ASSERT(data == In(val));
+			T val = static_cast<T>(data);
+			TORRENT_ASSERT(data == static_cast<In>(val));
 			for (int i = int(sizeof(T)) - 1; i >= 0; --i)
 			{
 				*start = static_cast<unsigned char>((val >> (i * 8)) & 0xff);
 				++start;
 			}
 		}
+
+		template <class T, class OutIt>
+		inline void write_impl(bool val, OutIt& start)
+		{ write_impl<std::uint8_t>(val ? 1 : 0, start); }
 
 		// -- adaptors
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1189,7 +1189,7 @@ namespace libtorrent
 			// processes.
 			file_checks_delay_per_block,
 #else
-			deprecated14,
+			deprecated23,
 #endif
 
 			// ``read_cache_line_size`` is the number of blocks to read into the
@@ -1308,7 +1308,7 @@ namespace libtorrent
 			// the session-global limits of upload and download rate limits, in
 			// bytes per second. By default peers on the local network are not rate
 			// limited.
-			// 
+			//
 			// A value of 0 means unlimited.
 			upload_rate_limit,
 			download_rate_limit,

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -81,8 +81,8 @@ namespace libtorrent
 		return ret;
 	}
 
-	void rc4_init(const unsigned char* in, unsigned long len, rc4 *state);
-	unsigned long rc4_encrypt(unsigned char *out, unsigned long outlen, rc4 *state);
+	void rc4_init(const unsigned char* in, std::size_t len, rc4 *state);
+	std::size_t rc4_encrypt(unsigned char *out, std::size_t outlen, rc4 *state);
 
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
@@ -349,9 +349,9 @@ namespace libtorrent
 // this library is public domain and has been specially
 // tailored for libtorrent by Arvid Norberg
 
-void rc4_init(const unsigned char* in, unsigned long len, rc4 *state)
+void rc4_init(const unsigned char* in, std::size_t len, rc4 *state)
 {
-	size_t const key_size = sizeof(state->buf);
+	std::size_t const key_size = sizeof(state->buf);
 	aux::array<std::uint8_t, key_size> key;
 	std::uint8_t tmp, *s;
 	int keylen, x, y, j;
@@ -386,10 +386,10 @@ void rc4_init(const unsigned char* in, unsigned long len, rc4 *state)
 	state->y = 0;
 }
 
-unsigned long rc4_encrypt(unsigned char *out, unsigned long outlen, rc4 *state)
+std::size_t rc4_encrypt(unsigned char *out, std::size_t outlen, rc4 *state)
 {
 	std::uint8_t x, y, *s, tmp;
-	unsigned long n;
+	std::size_t n;
 
 	TORRENT_ASSERT(out != nullptr);
 	TORRENT_ASSERT(state != nullptr);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -861,10 +861,10 @@ namespace libtorrent
 			return;
 		m_fast_reconnect = r;
 		peer_info_struct()->last_connected = std::uint16_t(m_ses.session_time());
-		int rewind = m_settings.get_int(settings_pack::min_reconnect_time)
+		int const rewind = m_settings.get_int(settings_pack::min_reconnect_time)
 			* m_settings.get_int(settings_pack::max_failcount);
-		if (peer_info_struct()->last_connected < rewind) peer_info_struct()->last_connected = 0;
-		else peer_info_struct()->last_connected -= rewind;
+		if (int(peer_info_struct()->last_connected) < rewind) peer_info_struct()->last_connected = 0;
+		else peer_info_struct()->last_connected -= std::uint16_t(rewind);
 
 		if (peer_info_struct()->fast_reconnects < 15)
 			++peer_info_struct()->fast_reconnects;

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3155,9 +3155,10 @@ namespace aux {
 		m_ssl_utp_socket_manager.decay();
 #endif
 
-		int tick_interval_ms = int(total_milliseconds(now - m_last_second_tick));
+		int const tick_interval_ms = aux::numeric_cast<int>(total_milliseconds(now - m_last_second_tick));
 		m_last_second_tick = now;
-		m_tick_residual += tick_interval_ms - 1000;
+		m_tick_residual = aux::numeric_cast<std::int16_t>(m_tick_residual + tick_interval_ms - 1000);
+		TORRENT_ASSERT(m_tick_residual >= 0);
 
 		std::int32_t const stime = session_time();
 		if (stime > 65000)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -523,7 +523,7 @@ namespace libtorrent
 		TORRENT_ASSERT(new_gauge_state >= 0);
 		TORRENT_ASSERT(new_gauge_state <= no_gauge_state);
 
-		if (new_gauge_state == m_current_gauge_state) return;
+		if (new_gauge_state == int(m_current_gauge_state)) return;
 
 		if (m_current_gauge_state != no_gauge_state)
 			inc_stats_counter(m_current_gauge_state + counters::num_checking_torrents, -1);
@@ -2919,14 +2919,14 @@ namespace libtorrent
 			downloaded = (std::max)(t.scrape_downloaded, downloaded);
 		}
 
-		if ((complete >= 0 && m_complete != complete)
-			|| (incomplete >= 0 && m_incomplete != incomplete)
-			|| (downloaded >= 0 && m_downloaded != downloaded))
+		if ((complete >= 0 && int(m_complete) != complete)
+			|| (incomplete >= 0 && int(m_incomplete) != incomplete)
+			|| (downloaded >= 0 && int(m_downloaded) != downloaded))
 			state_updated();
 
-		if (m_complete != complete
-			|| m_incomplete != incomplete
-			|| m_downloaded != downloaded)
+		if (int(m_complete) != complete
+			|| int(m_incomplete) != incomplete
+			|| int(m_downloaded) != downloaded)
 		{
 			m_complete = std::uint32_t(complete);
 			m_incomplete = std::uint32_t(incomplete);
@@ -3419,7 +3419,7 @@ namespace libtorrent
 
 		std::vector<file_slice> files = fs.map_block(
 			p.piece_index, offset, (std::min)(piece_size - offset, block_size()));
-		int ret = 0;
+		std::int64_t ret = 0;
 		for (std::vector<file_slice>::iterator i = files.begin()
 			, end(files.end()); i != end; ++i)
 		{
@@ -3427,7 +3427,7 @@ namespace libtorrent
 			ret += i->size;
 		}
 		TORRENT_ASSERT(ret <= (std::min)(piece_size - offset, block_size()));
-		return ret;
+		return aux::numeric_cast<int>(ret);
 	}
 
 	// fills in total_wanted, total_wanted_done and total_done
@@ -5385,8 +5385,8 @@ namespace libtorrent
 
 			TORRENT_ASSERT(pp->prev_amount_upload == 0);
 			TORRENT_ASSERT(pp->prev_amount_download == 0);
-			pp->prev_amount_download += p->statistics().total_payload_download() >> 10;
-			pp->prev_amount_upload += p->statistics().total_payload_upload() >> 10;
+			pp->prev_amount_download += aux::numeric_cast<std::uint32_t>(p->statistics().total_payload_download() >> 10);
+			pp->prev_amount_upload += aux::numeric_cast<std::uint32_t>(p->statistics().total_payload_upload() >> 10);
 
 			if (pp->seed)
 			{
@@ -7997,7 +7997,7 @@ namespace libtorrent
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(limit >= -1);
 		if (limit <= 0) limit = (1 << 24) - 1;
-		if (m_max_uploads != limit && state_update) state_updated();
+		if (int(m_max_uploads)!= limit && state_update) state_updated();
 		m_max_uploads = aux::numeric_cast<std::uint32_t>(limit);
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("*** set-max-uploads: %d", m_max_uploads);
@@ -8012,7 +8012,7 @@ namespace libtorrent
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(limit >= -1);
 		if (limit <= 0) limit = (1 << 24) - 1;
-		if (m_max_connections != limit && state_update) state_updated();
+		if (int(m_max_connections) != limit && state_update) state_updated();
 		m_max_connections = aux::numeric_cast<std::uint32_t>(limit);
 		update_want_peers();
 
@@ -9421,7 +9421,7 @@ namespace libtorrent
 
 			// only allow a single additional request per block, in order
 			// to spread it out evenly across all stalled blocks
-			if (info[k].num_peers > timed_out)
+			if (int(info[k].num_peers) > timed_out)
 				continue;
 
 			busy_blocks[busy_count].peers = info[k].num_peers;


### PR DESCRIPTION
Hi @arvidn, something must be changed with the compiler. These warnings are new (the code is old) and both `clang` and `gcc` are able to detect that the bitfields will not overflow and avoid the warnings.

Feel free to discard this PR, cherry-pick or just copy the useful parts