### PR TITLE
make file open mode flags be an enum class for type-safety

### DIFF
--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -869,7 +869,7 @@ void generate_data(char const* path, torrent_info const& ti)
 			iovec_t const b = { reinterpret_cast<char*>(piece)
 				, size_t(std::min(left_in_piece, 0x4000))};
 			storage_error error;
-			st->writev(b, i, j, 0, error);
+			st->writev(b, i, j, open_mode_t::write_only, error);
 			if (error)
 				std::fprintf(stderr, "storage error: %s\n", error.ec.message().c_str());
 		}

--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -51,6 +51,7 @@ nobase_include_HEADERS = \
   file_pool.hpp                \
   file_storage.hpp             \
   fingerprint.hpp              \
+  flags.hpp                    \
   fwd.hpp                      \
   gzip.hpp                     \
   hasher.hpp                   \

--- a/include/libtorrent/file_pool.hpp
+++ b/include/libtorrent/file_pool.hpp
@@ -64,7 +64,7 @@ namespace libtorrent {
 		// file_storage ``fs`` opened at save path ``p``. ``m`` is the
 		// file open mode (see file::open_mode_t).
 		file_handle open_file(storage_index_t st, std::string const& p
-			, file_index_t file_index, file_storage const& fs, std::uint32_t m
+			, file_index_t file_index, file_storage const& fs, open_mode_t m
 			, error_code& ec);
 		// release all files belonging to the specified storage_interface (``st``)
 		// the overload that takes ``file_index`` releases only the file with
@@ -111,7 +111,7 @@ namespace libtorrent {
 			file_handle file_ptr;
 			time_point const opened{aux::time_now()};
 			time_point last_use{opened};
-			std::uint32_t mode = 0;
+			open_mode_t mode = open_mode_t::none;
 		};
 
 		// maps storage pointer, file index pairs to the

--- a/include/libtorrent/part_file.hpp
+++ b/include/libtorrent/part_file.hpp
@@ -76,7 +76,7 @@ namespace libtorrent {
 
 	private:
 
-		void open_file(std::uint32_t mode, error_code& ec);
+		void open_file(open_mode_t mode, error_code& ec);
 		void flush_metadata_impl(error_code& ec);
 
 		std::string m_path;

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -208,9 +208,9 @@ namespace libtorrent {
 		// error. If there's an error, the ``storage_error`` must be filled out
 		// to represent the error that occurred.
 		virtual int readv(span<iovec_t const> bufs
-			, piece_index_t piece, int offset, std::uint32_t flags, storage_error& ec) = 0;
+			, piece_index_t piece, int offset, open_mode_t flags, storage_error& ec) = 0;
 		virtual int writev(span<iovec_t const> bufs
-			, piece_index_t piece, int offset, std::uint32_t flags, storage_error& ec) = 0;
+			, piece_index_t piece, int offset, open_mode_t flags, storage_error& ec) = 0;
 
 		// This function is called when first checking (or re-checking) the
 		// storage for a torrent. It should return true if any of the files that
@@ -398,9 +398,9 @@ namespace libtorrent {
 		virtual bool tick() override;
 
 		int readv(span<iovec_t const> bufs
-			, piece_index_t piece, int offset, std::uint32_t flags, storage_error& ec) override;
+			, piece_index_t piece, int offset, open_mode_t flags, storage_error& ec) override;
 		int writev(span<iovec_t const> bufs
-			, piece_index_t piece, int offset, std::uint32_t flags, storage_error& ec) override;
+			, piece_index_t piece, int offset, open_mode_t flags, storage_error& ec) override;
 
 		// if the files in this storage are mapped, returns the mapped
 		// file_storage, otherwise returns the original file_storage object.
