### PR TITLE
fix typo in natpmp::start

### DIFF
--- a/src/natpmp.cpp
+++ b/src/natpmp.cpp
@@ -135,7 +135,7 @@ void natpmp::start()
 	for (std::vector<mapping_t>::iterator i = m_mappings.begin()
 		, end(m_mappings.end()); i != end; ++i)
 	{
-		if (i->protocol != none
+		if (i->protocol == none
 			|| i->action != mapping_t::action_none)
 			continue;
 		i->action = mapping_t::action_add;


### PR DESCRIPTION
Calling update_mapping() on a mapping with protocol set to none is a no-op so
I'm pretty sure this check was meant to skip over such mappings.