### PR TITLE
fix m_host_resolver

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -823,6 +823,8 @@ namespace libtorrent
 			// peer class for local peers
 			peer_class_t m_local_peer_class{0};
 
+			resolver m_host_resolver;
+
 			tracker_manager m_tracker_manager;
 			torrent_map m_torrents;
 
@@ -1173,8 +1175,6 @@ namespace libtorrent
 			// object. This closes the file that's been opened the longest every
 			// time it's called, to force the windows disk cache to be flushed
 			deadline_timer m_close_file_timer;
-
-			resolver m_host_resolver;
 
 			// the index of the torrent that will be offered to
 			// connect to a peer next time on_tick is called.

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -423,6 +423,7 @@ namespace aux {
 		, m_disk_thread(m_io_service, m_stats_counters)
 		, m_download_rate(peer_connection::download_channel)
 		, m_upload_rate(peer_connection::upload_channel)
+		, m_host_resolver(m_io_service)
 		, m_tracker_manager(
 			std::bind(&session_impl::send_udp_packet, this, false, _1, _2, _3, _4)
 			, std::bind(&session_impl::send_udp_packet_hostname, this, _1, _2, _3, _4, _5)
@@ -462,7 +463,6 @@ namespace aux {
 		, m_timer(m_io_service)
 		, m_lsd_announce_timer(m_io_service)
 		, m_close_file_timer(m_io_service)
-		, m_host_resolver(m_io_service)
 	{
 		update_time_now();
 	}


### PR DESCRIPTION
  V670 The uninitialized class member 'm_host_resolver' is used to initialize the 'm_tracker_manager' member.
  Remember that members are initialized in the order of their declarations inside a class. session_impl.cpp