### PR TITLE
need_save_resume_data() will no longer return true every 15 minutes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* need_save_resume_data() will no longer return true every 15 minutes
 	* make the file_status interface explicitly public types
 	* added resolver_cache_timeout setting for internal host name resolver
 	* make parse_magnet_uri take a string_view instead of std::string

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -527,13 +527,7 @@ namespace libtorrent {
 		void force_recheck();
 		void save_resume_data(int flags);
 
-		bool need_save_resume_data() const
-		{
-			// save resume data every 15 minutes regardless, just to
-			// keep stats up to date
-			return m_need_save_resume_data ||
-				aux::time_now32() - m_last_saved_resume > minutes(15);
-		}
+		bool need_save_resume_data() const { return m_need_save_resume_data; }
 
 		void set_need_save_resume()
 		{
@@ -1359,8 +1353,6 @@ namespace libtorrent {
 
 		// m_num_verified = m_verified.count()
 		std::uint32_t m_num_verified = 0;
-
-		time_point32 m_last_saved_resume = aux::time_now32();
 
 		// if this torrent is running, this was the time
 		// when it was started. This is used to have a

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8197,7 +8197,6 @@ namespace libtorrent {
 		}
 
 		m_need_save_resume_data = false;
-		m_last_saved_resume = aux::time_now32();
 		m_save_resume_flags = aux::numeric_cast<std::uint8_t>(flags);
 		state_updated();
 


### PR DESCRIPTION
If clients want to save resume data regularly, they can call save_resume_data() with whatever interval they choose