### PR TITLE
avoid connections to trackers when the event is stopped and stop_tracker_timeout <= 0

### DIFF
--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -127,7 +127,7 @@ namespace libtorrent {
 		{
 			// the tracker was part of the .torrent file
 			source_torrent = 1,
-			// the tracker was added programatically via the add_troacker()_ function
+			// the tracker was added programatically via the add_tracker()_ function
 			source_client = 2,
 			// the tracker was part of a magnet link
 			source_magnet_link = 4,

--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -127,7 +127,7 @@ namespace libtorrent {
 		{
 			// the tracker was part of the .torrent file
 			source_torrent = 1,
-			// the tracker was added programatically via the add_tracker()_ function
+			// the tracker was added programatically via the add_tracker() function
 			source_client = 2,
 			// the tracker was part of a magnet link
 			source_magnet_link = 4,

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -776,7 +776,7 @@ namespace libtorrent {
 		// in the download queue is vacated and avery subsequent torrent in the
 		// queue has their queue positions updated. This can potentially cause a
 		// large state_update to be posted. When removing all torrents, it is
-		// adviced to remove them from the back of the queue, to minimize the
+		// advised to remove them from the back of the queue, to minimize the
 		// shifting.
 		void remove_torrent(const torrent_handle& h, int options = 0);
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -730,7 +730,7 @@ namespace libtorrent {
 			// sending a stopped message before considering a tracker to have
 			// timed out. This is usually shorter, to make the client quit faster.
 			// If the value is set to 0, the connections to trackers with the
-			// stopped event are avoided.
+			// stopped event are suppressed.
 			stop_tracker_timeout,
 
 			// this is the maximum number of bytes in a tracker response. If a

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -729,6 +729,8 @@ namespace libtorrent {
 			// ``stop_tracker_timeout`` is the number of seconds to wait when
 			// sending a stopped message before considering a tracker to have
 			// timed out. This is usually shorter, to make the client quit faster.
+			// If the value is set to 0, the connections to trackers with the
+			// stopped event are avoided.
 			stop_tracker_timeout,
 
 			// this is the maximum number of bytes in a tracker response. If a

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2584,6 +2584,18 @@ namespace libtorrent {
 
 		if (m_abort) e = tracker_request::stopped;
 
+		// having stop_tracker_timeout <= 0 means that there is
+		// no need to send any request to trackers or trigger any
+		// related logic when the event is stopped
+		if (e == tracker_request::stopped
+			&& settings().get_int(settings_pack::stop_tracker_timeout) <= 0)
+		{
+#ifndef TORRENT_DISABLE_LOGGING
+			debug_log("*** announce: event == stopped && stop_tracker_timeout <= 0");
+#endif
+			return;
+		}
+
 		// if we're not announcing to trackers, only allow
 		// stopping
 		if (e != tracker_request::stopped && !m_announce_to_trackers)

--- a/test/test_settings_pack.cpp
+++ b/test/test_settings_pack.cpp
@@ -248,6 +248,9 @@ TORRENT_TEST(settings_pack_abi)
 	TEST_EQUAL(settings_pack::proxy_tracker_connections, settings_pack::bool_type_base + 67);
 
 	// ints
+	TEST_EQUAL(settings_pack::tracker_completion_timeout, settings_pack::int_type_base + 0);
+	TEST_EQUAL(settings_pack::tracker_receive_timeout, settings_pack::int_type_base + 1);
+	TEST_EQUAL(settings_pack::stop_tracker_timeout, settings_pack::int_type_base + 2);
 	TEST_EQUAL(settings_pack::max_suggest_pieces, settings_pack::int_type_base + 66);
 	TEST_EQUAL(settings_pack::connections_slack, settings_pack::int_type_base + 86);
 	TEST_EQUAL(settings_pack::aio_threads, settings_pack::int_type_base + 104);


### PR DESCRIPTION
@arvidn the context of this change is that I was having "session destruction" issues and the problem was having these trackers communications during the "torrent abort". Now, this problem was not easy to replicate and it probably depends on the underlying networking conditions and OS. Having a small `stop_tracker_timeout` does not guarantee a small duration in the overall shutdown.

I think that this addition helps, since setting `stop_tracker_timeout = 0` is an explicit intention of having no slowness at all during the `stopped` event, the only way to guarantee that is not doing the communication.

I hope it really makes sense, because it fix my problem :)