### PR TITLE
fix MSVC 14.1 warnings-as-errors=on build

### DIFF
--- a/include/libtorrent/ip_filter.hpp
+++ b/include/libtorrent/ip_filter.hpp
@@ -68,7 +68,7 @@ namespace detail {
 	Addr zero()
 	{
 		Addr zero;
-		std::fill(zero.begin(), zero.end(), 0);
+		std::fill(zero.begin(), zero.end(), static_cast<typename Addr::value_type>(0));
 		return zero;
 	}
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2084,7 +2084,7 @@ namespace libtorrent {
 
 		if (t->is_seed())
 		{
-			std::fill_n(ptr, packet_size - 5, static_cast<std::uint8_t>(0xff));
+			std::fill_n(ptr, packet_size - 5, std::uint8_t{0xff});
 
 			// Clear trailing bits
 			msg.back() = (0xff << ((8 - (num_pieces & 7)) & 7)) & 0xff;

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2716,7 +2716,7 @@ namespace libtorrent {
 					disconnect(errors::no_memory, op_encryption);
 					return;
 				}
-				std::fill(m_sync_vc.get(), m_sync_vc.get() + 8, static_cast<char>(0));
+				std::fill(m_sync_vc.get(), m_sync_vc.get() + 8, char{0});
 				rc4_decrypt({m_sync_vc.get(), 8});
 			}
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2084,7 +2084,7 @@ namespace libtorrent {
 
 		if (t->is_seed())
 		{
-			std::fill_n(ptr, packet_size - 5, 0xff);
+			std::fill_n(ptr, packet_size - 5, static_cast<std::uint8_t>(0xff));
 
 			// Clear trailing bits
 			msg.back() = (0xff << ((8 - (num_pieces & 7)) & 7)) & 0xff;
@@ -2716,7 +2716,7 @@ namespace libtorrent {
 					disconnect(errors::no_memory, op_encryption);
 					return;
 				}
-				std::fill(m_sync_vc.get(), m_sync_vc.get() + 8, 0);
+				std::fill(m_sync_vc.get(), m_sync_vc.get() + 8, static_cast<char>(0));
 				rc4_decrypt({m_sync_vc.get(), 8});
 			}
 

--- a/src/i2p_stream.cpp
+++ b/src/i2p_stream.cpp
@@ -39,6 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/string_util.hpp"
 #include "libtorrent/settings_pack.hpp"
+#include "libtorrent/random.hpp"
 #include "libtorrent/hex.hpp" // for to_hex
 #include "libtorrent/debug.hpp"
 
@@ -130,7 +131,7 @@ namespace libtorrent {
 		m_state = sam_connecting;
 
 		char tmp[20];
-		std::generate(tmp, tmp + sizeof(tmp), &std::rand);
+		aux::random_bytes(tmp);
 		m_session_id.resize(sizeof(tmp)*2);
 		aux::to_hex(tmp, &m_session_id[0]);
 

--- a/src/receive_buffer.cpp
+++ b/src/receive_buffer.cpp
@@ -125,7 +125,7 @@ void receive_buffer::cut(int const size, int const packet_size, int const offset
 		m_recv_end -= size;
 
 #if TORRENT_USE_ASSERTS
-		std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), static_cast<unsigned char>(0xcc));
+		std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), std::uint8_t{0xcc});
 #endif
 	}
 	else
@@ -209,7 +209,7 @@ void receive_buffer::normalize(int const force_shrink)
 	m_recv_start = 0;
 
 #if TORRENT_USE_ASSERTS
-	std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), static_cast<unsigned char>(0xcc));
+	std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), std::uint8_t{0xcc});
 #endif
 }
 

--- a/src/receive_buffer.cpp
+++ b/src/receive_buffer.cpp
@@ -125,7 +125,7 @@ void receive_buffer::cut(int const size, int const packet_size, int const offset
 		m_recv_end -= size;
 
 #if TORRENT_USE_ASSERTS
-		std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), 0xcc);
+		std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), static_cast<unsigned char>(0xcc));
 #endif
 	}
 	else
