### PR TITLE
Add a python bindings test for pickling trackers

### DIFF
--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import binascii
 import inspect
+import pickle
 
 class test_create_torrent(unittest.TestCase):
 
@@ -71,6 +72,20 @@ class test_torrent_handle(unittest.TestCase):
 		self.assertEqual(new_trackers[0]['url'], 'udp://tracker1.com')
 		self.assertEqual(new_trackers[1]['tier'], 1)
 		self.assertEqual(new_trackers[1]['fail_limit'], 2)
+
+	def test_pickle_trackers(self):
+		"""Test lt objects convertors are working and trackers can be pickled"""
+		self.setup()
+		tracker = lt.announce_entry('udp://tracker1.com')
+		tracker.tier = 0
+		tracker.fail_limit = 1
+		trackers = [tracker]
+		self.h.replace_trackers(trackers)
+		tracker_list = [tracker for tracker in self.h.trackers()]
+		pickled_trackers = pickle.dumps(tracker_list)
+		unpickled_trackers = pickle.loads(pickled_trackers)
+		self.assertEqual(unpickled_trackers[0]['url'], 'udp://tracker1.com')
+		self.assertEqual(unpickled_trackers[0]['last_error']['value'], 0)
 
 	def test_file_status(self):
 		self.setup()
@@ -158,6 +173,7 @@ class test_torrent_info(unittest.TestCase):
 		self.assertEquals(ae.can_announce(False), True)
 		self.assertEquals(ae.scrape_incomplete, -1)
 		self.assertEquals(ae.next_announce, None)
+		self.assertEquals(ae.last_error['value'], 0)
 
 class test_alerts(unittest.TestCase):
 


### PR DESCRIPTION
 * If ae.last_error (lt.error_code) is not converted in bindings to a dict
 then pickling the trackers with fail.

For #1738 