### PR TITLE
fix bandwith rate limit calculation

### DIFF
--- a/include/libtorrent/bandwidth_limit.hpp
+++ b/include/libtorrent/bandwidth_limit.hpp
@@ -43,7 +43,7 @@ namespace libtorrent {
 // member of peer_connection
 struct TORRENT_EXTRA_EXPORT bandwidth_channel
 {
-	static constexpr int inf = std::numeric_limits<int>::max();
+	static constexpr int inf = std::numeric_limits<std::int32_t>::max();
 
 	bandwidth_channel();
 
@@ -93,7 +93,7 @@ private:
 
 	// the limit is the number of bytes
 	// per second we are allowed to use.
-	int m_limit;
+	std::int32_t m_limit;
 };
 
 }

--- a/include/libtorrent/bandwidth_limit.hpp
+++ b/include/libtorrent/bandwidth_limit.hpp
@@ -51,8 +51,9 @@ struct TORRENT_EXTRA_EXPORT bandwidth_channel
 	void throttle(int limit);
 	int throttle() const
 	{
+		TORRENT_ASSERT_VAL(m_limit >= 0, m_limit);
 		TORRENT_ASSERT_VAL(m_limit < inf, m_limit);
-		return int(m_limit);
+		return m_limit;
 	}
 
 	int quota_left() const;
@@ -92,7 +93,7 @@ private:
 
 	// the limit is the number of bytes
 	// per second we are allowed to use.
-	std::int64_t m_limit;
+	int m_limit;
 };
 
 }

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -61,16 +61,12 @@ namespace libtorrent {
 	{
 		if (m_limit == 0) return;
 
+		m_quota_left += (m_limit * dt_milliseconds + 500) / 1000;
+		if (m_quota_left / 3 > m_limit) m_quota_left = m_limit * 3;
+
 		// avoid integer overflow
-		if (m_limit >= (std::int64_t(std::numeric_limits<int>::max()) * 1000) / dt_milliseconds)
-		{
-			m_quota_left = std::numeric_limits<int>::max();
-		}
-		else
-		{
-			m_quota_left += (m_limit * dt_milliseconds + 500) / 1000;
-			if (m_quota_left / 3 > m_limit) m_quota_left = m_limit * 3;
-		}
+		m_quota_left = std::min(m_quota_left, std::int64_t(std::numeric_limits<int>::max()));
+
 		distribute_quota = int(std::max(m_quota_left, std::int64_t(0)));
 	}
 

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -65,7 +65,7 @@ namespace libtorrent {
 		if (m_limit == 0) return;
 
 		// "to_add" should never have int64 overflow: "m_limit" contains < "<int>::max"
-		std::int64_t to_add = (m_limit * dt_milliseconds + 500) / 1000;
+		std::int64_t to_add = (std::int64_t(m_limit) * dt_milliseconds + 500) / 1000;
 
 		if (to_add > inf - m_quota_left)
 		{
@@ -74,7 +74,7 @@ namespace libtorrent {
 		else
 		{
 			m_quota_left += to_add;
-			if (m_quota_left / 3 > m_limit) m_quota_left = m_limit * 3;
+			if (m_quota_left / 3 > m_limit) m_quota_left = std::int64_t(m_limit) * 3;
 			// "m_quota_left" will never have int64 overflow but may exceed "<int>::max"
 			m_quota_left = std::min(m_quota_left, std::int64_t(inf));
 		}

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -61,7 +61,7 @@ namespace libtorrent {
 	{
 		TORRENT_ASSERT_VAL(m_limit >= 0, m_limit);
 
-		TORRENT_ASSERT_VAL(m_limit < inf, m_limit);
+		TORRENT_ASSERT_VAL(m_limit <= inf, m_limit);
 
 		if (m_limit == 0) return;
 

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -45,9 +45,9 @@ namespace libtorrent {
 	// 0 means infinite
 	void bandwidth_channel::throttle(int limit)
 	{
-		TORRENT_ASSERT(limit >= 0);
+		TORRENT_ASSERT_VAL(limit >= 0, limit);
 		// if the throttle is more than this, we might overflow
-		TORRENT_ASSERT(limit < inf);
+		TORRENT_ASSERT_VAL(limit < inf, limit);
 		m_limit = limit;
 	}
 
@@ -60,15 +60,14 @@ namespace libtorrent {
 	void bandwidth_channel::update_quota(int dt_milliseconds)
 	{
 		TORRENT_ASSERT_VAL(m_limit >= 0, m_limit);
-
-		TORRENT_ASSERT_VAL(m_limit <= inf, m_limit);
+		TORRENT_ASSERT_VAL(m_limit < inf, m_limit);
 
 		if (m_limit == 0) return;
 
 		// "to_add" should never have int64 overflow: "m_limit" contains < "<int>::max"
 		std::int64_t to_add = (m_limit * dt_milliseconds + 500) / 1000;
 
-		if (to_add > inf)
+		if (to_add > inf - m_quota_left)
 		{
 			m_quota_left = inf;
 		}

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -62,7 +62,7 @@ namespace libtorrent {
 		if (m_limit == 0) return;
 
 		// avoid integer overflow
-		if (m_limit >= std::numeric_limits<int>::max() / dt_milliseconds)
+		if (m_limit >= (std::int64_t(std::numeric_limits<int>::max()) * 1000) / dt_milliseconds)
 		{
 			m_quota_left = std::numeric_limits<int>::max();
 		}

--- a/test/test_bandwidth_limiter.cpp
+++ b/test/test_bandwidth_limiter.cpp
@@ -466,6 +466,7 @@ TORRENT_TEST(equal_connection)
 	test_equal_connections(33,   60000);
 	test_equal_connections(33,  500000);
 	test_equal_connections( 1, 1000000);
+	test_equal_connections( 1, 6000000);
 }
 
 TORRENT_TEST(conn_var_rate)


### PR DESCRIPTION
c9a2fed2c95ff4d42d216d4b19248ca751e7edd6 introduces regression:
any *rate_limit value above 4294966 with "tick_count"==500 leads to wrong quota calculation (unable to set upload/dowload limit e.t.c).
