### PR TITLE
python bindings: fix "TypeError: 'dict_keys' object does not support

### DIFF
--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -132,11 +132,16 @@ struct dict_to_map
         dict o(borrowed(x));
         std::map<T1, T2> m;
 
-        list iterkeys = (list)o.keys();
-        int const len = int(boost::python::len(iterkeys));
-        for (int i = 0; i < len; i++)
+        const object dictkeys = o.keys();
+        const size_t len = size_t(boost::python::len(dictkeys));
+        const object dictkeys_iter = dictkeys.attr("__iter__")();
+        for (size_t i = 0; i < len; i++)
         {
-            object key = iterkeys[i];
+#if PY_VERSION_HEX >= 0x03000000
+            object key = dictkeys_iter.attr("__next__")();
+#else
+            object key = dictkeys_iter.attr("next")();
+#endif
             m[extract<T1>(key)] = extract<T2>(o[key]);
         }
         new (storage) std::map<T1, T2>(m);

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -110,11 +110,16 @@ namespace
 
 	void make_settings_pack(lt::settings_pack& p, dict const& sett_dict)
 	{
-		list iterkeys = (list)sett_dict.keys();
-		int const len = int(boost::python::len(iterkeys));
-		for (int i = 0; i < len; i++)
+		const object dictkeys = sett_dict.keys();
+		const size_t len = size_t(boost::python::len(dictkeys));
+		const object dictkeys_iter = dictkeys.attr("__iter__")();
+		for (size_t i = 0; i < len; i++)
 		{
-			std::string const key = extract<std::string>(iterkeys[i]);
+#if PY_VERSION_HEX >= 0x03000000
+			std::string const key = extract<std::string>(dictkeys_iter.attr("__next__")());
+#else
+			std::string const key = extract<std::string>(dictkeys_iter.attr("next")());
+#endif
 
 			int sett = setting_by_name(key);
 			if (sett < 0)


### PR DESCRIPTION
This fixes a problem when using the bindings with python3 when passing
python dictionaries will result in the error:
```
TypeError: 'dict_keys' object does not support indexing
```
This is because the keys() method of a dictionary no longer returns an
object that is indexable. Instead of indexing, use the iterator's
`__next__` method to get the next object the appropiate number of times.