### PR TITLE
Add torrent_handle::keep_redundant_connections and implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,8 @@ script:
     bjam --hash -j3 warnings-as-errors=on debug-iterators=on picker-debugging=on invariant-checks=full variant=$variant $coverage_toolset stage_module libtorrent-link=shared install-type=LIB dll-path=../../lib;
     LD_LIBRARY_PATH=../../lib DYLD_LIBRARY_PATH=../../lib python test.py;
     fi'
+  - objdump -T libtorrent.so | grep keep_redundant_connections
+  - objdump -T ../../lib/libtorrent.so.1.1.4 | grep keep_redundant_connections
   - cd ../..
 
   - cd simulation

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,8 +132,6 @@ script:
     bjam --hash -j3 warnings-as-errors=on debug-iterators=on picker-debugging=on invariant-checks=full variant=$variant $coverage_toolset stage_module libtorrent-link=shared install-type=LIB dll-path=../../lib;
     LD_LIBRARY_PATH=../../lib DYLD_LIBRARY_PATH=../../lib python test.py;
     fi'
-  - objdump -T libtorrent.so | grep keep_redundant_connections
-  - objdump -T ../../lib/libtorrent.so.1.1.4 | grep keep_redundant_connections
   - cd ../..
 
   - cd simulation

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* add keep-redundant-connections at a per-torrent level
 
 1.1.6 release
 

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -510,6 +510,8 @@ void bind_torrent_handle()
         .def("set_download_limit", _(&torrent_handle::set_download_limit))
         .def("download_limit", _(&torrent_handle::download_limit))
         .def("set_sequential_download", _(&torrent_handle::set_sequential_download))
+        .def("set_keep_redundant_connections", _(&torrent_handle::set_keep_redundant_connections))
+        .def("keep_redundant_connections", _(&torrent_handle::keep_redundant_connections))
 #ifndef TORRENT_NO_DEPRECATE
         .def("set_peer_upload_limit", &set_peer_upload_limit)
         .def("set_peer_download_limit", &set_peer_download_limit)

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -90,6 +90,12 @@ class test_torrent_handle(unittest.TestCase):
 		self.assertEqual(len(torrents), 1)
 		self.assertEqual(torrents[self.h], 'bar')
 
+	def test_redundant_connections(self):
+		self.setup()
+		self.assertFalse(self.h.keep_redundant_connections())
+		self.h.set_keep_redundant_connections(True)
+		self.assertTrue(self.h.keep_redundant_connections())
+
 	def test_replace_trackers(self):
 		self.setup()
 		trackers = []

--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -275,6 +275,17 @@ namespace libtorrent
 			// added.
 			flag_stop_when_ready = 0x4000,
 
+			// specifies whether we should keep open any connections where both ends
+			// have no utility in keeping the connections open. For instance if both
+			// ends have completed their downloads, there's no point in keeping them
+			// open. This can be useful if a partial set of pieces are requested,
+			// and all have been downloaded, but you know that you may request more
+			// soon.
+			//
+			// This acts as a per-torrent override to
+			// ``settings_pack::close_redundant_connections``.
+			flag_keep_redundant_connections = 0x20000,
+
 			// internal
 			default_flags = flag_pinned | flag_update_subscribe | flag_auto_managed | flag_paused | flag_apply_ip_filter
 

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -429,6 +429,10 @@ namespace libtorrent
 		bool is_sequential_download() const
 		{ return m_sequential_download || m_auto_sequential; }
 
+		void set_keep_redundant_connections(bool keep);
+		bool keep_redundant_connections() const;
+		void maybe_close_redundant_connections();
+
 		void queue_up();
 		void queue_down();
 		void set_queue_position(int p);
@@ -1520,6 +1524,9 @@ namespace libtorrent
 		// there's mostly seeds in the swarm, download the files sequentially
 		// for improved disk I/O performance.
 		bool m_auto_sequential:1;
+
+		// this backs the torrent_handle::keep_redundant_connections setting.
+		bool m_keep_redundant_connections:1;
 
 		// this means we haven't verified the file content
 		// of the files we're seeding. the m_verified bitfield

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1186,6 +1186,20 @@ namespace libtorrent
 		void connect_peer(tcp::endpoint const& adr, int source = 0
 			, int flags = 0x1 + 0x4 + 0x8) const;
 
