### PR TITLE
mark connection as upload only manually instead of with set_upload_on…

### DIFF
--- a/src/web_connection_base.cpp
+++ b/src/web_connection_base.cpp
@@ -113,7 +113,11 @@ namespace libtorrent
 
 	void web_connection_base::start()
 	{
-		set_upload_only(true);
+		// avoid calling torrent::set_seed because it calls torrent::check_invariant
+		// which fails because the m_num_connecting count is not consistent until
+		// after we call peer_connection::start
+		m_upload_only = true;
+		disconnect_if_redundant();
 		if (is_disconnecting()) return;
 		peer_connection::start();
 	}


### PR DESCRIPTION
…ly()

We can't call set_upload_only() in this context because it can trigger an invariant
check in the torrent and m_num_connecting is not consistent.