### PR TITLE
avoid runtime fail with wrong arguments in upnp::update_map

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -779,7 +779,7 @@ void upnp::update_map(rootdevice& d, int const i)
 	if (d.upnp_connection) return;
 
 	// this should not happen, but in case it does, don't fail at runtime
-	if (i >= int(d.mapping.size())) return;
+	if (i >= d.mapping.end_index()) return;
 
 	std::shared_ptr<upnp> me(self());
 

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -778,6 +778,9 @@ void upnp::update_map(rootdevice& d, int const i)
 
 	if (d.upnp_connection) return;
 
+	// this should not happen, but in case it does, don't fail at runtime
+	if (i >= int(d.mapping.size())) return;
+
 	std::shared_ptr<upnp> me(self());
 
 	mapping_t& m = d.mapping[i];


### PR DESCRIPTION
This is an attempt to fix (or rather avoid) the upnp issue mentioned in https://github.com/arvidn/libtorrent/issues/1370.

The problem is more likely an invalid memory access, because I can see more strange related errors  in my reports. For what I see, it's possible that `upnp::update_map` is called with a wrong index in `upnp::add_mapping` because of the logic
```cpp
if (d.mapping.end_index() <= mapping_index)
    d.mapping.resize(mapping_index + 1);
```
See https://github.com/arvidn/libtorrent/blob/master/src/upnp.cpp#L229