### PR TITLE
fix memory leak in the disk cache

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix memory leak in the disk cache
 	* fix double free in disk cache
 	* forward declaring libtorrent types is discouraged. a new fwd.hpp header is provided
 

--- a/include/libtorrent/block_cache.hpp
+++ b/include/libtorrent/block_cache.hpp
@@ -181,7 +181,6 @@ namespace libtorrent
 		{
 			return refcount == 0
 				&& piece_refcount == 0
-				&& num_blocks == 0
 				&& !hashing
 				&& read_jobs.size() == 0
 				&& outstanding_read == 0
@@ -247,7 +246,8 @@ namespace libtorrent
 		boost::uint32_t hashing_done:1;
 
 		// if this is true, whenever refcount hits 0,
-		// this piece should be deleted
+		// this piece should be deleted from the cache
+		// (not just demoted)
 		boost::uint32_t marked_for_deletion:1;
 
 		// this is set to true once we flush blocks past
@@ -310,8 +310,13 @@ namespace libtorrent
 		// read job queue (read_jobs).
 		boost::uint32_t outstanding_read:1;
 
+		// this is set when the piece should be evicted as soon as there
+		// no longer are any references to it. Evicted here means demoted
+		// to a ghost list
+		boost::uint32_t marked_for_eviction:1;
+
 		// the number of blocks that have >= 1 refcount
-		boost::uint32_t pinned:16;
+		boost::uint32_t pinned:15;
 
 		// ---- 32 bit boundary ---
 
@@ -367,15 +372,22 @@ namespace libtorrent
 
 		int num_write_lru_pieces() const { return int(m_lru[cached_piece_entry::write_lru].size()); }
 
+		enum eviction_mode
+		{
+			allow_ghost,
+			disallow_ghost
+		};
+
 		// mark this piece for deletion. If there are no outstanding
 		// requests to this piece, it's removed immediately, and the
 		// passed in iterator will be invalidated
-		void mark_for_deletion(cached_piece_entry* p);
+		void mark_for_eviction(cached_piece_entry* p, eviction_mode mode);
 
-		// similar to mark_for_deletion, except for actually marking the
+		// similar to mark_for_eviction, except for actually marking the
 		// piece for deletion. If the piece was actually deleted,
 		// the function returns true
-		bool evict_piece(cached_piece_entry* p, tailqueue<disk_io_job>& jobs);
+		bool evict_piece(cached_piece_entry* p, tailqueue<disk_io_job>& jobs
+			, eviction_mode mode);
 
 		// if this piece is in L1 or L2 proper, move it to
 		// its respective ghost list

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -131,6 +131,7 @@ test-suite libtorrent :
 	[ run test_storage.cpp ]
 	[ run test_session.cpp ]
 	[ run test_read_piece.cpp ]
+	[ run test_remove_torrent.cpp ]
 
 	[ run test_file.cpp ]
 	[ run test_fast_extension.cpp ]

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,6 +10,7 @@ test_programs = \
   test_file                  \
   test_privacy               \
   test_priority              \
+  test_remove_torrent        \
   test_auto_unchoke          \
   test_checking              \
   test_fast_extension        \
@@ -197,6 +198,7 @@ test_stat_cache_SOURCES = test_stat_cache.cpp
 test_file_SOURCES = test_file.cpp
 test_privacy_SOURCES = test_privacy.cpp
 test_priority_SOURCES = test_priority.cpp
+test_remove_torrent_SOURCES = test_remove_torrent.cpp
 test_auto_unchoke_SOURCES = test_auto_unchoke.cpp
 test_checking_SOURCES = test_checking.cpp
 test_enum_net_SOURCES = test_enum_net.cpp

--- a/test/test_block_cache.cpp
+++ b/test/test_block_cache.cpp
@@ -267,7 +267,7 @@ void test_evict()
 	// this should make it not be evicted
 	// just free the buffers
 	++pe->piece_refcount;
-	bc.evict_piece(pe, jobs);
+	bc.evict_piece(pe, jobs, block_cache::allow_ghost);
 
 	bc.update_stats_counters(c);
 	TEST_EQUAL(c[counters::write_cache_blocks], 0);
@@ -281,7 +281,7 @@ void test_evict()
 	TEST_EQUAL(c[counters::arc_volatile_size], 0);
 
 	--pe->piece_refcount;
-	bc.evict_piece(pe, jobs);
+	bc.evict_piece(pe, jobs, block_cache::allow_ghost);
 
 	bc.update_stats_counters(c);
 	TEST_EQUAL(c[counters::write_cache_blocks], 0);
@@ -382,7 +382,7 @@ void test_arc_unghost()
 	TEST_EQUAL(c[counters::arc_volatile_size], 0);
 
 	tailqueue<disk_io_job> jobs;
-	bc.evict_piece(pe, jobs);
+	bc.evict_piece(pe, jobs, block_cache::allow_ghost);
 
 	bc.update_stats_counters(c);
 	TEST_EQUAL(c[counters::write_cache_blocks], 0);
@@ -472,5 +472,30 @@ TORRENT_TEST(block_cache)
 	// TODO: test free_piece
 	// TODO: test abort_dirty
 	// TODO: test unaligned reads
+}
+
+TORRENT_TEST(delete_piece)
+{
+	TEST_SETUP;
+
+	TEST_CHECK(bc.num_pieces() == 0);
+
+	INSERT(0, 0);
+
+	TEST_CHECK(bc.num_pieces() == 1);
+
+	rj.action = disk_io_job::read;
+	rj.d.io.offset = 0x2000;
+	rj.d.io.buffer_size = 0x4000;
+	rj.piece = 0;
+	rj.storage = pm;
+	rj.requester = (void*)1;
+	rj.buffer.disk_block = 0;
+	ret = bc.try_read(&rj);
+
+	cached_piece_entry* pe_ = bc.find_piece(pm.get(), 0);
+	bc.mark_for_eviction(pe_, block_cache::disallow_ghost);
+
+	TEST_CHECK(bc.num_pieces() == 0);
 }
 

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/thread.hpp"
@@ -122,10 +121,6 @@ void test_transfer(settings_pack const& sett)
 	std::ofstream file("tmp1_priority/temporary");
 	boost::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
