### PR TITLE
only listen on preferred IPv6 addresses on Windows

### DIFF
--- a/include/libtorrent/enum_net.hpp
+++ b/include/libtorrent/enum_net.hpp
@@ -62,6 +62,9 @@ namespace libtorrent {
 		address netmask;
 		char name[64];
 		int mtu;
+		// an interface is preferred if its address is
+		// not tenative/duplicate/deprecated
+		bool preferred = true;
 	};
 
 	struct ip_route

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -617,6 +617,7 @@ namespace libtorrent {
 				{
 					if (!valid_addr_family(unicast->Address.lpSockaddr->sa_family))
 						continue;
+					r.preferred = unicast->DadState == IpDadStatePreferred;
 					r.interface_address = sockaddr_to_address(unicast->Address.lpSockaddr);
 					ret.push_back(r);
 				}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -310,6 +310,8 @@ namespace aux {
 		{
 			for (auto const& ipface : ifs)
 			{
+				if (!ipface.preferred)
+					continue;
 				if (ipface.interface_address.is_v4())
 					continue;
 				if (ipface.interface_address.is_loopback())


### PR DESCRIPTION
We shouldn't listen on addresses which are duplicates, deprecated,
or tentative unless explicitly requested.

This is only supported on Windows for now because the Linux interface
to get this information is much less convenient for libtorrent to use.
As far as I've been able to determine, Linux only exposes this information
via the RTM_NEWADDR and RTM_GETADDR netlink messages. Currently libtorrent
uses getifaddrs() to enumerate network interfaces on Linux so this will
probably need to be changed to use netlink if available.

MacOS: ???