### PR TITLE
refactor static asserts related to nothrow in macros

### DIFF
--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -525,18 +525,13 @@ namespace libtorrent {
 
 	};
 
-	static_assert(std::is_nothrow_move_constructible<add_torrent_params>::value
-		, "should be nothrow move constructible");
-
+	TORRENT_ASSERT_NOTHROW_MOVE_CONSTRUCTIBLE(add_torrent_params);
 	// TODO: pre C++17, GCC and msvc does not make std::string nothrow move
 	// assignable, which means no type containing a string will be nothrow move
 	// assignable by default either
-//	static_assert(std::is_nothrow_move_assignable<add_torrent_params>::value
-//		, "should be nothrow move assignable");
-
+	//TORRENT_ASSERT_NOTHROW_MOVE_ASSIGNABLE(add_torrent_params);
 	// TODO: it would be nice if this was nothrow default constructible
-//	static_assert(std::is_nothrow_default_constructible<add_torrent_params>::value
-//		, "should be nothrow default constructible");
+	//TORRENT_ASSERT_NOTHROW_DEFAULT_CONSTRUCTIBLE(add_torrent_params);
 }
 
 #endif

--- a/include/libtorrent/aux_/noexcept_movable.hpp
+++ b/include/libtorrent/aux_/noexcept_movable.hpp
@@ -69,4 +69,29 @@ namespace aux {
 }
 }
 
+#ifndef TORRENT_ASSERT_NOTHROW_MOVE_CONSTRUCTIBLE
+#define TORRENT_ASSERT_NOTHROW_MOVE_CONSTRUCTIBLE(T) \
+	static_assert(std::is_nothrow_move_constructible<T>::value \
+		, "should be nothrow move constructible");
+#endif
+
+#ifndef TORRENT_ASSERT_NOTHROW_MOVE_ASSIGNABLE
+#define TORRENT_ASSERT_NOTHROW_MOVE_ASSIGNABLE(T) \
+	static_assert(std::is_nothrow_move_assignable<T>::value \
+		, "should be nothrow move assignable");
+#endif
+
+#ifndef TORRENT_ASSERT_NOTHROW_DEFAULT_CONSTRUCTIBLE
+#define TORRENT_ASSERT_NOTHROW_DEFAULT_CONSTRUCTIBLE(T) \
+	static_assert(std::is_nothrow_default_constructible<T>::value \
+		, "should be nothrow default constructible");
+#endif
+
+#ifndef TORRENT_ASSERT_NOTHROW_TYPE
+#define TORRENT_ASSERT_NOTHROW_TYPE(T) \
+	TORRENT_ASSERT_NOTHROW_MOVE_CONSTRUCTIBLE(T); \
+	TORRENT_ASSERT_NOTHROW_MOVE_ASSIGNABLE(T); \
+	TORRENT_ASSERT_NOTHROW_DEFAULT_CONSTRUCTIBLE(T);
+#endif
+
 #endif

--- a/include/libtorrent/bitfield.hpp
+++ b/include/libtorrent/bitfield.hpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/unique_ptr.hpp"
 #include "libtorrent/aux_/byteswap.hpp"
 #include "libtorrent/aux_/ffs.hpp"
+#include "libtorrent/aux_/noexcept_movable.hpp" // for TORRENT_ASSERT_NOTHROW_TYPE
 
 #include <cstring> // for memset and memcpy
 #include <cstdint> // uint32_t
@@ -256,12 +257,7 @@ namespace libtorrent {
 		aux::unique_ptr<std::uint32_t[]> m_buf;
 	};
 
-	static_assert(std::is_nothrow_move_constructible<bitfield>::value
-		, "should be nothrow move constructible");
-	static_assert(std::is_nothrow_move_assignable<bitfield>::value
-		, "should be nothrow move assignable");
-	static_assert(std::is_nothrow_default_constructible<bitfield>::value
-		, "should be nothrow default constructible");
+	TORRENT_ASSERT_NOTHROW_TYPE(bitfield);
 
 	template <typename IndexType>
 	struct typed_bitfield : bitfield
@@ -302,12 +298,7 @@ namespace libtorrent {
 		IndexType end_index() const { return IndexType(this->size()); }
 	};
 
-	static_assert(std::is_nothrow_move_constructible<typed_bitfield<int>>::value
-		, "should be nothrow move constructible");
-	static_assert(std::is_nothrow_move_assignable<typed_bitfield<int>>::value
-		, "should be nothrow move assignable");
-	static_assert(std::is_nothrow_default_constructible<typed_bitfield<int>>::value
-		, "should be nothrow default constructible");
+	TORRENT_ASSERT_NOTHROW_TYPE(typed_bitfield<int>);
 
 }
 

--- a/include/libtorrent/sha1_hash.hpp
+++ b/include/libtorrent/sha1_hash.hpp
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/byteswap.hpp"
 #include "libtorrent/aux_/ffs.hpp"
 #include "libtorrent/aux_/typed_span.hpp"
+#include "libtorrent/aux_/noexcept_movable.hpp" // for TORRENT_ASSERT_NOTHROW_TYPE
 
 #if TORRENT_USE_IOSTREAM
 #include <iosfwd>
@@ -276,12 +277,7 @@ namespace aux {
 	// peer IDs, node IDs etc.
 	using sha1_hash = digest32<160>;
 
-	static_assert(std::is_nothrow_move_constructible<sha1_hash>::value
-		, "should be nothrow move constructible");
-	static_assert(std::is_nothrow_move_assignable<sha1_hash>::value
-		, "should be nothrow move assignable");
-	static_assert(std::is_nothrow_default_constructible<sha1_hash>::value
-		, "should be nothrow default constructible");
+	TORRENT_ASSERT_NOTHROW_TYPE(sha1_hash);
 
 #if TORRENT_USE_IOSTREAM
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1313,12 +1313,7 @@ namespace libtorrent { namespace aux {
 		std::weak_ptr<torrent> m_torrent;
 	};
 
-	static_assert(std::is_nothrow_move_constructible<torrent_handle>::value
-		, "should be nothrow move constructible");
-	static_assert(std::is_nothrow_move_assignable<torrent_handle>::value
-		, "should be nothrow move assignable");
-	static_assert(std::is_nothrow_default_constructible<torrent_handle>::value
-		, "should be nothrow default constructible");
+	TORRENT_ASSERT_NOTHROW_TYPE(torrent_handle);
 }
 
 namespace std

--- a/include/libtorrent/torrent_status.hpp
+++ b/include/libtorrent/torrent_status.hpp
@@ -561,12 +561,9 @@ namespace libtorrent {
 		seconds seeding_duration;
 	};
 
-	static_assert(std::is_nothrow_move_constructible<torrent_status>::value
-		, "should be nothrow move constructible");
-//	static_assert(std::is_nothrow_move_assignable<torrent_status>::value
-//		, "should be nothrow move assignable");
-	static_assert(std::is_nothrow_default_constructible<torrent_status>::value
-		, "should be nothrow default constructible");
+	TORRENT_ASSERT_NOTHROW_MOVE_CONSTRUCTIBLE(torrent_status);
+	//TORRENT_ASSERT_NOTHROW_MOVE_ASSIGNABLE(torrent_status);
+	TORRENT_ASSERT_NOTHROW_DEFAULT_CONSTRUCTIBLE(torrent_status);
 }
 
 namespace std


### PR DESCRIPTION
The main motivation of this change is that SWIG is having a hard time with `static_assert` at namespace level. This allows me to pass empty macro definitions and avoid the problem. But I think overall it is a good DRY refactor.