-
-	add_torrent_params addp;
-	addp.flags &= ~add_torrent_params::flag_paused;
-	addp.flags &= ~add_torrent_params::flag_auto_managed;
 
 	wait_for_listen(ses1, "ses1");
 	wait_for_listen(ses2, "ses1");

--- a/test/test_remove_torrent.cpp
+++ b/test/test_remove_torrent.cpp
@@ -1,0 +1,198 @@
+/*
+
+Copyright (c) 2017, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/session.hpp"
+#include "libtorrent/torrent_handle.hpp"
+#include "libtorrent/torrent_status.hpp"
+#include "libtorrent/session_settings.hpp"
+#include "libtorrent/torrent_info.hpp"
+#include "libtorrent/ip_filter.hpp"
+
+#include "test.hpp"
+#include "setup_transfer.hpp"
+#include "settings.hpp"
+#include <fstream>
+#include <iostream>
+#include <boost/cstdint.hpp>
+
+using namespace libtorrent;
+namespace lt = libtorrent;
+using boost::tuples::ignore;
+
+enum test_case {
+	complete_download,
+	partial_download,
+	mid_download
+};
+
+void test_remove_torrent(int const remove_options
+	, test_case const test = complete_download)
+{
+	// this allows shutting down the sessions in parallel
+	std::vector<session_proxy> sp;
+	settings_pack pack = settings();
+
+	// we do this to force pieces to be evicted into the ghost lists
+	pack.set_int(settings_pack::cache_size, 10);
+
+	pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:48075");
+	lt::session ses1(pack);
+
+	pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:49075");
+	lt::session ses2(pack);
+
+	torrent_handle tor1;
+	torrent_handle tor2;
+
+	int const num_pieces = (test == mid_download) ? 500 : 100;
+
+	error_code ec;
+	remove_all("tmp1_remove", ec);
+	remove_all("tmp2_remove", ec);
+	create_directory("tmp1_remove", ec);
+	std::ofstream file("tmp1_remove/temporary");
+	boost::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary"
+		, 16 * 1024, num_pieces, false);
+	file.close();
+
+	wait_for_listen(ses1, "ses1");
+	wait_for_listen(ses2, "ses1");
+
+	// test using piece sizes smaller than 16kB
+	boost::tie(tor1, tor2, ignore) = setup_transfer(&ses1, &ses2, 0
+		, true, false, true, "_remove", 8 * 1024, &t, false, 0);
+
+	if (test == partial_download)
+	{
+		std::vector<int> priorities(num_pieces, 1);
+		// set half of the pieces to priority 0
+		std::fill(priorities.begin(), priorities.begin() + (num_pieces / 2), 0);
+		tor2.prioritize_pieces(priorities);
+	}
+
+	torrent_status st1;
+	torrent_status st2;
+
+	for (int i = 0; i < 200; ++i)
+	{
+		print_alerts(ses1, "ses1", true, true, true);
+		print_alerts(ses2, "ses2", true, true, true);
+
+		st1 = tor1.status();
+		st2 = tor2.status();
+
+		if (test == mid_download && st2.num_pieces > num_pieces / 2)
+		{
+			TEST_CHECK(st2.is_finished == false);
+			break;
+		}
+		if (st2.is_finished) break;
+
+		TEST_CHECK(st1.state == torrent_status::seeding
+			|| st1.state == torrent_status::checking_files);
+		TEST_CHECK(st2.state == torrent_status::downloading
+			|| st2.state == torrent_status::checking_resume_data);
+
+		// if nothing is being transferred after 2 seconds, we're failing the test
+		if (st1.upload_payload_rate == 0 && i > 20)
+		{
+			TEST_ERROR("no transfer");
+			return;
+		}
+
+		test_sleep(100);
+	}
+
+	TEST_CHECK(st1.num_pieces > 0);
+	TEST_CHECK(st2.num_pieces > 0);
+
+	ses2.remove_torrent(tor2, remove_options);
+	ses1.remove_torrent(tor1, remove_options);
+
+	std::cerr << "removed" << std::endl;
+
+	for (int i = 0; tor2.is_valid() || tor1.is_valid(); ++i)
+	{
+		test_sleep(100);
+		if (++i > 40)
+		{
+			std::cerr << "torrent handle(s) still valid: "
+				<< (tor1.is_valid() ? "tor1 " : "")
+				<< (tor2.is_valid() ? "tor2 " : "")
+				<< std::endl;
+
+			TEST_ERROR("handle did not become invalid");
+			return;
+		}
+	}
+
+	if (remove_options & session::delete_files)
+	{
+		TEST_CHECK(!exists("tmp1_remove/temporary"));
+		TEST_CHECK(!exists("tmp2_remove/temporary"));
+	}
+
+	sp.push_back(ses1.abort());
+	sp.push_back(ses2.abort());
+}
+
+TORRENT_TEST(remove_torrent)
+{
+	test_remove_torrent(0);
+}
+
+TORRENT_TEST(remove_torrent_and_files)
+{
+	test_remove_torrent(session::delete_files);
+}
+
+TORRENT_TEST(remove_torrent_partial)
+{
+	test_remove_torrent(0, partial_download);
+}
+
+TORRENT_TEST(remove_torrent_and_files_partial)
+{
+	test_remove_torrent(session::delete_files, partial_download);
+}
+
+TORRENT_TEST(remove_torrent_mid_download)
+{
+	test_remove_torrent(0, mid_download);
+}
+
+TORRENT_TEST(remove_torrent_and_files_mid_download)
+{
+	test_remove_torrent(session::delete_files, mid_download);
+}
+
+


### PR DESCRIPTION
if a cached_piece_entry would stick around in a ghost list (ARC), it would keep the torrent object itself alive