### PR TITLE
invert logic in read_nl_sock for better clarity and reliability

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -191,7 +191,7 @@ namespace libtorrent {namespace {
 
 			if ((nl_hdr->nlmsg_flags & NLM_F_MULTI) == 0) break;
 
-		} while((nl_hdr->nlmsg_seq != seq) || (int(nl_hdr->nlmsg_pid) != pid));
+		} while((nl_hdr->nlmsg_seq == seq) && (int(nl_hdr->nlmsg_pid) == pid));
 		return msg_len;
 	}
 
@@ -1052,7 +1052,7 @@ namespace libtorrent {
 		nl_msg->nlmsg_len = NLMSG_LENGTH(sizeof(rtmsg));
 		nl_msg->nlmsg_type = RTM_GETROUTE;
 		nl_msg->nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
-		nl_msg->nlmsg_seq = seq++;
+		nl_msg->nlmsg_seq = seq;
 		nl_msg->nlmsg_pid = std::uint32_t(getpid());
 
 		if (send(sock, nl_msg, nl_msg->nlmsg_len, 0) < 0)


### PR DESCRIPTION
The seq and pid parameter are apparently used as a safety check in case
a stream of netlink messages is not properly terminated. I initially thought
that they represented the expected values of the incoming messages.
Instead seq is set to one-past the expected value and the loop aborts when
seq and pid match the message.

Inverting the logic so that reading continues as long as the seq and pid match
the incoming messages is, to me at least, more intuitive. It is also more
reliable since it does not rely on the next seq being strictly sequential. It
also catches unexpected messages preceding or interleaved with the expected
messages.