@@ -424,8 +424,8 @@ namespace libtorrent {
 		mutable stat_cache m_stat_cache;
 
 		// helper function to open a file in the file pool with the right mode
-		file_handle open_file(file_index_t file, std::uint32_t mode, storage_error& ec) const;
-		file_handle open_file_impl(file_index_t file, std::uint32_t mode, error_code& ec) const;
+		file_handle open_file(file_index_t file, open_mode_t mode, storage_error& ec) const;
+		file_handle open_file_impl(file_index_t file, open_mode_t mode, error_code& ec) const;
 
 		aux::vector<std::uint8_t, file_index_t> m_file_priority;
 		std::string m_save_path;

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -92,7 +92,7 @@ namespace libtorrent {
 
 		error_code ec;
 		std::string fn = combine_path(m_path, m_name);
-		m_file.open(fn, file::read_only, ec);
+		m_file.open(fn, open_mode_t::read_only, ec);
 		if (ec) return;
 
 		// parse header
@@ -178,7 +178,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(offset >= 0);
 		std::unique_lock<std::mutex> l(m_mutex);
 
-		open_file(file::read_write, ec);
+		open_file(open_mode_t::read_write, ec);
 		if (ec) return -1;
 
 		auto const i = m_piece_map.find(piece);
@@ -206,7 +206,7 @@ namespace libtorrent {
 		}
 
 		slot_index_t const slot = i->second;
-		open_file(file::read_write, ec);
+		open_file(open_mode_t::read_write, ec);
 		if (ec) return -1;
 
 		l.unlock();
@@ -215,15 +215,15 @@ namespace libtorrent {
 		return int(m_file.readv(slot_offset + offset, bufs, ec));
 	}
 
-	void part_file::open_file(std::uint32_t const mode, error_code& ec)
+	void part_file::open_file(open_mode_t const mode, error_code& ec)
 	{
 		if (m_file.is_open()
-			&& ((m_file.open_mode() & file::rw_mask) == mode
-				|| mode == file::read_only)) return;
+			&& ((m_file.open_mode() & open_mode_t::rw_mask) == mode
+				|| mode == open_mode_t::read_only)) return;
 
 		std::string fn = combine_path(m_path, m_name);
 		m_file.open(fn, mode, ec);
-		if (((mode & file::rw_mask) != file::read_only)
+		if (((mode & open_mode_t::rw_mask) != open_mode_t::read_only)
 			&& ec == boost::system::errc::no_such_file_or_directory)
 		{
 			// this means the directory the file is in doesn't exist.
@@ -301,7 +301,7 @@ namespace libtorrent {
 			if (i != m_piece_map.end())
 			{
 				slot_index_t const slot = i->second;
-				open_file(file::read_only, ec);
+				open_file(open_mode_t::read_only, ec);
 				if (ec) return;
 
 				if (!buf) buf.reset(new char[m_piece_size]);
@@ -375,7 +375,7 @@ namespace libtorrent {
 			return;
 		}
 
-		open_file(file::read_write, ec);
+		open_file(open_mode_t::read_write, ec);
 		if (ec) return;
 
 		std::vector<char> header(static_cast<std::size_t>(m_header_size));

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -552,7 +552,7 @@ namespace libtorrent {
 	{
 		ec.clear();
 		file f;
-		if (!f.open(filename, file::read_only, ec)) return -1;
+		if (!f.open(filename, open_mode_t::read_only, ec)) return -1;
 		std::int64_t s = f.get_size(ec);
 		if (ec) return -1;
 		v.resize(std::size_t(s));

--- a/test/make_torrent.cpp
+++ b/test/make_torrent.cpp
@@ -192,7 +192,7 @@ void generate_files(lt::torrent_info const& ti, std::string const& path
 
 		iovec_t b = { &buffer[0], size_t(piece_size) };
 		storage_error ec;
-		int ret = st.writev(b, i, 0, 0, ec);
+		int ret = st.writev(b, i, 0, open_mode_t::read_only, ec);
 		if (ret != piece_size || ec)
 		{
 			std::printf("ERROR writing files: (%d expected %d) %s\n"

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -658,7 +658,7 @@ void create_random_files(std::string const& path, const int file_sizes[], int nu
 		full_path = combine_path(full_path, filename);
 
 		int to_write = file_sizes[i];
-		file f(full_path, file::write_only, ec);
+		file f(full_path, open_mode_t::write_only, ec);
 		if (ec) std::printf("failed to create file \"%s\": (%d) %s\n"
 			, full_path.c_str(), ec.value(), ec.message().c_str());
 		std::int64_t offset = 0;

--- a/test/test_block_cache.cpp
+++ b/test/test_block_cache.cpp
@@ -51,12 +51,12 @@ struct test_storage_impl : storage_interface
 	void initialize(storage_error& ec) override {}
 
 	int readv(span<iovec_t const> bufs
-		, piece_index_t piece, int offset, std::uint32_t flags, storage_error& ec) override
+		, piece_index_t piece, int offset, open_mode_t flags, storage_error& ec) override
 	{
 		return bufs_size(bufs);
 	}
 	int writev(span<iovec_t const> bufs
-		, piece_index_t piece, int offset, std::uint32_t flags, storage_error& ec) override
+		, piece_index_t piece, int offset, open_mode_t flags, storage_error& ec) override
 	{
 		return bufs_size(bufs);
 	}

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -132,7 +132,7 @@ void test_checking(int flags = read_only_files)
 			path = combine_path(path, name);
 
 			error_code ec;
-			file f(path, file::read_write, ec);
+			file f(path, open_mode_t::read_write, ec);
 			if (ec) std::printf("ERROR: opening file \"%s\": (%d) %s\n"
 				, path.c_str(), ec.value(), ec.message().c_str());
 			f.set_size(file_sizes[i] / 2, ec);

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -52,7 +52,7 @@ int touch_file(std::string const& filename, int size)
 
 	file f;
 	error_code ec;
-	if (!f.open(filename, file::write_only, ec)) return -1;
+	if (!f.open(filename, open_mode_t::write_only, ec)) return -1;
 	if (ec) return -1;
 	iovec_t b = {&v[0], v.size()};
 	std::int64_t written = f.writev(0, b, ec);
@@ -283,9 +283,9 @@ TORRENT_TEST(file)
 	error_code ec;
 	file f;
 #if TORRENT_USE_UNC_PATHS || !defined _WIN32
-	TEST_CHECK(f.open("con", file::read_write, ec));
+	TEST_CHECK(f.open("con", open_mode_t::read_write, ec));
 #else
-	TEST_CHECK(f.open("test_file", file::read_write, ec));
+	TEST_CHECK(f.open("test_file", open_mode_t::read_write, ec));
 #endif
 	if (ec)
 		std::printf("open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
@@ -316,7 +316,7 @@ TORRENT_TEST(hard_link)
 	// read that file and assert we get the same stuff we wrote to the first file
 	error_code ec;
 	file f;
-	TEST_CHECK(f.open("original_file", file::read_write, ec));
+	TEST_CHECK(f.open("original_file", open_mode_t::read_write, ec));
 	if (ec)
 		std::printf("open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
@@ -336,7 +336,7 @@ TORRENT_TEST(hard_link)
 	TEST_EQUAL(ec, error_code());
 
 
-	TEST_CHECK(f.open("second_link", file::read_write, ec));
+	TEST_CHECK(f.open("second_link", open_mode_t::read_write, ec));
 	if (ec)
 		std::printf("open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
@@ -363,7 +363,7 @@ TORRENT_TEST(coalesce_buffer)
 {
 	error_code ec;
 	file f;
-	TEST_CHECK(f.open("test_file", file::read_write, ec));
+	TEST_CHECK(f.open("test_file", open_mode_t::read_write, ec));
 	if (ec)
 		std::printf("open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
@@ -371,7 +371,7 @@ TORRENT_TEST(coalesce_buffer)
 	char test[] = "test";
 	char foobar[] = "foobar";
 	iovec_t b[2] = {{test, 4}, {foobar, 6}};
-	TEST_EQUAL(f.writev(0, b, ec, file::coalesce_buffers), 4 + 6);
+	TEST_EQUAL(f.writev(0, b, ec, open_mode_t::coalesce_buffers), 4 + 6);
 	if (ec)
 		std::printf("writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_CHECK(!ec);

--- a/test/test_http_connection.cpp
+++ b/test/test_http_connection.cpp
@@ -146,7 +146,7 @@ void write_test_file()
 	std::srand(unsigned(std::time(nullptr)));
 	std::generate(data_buffer, data_buffer + sizeof(data_buffer), &std::rand);
 	error_code ec;
-	file test_file("test_file", file::write_only, ec);
+	file test_file("test_file", open_mode_t::write_only, ec);
 	TEST_CHECK(!ec);
 	if (ec) std::printf("file error: %s\n", ec.message().c_str());
 	iovec_t b = { data_buffer, 3216};

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -242,50 +242,50 @@ void run_storage_tests(std::shared_ptr<torrent_info> info
 
 	// write piece 1 (in slot 0)
 	iovec_t iov = { piece1.data(), half};
-	ret = s->writev(iov, piece_index_t(0), 0, 0, ec);
+	ret = s->writev(iov, piece_index_t(0), 0, open_mode_t::read_write, ec);
 	if (ret != half) print_error("writev", ret, ec);
 
 	iov = { piece1.data() + half, half };
-	ret = s->writev(iov, piece_index_t(0), half, 0, ec);
+	ret = s->writev(iov, piece_index_t(0), half, open_mode_t::read_write, ec);
 	if (ret != half) print_error("writev", ret, ec);
 
 	// test unaligned read (where the bytes are aligned)
 	iov = { piece + 3, piece_size - 9};
-	ret = s->readv(iov, piece_index_t(0), 3, 0, ec);
+	ret = s->readv(iov, piece_index_t(0), 3, open_mode_t::read_write, ec);
 	if (ret != piece_size - 9) print_error("readv",ret, ec);
 	TEST_CHECK(std::equal(piece+3, piece + piece_size-9, piece1.data()+3));
 
 	// test unaligned read (where the bytes are not aligned)
 	iov = { piece, piece_size - 9};
-	ret = s->readv(iov, piece_index_t(0), 3, 0, ec);
+	ret = s->readv(iov, piece_index_t(0), 3, open_mode_t::read_write, ec);
 	TEST_CHECK(ret == piece_size - 9);
 	if (ret != piece_size - 9) print_error("readv", ret, ec);
 	TEST_CHECK(std::equal(piece, piece + piece_size-9, piece1.data()+3));
 
 	// verify piece 1
 	iov = { piece, piece_size };
-	ret = s->readv(iov, piece_index_t(0), 0, 0, ec);
+	ret = s->readv(iov, piece_index_t(0), 0, open_mode_t::read_write, ec);
 	TEST_CHECK(ret == piece_size);
 	if (ret != piece_size) print_error("readv", ret, ec);
 	TEST_CHECK(std::equal(piece, piece + piece_size, piece1.data()));
 
 	// do the same with piece 0 and 2 (in slot 1 and 2)
 	iov = { piece0.data(), piece_size };
-	ret = s->writev(iov, piece_index_t(1), 0, 0, ec);
+	ret = s->writev(iov, piece_index_t(1), 0, open_mode_t::read_write, ec);
 	if (ret != piece_size) print_error("writev", ret, ec);
 
 	iov = { piece2.data(), piece_size };
-	ret = s->writev(iov, piece_index_t(2), 0, 0, ec);
+	ret = s->writev(iov, piece_index_t(2), 0, open_mode_t::read_write, ec);
 	if (ret != piece_size) print_error("writev", ret, ec);
 
 	// verify piece 0 and 2
 	iov = { piece, piece_size };
-	ret = s->readv(iov, piece_index_t(1), 0, 0, ec);
+	ret = s->readv(iov, piece_index_t(1), 0, open_mode_t::read_write, ec);
 	if (ret != piece_size) print_error("readv", ret, ec);
 	TEST_CHECK(std::equal(piece, piece + piece_size, piece0.data()));
 
 	iov = { piece, piece_size };
-	ret = s->readv(iov, piece_index_t(2), 0, 0, ec);
+	ret = s->readv(iov, piece_index_t(2), 0, open_mode_t::read_write, ec);
 	if (ret != piece_size) print_error("readv", ret, ec);
 	TEST_CHECK(std::equal(piece, piece + piece_size, piece2.data()));
 
@@ -337,7 +337,7 @@ void test_remove(std::string const& test_path, bool unbuffered)
 
 	iovec_t b = {&buf[0], 4};
 	storage_error se;
-	s->writev(b, piece_index_t(2), 0, 0, se);
+	s->writev(b, piece_index_t(2), 0, open_mode_t::read_write, se);
 
 	TEST_CHECK(exists(combine_path(test_path, combine_path("temp_storage"
 		, combine_path("folder1", "test2.tmp")))));
@@ -348,7 +348,7 @@ void test_remove(std::string const& test_path, bool unbuffered)
 		, combine_path("folder1", "test2.tmp"))), &st, ec);
 	TEST_EQUAL(st.file_size, 8);
 
-	s->writev(b, piece_index_t(4), 0, 0, se);
+	s->writev(b, piece_index_t(4), 0, open_mode_t::read_write, se);
 
 	TEST_CHECK(exists(combine_path(test_path, combine_path("temp_storage"
 		, combine_path("_folder3", combine_path("subfolder", "test5.tmp"))))));
@@ -1362,7 +1362,7 @@ TORRENT_TEST(move_storage_to_self)
 
 	iovec_t const b = {&buf[0], 4};
 	storage_error se;
-	s->writev(b, piece_index_t(1), 0, 0, se);
+	s->writev(b, piece_index_t(1), 0, open_mode_t::read_write, se);
 
 	TEST_CHECK(exists(combine_path(test_path, combine_path("folder2", "test3.tmp"))));
 	TEST_CHECK(exists(combine_path(test_path, combine_path("_folder3", "test4.tmp"))));
@@ -1391,7 +1391,7 @@ TORRENT_TEST(move_storage_into_self)
 
 	iovec_t const b = {&buf[0], 4};
 	storage_error se;
-	s->writev(b, piece_index_t(2), 0, 0, se);
+	s->writev(b, piece_index_t(2), 0, open_mode_t::read_write, se);
 
 	std::string const test_path = combine_path(save_path, combine_path("temp_storage", "folder1"));
 	s->move_storage(test_path, 0, se);
@@ -1437,7 +1437,7 @@ TORRENT_TEST(dont_move_intermingled_files)
 
 	iovec_t b = {&buf[0], 4};
 	storage_error se;
-	s->writev(b, piece_index_t(2), 0, 0, se);
+	s->writev(b, piece_index_t(2), 0, open_mode_t::read_write, se);
 
 	error_code ec;
 	create_directory(combine_path(save_path, combine_path("temp_storage"
@@ -1445,11 +1445,11 @@ TORRENT_TEST(dont_move_intermingled_files)
 	TEST_EQUAL(ec, boost::system::errc::success);
 	file f;
 	f.open(combine_path(save_path, combine_path("temp_storage", "alien1.tmp"))
-		, file::write_only, ec);
+		, open_mode_t::write_only, ec);
 	f.close();
 	TEST_EQUAL(ec, boost::system::errc::success);
 	f.open(combine_path(save_path, combine_path("temp_storage"
-		, combine_path("folder1", "alien2.tmp"))), file::write_only, ec);
+		, combine_path("folder1", "alien2.tmp"))), open_mode_t::write_only, ec);
 	f.close();
 	TEST_EQUAL(ec, boost::system::errc::success);
 

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -89,7 +89,7 @@ struct test_storage : default_storage
 		span<iovec_t const> bufs
 		, piece_index_t piece_index
 		, int offset
-		, std::uint32_t const flags
+		, open_mode_t const flags
 		, storage_error& se) override
 	{
 		std::unique_lock<std::mutex> l(m_mutex);

--- a/test/test_web_seed_redirect.cpp
+++ b/test/test_web_seed_redirect.cpp
@@ -50,7 +50,7 @@ TORRENT_TEST(web_seed_redirect)
 
 	char random_data[16000];
 	std::generate(random_data, random_data + sizeof(random_data), random_byte);
-	file f("test_file", file::write_only, ec);
+	file f("test_file", open_mode_t::write_only, ec);
 	if (ec)
 	{
 		std::printf("failed to create file \"test_file\": (%d) %s\n"


### PR DESCRIPTION
The main purpose of this patch is to lay the foundation for transitioning flags over to enum classes and make new flags enum classes. This is based on Anthony William's [blog post](https://www.justsoftwaresolutions.co.uk/cplusplus/using-enum-classes-as-bitfields.html).