### PR TITLE
restore find_plugin API

### DIFF
--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -370,6 +370,10 @@ namespace libtorrent {
 		// hidden
 		virtual ~peer_plugin() {}
 
+		// This function is expected to return the name of
+		// the plugin.
+		virtual span<char const> type() const { return span<char const>(); }
+
 		// can add entries to the extension handshake
 		// this is not called for web seeds
 		virtual void add_handshake(entry&) {}

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -372,7 +372,7 @@ namespace libtorrent {
 
 		// This function is expected to return the name of
 		// the plugin.
-		virtual span<char const> type() const { return span<char const>(); }
+		virtual string_view type() const { return {}; }
 
 		// can add entries to the extension handshake
 		// this is not called for web seeds

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -303,7 +303,7 @@ namespace aux {
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		void add_extension(std::shared_ptr<peer_plugin>);
-		peer_plugin const* find_plugin(span<char const> type);
+		peer_plugin const* find_plugin(string_view type);
 #endif
 
 		// this function is called once the torrent associated

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -303,6 +303,7 @@ namespace aux {
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		void add_extension(std::shared_ptr<peer_plugin>);
+		peer_plugin const* find_plugin(span<char const> type);
 #endif
 
 		// this function is called once the torrent associated

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -57,7 +57,7 @@ struct TORRENT_EXPORT peer_connection_handle
 	connection_type type() const;
 
 	void add_extension(std::shared_ptr<peer_plugin>);
-	peer_plugin const* find_plugin(span<char const> type);
+	peer_plugin const* find_plugin(string_view type);
 
 	bool is_seed() const;
 

--- a/include/libtorrent/peer_connection_handle.hpp
+++ b/include/libtorrent/peer_connection_handle.hpp
@@ -57,6 +57,7 @@ struct TORRENT_EXPORT peer_connection_handle
 	connection_type type() const;
 
 	void add_extension(std::shared_ptr<peer_plugin>);
+	peer_plugin const* find_plugin(span<char const> type);
 
 	bool is_seed() const;
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -518,6 +518,16 @@ namespace libtorrent {
 		TORRENT_ASSERT(is_single_thread());
 		m_extensions.push_back(ext);
 	}
+
+	peer_plugin const* peer_connection::find_plugin(span<char const> type)
+	{
+		TORRENT_ASSERT(is_single_thread());
+		for (auto p : m_extensions)
+		{
+			if (p->type() == type) return p.get();
+		}
+		return nullptr;
+	}
 #endif
 
 	void peer_connection::send_allowed_set()

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -519,14 +519,12 @@ namespace libtorrent {
 		m_extensions.push_back(ext);
 	}
 
-	peer_plugin const* peer_connection::find_plugin(span<char const> type)
+	peer_plugin const* peer_connection::find_plugin(string_view type)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		for (auto p : m_extensions)
-		{
-			if (p->type() == type) return p.get();
-		}
-		return nullptr;
+		auto p = std::find_if(m_extensions.begin(), m_extensions.end()
+			, [&](std::shared_ptr<peer_plugin> const& e) { return e->type() == type; });
+		return p != m_extensions.end() ? p->get() : nullptr;
 	}
 #endif
 

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -57,6 +57,18 @@ void peer_connection_handle::add_extension(std::shared_ptr<peer_plugin> ext)
 #endif
 }
 
+peer_plugin const* peer_connection_handle::find_plugin(span<char const> type)
+{
+#ifndef TORRENT_DISABLE_EXTENSIONS
+	std::shared_ptr<peer_connection> pc = native_handle();
+	TORRENT_ASSERT(pc);
+	return pc->find_plugin(type);
+#else
+	TORRENT_UNUSED(type);
+	return nullptr;
+#endif
+}
+
 bool peer_connection_handle::is_seed() const
 {
 	std::shared_ptr<peer_connection> pc = native_handle();

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -57,7 +57,7 @@ void peer_connection_handle::add_extension(std::shared_ptr<peer_plugin> ext)
 #endif
 }
 
-peer_plugin const* peer_connection_handle::find_plugin(span<char const> type)
+peer_plugin const* peer_connection_handle::find_plugin(string_view type)
 {
 #ifndef TORRENT_DISABLE_EXTENSIONS
 	std::shared_ptr<peer_connection> pc = native_handle();


### PR DESCRIPTION
My reputation plugin uses this API.

@aldenml For future reference, the interfaces in `extensions.hpp` and `peer_connection_handle` are part of the public API. Do not remove parts of them just because libtorrent itself isn't using them.