### PR TITLE
don't remove peers from the connection list immediately when disconnecting

### DIFF
--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -166,6 +166,7 @@ nobase_include_HEADERS = \
   aux_/disable_warnings_push.hpp    \
   aux_/disable_warnings_pop.hpp     \
   aux_/disk_job_fence.hpp           \
+  aux_/deferred_handler.hpp         \
   aux_/dev_random.hpp               \
   aux_/deque.hpp                    \
   aux_/escape_string.hpp            \

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -347,7 +347,7 @@ namespace libtorrent
 
 			peer_id const& get_peer_id() const override { return m_peer_id; }
 
-			void close_connection(peer_connection* p, error_code const& ec) override;
+			void close_connection(peer_connection* p) override;
 
 			void apply_settings_pack(std::shared_ptr<settings_pack> pack) override;
 			void apply_settings_pack_impl(settings_pack const& pack

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -189,7 +189,7 @@ namespace libtorrent { namespace aux
 
 		virtual peer_id const& get_peer_id() const = 0;
 
-		virtual void close_connection(peer_connection* p, error_code const& ec) = 0;
+		virtual void close_connection(peer_connection* p) = 0;
 		virtual int num_connections() const = 0;
 
 		virtual ses_buffer_holder allocate_buffer() = 0;

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4239,6 +4239,8 @@ namespace libtorrent
 					handle, performance_alert::too_few_outgoing_ports);
 		}
 
+		m_disconnecting = true;
+
 		if (t)
 		{
 			if (ec)
@@ -4294,24 +4296,26 @@ namespace libtorrent
 			check_invariant();
 #endif
 			t->remove_peer(this);
+
+			// we need to do this here to maintain accurate accounting of number of
+			// unhoke slots. Ideally the updating of choked state and the
+			// accounting should be tighter
+			if (!m_choked)
+			{
+				m_choked = true;
+				m_counters.inc_stats_counter(counters::num_peers_up_unchoked_all, -1);
+				if (!ignore_unchoke_slots())
+					m_counters.inc_stats_counter(counters::num_peers_up_unchoked, -1);
+			}
 		}
 		else
 		{
 			TORRENT_ASSERT(m_download_queue.empty());
 			TORRENT_ASSERT(m_request_queue.empty());
+			m_ses.close_connection(this);
 		}
 
-#if defined TORRENT_EXPENSIVE_INVARIANT_CHECKS
-		// since this connection doesn't have a torrent reference
-		// no torrent should have a reference to this connection either
-		TORRENT_ASSERT(!m_ses.any_torrent_has_peer(this));
-#endif
-
-		m_disconnecting = true;
-
 		async_shutdown(*m_socket, m_socket);
