### PR TITLE
Set connection timeout when next endpoint is tried

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix http connection timeout on multi-homed hosts
 	* removed depdendency on boost::uintptr_t for better compatibility
 	* fix memory leak in the disk cache
 	* fix double free in disk cache

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -232,7 +232,7 @@ void run_suite(lt::aux::proxy_settings ps)
 	if (ps.type != settings_pack::socks5
 		&& ps.type != settings_pack::http)
 	{
-		auto expected_code = ps.type == settings_pack::socks4 ?
+		const auto expected_code = ps.type == settings_pack::socks4 ?
 			boost::system::errc::address_family_not_supported :
 			boost::system::errc::address_not_available;
 
@@ -449,6 +449,9 @@ TORRENT_TEST(http_connection_socks5_proxy_names)
 	run_suite(ps);
 }
 
+// tests the error scenario of a http server listening on two sockets (ipv4/ipv6) which
+// both accept the incoming connection but never send anything back. we test that
+// both ip addresses get tried in turn and that the connection attempts time out as expected.
 TORRENT_TEST(http_connection_timeout)
 {
 	sim_config network_cfg;
@@ -486,8 +489,8 @@ TORRENT_TEST(http_connection_timeout)
 	error_code e;
 	sim.run(e);
 	TEST_CHECK(!e);
-	TEST_EQUAL(2, connect_counter);
-	TEST_EQUAL(1, handler_counter);
+	TEST_EQUAL(2, connect_counter); // both endpoints are connected to
+	TEST_EQUAL(1, handler_counter); // the handler only gets called once with error_code == timed_out
 }
 
 void test_proxy_failure(lt::settings_pack::proxy_type_t proxy_type)

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -453,12 +453,14 @@ TORRENT_TEST(http_connection_timeout)
 {
 	sim_config network_cfg;
 	sim::simulation sim{network_cfg};
-
+	// server has two ip addresses (ipv4/ipv6)
 	sim::asio::io_service server_ios(sim, address_v4::from_string("10.0.0.2"));
 	sim::asio::io_service server_ios_ipv6(sim, address_v6::from_string("ff::dead:beef"));
-
-	sim::asio::io_service client_ios(sim, {address_v4::from_string("10.0.0.1"),
-			                               address_v6::from_string("ff::abad:cafe")});
+	// same for client
+	sim::asio::io_service client_ios(sim, {
+		address_v4::from_string("10.0.0.1"),
+		address_v6::from_string("ff::abad:cafe")
+	});
 	lt::resolver resolver(client_ios);
 
 	const unsigned short http_port = 8080;
@@ -478,7 +480,7 @@ TORRENT_TEST(http_connection_timeout)
 
 	auto c = test_request(client_ios, resolver
 		, "http://dual-stack.test-hostname.com:8080/timeout", data_buffer, -1, -1
-        , timed_out, lt::aux::proxy_settings()
+		, timed_out, lt::aux::proxy_settings()
 		, &connect_counter, &handler_counter);
 
 	error_code e;
@@ -486,8 +488,6 @@ TORRENT_TEST(http_connection_timeout)
 	TEST_CHECK(!e);
 	TEST_EQUAL(2, connect_counter);
 	TEST_EQUAL(1, handler_counter);
-
-	TEST_CHECK(c->socket().local_endpoint().address().is_v6());
 }
 
 void test_proxy_failure(lt::settings_pack::proxy_type_t proxy_type)

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -449,12 +449,14 @@ void http_connection::on_timeout(boost::weak_ptr<http_connection> p
 			error_code ec;
 			c->m_sock.close(ec);
 			if (!c->m_connecting) c->connect();
+			c->m_last_receive = now;
+			c->m_start_time = c->m_last_receive;
 		}
 		else
 		{
 			c->callback(boost::asio::error::timed_out);
+			return;
 		}
-		return;
 	}
 	else
 	{


### PR DESCRIPTION
After a timeout on the first endpoint the timer won't get reset, so there's no timeout active for the next endpoint on the list, which means the connection can potentially hang forever.