@@ -209,7 +209,7 @@ void receive_buffer::normalize(int const force_shrink)
 	m_recv_start = 0;
 
 #if TORRENT_USE_ASSERTS
-	std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), 0xcc);
+	std::fill(m_recv_buffer.begin() + m_recv_end, m_recv_buffer.end(), static_cast<unsigned char>(0xcc));
 #endif
 }
 

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -576,7 +576,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 	{
 		TORRENT_ASSERT((name & type_mask) == string_type_base);
 		if ((name & type_mask) != string_type_base) return;
-		std::pair<std::uint16_t, std::string> v(name, std::move(val));
+		std::pair<std::uint16_t, std::string> v(aux::numeric_cast<std::uint16_t>(name), std::move(val));
 		insort_replace(m_strings, std::move(v));
 	}
 
@@ -584,7 +584,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 	{
 		TORRENT_ASSERT((name & type_mask) == int_type_base);
 		if ((name & type_mask) != int_type_base) return;
-		std::pair<std::uint16_t, int> v(name, val);
+		std::pair<std::uint16_t, int> v(aux::numeric_cast<std::uint16_t>(name), val);
 		insort_replace(m_ints, v);
 	}
 
@@ -592,7 +592,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 	{
 		TORRENT_ASSERT((name & type_mask) == bool_type_base);
 		if ((name & type_mask) != bool_type_base) return;
-		std::pair<std::uint16_t, bool> v(name, val);
+		std::pair<std::uint16_t, bool> v(aux::numeric_cast<std::uint16_t>(name), val);
 		insort_replace(m_bools, v);
 	}
 
@@ -606,7 +606,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 				// i.e. has every key, we don't need to search, it's just a lookup
 				if (m_strings.size() == settings_pack::num_string_settings)
 					return true;
-				std::pair<std::uint16_t, std::string> v(name, std::string());
+				std::pair<std::uint16_t, std::string> v(aux::numeric_cast<std::uint16_t>(name), std::string());
 				auto i = std::lower_bound(m_strings.begin(), m_strings.end(), v
 						, &compare_first<std::string>);
 				return i != m_strings.end() && i->first == name;
@@ -617,7 +617,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 				// i.e. has every key, we don't need to search, it's just a lookup
 				if (m_ints.size() == settings_pack::num_int_settings)
 					return true;
-				std::pair<std::uint16_t, int> v(name, 0);
+				std::pair<std::uint16_t, int> v(aux::numeric_cast<std::uint16_t>(name), 0);
 				auto i = std::lower_bound(m_ints.begin(), m_ints.end(), v
 						, &compare_first<int>);
 				return i != m_ints.end() && i->first == name;
@@ -628,7 +628,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 				// i.e. has every key, we don't need to search, it's just a lookup
 				if (m_bools.size() == settings_pack::num_bool_settings)
 					return true;
-				std::pair<std::uint16_t, bool> v(name, false);
+				std::pair<std::uint16_t, bool> v(aux::numeric_cast<std::uint16_t>(name), false);
 				auto i = std::lower_bound(m_bools.begin(), m_bools.end(), v
 						, &compare_first<bool>);
 				return i != m_bools.end() && i->first == name;
@@ -651,7 +651,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 			TORRENT_ASSERT(m_strings[name & index_mask].first == name);
 			return m_strings[name & index_mask].second;
 		}
-		std::pair<std::uint16_t, std::string> v(name, std::string());
+		std::pair<std::uint16_t, std::string> v(aux::numeric_cast<std::uint16_t>(name), std::string());
 		auto i = std::lower_bound(m_strings.begin(), m_strings.end(), v
 				, &compare_first<std::string>);
 		if (i != m_strings.end() && i->first == name) return i->second;