-
-		m_ses.close_connection(this, ec);
 	}
 
 	bool peer_connection::ignore_unchoke_slots() const

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -977,14 +977,12 @@ namespace aux {
 		session_log(" aborting all connections (%d)", int(m_connections.size()));
 #endif
 		// abort all connections
-		while (!m_connections.empty())
-		{
-#if TORRENT_USE_ASSERTS
-			int conn = int(m_connections.size());
-#endif
-			(*m_connections.begin())->disconnect(errors::stopping_torrent, op_bittorrent);
-			TORRENT_ASSERT_VAL(conn == int(m_connections.size()) + 1, conn);
-		}
+		// keep in mind that connections that are not associated with a torrent
+		// will remove its entry from m_connections immediately, which means we
+		// can't iterate over it here
+		auto conns = m_connections;
+		for (auto const& p : conns)
+			p->disconnect(errors::stopping_torrent, op_bittorrent);
 
 		// we need to give all the sockets an opportunity to actually have their handlers
 		// called and cancelled before we continue the shutdown. This is a bit
@@ -2877,8 +2875,7 @@ namespace aux {
 	// currently expected to be scheduled for a connection
 	// with the connection queue, and should be cancelled
 	// TODO: should this function take a shared_ptr instead?
-	void session_impl::close_connection(peer_connection* p
-		, error_code const& ec)
+	void session_impl::close_connection(peer_connection* p)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		std::shared_ptr<peer_connection> sp(p->self());
@@ -2888,16 +2885,6 @@ namespace aux {
 		// last reference is held by the network thread.
 		if (!sp.unique())
 			m_undead_peers.push_back(sp);
-
-#ifndef TORRENT_DISABLE_LOGGING
-		if (should_log())
-		{
-			session_log(" CLOSING CONNECTION %s : %s"
-				, print_endpoint(p->remote()).c_str(), ec.message().c_str());
-		}
-#else
-		TORRENT_UNUSED(ec);
-#endif
 
 		TORRENT_ASSERT(p->is_disconnecting());
 
@@ -6836,19 +6823,18 @@ namespace aux {
 		int unchokes_all = 0;
 		int num_optimistic = 0;
 		int disk_queue[2] = {0, 0};
-		for (connection_map::const_iterator i = m_connections.begin();
-			i != m_connections.end(); ++i)
+		for (auto const& p : m_connections)
 		{
-			TORRENT_ASSERT(*i);
-			std::shared_ptr<torrent> t = (*i)->associated_torrent().lock();
-			TORRENT_ASSERT(unique_peers.find(i->get()) == unique_peers.end());
-			unique_peers.insert(i->get());
+			TORRENT_ASSERT(p);
+			if (p->is_disconnecting()) continue;
 
-			if ((*i)->m_channel_state[0] & peer_info::bw_disk) ++disk_queue[0];
-			if ((*i)->m_channel_state[1] & peer_info::bw_disk) ++disk_queue[1];
+			std::shared_ptr<torrent> t = p->associated_torrent().lock();
+			TORRENT_ASSERT(unique_peers.find(p.get()) == unique_peers.end());
+			unique_peers.insert(p.get());
 
-			peer_connection* p = i->get();
-			TORRENT_ASSERT(!p->is_disconnecting());
+			if (p->m_channel_state[0] & peer_info::bw_disk) ++disk_queue[0];
+			if (p->m_channel_state[1] & peer_info::bw_disk) ++disk_queue[1];
+
 			if (p->ignore_unchoke_slots())
 			{
 				if (!p->is_choked()) ++unchokes_all;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6417,7 +6417,8 @@ namespace libtorrent
 		{
 			// this asserts that we don't have duplicates in the peer_list's peer list
 			peer_iterator i_ = std::find_if(m_connections.begin(), m_connections.end()
-				, [peerinfo] (peer_connection const* p) { return p->remote() == peerinfo->ip(); });
+				, [peerinfo] (peer_connection const* p)
+				{ return !p->is_disconnecting() && p->remote() == peerinfo->ip(); });
 #if TORRENT_USE_I2P
 			TORRENT_ASSERT(i_ == m_connections.end()
 				|| (*i_)->type() != connection_type::bittorrent
@@ -7168,8 +7169,8 @@ namespace libtorrent
 		for (auto p : m_connections)
 			TORRENT_ASSERT(m_ses.has_peer(p));
 #endif
-		std::vector<peer_connection*> to_disconnect;
-		to_disconnect.resize(static_cast<std::size_t>(num));
+		aux::vector<peer_connection*> to_disconnect;
+		to_disconnect.resize(num);
 		auto end = std::partial_sort_copy(m_connections.begin(), m_connections.end()
 			, to_disconnect.begin(), to_disconnect.end(), compare_disconnect_peer);
 		for (auto p : range(to_disconnect.begin(), end))

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5443,7 +5443,7 @@ namespace libtorrent
 		TORRENT_ASSERT(!web->resolving);
 		if (web->resolving) return;
 
-		if (num_peers() >= m_max_connections
+		if (num_peers() >= int(m_max_connections)
 			|| m_ses.num_connections() >= settings().get_int(settings_pack::connections_limit))
 			return;
 
@@ -5635,7 +5635,7 @@ namespace libtorrent
 
 		if (m_ses.is_aborted()) return;
 
-		if (num_peers() >= m_max_connections
+		if (num_peers() >= int(m_max_connections)
 			|| m_ses.num_connections() >= settings().get_int(settings_pack::connections_limit))
 			return;
 
@@ -5731,7 +5731,7 @@ namespace libtorrent
 #endif
 		}
 
-		if (num_peers() >= m_max_connections
+		if (num_peers() >= int(m_max_connections)
 			|| m_ses.num_connections() >= settings().get_int(settings_pack::connections_limit))
 			return;
 
@@ -7007,7 +7007,7 @@ namespace libtorrent
 	bool torrent::want_peers() const
 	{
 		// if all our connection slots are taken, we can't connect to more
-		if (num_peers() >= m_max_connections) return false;
+		if (num_peers() >= int(m_max_connections)) return false;
 
 		// if we're paused, obviously we're not connecting to peers
 		if (is_paused() || m_abort || m_graceful_pause_mode) return false;
@@ -9028,7 +9028,7 @@ namespace libtorrent
 
 		// if we have everything we want we don't need to connect to any web-seed
 		if (!is_finished() && !m_web_seeds.empty() && m_files_checked
-			&& num_peers() < m_max_connections
+			&& num_peers() < int(m_max_connections)
 			&& m_ses.num_connections() < settings().get_int(settings_pack::connections_limit))
 		{
 			// keep trying web-seeds if there are any


### PR DESCRIPTION
but defer it until later. This makes it less error prone to disconnect peers in loops over the connections