### PR TITLE
drop support for windows compilers without std::string and wchar_t

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* drop support for windows compilers without std::wstring
 	* implemented support for DHT infohash indexing, BEP51
 	* removed deprecated support for file_base in file_storage
 	* added support for running separate DHT nodes on each network interface

--- a/Jamfile
+++ b/Jamfile
@@ -465,9 +465,6 @@ feature.compose <crypto>libgcrypt : <define>TORRENT_USE_LIBGCRYPT ;
 feature ssl : off openssl : composite propagated ;
 feature.compose <ssl>openssl : <define>TORRENT_USE_OPENSSL <define>OPENSSL_NO_SSL2 ;
 
-feature character-set : unicode ansi : composite propagated link-incompatible ;
-feature.compose <character-set>unicode : <define>_UNICODE <define>UNICODE ;
-
 feature deprecated-functions : on off : composite propagated link-incompatible ;
 feature.compose <deprecated-functions>off : <define>TORRENT_NO_DEPRECATE ;
 
@@ -751,6 +748,8 @@ lib torrent
 	<link>shared:<define>TORRENT_BUILDING_SHARED
 	<define>BOOST_NO_DEPRECATED
 	<link>shared:<define>BOOST_SYSTEM_SOURCE
+	<target-os>windows:<define>UNICODE
+	<target-os>windows:<define>_UNICODE
 
 	<dht>on:<source>src/kademlia/$(KADEMLIA_SOURCES).cpp
 	<dht>on:<source>ed25519/src/$(ED25519_SOURCES).cpp

--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -101,13 +101,11 @@ namespace
     FileIter end_files(file_storage const& self)
     { return FileIter(self, self.end_file()); }
 
