### PR TITLE
Add keep_redundant_connections, a per-torrent override to close_redundant_connections.

### DIFF
--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -510,6 +510,8 @@ void bind_torrent_handle()
         .def("set_download_limit", _(&torrent_handle::set_download_limit))
         .def("download_limit", _(&torrent_handle::download_limit))
         .def("set_sequential_download", _(&torrent_handle::set_sequential_download))
+        .def("set_keep_redundant_connections", _(&torrent_handle::set_keep_redundant_connections))
+        .def("keep_redundant_connections", _(&torrent_handle::keep_redundant_connections))
 #ifndef TORRENT_NO_DEPRECATE
         .def("set_peer_upload_limit", &set_peer_upload_limit)
         .def("set_peer_download_limit", &set_peer_download_limit)

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -59,6 +59,11 @@ class test_torrent_handle(unittest.TestCase):
 		self.h.prioritize_pieces([(0, 1)])
 		self.assertEqual(self.h.piece_priorities(), [1])
 
+	def test_redundant_connections(self):
+		self.assertFalse(self.h.keep_redundant_connections())
+		self.h.set_keep_redundant_connections(True)
+		self.assertTrue(self.h.keep_redundant_connections())
+
 	def test_replace_trackers(self):
 		self.setup()
 		trackers = []

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -417,6 +417,10 @@ namespace libtorrent
 		bool is_sequential_download() const
 		{ return m_sequential_download || m_auto_sequential; }
 
+		void set_keep_redundant_connections(bool keep);
+		bool keep_redundant_connections() const;
+		void maybe_close_redundant_connections();
+
 		void queue_up();
 		void queue_down();
 		void set_queue_position(int p);
@@ -1512,6 +1516,8 @@ namespace libtorrent
 		// there's mostly seeds in the swarm, download the files sequentially
 		// for improved disk I/O performance.
 		bool m_auto_sequential:1;
+
+		bool m_keep_redundant_connections:1;
 
 		// this means we haven't verified the file content
 		// of the files we're seeding. the m_verified bitfield

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1180,6 +1180,9 @@ namespace libtorrent
 		void connect_peer(tcp::endpoint const& adr, int source = 0
 			, int flags = 0x1 + 0x4 + 0x8) const;
 
+                void set_keep_redundant_connections(bool keep) const;
+                bool keep_redundant_connections() const;
+
 		// ``set_max_uploads()`` sets the maximum number of peers that's unchoked
 		// at the same time on this torrent. If you set this to -1, there will be
 		// no limit. This defaults to infinite. The primary setting controlling

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -1906,7 +1906,7 @@ namespace libtorrent
 		// if we're finished and this peer is uploading only
 		// disconnect it
 		if (t->is_finished() && upload_only()
-			&& m_settings.get_bool(settings_pack::close_redundant_connections)
+			&& !t->keep_redundant_connections()
 			&& !t->share_mode())
 			disconnect(errors::upload_upload_connection, op_bittorrent);
 
@@ -2006,7 +2006,7 @@ namespace libtorrent
 		// if we send upload-only, the other end is very likely to disconnect
 		// us, at least if it's a seed. If we don't want to close redundant
 		// connections, don't sent upload-only
-		if (!m_settings.get_bool(settings_pack::close_redundant_connections)) return;
+		if (t->keep_redundant_connections()) return;
 
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::outgoing_message, "UPLOAD_ONLY", "%d"

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2151,10 +2151,11 @@ namespace libtorrent
 
 		// we cannot disconnect in a constructor
 		TORRENT_ASSERT(m_in_constructor == false);
-		if (!m_settings.get_bool(settings_pack::close_redundant_connections)) return false;
 
 		boost::shared_ptr<torrent> t = m_torrent.lock();
 		if (!t) return false;
+
+		if (t->keep_redundant_connections()) return false;
 
 		// if we don't have the metadata yet, don't disconnect
 		// also, if the peer doesn't have metadata we shouldn't
