### PR TITLE
Improve Documantation

### DIFF
--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -905,6 +905,7 @@ namespace libtorrent
 			// high capacity connections, setting this higher can improve upload
 			// performance and disk throughput. Setting it too high may waste RAM
 			// and create a bias towards read jobs over write jobs.
+			// Have a look at http://libtorrent.org/tuning.html for more details
 			send_buffer_low_watermark,
 			send_buffer_watermark,
 			send_buffer_watermark_factor,

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -321,7 +321,9 @@ namespace libtorrent
 
 			// prefer seeding torrents when determining which torrents to give
 			// active slots to, the default is false which gives preference to
-			// downloading torrents
+			// downloading torrents. Be carefull if you want to prefer seeds,
+			// because if you have more seeds than ``active_limit`` you will never
+			// have an active download.
 			auto_manage_prefer_seeds,
 
 			// if ``dont_count_slow_torrents`` is true, torrents without any
@@ -1046,8 +1048,15 @@ namespace libtorrent
 			// torrents.
 			//
 			// ``active_limit`` is a hard limit on the number of active (auto
-			// managed) torrents. This limit also applies to slow torrents.
-			//
+			// managed) torrents. This limit also applies to slow torrents and it
+			// does apply to all announcement protocols as well. If you have a
+			// large amount of seeds, only a limited amount get annonced based on
+			// the seed rank. Use low values if you want to work with
+			// ``seed_time_ratio_limit``, ``seed_time_limit`` or
+			// ``share_ratio_limit`` to controll your active torrents
+			// ``auto_manage_prefer_seeds`` controlls which torrents will drain
+			// this limit value first.
+			// 
 			// ``active_dht_limit`` is the max number of torrents to announce to
 			// the DHT. By default this is set to 88, which is no more than one
 			// DHT announce every 10 seconds.
@@ -1094,7 +1103,9 @@ namespace libtorrent
 
 			// this is the limit on the time a torrent has been an active seed
 			// (specified in seconds) before it is considered having met the seed
-			// limit criteria. See queuing_.
+			// limit criteria. See queuing_. It does not disable the torrent, it
+			// does only move to a lower queue position which may result into an
+			// inactive torrent depending on your active limit definitions
 			seed_time_limit,
 
 			// ``auto_scrape_interval`` is the number of seconds between scrapes
@@ -1504,7 +1515,9 @@ namespace libtorrent
 			// bytes down) or the seed time ratio (seconds as seed / seconds as
 			// downloader) or the seed time limit (seconds as seed) it is
 			// considered done, and it will leave room for other torrents these
-			// are specified as percentages
+			// are specified as percentages. They does not disable the torrent,
+			// they do only controll the queue position which may result into an
+			// inactive torrent depending on your active limit definitions
 			share_ratio_limit,
 			seed_time_ratio_limit,
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -211,8 +211,8 @@ namespace libtorrent
 
 		set.set_int(settings_pack::choking_algorithm, settings_pack::fixed_slots_choker);
 
-		// of 500 ms, and a send rate of 4 MB/s, the upper
-		// limit should be 2 MB
+		// calculate with 500ms read time and a send rate of 6 MiB/s,
+		// the upper limit should be 3 MiB
 		set.set_int(settings_pack::send_buffer_watermark, 3 * 1024 * 1024);
 
 		// put 1.5 seconds worth of data in the send buffer


### PR DESCRIPTION
If you don't have any references to http://www.rasterbar.com/products/libtorrent/manual.html anymore, you should delete it otherwise you should update this page with the manual of the master branch.

Maybe this should be marged to RC_1_1 as well