### PR TITLE
added reachability based ip_change_notifier_impl for iOS

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -161,6 +161,7 @@ rule linking ( properties * )
 	}
 
 	if <target-os>darwin in $(properties)
+		|| <target-os>iphone in $(properties)
 	{
 		# for ip_notifier
 		result += <framework>CoreFoundation <framework>SystemConfiguration ;

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -153,6 +153,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #  define TORRENT_USE_LOCALE 0
 # endif
 #include <AvailabilityMacros.h>
+#include <TargetConditionals.h>
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
 // on OSX, use the built-in common crypto for built-in
@@ -167,6 +168,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #define TORRENT_USE_SYSTEMCONFIGURATION 1
+
+#if TARGET_OS_IPHONE
+#define TORRENT_USE_SC_NETWORK_REACHABILITY 1
+#endif
 
 #else // __APPLE__
 // FreeBSD has a reasonable iconv signature
@@ -440,6 +445,10 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef TORRENT_USE_SYSTEMCONFIGURATION
 #define TORRENT_USE_SYSTEMCONFIGURATION 0
+#endif
+
+#ifndef TORRENT_USE_SC_NETWORK_REACHABILITY
+#define TORRENT_USE_SC_NETWORK_REACHABILITY 0
 #endif
 
 #ifndef TORRENT_USE_CRYPTOAPI

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -262,7 +262,7 @@ TORRENT_EXPORT void print_backtrace(char* out, int len, int max_depth
 TORRENT_EXPORT void print_backtrace(char* out, int len, int /*max_depth*/, void* /* ctx */)
 {
 	out[0] = 0;
-	strncat(out, "<not supported>", len);
+	std::strncat(out, "<not supported>", std::size_t(len));
 }
 
 #endif

--- a/src/ip_notifier.cpp
+++ b/src/ip_notifier.cpp
@@ -130,11 +130,13 @@ struct ip_change_notifier_impl final : ip_change_notifier
 			[](SCNetworkReachabilityRef /*target*/, SCNetworkReachabilityFlags /*flags*/, void *info)
 			{
 				auto obj = static_cast<ip_change_notifier_impl*>(info);
-				if (!obj->m_cb) return;
-
-				auto cb = std::move(obj->m_cb);
-				obj->m_cb = nullptr;
-				obj->m_ios.post([cb]() { cb(error_code()); });
+				obj->m_ios.post([obj]()
+				{
+					if (!obj->m_cb) return;
+					auto cb = std::move(obj->m_cb);
+					obj->m_cb = nullptr;
+					cb(error_code());
+				});
 			}, this);
 
 		if (!m_queue || !m_reach
@@ -220,11 +222,13 @@ struct ip_change_notifier_impl final : ip_change_notifier
 			[](SCDynamicStoreRef /*store*/, CFArrayRef /*changedKeys*/, void *info)
 			{
 				auto obj = static_cast<ip_change_notifier_impl*>(info);
-				if (!obj->m_cb) return;
-
-				auto cb = std::move(obj->m_cb);
-				obj->m_cb = nullptr;
-				obj->m_ios.post([cb]() { cb(error_code()); });
+				obj->m_ios.post([obj]()
+				{
+					if (!obj->m_cb) return;
+					auto cb = std::move(obj->m_cb);
+					obj->m_cb = nullptr;
+					cb(error_code());
+				});
 			}, this);
 
 		if (!m_queue || !m_store


### PR DESCRIPTION
Possible to test in macOS adding `define=TORRENT_FORCE_IOS_IP_NOTIFIER` to the bjam command, to test with `session_log_alerts` tool.

This only detect "actual" reachability of ANY in the default routing table selected by the OS.