@@ -6692,8 +6693,7 @@ namespace libtorrent
 			TORRENT_ASSERT(t->torrent_file().num_pieces() == int(m_have_piece.size()));
 
 		// in share mode we don't close redundant connections
-		if (m_settings.get_bool(settings_pack::close_redundant_connections)
-			&& !t->share_mode())
+		if (!t->keep_redundant_connections() && !t->share_mode())
 		{
 			bool const ok_to_disconnect =
 				can_disconnect(errors::upload_upload_connection)
@@ -6724,7 +6724,7 @@ namespace libtorrent
 		}
 
 		if (!m_disconnect_started && m_initialized
-			&& m_settings.get_bool(settings_pack::close_redundant_connections))
+			&& !t->keep_redundant_connections())
 		{
 			// none of this matters if we're disconnecting anyway
 			if (t->is_upload_only() && !m_need_interest_update)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -236,6 +236,7 @@ namespace libtorrent
 		, m_finished_time(0)
 		, m_sequential_download(false)
 		, m_auto_sequential(false)
+		, m_keep_redundant_connections(false)
 		, m_seed_mode(false)
 		, m_super_seeding(false)
 		, m_override_resume_data((p.flags & add_torrent_params::flag_override_resume_data) != 0)
@@ -6929,6 +6930,9 @@ namespace libtorrent
 			int sequential_ = rd.dict_find_int_value("sequential_download", -1);
 			if (sequential_ != -1) set_sequential_download(sequential_ != 0);
 
+			int keep_redundant_ = rd.dict_find_int_value("keep_redundant_connections", -1);
+			if (keep_redundant_ != -1) set_keep_redundant_connections(keep_redundant_ != 0);
+
 			int paused_ = rd.dict_find_int_value("paused", -1);
 			if (paused_ != -1)
 			{
@@ -7202,6 +7206,8 @@ namespace libtorrent
 		ret["num_downloaded"] = m_downloaded;
 
 		ret["sequential_download"] = m_sequential_download;
+
+		ret["keep_redundant_connections"] = m_keep_redundant_connections;
 
 		ret["seed_mode"] = m_seed_mode;
 		ret["super_seeding"] = m_super_seeding;
@@ -8539,29 +8545,7 @@ namespace libtorrent
 			m_completed_time = time(0);
 
 		// disconnect all seeds
-		if (settings().get_bool(settings_pack::close_redundant_connections))
-		{
-			// TODO: 1 should disconnect all peers that have the pieces we have
-			// not just seeds. It would be pretty expensive to check all pieces
-			// for all peers though
-			std::vector<peer_connection*> seeds;
-			for (peer_iterator i = m_connections.begin();
-				i != m_connections.end(); ++i)
-			{
-				peer_connection* p = *i;
-				TORRENT_ASSERT(p->associated_torrent().lock().get() == this);
-				if (p->upload_only())
-				{
-#ifndef TORRENT_DISABLE_LOGGING
-					p->peer_log(peer_log_alert::info, "SEED", "CLOSING CONNECTION");
-#endif
-					seeds.push_back(p);
-				}
-			}
-			std::for_each(seeds.begin(), seeds.end()
-				, boost::bind(&peer_connection::disconnect, _1, errors::torrent_finished
-				, op_bittorrent, 0));
-		}
+		maybe_close_redundant_connections();
 
 		if (m_abort) return;
 
@@ -8580,6 +8564,32 @@ namespace libtorrent
 		// update auto-manage torrents in that case
 		if (m_auto_managed)
 			m_ses.trigger_auto_manage();
+	}
+
+	void torrent::maybe_close_redundant_connections()
+	{
+		if (keep_redundant_connections()) return;
+
+		// TODO: 1 should disconnect all peers that have the pieces we have
+		// not just seeds. It would be pretty expensive to check all pieces
+		// for all peers though
+		std::vector<peer_connection*> seeds;
+		for (peer_iterator i = m_connections.begin();
+			i != m_connections.end(); ++i)
+		{
+			peer_connection* p = *i;
+			TORRENT_ASSERT(p->associated_torrent().lock().get() == this);
+			if (p->upload_only())
+			{
+#ifndef TORRENT_DISABLE_LOGGING
+				p->peer_log(peer_log_alert::info, "SEED", "CLOSING CONNECTION");
+#endif
+				seeds.push_back(p);
+			}
+		}
+		std::for_each(seeds.begin(), seeds.end()
+			, boost::bind(&peer_connection::disconnect, _1, errors::torrent_finished
+			, op_bittorrent, 0));
 	}
 
 	// this is called when we were finished, but some files were
@@ -9254,6 +9264,23 @@ namespace libtorrent
 
 		set_need_save_resume();
 
+		state_updated();
+	}
+
+	bool torrent::keep_redundant_connections() const
+	{
+		return m_keep_redundant_connections ||
+			!settings().get_bool(settings_pack::close_redundant_connections);
+	}
+
+	void torrent::set_keep_redundant_connections(bool keep)
+	{
+		if (m_keep_redundant_connections == keep) return;
+		m_keep_redundant_connections = keep;
+
+		maybe_close_redundant_connections();
+
+		set_need_save_resume();
 		state_updated();
 	}
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -413,6 +413,11 @@ namespace libtorrent
 		TORRENT_ASYNC_CALL1(set_sequential_download, sd);
 	}
 
