### PR TITLE
making torrent::we_have a little more robust while iterating connections

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3762,7 +3762,7 @@ namespace libtorrent
 		// (unless it has already been announced through predictive_piece_announce
 		// feature).
 		bool announce_piece = true;
-		auto it = std::lower_bound(m_predictive_pieces.begin()
+		auto const it = std::lower_bound(m_predictive_pieces.begin()
 			, m_predictive_pieces.end(), index);
 		if (it != m_predictive_pieces.end() && *it == index)
 		{
@@ -3773,11 +3773,10 @@ namespace libtorrent
 
 		// make a copy of the peer list since peers
 		// may disconnect while looping
-		std::vector<peer_connection*> peers = m_connections;
-
-		for (peer_iterator i = peers.begin(); i != peers.end(); ++i)
+		for (auto const c : std::vector<peer_connection*>(m_connections))
 		{
-			std::shared_ptr<peer_connection> p = (*i)->self();
+			TORRENT_ASSERT(c != nullptr);
+			auto const p = c->self();
 
 			// received_piece will check to see if we're still interested
 			// in this peer, and if neither of us is interested in the other,
@@ -3804,13 +3803,14 @@ namespace libtorrent
 		// since this piece just passed, we might have
 		// become uninterested in some peers where this
 		// was the last piece we were interested in
-		for (peer_iterator i = m_connections.begin();
-			i != m_connections.end();)
+		//
+		// make a copy of the peer list since peers
+		// may disconnect while looping
+		for (auto const c : std::vector<peer_connection*>(m_connections))
 		{
-			peer_connection* p = *i;
-			// update_interest may disconnect the peer and
-			// invalidate the iterator
-			++i;
+			TORRENT_ASSERT(c != nullptr);
+			auto const p = c->self();
+
 			// if we're not interested already, no need to check
 			if (!p->is_interesting()) continue;
 			// if the peer doesn't have the piece we just got, it


### PR DESCRIPTION
This is to partially address this issue https://github.com/frostwire/frostwire-jlibtorrent/issues/157