### PR TITLE
fix setup of DHT logic in session_impl::init

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -737,6 +737,7 @@ namespace libtorrent
 			peer_class_pool m_classes;
 
 			void init(std::shared_ptr<settings_pack> pack);
+			void init_dht();
 
 			void submit_disk_jobs();
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -632,23 +632,42 @@ namespace aux {
 		update_lsd();
 		update_peer_fingerprint();
 
+		init_dht();
+	}
+
+	void session_impl::init_dht()
+	{
+		// the need of this elaborated logic is because if the value
+		// of settings_pack::dht_bootstrap_nodes is not the default,
+		// then update_dht_bootstrap_nodes is called. For this reason,
+		// three different cases should be considered.
+		// 1-) dht_bootstrap_nodes setting not touched
+		// 2-) dht_bootstrap_nodes changed but not empty
+		// 3-) dht_bootstrap_nodes set to empty ("")
+		// TODO: find a solution and refactor to avoid potentially stalling
+		// for minutes due to the name resolution
+
 #ifndef TORRENT_DISABLE_DHT
-		// setup DHT
 		if (m_outstanding_router_lookups == 0)
 		{
 			// this can happens because either the setting value was untouched
 			// or the value in the initial settings is empty
 			if (m_settings.get_str(settings_pack::dht_bootstrap_nodes).empty())
 			{
+				// case 3)
 				update_dht();
 				update_dht_announce_interval();
 			}
 			else
 			{
+				// case 1)
 				// eventually update_dht() is called when all resolves are done
 				update_dht_bootstrap_nodes();
 			}
 		}
+		// else is case 2)
+		// in this case the call to update_dht_bootstrap_nodes() by the apply settings
+		// will eventually call update_dht() when all resolves are done
 #endif
 	}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -630,10 +630,26 @@ namespace aux {
 		update_upnp();
 		update_natpmp();
 		update_lsd();
-		update_dht();
 		update_peer_fingerprint();
-		update_dht_bootstrap_nodes();
-		update_dht_announce_interval();
+
+#ifndef TORRENT_DISABLE_DHT
+		// setup DHT
+		if (m_outstanding_router_lookups == 0)
+		{
+			// this can happens because either the setting value was untouched
+			// or the value in the initial settings is empty
+			if (m_settings.get_str(settings_pack::dht_bootstrap_nodes).empty())
+			{
+				update_dht();
+				update_dht_announce_interval();
+			}
+			else
+			{
+				// eventually update_dht() is called when all resolves are done
+				update_dht_bootstrap_nodes();
+			}
+		}
+#endif
 	}
 
 	void session_impl::async_resolve(std::string const& host, int flags


### PR DESCRIPTION
Due to the way `settings_pack` works when applied, special care should be taken when creating the session and the DHT. Three cases should be considered:
1-) `dht_bootstrap_nodes` setting not touched
2-) `dht_bootstrap_nodes` changed but not empty (`""`)
3-) `dht_bootstrap_nodes` set to empty (`""`)

### In `master`
Currently, with head `master`, if you see the log stream, this is what you get:
1-) `dht_bootstrap_nodes` setting not touched
**This is the worst case, the DHT is twice created and bootstrapped.**
```
log_alert - start session
...
log_alert - about to start DHT, running: false, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: false
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXXX
...
log_alert - about to start DHT, running: true, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: true
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXX
...
```

2-) `dht_bootstrap_nodes` changed but not empty (`""`)
_unnecessary call to `update_dht_announce_interval()`_
```
log_alert - start session
...
log_alert - about to start DHT, running: false, router lookups: 4, aborting: false
log_alert - about to stop DHT, running: false
log_alert - not starting DHT announce timer: m_dht == nullptr
...
log_alert - about to start DHT, running: false, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: false
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXXX
...
```
3-) `dht_bootstrap_nodes` set to empty (`""`)
_it is fine_
```
log_alert - start session
...
log_alert - about to start DHT, running: false, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: false
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXXX
...
```

### With this PR
1-) `dht_bootstrap_nodes` setting not touched
```
log_alert - start session
...
log_alert - about to start DHT, running: false, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: false
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXXX
...
```

2-) `dht_bootstrap_nodes` changed but not empty (`""`)
```
log_alert - start session
...
log_alert - about to start DHT, running: false, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: false
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXXX
...
```
3-) `dht_bootstrap_nodes` set to empty (`""`)
```
log_alert - start session
...
log_alert - about to start DHT, running: false, router lookups: 0, aborting: false
log_alert - about to stop DHT, running: false
dht_log_alert - DHT tracker: starting IPv4 DHT tracker with node id: XXXX
dht_log_alert - DHT tracker: starting IPv6 DHT tracker with node id: XXXX
...
```