### PR TITLE
Fix Debug build when building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # add_definitions() doesn't seem to let you say wich build type to apply it to
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DTORRENT_DEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DTORRENT_DEBUG")
 if(UNIX)
 	set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Os -g")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")


### PR DESCRIPTION
Flags added to CMAKE_C_FLAGS_DEBUG are not applied to C++ files, CMAKE_CXX_FLAGS_DEBUG should be used instead.