+	void torrent_handle::set_keep_redundant_connections(bool keep) const
+	{
+		TORRENT_ASYNC_CALL1(set_keep_redundant_connections, keep);
+	}
+
 	void torrent_handle::piece_availability(std::vector<int>& avail) const
 	{
 		TORRENT_SYNC_CALL1(piece_availability, boost::ref(avail));
@@ -510,6 +515,12 @@ namespace libtorrent
 	bool torrent_handle::is_sequential_download() const
 	{
 		TORRENT_SYNC_CALL_RET(bool, false, is_sequential_download);
+		return r;
+	}
+
+	bool torrent_handle::keep_redundant_connections() const
+	{
+		TORRENT_SYNC_CALL_RET(bool, false, keep_redundant_connections);
 		return r;
 	}
 


### PR DESCRIPTION
Hi,

I added a "keep_redundant_connections" torrent setting, which is a per-torrent override to the session-wide "close_redundant_connections" setting.

Existing unit tests all ran successfully. I will fix any errors from Jenkins once it runs. I end-to-end tested this against my code and it seems to work, though I would appreciate guidance on how to write unit tests for this.

Motivation:

I've been developing a bittorrent-backed FUSE filesystem, which downloads pieces on demand as files are read.

This mechanism means the backing torrents flap between "downloading" and "seeding" state fairly often, under many different access patterns. So I had a significant performance problem due to the fact that libtorrent automatically disconnects seeds once all outstanding pieces are downloaded. It would often take several seconds to reconnect seeds, and some seeds would appear to start blocking new connections due to the flapping.

It helps to have a readahead buffer of outstanding pieces. This keeps the torrent in a downloading state more often, but it's no guarantee.

I tried disabling the "close_redundant_connections" session setting, but it's too broad. Once I touch a few torrents (particularly with large swarms) I quickly reach my maximum number of connections, with no way to selectively close connections for least-recently-used torrents. The "keep_redundant_connections" setting lets me create a policy like that.

My filesystem code is here: https://github.com/AllSeeingEyeTolledEweSew/yatfs ; requires deluge with this plugin https://github.com/AllSeeingEyeTolledEweSew/Deluge-PieceIO-Plugin . My code is still super experimental. TL;DR for testing I currently set keep_redundant_connections to true when a file is read, and set to false 30s after it's last closed. I have more complex LRU-based schemes in mind though.