### PR TITLE
remove torrent_file_path asynchronous loading of .torrent files.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 	* optimize download queue management
-	* deprecated (undocumented) file:// urls, added torrent_file_path alternative
+	* deprecated (undocumented) file:// urls
 	* add limit for number of web seed connections
 	* added support for retrieval of DHT live nodes
 	* complete UNC path support

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -1514,8 +1514,8 @@ int main(int argc, char* argv[])
 					char url[4096];
 					url[0] = '\0';
 					puts("Enter magnet link:\n");
-					std::scanf("%4095s", url);
-					add_magnet(ses, url);
+					if (std::scanf("%4095s", url) == 1) add_magnet(ses, url);
+					else std::printf("failed to read magnet link\n");
 				}
 
 				if (c == 'q') break;

--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -60,8 +60,6 @@ namespace libtorrent
 	// * url - when you have a magnet link
 	// * info_hash - when all you have is an info-hash (this is similar to a
 	//   magnet link)
-	// * torrent_file_path - when you have the path to a .torrent file and want
-	//   libtorrent to load it. (This is especially useful with async_add_torrent)
 	//
 	// one of those fields must be set. Another mandatory field is
 	// ``save_path``. The add_torrent_params object is passed into one of the
@@ -359,10 +357,6 @@ namespace libtorrent
 		// while downloading, the torrent will be stopped and the torrent error
 		// state (``torrent_status::error``) will indicate what went wrong.
 		std::string url;
-
-		// if you specify a ``torrent_file_path``, libtorrent will attempt to load
-		// a .torrent file from the file at the given path.
-		std::string torrent_file_path;
 
 		// flags controlling aspects of this torrent and how it's added. See
 		// flags_t for details.

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -480,7 +480,10 @@ namespace libtorrent
 			std::pair<std::shared_ptr<torrent>, bool>
 			add_torrent_impl(add_torrent_params& p, error_code& ec);
 			void async_add_torrent(add_torrent_params* params);
+
+#ifndef TORRENT_NO_DEPRECATE
 			void on_async_load_torrent(add_torrent_params* params, error_code ec);
+#endif
 
 			void remove_torrent(torrent_handle const& h, int options) override;
 			void remove_torrent_impl(std::shared_ptr<torrent> tptr, int options) override;
@@ -1091,6 +1094,7 @@ namespace libtorrent
 			std::shared_ptr<upnp> m_upnp;
 			std::shared_ptr<lsd> m_lsd;
 
+#ifndef TORRENT_NO_DEPRECATE
 			struct work_thread_t
 			{
 				work_thread_t()
@@ -1110,6 +1114,7 @@ namespace libtorrent
 				std::thread thread;
 			};
 			std::unique_ptr<work_thread_t> m_torrent_load_thread;
+#endif
 
 			// mask is a bitmask of which protocols to remap on:
 			// 1: NAT-PMP

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -167,7 +167,7 @@ namespace libtorrent
 #endif // BOOST_NO_EXCEPTIONS
 #endif // TORRENT_NO_DEPRECATE
 
-	// TODO: 3 take string_ref here instead
+	// TODO: 3 take string_view here instead
 	void parse_magnet_uri(std::string const& uri, add_torrent_params& p, error_code& ec)
 	{
 		ec.clear();

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -440,31 +440,6 @@ TORRENT_TEST(async_load_deprecated)
 }
 #endif
 
-TORRENT_TEST(async_load)
-{
-	settings_pack pack = settings();
-	lt::session ses(pack);
-
-	add_torrent_params p;
-	p.flags &= ~add_torrent_params::flag_paused;
-	p.flags &= ~add_torrent_params::flag_auto_managed;
-	std::string dir = parent_path(current_working_directory());
-
-	p.torrent_file_path = combine_path(combine_path(dir, "test_torrents"), "base.torrent");
-	p.save_path = ".";
-	ses.async_add_torrent(p);
-
-	alert const* a = wait_for_alert(ses, add_torrent_alert::alert_type);
-	TEST_CHECK(a);
-	if (a == nullptr) return;
-	auto const* ta = alert_cast<add_torrent_alert const>(a);
-	TEST_CHECK(ta);
-	if (ta == nullptr) return;
-	TEST_CHECK(!ta->error);
-	TEST_CHECK(ta->params.ti->name() == "temp");
-}
-
-
 TORRENT_TEST(torrent_status)
 {
 	TEST_EQUAL(static_cast<int>(torrent_status::error_file_none), -1);


### PR DESCRIPTION
 This is not the responsibility of the client, to simplify and unify the path of adding torrents