### PR TITLE
using unique_ptr for m_ip_notifier in session_impl

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -884,7 +884,7 @@ namespace libtorrent
 			std::uint32_t m_key = 0;
 
 			// posts a notification when the set of local IPs changes
-			ip_change_notifier m_ip_notifier;
+			std::unique_ptr<ip_change_notifier> m_ip_notifier;
 
 			// the addresses or device names of the interfaces we are supposed to
 			// listen on. if empty, it means that we should let the os decide

--- a/include/libtorrent/ip_notifier.hpp
+++ b/include/libtorrent/ip_notifier.hpp
@@ -50,7 +50,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 #endif
 
-namespace libtorrent
+namespace libtorrent { namespace aux
 {
 	struct ip_change_notifier
 	{
@@ -79,6 +79,8 @@ namespace libtorrent
 		boost::asio::windows::object_handle m_hnd;
 #endif
 	};
-}
+
+	TORRENT_EXTRA_EXPORT std::unique_ptr<ip_change_notifier> create_ip_notifier(io_service& ios);
+}}
 
 #endif

--- a/src/ip_notifier.cpp
+++ b/src/ip_notifier.cpp
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 using namespace std::placeholders;
 
-namespace libtorrent
+namespace libtorrent { namespace aux
 {
 	ip_change_notifier::ip_change_notifier(io_service& ios)
 #if defined TORRENT_BUILD_SIMULATOR
@@ -124,4 +124,9 @@ namespace libtorrent
 		else
 			cb(ec);
 	}
-}
+
+	std::unique_ptr<ip_change_notifier> create_ip_notifier(io_service& ios)
+	{
+		return std::unique_ptr<ip_change_notifier>(new ip_change_notifier(ios));
+	}
+}}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -433,7 +433,7 @@ namespace aux {
 #endif
 			)
 		, m_work(new io_service::work(m_io_service))
-		, m_ip_notifier(m_io_service)
+		, m_ip_notifier(create_ip_notifier(m_io_service))
 #if TORRENT_USE_I2P
 		, m_i2p_conn(m_io_service)
 #endif
@@ -609,7 +609,7 @@ namespace aux {
 		session_log(" done starting session");
 #endif
 
-		m_ip_notifier.async_wait([this](error_code const& e)
+		m_ip_notifier->async_wait([this](error_code const& e)
 			{ this->wrap(&session_impl::on_ip_change, e); });
 
 		apply_settings_pack_impl(*pack, true);
@@ -905,7 +905,7 @@ namespace aux {
 		m_abort = true;
 		error_code ec;
 
-		m_ip_notifier.cancel();
+		m_ip_notifier->cancel();
 
 #if TORRENT_USE_I2P
 		m_i2p_conn.close(ec);
@@ -1758,7 +1758,7 @@ namespace aux {
 			session_log("received error on_ip_change: %d, %s", ec.value(), ec.message().c_str());
 #endif
 		if (ec || m_abort) return;
-		m_ip_notifier.async_wait([this] (error_code const& e)
+		m_ip_notifier->async_wait([this] (error_code const& e)
 			{ this->wrap(&session_impl::on_ip_change, e); });
 		reopen_listen_sockets();
 	}


### PR DESCRIPTION
@arvidn the context of this PR is because I need to prepare the code first, in order to be able to hide all the platform dependent code in the compilation unit. This way it should be easy to split `ip_change_notifier` per platform and easy the review of new code.