### PR TITLE
remove calls to RAND_add

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5945,20 +5945,6 @@ namespace libtorrent {
 		}
 #endif
 
-#ifdef TORRENT_USE_OPENSSL
-#ifdef TORRENT_MACOS_DEPRECATED_LIBCRYPTO
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-		// add this RTT to the PRNG seed, to add more unpredictability
-		std::int64_t now = total_microseconds(completed - m_connect);
-		// assume 12 bits of entropy (i.e. about 8 milliseconds)
-		RAND_add(&now, 8, 1.5);
-#ifdef TORRENT_MACOS_DEPRECATED_LIBCRYPTO
-#pragma clang diagnostic pop
-#endif
-#endif
-
 		// if t is nullptr, we better not be connecting, since
 		// we can't decrement the connecting counter
 		std::shared_ptr<torrent> t = m_torrent.lock();

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2513,20 +2513,6 @@ namespace {
 	{
 		TORRENT_ASSERT(is_single_thread());
 
-#ifdef TORRENT_USE_OPENSSL
-#ifdef TORRENT_MACOS_DEPRECATED_LIBCRYPTO
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-		// add the current time to the PRNG, to add more unpredictability
-		std::int64_t now = clock_type::now().time_since_epoch().count();
-		// assume 12 bits of entropy (i.e. about 8 milliseconds)
-		RAND_add(&now, 8, 1.5);
-#ifdef TORRENT_MACOS_DEPRECATED_LIBCRYPTO
-#pragma clang diagnostic pop
-#endif
-#endif // TORRENT_USE_OPENSSL
-
 		if (m_paused)
 		{
 #ifndef TORRENT_DISABLE_LOGGING

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1473,12 +1473,6 @@ namespace libtorrent {
 		// this is needed for openssl < 1.0 to decrypt keys created by openssl 1.0+
 		OpenSSL_add_all_algorithms();
 
-		std::int64_t const now = clock_type::now().time_since_epoch().count();
-		// assume 9 bits of entropy (i.e. about 1 millisecond)
-		RAND_add(&now, 8, 1.125);
-		RAND_add(&info_hash()[0], 20, 3);
-		// entropy is also added on incoming and completed connection attempts
-
 		TORRENT_ASSERT(RAND_status() == 1);
 
 		// create the SSL context for this torrent. We need to


### PR DESCRIPTION
This function has been removed from LibreSSL and offers dubious value.
The PRNGs in modern operating systems are robust enough that these little extra
bits aren't going to make a difference.