+		// ``set_keep_redundant_connections()`` specifies whether we should keep
+		// open any connections where both ends have no utility in keeping the
+		// connections open. For instance if both ends have completed their
+		// downloads, there's no point in keeping them open. This can be useful if
+		// a partial set of pieces are requested, and all have been downloaded, but
+		// you know that you may request more soon.
+		//
+		// This acts as a per-torrent override to
+		// ``settings_pack::close_redundant_connections``.
+		//
+		// ``keep_redundant_connections()`` returns the current setting.
+		void set_keep_redundant_connections(bool keep) const;
+		bool keep_redundant_connections() const;
+
 		// ``set_max_uploads()`` sets the maximum number of peers that's unchoked
 		// at the same time on this torrent. If you set this to -1, there will be
 		// no limit. This defaults to infinite. The primary setting controlling

--- a/simulation/Jamfile
+++ b/simulation/Jamfile
@@ -47,5 +47,6 @@ alias libtorrent-sims :
 	[ run test_ip_filter.cpp ]
 	[ run test_fast_extensions.cpp ]
 	[ run test_file_pool.cpp ]
+	[ run test_keep_redundant_connections.cpp ]
 	;
 

--- a/simulation/test_keep_redundant_connections.cpp
+++ b/simulation/test_keep_redundant_connections.cpp
@@ -1,0 +1,165 @@
+/*
+
+Copyright (c) 2017, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/session.hpp"
+#include "libtorrent/torrent_handle.hpp"
+#include "libtorrent/peer_info.hpp"
+#include "libtorrent/torrent_status.hpp"
+#include "libtorrent/settings_pack.hpp"
+#include "libtorrent/deadline_timer.hpp"
+#include "settings.hpp"
+#include "create_torrent.hpp"
+#include "simulator/simulator.hpp"
+#include "simulator/utils.hpp" // for timer
+#include <iostream>
+
+using namespace sim;
+using namespace libtorrent;
+
+const int num_torrents = 10;
+namespace lt = libtorrent;
+
+using sim::asio::ip::address_v4;
+
+std::unique_ptr<sim::asio::io_service> make_io_service(sim::simulation& sim, int i)
+{
+	char ep[30];
+	snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
+	return std::unique_ptr<sim::asio::io_service>(new sim::asio::io_service(
+		sim, asio::ip::address_v4::from_string(ep)));
+}
+
+// this is the general template for these tests. create the session with custom
+// settings (Settings), set up the test, by adding torrents with certain
+// arguments (Setup), run the test and verify the end state (Test)
+template <typename Settings, typename Setup, typename Test>
+void run_test(Settings const& sett, Setup const& setup, Test const& test)
+{
+	// setup the simulation
+	sim::default_config network_cfg;
+	sim::simulation sim{network_cfg};
+	std::unique_ptr<sim::asio::io_service> ios0 = make_io_service(sim, 0);
+	std::unique_ptr<sim::asio::io_service> ios1 = make_io_service(sim, 1);
+	lt::session_proxy zombie0;
+	lt::session_proxy zombie1;
+
+	// setup settings packs to use (customization point)
+	lt::settings_pack pack0 = settings();
+	lt::settings_pack pack1 = settings();
+	sett(pack0, pack1);
+
+	// create session
+	std::shared_ptr<lt::session> ses0 = std::make_shared<lt::session>(pack0, *ios0);
+	std::shared_ptr<lt::session> ses1 = std::make_shared<lt::session>(pack1, *ios1);
+
+	// set up test, like adding torrents (customization point)
+	setup(*ses0, *ses1);
+
+	// set up a timer to fire later, to verify everything we expected to happen
+	// happened
+	sim::timer t(sim, lt::seconds((num_torrents + 1) * 60)
+		, [&](boost::system::error_code const& ec)
+	{
+		test(*ses0, *ses1);
+
+		// shut down
+		zombie0 = ses0->abort();
+		zombie1 = ses1->abort();
+		ses0.reset();
+		ses1.reset();
+	});
+
+	sim.run();
+}
+
+TORRENT_TEST(keep_redundant_connections)
+{
+	run_test(
+		[](lt::settings_pack& sett0, lt::settings_pack& sett1) {
+			// session 0
+			sett0.set_int(lt::settings_pack::active_downloads, 1);
+			sett0.set_int(lt::settings_pack::active_seeds, 1);
+			// session 1
+			sett1.set_int(lt::settings_pack::active_seeds, 1);
+		},
+
+		[](lt::session& ses0, lt::session& ses1) {
+			// session 0: the downloader
+			lt::add_torrent_params params0 = create_torrent(0, false);
+			params0.flags |= lt::add_torrent_params::flag_keep_redundant_connections;
+			ses0.async_add_torrent(params0);
+			// session 1: the seed
+			lt::add_torrent_params params1 = create_torrent(0, true);
+			params1.flags |= lt::add_torrent_params::flag_keep_redundant_connections;
+			ses1.async_add_torrent(params1);
+		},
+
+		[](lt::session& ses0, lt::session& ses1) {
+			std::vector<lt::alert*> alerts;
+
+			ses0.pop_alerts(&alerts);
+			lt::time_point start_time = alerts[0]->timestamp();
+			for (alert* a : alerts)
+			{
+				fprintf(stderr, "0:%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+						- start_time).count()), a->message().c_str());
+			}
+
+			ses1.pop_alerts(&alerts);
+			for (alert* a : alerts)
+			{
+				fprintf(stderr, "1:%-3d %s\n", int(duration_cast<lt::seconds>(a->timestamp()
+						- start_time).count()), a->message().c_str());
+			}
+
+			// session 0: the downloader
+			for (torrent_handle const& h : ses0.get_torrents())
+			{
+				TEST_CHECK(h.keep_redundant_connections());
+				TEST_CHECK(!h.status().paused);
+				TEST_EQUAL(h.status().state, torrent_status::seeding);
+				std::vector<lt::peer_info> peers;
+				h.get_peer_info(peers);
+				TEST_EQUAL(peers.size(), 1);
+			}
+			// session 1: the seed
+			for (torrent_handle const& h : ses1.get_torrents())
+			{
+				TEST_CHECK(h.keep_redundant_connections());
+				TEST_CHECK(!h.status().paused);
+				std::vector<lt::peer_info> peers;
+				h.get_peer_info(peers);
+				TEST_EQUAL(peers.size(), 1);
+			}
+		});
+}
+

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -1906,7 +1906,7 @@ namespace libtorrent
 		// if we're finished and this peer is uploading only
 		// disconnect it
 		if (t->is_finished() && upload_only()
-			&& m_settings.get_bool(settings_pack::close_redundant_connections)
+			&& !t->keep_redundant_connections()
 			&& !t->share_mode())
 			disconnect(errors::upload_upload_connection, op_bittorrent);
 
@@ -2006,7 +2006,7 @@ namespace libtorrent
 		// if we send upload-only, the other end is very likely to disconnect
 		// us, at least if it's a seed. If we don't want to close redundant
 		// connections, don't sent upload-only
-		if (!m_settings.get_bool(settings_pack::close_redundant_connections)) return;
+		if (t->keep_redundant_connections()) return;
 
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::outgoing_message, "UPLOAD_ONLY", "%d"

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2160,10 +2160,11 @@ namespace libtorrent
 
 		// we cannot disconnect in a constructor
 		TORRENT_ASSERT(m_in_constructor == false);
-		if (!m_settings.get_bool(settings_pack::close_redundant_connections)) return false;
 
 		boost::shared_ptr<torrent> t = m_torrent.lock();
 		if (!t) return false;
+
+		if (t->keep_redundant_connections()) return false;
 
 		// if we don't have the metadata yet, don't disconnect
 		// also, if the peer doesn't have metadata we shouldn't
@@ -6700,8 +6701,7 @@ namespace libtorrent
 			TORRENT_ASSERT(t->torrent_file().num_pieces() == int(m_have_piece.size()));
 
 		// in share mode we don't close redundant connections
-		if (m_settings.get_bool(settings_pack::close_redundant_connections)
-			&& !t->share_mode())
+		if (!t->keep_redundant_connections() && !t->share_mode())
 		{
 			bool const ok_to_disconnect =
 				can_disconnect(errors::upload_upload_connection)
@@ -6732,7 +6732,7 @@ namespace libtorrent
 		}
 
 		if (!m_disconnect_started && m_initialized
-			&& m_settings.get_bool(settings_pack::close_redundant_connections))
+			&& !t->keep_redundant_connections())
 		{
 			// none of this matters if we're disconnecting anyway
 			if (t->is_upload_only() && !m_need_interest_update)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -283,6 +283,7 @@ namespace libtorrent
 		, m_use_resume_save_path((p.flags & add_torrent_params::flag_use_resume_save_path) != 0)
 		, m_merge_resume_http_seeds((p.flags & add_torrent_params::flag_merge_resume_http_seeds) != 0)
 		, m_stop_when_ready((p.flags & add_torrent_params::flag_stop_when_ready) != 0)
+		, m_keep_redundant_connections((p.flags & add_torrent_params::flag_keep_redundant_connections) != 0)
 #if TORRENT_USE_ASSERTS
 		, m_resume_data_loaded(false)
 		, m_was_started(false)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -236,7 +236,7 @@ namespace libtorrent
 		, m_finished_time(0)
 		, m_sequential_download(false)
 		, m_auto_sequential(false)
-		, m_keep_redundant_connections(false)
+		, m_keep_redundant_connections((p.flags & add_torrent_params::flag_keep_redundant_connections) != 0)
 		, m_seed_mode(false)
 		, m_super_seeding(false)
 		, m_override_resume_data((p.flags & add_torrent_params::flag_override_resume_data) != 0)
@@ -283,7 +283,6 @@ namespace libtorrent
 		, m_use_resume_save_path((p.flags & add_torrent_params::flag_use_resume_save_path) != 0)
 		, m_merge_resume_http_seeds((p.flags & add_torrent_params::flag_merge_resume_http_seeds) != 0)
 		, m_stop_when_ready((p.flags & add_torrent_params::flag_stop_when_ready) != 0)
-		, m_keep_redundant_connections((p.flags & add_torrent_params::flag_keep_redundant_connections) != 0)
 #if TORRENT_USE_ASSERTS
 		, m_resume_data_loaded(false)
 		, m_was_started(false)

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -413,6 +413,11 @@ namespace libtorrent
 		TORRENT_ASYNC_CALL1(set_sequential_download, sd);
 	}
 
+	void torrent_handle::set_keep_redundant_connections(bool keep) const
+	{
+		TORRENT_ASYNC_CALL1(set_keep_redundant_connections, keep);
+	}
+
 	void torrent_handle::piece_availability(std::vector<int>& avail) const
 	{
 		TORRENT_SYNC_CALL1(piece_availability, boost::ref(avail));
@@ -510,6 +515,12 @@ namespace libtorrent
 	bool torrent_handle::is_sequential_download() const
 	{
 		TORRENT_SYNC_CALL_RET(bool, false, is_sequential_download);
+		return r;
+	}
+
+	bool torrent_handle::keep_redundant_connections() const
+	{
+		TORRENT_SYNC_CALL_RET(bool, false, keep_redundant_connections);
 		return r;
 	}
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -418,6 +418,12 @@ namespace libtorrent
 		TORRENT_ASYNC_CALL1(set_keep_redundant_connections, keep);
 	}
 
+	bool torrent_handle::keep_redundant_connections() const
+	{
+		TORRENT_SYNC_CALL_RET(bool, false, keep_redundant_connections);
+		return r;
+	}
+
 	void torrent_handle::piece_availability(std::vector<int>& avail) const
 	{
 		TORRENT_SYNC_CALL1(piece_availability, boost::ref(avail));
@@ -515,12 +521,6 @@ namespace libtorrent
 	bool torrent_handle::is_sequential_download() const
 	{
 		TORRENT_SYNC_CALL_RET(bool, false, is_sequential_download);
-		return r;
-	}
-
-	bool torrent_handle::keep_redundant_connections() const
-	{
-		TORRENT_SYNC_CALL_RET(bool, false, keep_redundant_connections);
 		return r;
 	}
 


### PR DESCRIPTION
Hi,

I added a "keep_redundant_connections" torrent setting, which is a per-torrent override to the session-wide "close_redundant_connections" setting.

Existing unit tests all ran successfully. I will fix any errors from Jenkins once it runs. I end-to-end tested this against my code and it seems to work, though I would appreciate guidance on how to write unit tests for this.

Motivation:

I've been developing a bittorrent-backed FUSE filesystem, which downloads pieces on demand as files are read.

This mechanism means the backing torrents flap between "downloading" and "seeding" state fairly often, under many different access patterns. So I had a significant performance problem due to the fact that libtorrent automatically disconnects seeds once all outstanding pieces are downloaded. It would often take several seconds to reconnect seeds, and some seeds would appear to start blocking new connections due to the flapping.

It helps to have a readahead buffer of outstanding pieces. This keeps the torrent in a downloading state more often, but it's no guarantee.

I tried disabling the "close_redundant_connections" session setting, but it's too broad. Once I touch a few torrents (particularly with large swarms) I quickly reach my maximum number of connections, with no way to selectively close connections for least-recently-used torrents. The "keep_redundant_connections" setting lets me create a policy like that.

My filesystem code is here: https://github.com/AllSeeingEyeTolledEweSew/yatfs ; requires deluge with this plugin https://github.com/AllSeeingEyeTolledEweSew/Deluge-PieceIO-Plugin . My code is still super experimental. TL;DR for testing I currently set keep_redundant_connections to true when a file is read, and set to false 30s after it's last closed. I have more complex LRU-based schemes in mind though.