### PR TITLE
use boost::variant for disk_io_job in/out parameter

### DIFF
--- a/include/libtorrent/aux_/block_cache_reference.hpp
+++ b/include/libtorrent/aux_/block_cache_reference.hpp
@@ -40,6 +40,10 @@ namespace libtorrent { namespace aux {
 
 	struct block_cache_reference
 	{
+		block_cache_reference() = default;
+		block_cache_reference(storage_index_t const idx, std::int32_t const c)
+			: storage(idx), cookie(c) {}
+
 		// if the cookie is set to this value, it doesn't refer to anything in the
 		// cache (and the buffer is mutable)
 		constexpr static std::int32_t none = 0x7fffffff;

--- a/include/libtorrent/block_cache.hpp
+++ b/include/libtorrent/block_cache.hpp
@@ -376,7 +376,8 @@ namespace aux {
 
 		// returns the number of bytes read on success (cache hit)
 		// -1 on cache miss
-		int try_read(disk_io_job* j, bool expect_no_fail = false);
+		int try_read(disk_io_job* j, buffer_allocator_interface& allocator
+			, bool expect_no_fail = false);
 
 		// called when we're reading and we found the piece we're
 		// reading from in the hash table (not necessarily that we
@@ -465,7 +466,8 @@ namespace aux {
 		// returns number of bytes read on success, -1 on cache miss
 		// (just because the piece is in the cache, doesn't mean all
 		// the blocks are there)
-		int copy_from_piece(cached_piece_entry* p, disk_io_job* j, bool expect_no_fail = false);
+		int copy_from_piece(cached_piece_entry* p, disk_io_job* j
+			, buffer_allocator_interface& allocator, bool expect_no_fail = false);
 
 		void free_piece(cached_piece_entry* p);
 		int drain_piece_bufs(cached_piece_entry& p, std::vector<char*>& buf);

--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -145,7 +145,7 @@ namespace libtorrent {
 			, std::uint8_t flags = 0) = 0;
 		virtual void async_hash(storage_index_t storage, piece_index_t piece, std::uint8_t flags
 			, std::function<void(piece_index_t, sha1_hash const&, storage_error const&)> handler, void* requester) = 0;
-		virtual void async_move_storage(storage_index_t storage, std::string const& p, std::uint8_t flags
+		virtual void async_move_storage(storage_index_t storage, std::string p, std::uint8_t flags
 			, std::function<void(status_t, std::string const&, storage_error const&)> handler) = 0;
 		virtual void async_release_files(storage_index_t storage
 			, std::function<void()> handler = std::function<void()>()) = 0;
@@ -158,12 +158,12 @@ namespace libtorrent {
 		virtual void async_stop_torrent(storage_index_t storage
 			, std::function<void()> handler = std::function<void()>()) = 0;
 		virtual void async_rename_file(storage_index_t storage
-			, file_index_t index, std::string const& name
+			, file_index_t index, std::string name
 			, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) = 0;
 		virtual void async_delete_files(storage_index_t storage, int options
 			, std::function<void(storage_error const&)> handler) = 0;
 		virtual void async_set_file_priority(storage_index_t storage
-			, aux::vector<std::uint8_t, file_index_t> const& prio
+			, aux::vector<std::uint8_t, file_index_t> prio
 			, std::function<void(storage_error const&)> handler) = 0;
 
 		virtual void async_clear_piece(storage_index_t storage, piece_index_t index

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -306,7 +306,7 @@ namespace aux {
 			, std::uint8_t flags = 0) override;
 		void async_hash(storage_index_t storage, piece_index_t piece, std::uint8_t flags
 			, std::function<void(piece_index_t, sha1_hash const&, storage_error const&)> handler, void* requester) override;
-		void async_move_storage(storage_index_t storage, std::string const& p, std::uint8_t flags
+		void async_move_storage(storage_index_t storage, std::string p, std::uint8_t flags
 			, std::function<void(status_t, std::string const&, storage_error const&)> handler) override;
 		void async_release_files(storage_index_t storage
 			, std::function<void()> handler = std::function<void()>()) override;
@@ -316,14 +316,14 @@ namespace aux {
 			, add_torrent_params const* resume_data
 			, aux::vector<std::string, file_index_t>& links
 			, std::function<void(status_t, storage_error const&)> handler) override;
-		void async_rename_file(storage_index_t storage, file_index_t index, std::string const& name
+		void async_rename_file(storage_index_t storage, file_index_t index, std::string name
 			, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) override;
 		void async_stop_torrent(storage_index_t storage
 			, std::function<void()> handler) override;
 		void async_flush_piece(storage_index_t storage, piece_index_t piece
 			, std::function<void()> handler = std::function<void()>()) override;
 		void async_set_file_priority(storage_index_t storage
-			, aux::vector<std::uint8_t, file_index_t> const& prio
+			, aux::vector<std::uint8_t, file_index_t> prio
 			, std::function<void(storage_error const&)> handler) override;
 
 		void async_clear_piece(storage_index_t storage, piece_index_t index

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1023,7 +1023,7 @@ namespace libtorrent {
 		// renames the file with the given index to the new name
 		// the name may include a directory path
 		// returns false on failure
-		void rename_file(file_index_t index, std::string const& name);
+		void rename_file(file_index_t index, std::string name);
 
 		// unless this returns true, new connections must wait
 		// with their initialization.

--- a/src/disk_buffer_holder.cpp
+++ b/src/disk_buffer_holder.cpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 
 	disk_buffer_holder::disk_buffer_holder(buffer_allocator_interface& alloc, char* buf) noexcept
-		: m_allocator(&alloc), m_buf(buf)
+		: m_allocator(&alloc), m_buf(buf), m_ref()
 	{}
 
 	disk_buffer_holder& disk_buffer_holder::operator=(disk_buffer_holder&& h) noexcept

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7410,7 +7410,7 @@ namespace libtorrent {
 		return m_save_path;
 	}
 
-	void torrent::rename_file(file_index_t const index, std::string const& name)
+	void torrent::rename_file(file_index_t const index, std::string name)
 	{
 		INVARIANT_CHECK;
 
@@ -7428,7 +7428,7 @@ namespace libtorrent {
 			return;
 		}
 
-		m_ses.disk_thread().async_rename_file(m_storage, index, name
+		m_ses.disk_thread().async_rename_file(m_storage, index, std::move(name)
 			, std::bind(&torrent::on_file_renamed, shared_from_this(), _1, _2, _3));
 		return;
 	}
@@ -7462,9 +7462,9 @@ namespace libtorrent {
 #if TORRENT_USE_UNC_PATHS
 			std::string path = canonicalize_path(save_path);
 #else
-			std::string const& path = save_path;
+			std::string path = save_path;
 #endif
-			m_ses.disk_thread().async_move_storage(m_storage, path, std::uint8_t(flags)
+			m_ses.disk_thread().async_move_storage(m_storage, std::move(path), std::uint8_t(flags)
 				, std::bind(&torrent::on_storage_moved, shared_from_this(), _1, _2, _3));
 			m_moving_storage = true;
 		}

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -50,6 +50,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <fstream>
 
+#include <boost/variant/get.hpp>
+
 using namespace std::placeholders;
 using namespace libtorrent;
 namespace lt = libtorrent;
@@ -67,7 +69,8 @@ void on_read_piece(int ret, disk_io_job const& j, char const* data, int size)
 {
 	std::cout << time_now_string() << " on_read_piece piece: " << j.piece << std::endl;
 	TEST_EQUAL(ret, size);
-	if (ret > 0) TEST_CHECK(std::equal(j.buffer.disk_block, j.buffer.disk_block + ret, data));
+	auto& buffer = boost::get<disk_buffer_holder>(j.argument);
+	if (ret > 0) TEST_CHECK(std::equal(buffer.get(), buffer.get() + ret, data));
 }
 
 void on_check_resume_data(status_t const status, storage_error const& error, bool* done)


### PR DESCRIPTION
to support holding a proper disk io buffer handle and string