### PR TITLE
fix check for fully allocated file on windows

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -2117,7 +2117,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 				offs = inf.AllocationSize;
 			}
 
-			if (offs.QuadPart != s)
+			if (offs.QuadPart < s)
 			{
 				// if the user has permissions, avoid filling
 				// the file with zeroes, but just fill it with


### PR DESCRIPTION
The file allocation size is in terms of clusters so it will likely be larger
than the file size even with a freshly allocated file.