@@ -670,7 +670,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 			TORRENT_ASSERT(m_ints[name & index_mask].first == name);
 			return m_ints[name & index_mask].second;
 		}
-		std::pair<std::uint16_t, int> v(name, 0);
+		std::pair<std::uint16_t, int> v(aux::numeric_cast<std::uint16_t>(name), 0);
 		auto i = std::lower_bound(m_ints.begin(), m_ints.end(), v
 				, &compare_first<int>);
 		if (i != m_ints.end() && i->first == name) return i->second;
@@ -689,7 +689,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 			TORRENT_ASSERT(m_bools[name & index_mask].first == name);
 			return m_bools[name & index_mask].second;
 		}
-		std::pair<std::uint16_t, bool> v(name, false);
+		std::pair<std::uint16_t, bool> v(aux::numeric_cast<std::uint16_t>(name), false);
 		auto i = std::lower_bound(m_bools.begin(), m_bools.end(), v
 					, &compare_first<bool>);
 		if (i != m_bools.end() && i->first == name) return i->second;
@@ -709,7 +709,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		{
 			case string_type_base:
 			{
-				std::pair<std::uint16_t, std::string> v(name, std::string());
+				std::pair<std::uint16_t, std::string> v(aux::numeric_cast<std::uint16_t>(name), std::string());
 				auto const i = std::lower_bound(m_strings.begin(), m_strings.end()
 					, v, &compare_first<std::string>);
 				if (i != m_strings.end() && i->first == name) m_strings.erase(i);
@@ -717,7 +717,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 			}
 			case int_type_base:
 			{
-				std::pair<std::uint16_t, int> v(name, 0);
+				std::pair<std::uint16_t, int> v(aux::numeric_cast<std::uint16_t>(name), 0);
 				auto const i = std::lower_bound(m_ints.begin(), m_ints.end()
 					, v, &compare_first<int>);
 				if (i != m_ints.end() && i->first == name) m_ints.erase(i);
@@ -725,7 +725,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 			}
 			case bool_type_base:
 			{
-				std::pair<std::uint16_t, bool> v(name, false);
+				std::pair<std::uint16_t, bool> v(aux::numeric_cast<std::uint16_t>(name), false);
 				auto const i = std::lower_bound(m_bools.begin(), m_bools.end()
 					, v, &compare_first<bool>);
 				if (i != m_bools.end() && i->first == name) m_bools.erase(i);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4869,7 +4869,7 @@ namespace libtorrent {
 		for (file_index_t i(0); i < limit; ++i, ++si)
 		{
 			// initialize pad files to priority 0
-			m_file_priority[i] = fs.pad_file_at(i) ? 0 : aux::numeric_cast<std::uint8_t>(*si);
+			m_file_priority[i] = fs.pad_file_at(i) ? 0 : aux::clamp(*si, 0, 7) & 0xff;
 		}
 
 		// storage may be nullptr during construction and shutdown

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4865,14 +4865,11 @@ namespace libtorrent {
 		if (m_file_priority.end_index() < limit)
 			m_file_priority.resize(static_cast<int>(limit), default_piece_priority);
 
-		std::copy(files.begin(), files.begin() + static_cast<int>(limit)
-			, m_file_priority.begin());
-
-		// initialize pad files to priority 0
-		for (file_index_t i(0); i < limit; ++i)
+		auto si = files.begin();
+		for (file_index_t i(0); i < limit; ++i, ++si)
 		{
-			if (!fs.pad_file_at(i)) continue;
-			m_file_priority[i] = 0;
+			// initialize pad files to priority 0
+			m_file_priority[i] = fs.pad_file_at(i) ? 0 : aux::numeric_cast<std::uint8_t>(*si);
 		}
 
 		// storage may be nullptr during construction and shutdown


### PR DESCRIPTION
fix type narrowing warns
use span random_bytes