-#if TORRENT_USE_WSTRING
     void add_file_wstring(file_storage& fs, std::wstring const& file, std::int64_t size
        , int flags, std::time_t md, std::string link)
     {
        fs.add_file(file, size, flags, md, link);
     }
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
     void add_files_callback(file_storage& fs, std::string const& file
@@ -132,7 +130,7 @@ void bind_create_torrent()
 {
     void (file_storage::*set_name0)(std::string const&) = &file_storage::set_name;
     void (file_storage::*rename_file0)(file_index_t, std::string const&) = &file_storage::rename_file;
-#if TORRENT_USE_WSTRING && !defined TORRENT_NO_DEPRECATE
+#if !defined TORRENT_NO_DEPRECATE
     void (file_storage::*set_name1)(std::wstring const&) = &file_storage::set_name;
     void (file_storage::*rename_file1)(file_index_t, std::wstring const&) = &file_storage::rename_file;
 #endif
@@ -163,9 +161,7 @@ void bind_create_torrent()
         .def("add_file", add_file_deprecated, arg("entry"))
         .def("__iter__", boost::python::range(&begin_files, &end_files))
         .def("__len__", &file_storage::num_files)
-#if TORRENT_USE_WSTRING
         .def("add_file", add_file_wstring, (arg("path"), arg("size"), arg("flags") = 0, arg("mtime") = 0, arg("linkpath") = ""))
-#endif
 #endif // TORRENT_NO_DEPRECATE
         .def("hash", file_storage_hash)
         .def("symlink", file_storage_symlink, return_value_policy<copy_const_reference>())
@@ -182,7 +178,7 @@ void bind_create_torrent()
         .def("piece_size", &file_storage::piece_size)
         .def("set_name", set_name0)
         .def("rename_file", rename_file0)
-#if TORRENT_USE_WSTRING && !defined TORRENT_NO_DEPRECATE
+#if !defined TORRENT_NO_DEPRECATE
         .def("set_name", set_name1)
         .def("rename_file", rename_file1)
 #endif

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -444,7 +444,7 @@ void bind_torrent_handle()
     void (torrent_handle::*move_storage0)(std::string const&, lt::move_flags_t) const = &torrent_handle::move_storage;
     void (torrent_handle::*rename_file0)(file_index_t, std::string const&) const = &torrent_handle::rename_file;
 
-#if TORRENT_USE_WSTRING && !defined TORRENT_NO_DEPRECATE
+#if !defined TORRENT_NO_DEPRECATE
     void (torrent_handle::*move_storage1)(std::wstring const&, int) const = &torrent_handle::move_storage;
     void (torrent_handle::*rename_file1)(file_index_t, std::wstring const&) const = &torrent_handle::rename_file;
 #endif
@@ -567,7 +567,7 @@ void bind_torrent_handle()
         .def("force_recheck", _(&torrent_handle::force_recheck))
         .def("rename_file", _(rename_file0))
         .def("set_ssl_certificate", &torrent_handle::set_ssl_certificate, (arg("cert"), arg("private_key"), arg("dh_params"), arg("passphrase")=""))
-#if TORRENT_USE_WSTRING && !defined TORRENT_NO_DEPRECATE
+#if !defined TORRENT_NO_DEPRECATE
         .def("move_storage", _(move_storage1), (arg("path"), arg("flags") = always_replace_files))
         .def("rename_file", _(rename_file1))
 #endif

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -241,7 +241,7 @@ void bind_torrent_info()
     return_value_policy<copy_const_reference> copy;
 
     void (torrent_info::*rename_file0)(file_index_t, std::string const&) = &torrent_info::rename_file;
-#if TORRENT_USE_WSTRING && !defined TORRENT_NO_DEPRECATE
+#if !defined TORRENT_NO_DEPRECATE
     void (torrent_info::*rename_file1)(file_index_t, std::wstring const&) = &torrent_info::rename_file;
 #endif
 
@@ -261,7 +261,7 @@ void bind_torrent_info()
         .def("__init__", make_constructor(&file_constructor1))
         .def(init<torrent_info const&>((arg("ti"))))
 
-#if TORRENT_USE_WSTRING && !defined TORRENT_NO_DEPRECATE
+#if !defined TORRENT_NO_DEPRECATE
         .def(init<std::wstring, int>((arg("file"), arg("flags") = 0)))
 #endif
 
@@ -294,9 +294,7 @@ void bind_torrent_info()
 #ifndef TORRENT_NO_DEPRECATE
         .def("file_at", &torrent_info::file_at)
         .def("file_at_offset", &torrent_info::file_at_offset)
-#if TORRENT_USE_WSTRING
         .def("rename_file", rename_file1)
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
         .def("is_valid", &torrent_info::is_valid)

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -316,14 +316,6 @@ Build features:
 |                          | * ``profile`` - builds libtorrent with profile     |
 |                          |   information.                                     |
 +--------------------------+----------------------------------------------------+
-| ``character-set``        | This setting will only have an affect on windows.  |
-|                          | Other platforms are expected to support UTF-8.     |
-|                          |                                                    |
-|                          | * ``unicode`` - The unicode version of the win32   |
-|                          |   API is used. This is default.                    |
-|                          | * ``ansi`` - The ansi version of the win32 API is  |
-|                          |   used.                                            |
-+--------------------------+----------------------------------------------------+
 | ``invariant-checks``     | This setting only affects debug builds (where      |
 |                          | ``NDEBUG`` is not defined). It defaults to ``on``. |
 |                          |                                                    |
@@ -534,11 +526,6 @@ defines you can use to control the build.
 |                                        | checks in the storage, including logging of     |
 |                                        | piece sorting.                                  |
 +----------------------------------------+-------------------------------------------------+
-| ``UNICODE``                            | If building on windows this will make sure the  |
-|                                        | UTF-8 strings in pathnames are converted into   |
-|                                        | UTF-16 before they are passed to the file       |
-|                                        | operations.                                     |
-+----------------------------------------+-------------------------------------------------+
 | ``TORRENT_DISABLE_POOL_ALLOCATOR``     | Disables use of ``boost::pool<>``.              |
 +----------------------------------------+-------------------------------------------------+
 | ``TORRENT_DISABLE_MUTABLE_TORRENTS``   | Disables mutable torrent support (`BEP 38`_)    |
@@ -575,10 +562,6 @@ defines you can use to control the build.
 | ``TORRENT_DISABLE_EXTENSIONS``         | When defined, libtorrent plugin support is      |
 |                                        | disabled along with support for the extension   |
 |                                        | handskake (BEP 10).                             |
-+----------------------------------------+-------------------------------------------------+
-| ``_UNICODE``                           | On windows, this will cause the file IO         |
-|                                        | use wide character API, to properly support     |
-|                                        | non-ansi characters.                            |
 +----------------------------------------+-------------------------------------------------+
 | ``TORRENT_USE_INVARIANT_CHECKS``       | If defined to non-zero, this will enable        |
 |                                        | internal invariant checks in libtorrent.        |

--- a/include/libtorrent/aux_/escape_string.hpp
+++ b/include/libtorrent/aux_/escape_string.hpp
@@ -96,7 +96,7 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT std::string read_until(char const*& str, char delim
 		, char const* end);
 
-#if defined TORRENT_WINDOWS && TORRENT_USE_WSTRING
+#if defined TORRENT_WINDOWS
 	TORRENT_EXTRA_EXPORT std::wstring convert_to_wstring(std::string const& s);
 	TORRENT_EXTRA_EXPORT std::string convert_from_wstring(std::wstring const& s);
 #endif

--- a/include/libtorrent/aux_/path.hpp
+++ b/include/libtorrent/aux_/path.hpp
@@ -172,7 +172,7 @@ namespace libtorrent {
 
 // internal type alias export should be used at unit tests only
 	using native_path_string =
-#if TORRENT_USE_WSTRING && defined TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS
 		std::wstring;
 #else
 		std::string;
@@ -181,12 +181,12 @@ namespace libtorrent {
 // internal export should be used at unit tests only
 	TORRENT_EXTRA_EXPORT native_path_string convert_to_native_path_string(std::string const& path);
 
-// internal export should be used at unit tests only
-	TORRENT_EXTRA_EXPORT std::string convert_from_native_path(char const* s);
-
-#if defined TORRENT_WINDOWS && TORRENT_USE_WSTRING
+#if defined TORRENT_WINDOWS
 // internal export should be used at unit tests only
 	TORRENT_EXTRA_EXPORT std::string convert_from_native_path(wchar_t const* s);
+#else
+// internal export should be used at unit tests only
+	TORRENT_EXTRA_EXPORT std::string convert_from_native_path(char const* s);
 #endif
 
 	TORRENT_EXTRA_EXPORT int bufs_size(span<iovec_t const> bufs);

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -414,13 +414,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_USE_LOCALE 0
 #endif
 
-#ifndef TORRENT_USE_WSTRING
-#if !defined BOOST_NO_STD_WSTRING
-#define TORRENT_USE_WSTRING 1
-#else
-#define TORRENT_USE_WSTRING 0
-#endif // BOOST_NO_STD_WSTRING
-#endif // TORRENT_USE_WSTRING
+#if defined BOOST_NO_STD_WSTRING
+#error your C++ standard library appears to be missing std::wstring. This type is required on windows
+#endif
 
 #ifndef TORRENT_HAS_FALLOCATE
 #define TORRENT_HAS_FALLOCATE 1

--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -423,9 +423,6 @@ namespace detail {
 	}
 #endif
 
-#if TORRENT_USE_WSTRING
-	// wstring versions
-
 	// all wstring APIs are deprecated since 0.16.11
 	// instead, use the wchar -> utf8 conversion functions
 	// and pass in utf8 strings
@@ -473,7 +470,6 @@ namespace detail {
 		set_piece_hashes_deprecated(t, p, detail::nop, ec);
 	}
 #endif // TORRENT_NO_DEPRECATE
-#endif // TORRENT_USE_WSTRING
 
 }
 

--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -106,11 +106,7 @@ namespace libtorrent {
 #ifdef TORRENT_WINDOWS
 		HANDLE m_handle;
 		int m_inode;
-#if TORRENT_USE_WSTRING
 		WIN32_FIND_DATAW m_fd;
-#else
-		WIN32_FIND_DATAA m_fd;
-#endif
 #else
 		DIR* m_handle;
 		// the dirent struct contains a zero-sized

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -291,7 +291,6 @@ namespace libtorrent {
 		TORRENT_DEPRECATED
 		void add_file(file_entry const& fe, char const* filehash = nullptr);
 
-#if TORRENT_USE_WSTRING
 		// all wstring APIs are deprecated since 0.16.11
 		// instead, use the wchar -> utf8 conversion functions
 		// and pass in utf8 strings
@@ -304,7 +303,6 @@ namespace libtorrent {
 		void set_name(std::wstring const& n);
 
 		void rename_file_deprecated(file_index_t index, std::wstring const& new_filename);
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
 		// returns a list of file_slice objects representing the portions of

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -539,7 +539,6 @@ namespace libtorrent {
 		void load_country_db(char const* file);
 		TORRENT_DEPRECATED
 		int as_for_ip(address const& addr);
-#if TORRENT_USE_WSTRING
 		// all wstring APIs are deprecated since 0.16.11
 		// instead, use the wchar -> utf8 conversion functions
 		// and pass in utf8 strings
@@ -547,7 +546,6 @@ namespace libtorrent {
 		void load_country_db(wchar_t const* file);
 		TORRENT_DEPRECATED
 		void load_asnum_db(wchar_t const* file);
-#endif // TORRENT_USE_WSTRING
 
 		// deprecated in 0.15
 		// use load_state and save_state instead

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1254,7 +1254,6 @@ namespace libtorrent { namespace aux {
 		void rename_file(file_index_t index, std::string const& new_name) const;
 
 #ifndef TORRENT_NO_DEPRECATE
-#if TORRENT_USE_WSTRING
 		// all wstring APIs are deprecated since 0.16.11
 		// instead, use the wchar -> utf8 conversion functions
 		// and pass in utf8 strings
@@ -1262,7 +1261,6 @@ namespace libtorrent { namespace aux {
 		void move_storage(std::wstring const& save_path, int flags = 0) const;
 		TORRENT_DEPRECATED
 		void rename_file(file_index_t index, std::wstring const& new_name) const;
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
 		// Enables or disabled super seeding/initial seeding for this torrent.

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -163,7 +163,6 @@ namespace libtorrent {
 		TORRENT_DEPRECATED
 		torrent_info(lazy_entry const& torrent_file, error_code& ec
 			, int flags = 0);
-#if TORRENT_USE_WSTRING
 		// all wstring APIs are deprecated since 0.16.11 instead, use the wchar
 		// -> utf8 conversion functions and pass in utf8 strings
 		TORRENT_DEPRECATED
@@ -171,7 +170,6 @@ namespace libtorrent {
 			, int flags = 0);
 		TORRENT_DEPRECATED
 		explicit torrent_info(std::wstring const& filename, int flags = 0);
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
 		// frees all storage associated with this torrent_info object
@@ -220,13 +218,11 @@ namespace libtorrent {
 			m_files.rename_file(index, new_filename);
 		}
 #ifndef TORRENT_NO_DEPRECATE
-#if TORRENT_USE_WSTRING
 		// all wstring APIs are deprecated since 0.16.11
 		// instead, use the wchar -> utf8 conversion functions
 		// and pass in utf8 strings
 		TORRENT_DEPRECATED
 		void rename_file(file_index_t index, std::wstring const& new_filename);
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
 		// Remaps the file storage to a new file layout. This can be used to, for

--- a/include/libtorrent/utf8.hpp
+++ b/include/libtorrent/utf8.hpp
@@ -35,10 +35,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/export.hpp"
 
-// on windows we need these functions for
-// convert_to_native and convert_from_native
-#if TORRENT_USE_WSTRING || defined TORRENT_WINDOWS
-
 #include <cstdint>
 #include <string>
 #include <cwchar>
@@ -84,6 +80,5 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT std::pair<std::int32_t, int>
 		parse_utf8_codepoint(char const* str, int len);
 }
-#endif // !BOOST_NO_STD_WSTRING
 
 #endif

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -62,13 +62,8 @@ namespace libtorrent {
 		{
 #ifdef TORRENT_WINDOWS
 			WIN32_FILE_ATTRIBUTE_DATA attr;
-#if TORRENT_USE_WSTRING
 			std::wstring path = convert_to_wstring(p);
 			GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attr);
-#else
-			std::string path = convert_to_native(p);
-			GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &attr);
-#endif // TORRENT_USE_WSTRING
 			if (attr.dwFileAttributes == INVALID_FILE_ATTRIBUTES) return 0;
 			if (attr.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) return file_storage::attribute_hidden;
 			return 0;
@@ -198,7 +193,6 @@ namespace libtorrent {
 
 	} // anonymous namespace
 
-#if TORRENT_USE_WSTRING
 #ifndef TORRENT_NO_DEPRECATE
 
 	void add_files(file_storage& fs, std::wstring const& wfile
@@ -231,7 +225,6 @@ namespace libtorrent {
 		set_piece_hashes(t, utf8, f, ec);
 	}
 #endif // TORRENT_NO_DEPRECATE
-#endif // TORRENT_USE_WSTRING
 
 	void add_files(file_storage& fs, std::string const& file
 		, std::function<bool(std::string)> p, std::uint32_t flags)

--- a/src/escape_string.cpp
+++ b/src/escape_string.cpp
@@ -499,7 +499,7 @@ namespace libtorrent {
 		return url.substr(pos, find(url, "&", pos) - pos);
 	}
 
-#if defined TORRENT_WINDOWS && TORRENT_USE_WSTRING
+#if defined TORRENT_WINDOWS
 	std::wstring convert_to_wstring(std::string const& s)
 	{
 		error_code ec;

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -347,7 +347,6 @@ namespace {
 			, fe.symlink_path);
 	}
 
-#if TORRENT_USE_WSTRING
 	void file_storage::set_name(std::wstring const& n)
 	{
 		m_name = wchar_utf8(n);
@@ -369,7 +368,6 @@ namespace {
 	{
 		rename_file_deprecated(index, new_filename);
 	}
-#endif // TORRENT_USE_WSTRING
 #endif // TORRENT_NO_DEPRECATE
 
 	void file_storage::rename_file(file_index_t const index

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -697,10 +697,8 @@ namespace {
 	int session_handle::as_for_ip(address const&)
 	{ return 0; }
 
-#if TORRENT_USE_WSTRING
 	void session_handle::load_asnum_db(wchar_t const*) {}
 	void session_handle::load_country_db(wchar_t const*) {}
-#endif // TORRENT_USE_WSTRING
 
 	void session_handle::load_state(entry const& ses_state
 		, std::uint32_t const flags)

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -199,12 +199,8 @@ namespace libtorrent {
 
 #ifdef TORRENT_WINDOWS
 		// don't do full file allocations on network drives
-#if TORRENT_USE_WSTRING
 		std::wstring file_name = convert_to_wstring(m_save_path);
 		int const drive_type = GetDriveTypeW(file_name.c_str());
-#else
-		int const drive_type = GetDriveTypeA(m_save_path.c_str());
-#endif
 
 		if (drive_type == DRIVE_REMOTE)
 			m_allocate_files = false;

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -225,7 +225,6 @@ namespace libtorrent {
 	}
 #endif
 
-#if TORRENT_USE_WSTRING
 #ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::move_storage(
 		std::wstring const& save_path, int flags) const
@@ -238,7 +237,6 @@ namespace libtorrent {
 		async_call(&torrent::rename_file, index, wchar_utf8(new_name));
 	}
 #endif // TORRENT_NO_DEPRECATE
-#endif // TORRENT_USE_WSTRING
 
 	void torrent_handle::rename_file(file_index_t index, std::string const& new_name) const
 	{

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -822,7 +822,6 @@ namespace libtorrent {
 		INVARIANT_CHECK;
 	}
 
-#if TORRENT_USE_WSTRING
 #ifndef TORRENT_NO_DEPRECATE
 	torrent_info::torrent_info(std::wstring const& filename
 		, int const flags)
@@ -849,7 +848,6 @@ namespace libtorrent {
 		m_files.rename_file_deprecated(index, new_filename);
 	}
 #endif // TORRENT_NO_DEPRECATE
-#endif // TORRENT_USE_WSTRING
 #endif
 
 	torrent_info::torrent_info(bdecode_node const& torrent_file
@@ -889,7 +887,6 @@ namespace libtorrent {
 		INVARIANT_CHECK;
 	}
 
-#if TORRENT_USE_WSTRING
 #ifndef TORRENT_NO_DEPRECATE
 	torrent_info::torrent_info(std::wstring const& filename
 		, error_code& ec
@@ -907,7 +904,6 @@ namespace libtorrent {
 		INVARIANT_CHECK;
 	}
 #endif // TORRENT_NO_DEPRECATE
-#endif // TORRENT_USE_WSTRING
 
 	// constructor used for creating new torrents
 	// will not contain any hashes, comments, creation date

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -32,10 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 
-// on windows we need these functions for
-// convert_to_native and convert_from_native
-#if TORRENT_USE_WSTRING || defined TORRENT_WINDOWS
-
 #include <iterator>
 #include "libtorrent/utf8.hpp"
 #include "libtorrent/assert.hpp"
@@ -307,4 +303,3 @@ namespace {
 #pragma clang diagnostic pop
 #endif
 
-#endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -223,16 +223,9 @@ void change_directory(std::string const& f, error_code& ec)
 	ec.clear();
 
 #ifdef TORRENT_WINDOWS
-#if TORRENT_USE_WSTRING
-#define SetCurrentDirectory_ SetCurrentDirectoryW
 	native_path_string const n = convert_to_wstring(f);
-#else
-#define SetCurrentDirectory_ SetCurrentDirectoryA
-	native_path_string const n = convert_to_native(f);
-#endif // TORRENT_USE_WSTRING
-	if (SetCurrentDirectory_(n.c_str()) == 0)
+	if (SetCurrentDirectoryW(n.c_str()) == 0)
 		ec.assign(GetLastError(), system_category());
-#undef SetCurrentDirectory_
 #else
 	native_path_string const n = convert_to_native_path_string(f);
 	int ret = ::chdir(n.c_str());


### PR DESCRIPTION
 believed to be old cygwin