### PR TITLE
sort input files

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -127,7 +127,7 @@ else:
 
         ext = [Extension(
             'libtorrent',
-            sources=source_list,
+            sources=sorted(source_list),
             language='c++',
             include_dirs=flags.include_dirs,
             library_dirs=flags.library_dirs,


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.