### PR TITLE
HTTP proxy: avoid connecting to itself

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix proxying of https connections
 	* fix race condition in disk I/O storage class
 	* fix http connection timeout on multi-homed hosts
 	* removed depdendency on boost::uintptr_t for better compatibility

--- a/include/libtorrent/proxy_base.hpp
+++ b/include/libtorrent/proxy_base.hpp
@@ -252,8 +252,8 @@ protected:
 	bool handle_error(error_code const& e, boost::shared_ptr<handler_type> const& h);
 
 	tcp::socket m_sock;
-	std::string m_hostname;
-	int m_port;
+	std::string m_hostname; // proxy host
+	int m_port;             // proxy port
 
 	endpoint_type m_remote_endpoint;
 

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -489,8 +489,8 @@ TORRENT_TEST(http_connection_timeout_server_stalls)
 	error_code e;
 	sim.run(e);
 	TEST_CHECK(!e);
-	TEST_EQUAL(2, connect_counter); // both endpoints are connected to
-	TEST_EQUAL(1, handler_counter); // the handler only gets called once with error_code == timed_out
+	TEST_EQUAL(connect_counter, 2); // both endpoints are connected to
+	TEST_EQUAL(handler_counter, 1); // the handler only gets called once with error_code == timed_out
 }
 
 // tests the error scenario of a http server listening on two sockets (ipv4/ipv6) neither of which
@@ -541,8 +541,8 @@ TORRENT_TEST(http_connection_timeout_server_does_not_accept)
 	error_code e;
 	sim.run(e);
 	TEST_CHECK(!e);
-	TEST_EQUAL(0, connect_counter); // no connection takes place
-	TEST_EQUAL(1, handler_counter); // the handler only gets called once with error_code == timed_out
+	TEST_EQUAL(connect_counter, 0); // no connection takes place
+	TEST_EQUAL(handler_counter, 1); // the handler only gets called once with error_code == timed_out
 }
 
 void test_proxy_failure(lt::settings_pack::proxy_type_t proxy_type)
@@ -639,8 +639,8 @@ TORRENT_TEST(http_connection_ssl_proxy)
 	error_code e;
 	sim.run(e);
 
-	TEST_EQUAL(1, client_counter);
-	TEST_EQUAL(1, proxy_counter);
+	TEST_EQUAL(client_counter, 1);
+	TEST_EQUAL(proxy_counter, 1);
 	if (e) std::cerr << " run failed: " << e.message() << std::endl;
 	TEST_EQUAL(e, error_code());
 }

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -617,7 +617,7 @@ TORRENT_TEST(http_connection_ssl_proxy)
 	int client_counter = 0;
 	int proxy_counter = 0;
 
-	http_proxy.register_handler("/10.0.0.2:8080"
+	http_proxy.register_handler("10.0.0.2:8080"
 		, [&proxy_counter](std::string method, std::string req, std::map<std::string, std::string>& headers)
 		{
 			proxy_counter++;

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -607,32 +607,30 @@ TORRENT_TEST(http_connection_ssl_proxy)
 	sim::simulation sim{network_cfg};
 
 	sim::asio::io_service client_ios(sim, address_v4::from_string("10.0.0.1"));
-	sim::asio::io_service server_ios(sim, address_v4::from_string("10.0.0.2"));
 	sim::asio::io_service proxy_ios(sim, address_v4::from_string("50.50.50.50"));
 	lt::resolver res(client_ios);
 
-	sim::http_server http(server_ios, 8080);
 	sim::http_server http_proxy(proxy_ios, 4445);
 
 	lt::aux::proxy_settings ps = make_proxy_settings(settings_pack::http);
 
-	int handler_counter = 0;
-	int server_counter = 0;
+	int client_counter = 0;
+	int proxy_counter = 0;
 
 	http_proxy.register_handler("/10.0.0.2:8080"
-		, [&handler_counter](std::string method, std::string req, std::map<std::string, std::string>& headers)
+		, [&proxy_counter](std::string method, std::string req, std::map<std::string, std::string>& headers)
 		{
-			handler_counter++;
+			proxy_counter++;
 			TEST_EQUAL(method, "CONNECT");
 			return sim::send_response(403, "Not supported", 1337);
 		});
 
 	auto h = boost::make_shared<http_connection>(client_ios
 		, res
-		, [&server_counter](error_code const& ec, http_parser const& parser
+		, [&client_counter](error_code const& ec, http_parser const& parser
 		, char const* data, const int size, http_connection& c)
 		{
-			server_counter++;
+			client_counter++;
 			TEST_EQUAL(ec, boost::asio::error::operation_not_supported);
 		});
 
@@ -641,8 +639,8 @@ TORRENT_TEST(http_connection_ssl_proxy)
 	error_code e;
 	sim.run(e);
 
-	TEST_EQUAL(1, handler_counter);
-	TEST_EQUAL(1, server_counter);
+	TEST_EQUAL(1, client_counter);
+	TEST_EQUAL(1, proxy_counter);
 	if (e) std::cerr << " run failed: " << e.message() << std::endl;
 	TEST_EQUAL(e, error_code());
 }

--- a/src/http_stream.cpp
+++ b/src/http_stream.cpp
@@ -61,15 +61,7 @@ namespace libtorrent
 
 		// send CONNECT
 		std::back_insert_iterator<std::vector<char> > p(m_buffer);
-		std::string endpoint;
-		if (!m_hostname.empty())
-		{
-			endpoint = m_hostname + ':' + to_string(m_remote_endpoint.port()).elems;
-		}
-		else
-		{
-			endpoint = print_endpoint(m_remote_endpoint);
-		}
+		std::string endpoint = print_endpoint(m_remote_endpoint);
 		write_string("CONNECT " + endpoint + " HTTP/1.0\r\n", p);
 		if (!m_user.empty())
 		{


### PR DESCRIPTION
Just wanted to sanity check something before I go off and write tests for this: I don't understand the current logic in `http_stream::connected`:

1. `m_hostname` is set (the proxy hostname)
2. `http_stream::async_connect` sets `m_endpoint` and resolves `m_hostname`.
3. after resolving the hostname a connection to the proxy is established
4. the `http_stream::connected` callbacks sends a proxy `CONNECT` to `m_hostname:m_endpoint.port`, therefore connecting to itself

To me, the correct thing to do would be to just `CONNECT` to `m_endpoint`, but maybe I've overlooked another case.

I run into this particular problem when using a SSL connection + http proxy to download the `.torrent` file.

