### PR TITLE
Add get_flags()/set_flags() to torrent_handle, deprecate individual functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-	* add get_flags()/set_flags() to torrent_handle, deprecate individual functions
+	* add flags()/set_flags()/unset_flags() to torrent_handle, deprecate individual functions
 	* drop support for windows compilers without std::wstring
 	* implemented support for DHT infohash indexing, BEP51
 	* removed deprecated support for file_base in file_storage

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* add get_flags()/set_flags() to torrent_handle, deprecate individual functions
 	* drop support for windows compilers without std::wstring
 	* implemented support for DHT infohash indexing, BEP51
 	* removed deprecated support for file_base in file_storage

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -489,11 +489,15 @@ void bind_torrent_handle()
         .def("is_valid", _(&torrent_handle::is_valid))
         .def("pause", _(&torrent_handle::pause), arg("flags") = 0)
         .def("resume", _(&torrent_handle::resume))
+#ifndef TORRENT_NO_DEPRECATE
         .def("stop_when_ready", _(&torrent_handle::stop_when_ready))
+#endif
         .def("clear_error", _(&torrent_handle::clear_error))
+#ifndef TORRENT_NO_DEPRECATE
         .def("super_seeding", super_seeding1)
 
         .def("auto_managed", _(&torrent_handle::auto_managed))
+#endif
         .def("queue_position", _(&torrent_handle::queue_position))
         .def("queue_position_up", _(&torrent_handle::queue_position_up))
         .def("queue_position_down", _(&torrent_handle::queue_position_down))
@@ -504,12 +508,16 @@ void bind_torrent_handle()
 #ifndef TORRENT_NO_DEPRECATE
         .def("set_priority", _(&torrent_handle::set_priority))
         .def("get_torrent_info", &get_torrent_info)
+#ifndef TORRENT_NO_DEPRECATE
         .def("super_seeding", super_seeding0)
+#endif
         .def("write_resume_data", _(&torrent_handle::write_resume_data))
         .def("is_seed", _(&torrent_handle::is_seed))
         .def("is_finished", _(&torrent_handle::is_finished))
+#ifndef TORRENT_NO_DEPRECATE
         .def("is_paused", _(&torrent_handle::is_paused))
         .def("is_auto_managed", _(&torrent_handle::is_auto_managed))
+#endif
         .def("has_metadata", _(&torrent_handle::has_metadata))
         .def("use_interface", &torrent_handle::use_interface)
         .def("name", _(&torrent_handle::name))
@@ -539,16 +547,20 @@ void bind_torrent_handle()
         .def("force_dht_announce", _(&torrent_handle::force_dht_announce))
 #endif
         .def("scrape_tracker", _(&torrent_handle::scrape_tracker), arg("index") = -1)
+#ifndef TORRENT_NO_DEPRECATE
         .def("set_upload_mode", _(&torrent_handle::set_upload_mode))
         .def("set_share_mode", _(&torrent_handle::set_share_mode))
+#endif
         .def("flush_cache", &torrent_handle::flush_cache)
+#ifndef TORRENT_NO_DEPRECATE
         .def("apply_ip_filter", &torrent_handle::apply_ip_filter)
+#endif
         .def("set_upload_limit", _(&torrent_handle::set_upload_limit))
         .def("upload_limit", _(&torrent_handle::upload_limit))
         .def("set_download_limit", _(&torrent_handle::set_download_limit))
         .def("download_limit", _(&torrent_handle::download_limit))
-        .def("set_sequential_download", _(&torrent_handle::set_sequential_download))
 #ifndef TORRENT_NO_DEPRECATE
+        .def("set_sequential_download", _(&torrent_handle::set_sequential_download))
         .def("set_peer_upload_limit", &torrent_handle::set_peer_upload_limit)
         .def("set_peer_download_limit", &torrent_handle::set_peer_download_limit)
         .def("set_ratio", _(&torrent_handle::set_ratio))
@@ -571,6 +583,8 @@ void bind_torrent_handle()
         .def("move_storage", _(move_storage1), (arg("path"), arg("flags") = always_replace_files))
         .def("rename_file", _(rename_file1))
 #endif
+        .def("get_flags", _(&torrent_handle::get_flags))
+        .def("set_flags", _(&torrent_handle::set_flags, arg("flags") = 0xffffffffffffffff))
         ;
 
     class_<open_file_state>("open_file_state")

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -584,7 +584,7 @@ void bind_torrent_handle()
         .def("rename_file", _(rename_file1))
 #endif
         .def("get_flags", _(&torrent_handle::get_flags))
-        .def("set_flags", _(&torrent_handle::set_flags, arg("flags") = 0xffffffffffffffff))
+        .def("set_flags", _(&torrent_handle::set_flags), arg("flags") = 0xffffffffffffffff)
         ;
 
     class_<open_file_state>("open_file_state")

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -435,8 +435,10 @@ void bind_torrent_handle()
 
 #ifndef TORRENT_NO_DEPRECATE
     bool (torrent_handle::*super_seeding0)() const = &torrent_handle::super_seeding;
-#endif
     void (torrent_handle::*super_seeding1)(bool) const = &torrent_handle::super_seeding;
+#endif
+    void (torrent_handle::*set_flags0)(boost::uint64_t) const = &torrent_handle::set_flags;
+    void (torrent_handle::*set_flags1)(boost::uint64_t, boost::uint64_t) const = &torrent_handle::set_flags;
 
     int (torrent_handle::*piece_priority0)(piece_index_t) const = &torrent_handle::piece_priority;
     void (torrent_handle::*piece_priority1)(piece_index_t, int) const = &torrent_handle::piece_priority;
@@ -583,8 +585,10 @@ void bind_torrent_handle()
         .def("move_storage", _(move_storage1), (arg("path"), arg("flags") = always_replace_files))
         .def("rename_file", _(rename_file1))
 #endif
-        .def("get_flags", _(&torrent_handle::get_flags))
-        .def("set_flags", _(&torrent_handle::set_flags), arg("flags") = 0xffffffffffffffff)
+        .def("flags", _(&torrent_handle::flags))
+        .def("set_flags", _(set_flags0))
+        .def("set_flags", _(set_flags1))
+        .def("unset_flags", _(&torrent_handle::unset_flags))
         ;
 
     class_<open_file_state>("open_file_state")

--- a/bindings/python/src/torrent_status.cpp
+++ b/bindings/python/src/torrent_status.cpp
@@ -36,10 +36,12 @@ void bind_torrent_status()
         .def_readonly("info_hash", &torrent_status::info_hash)
         .add_property("torrent_file", &get_torrent_file)
         .def_readonly("state", &torrent_status::state)
+#ifndef TORRENT_NO_DEPRECATE
         .def_readonly("paused", &torrent_status::paused)
         .def_readonly("stop_when_ready", &torrent_status::stop_when_ready)
         .def_readonly("auto_managed", &torrent_status::auto_managed)
         .def_readonly("sequential_download", &torrent_status::sequential_download)
+#endif
         .def_readonly("is_seeding", &torrent_status::is_seeding)
         .def_readonly("is_finished", &torrent_status::is_finished)
         .def_readonly("has_metadata", &torrent_status::has_metadata)
@@ -88,11 +90,11 @@ void bind_torrent_status()
         .def_readonly("all_time_download", &torrent_status::all_time_download)
         .def_readonly("seed_rank", &torrent_status::seed_rank)
         .def_readonly("has_incoming", &torrent_status::has_incoming)
+#ifndef TORRENT_NO_DEPRECATE
         .def_readonly("seed_mode", &torrent_status::seed_mode)
         .def_readonly("upload_mode", &torrent_status::upload_mode)
         .def_readonly("share_mode", &torrent_status::share_mode)
         .def_readonly("super_seeding", &torrent_status::super_seeding)
-#ifndef TORRENT_NO_DEPRECATE
         .def_readonly("active_time", &torrent_status::active_time)
         .def_readonly("finished_time", &torrent_status::finished_time)
         .def_readonly("seeding_time", &torrent_status::seeding_time)
@@ -111,7 +113,9 @@ void bind_torrent_status()
         .def_readonly("last_seen_complete", &torrent_status::last_seen_complete)
         .def_readonly("queue_position", &torrent_status::queue_position)
         .def_readonly("need_save_resume", &torrent_status::need_save_resume)
+#ifndef TORRENT_NO_DEPRECATE
         .def_readonly("ip_filter_applies", &torrent_status::ip_filter_applies)
+#endif
         .def_readonly("moving_storage", &torrent_status::moving_storage)
 #ifndef TORRENT_NO_DEPRECATE
         .def_readonly("is_loaded", &torrent_status::is_loaded)
@@ -125,6 +129,7 @@ void bind_torrent_status()
         .add_property("active_duration", make_getter(&torrent_status::active_duration, by_value()))
         .add_property("finished_duration", make_getter(&torrent_status::finished_duration, by_value()))
         .add_property("seeding_duration", make_getter(&torrent_status::seeding_duration, by_value()))
+        .def_readonly("flags", &torrent_status::flags)
         ;
 
     enum_<torrent_status::state_t>("states")

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -21,6 +21,8 @@ import pickle
 if os.name != 'nt':
     import pty
 
+HAVE_DEPRECATED_APIS = hasattr(lt, 'version')
+
 class test_create_torrent(unittest.TestCase):
 
     def test_from_torrent_info(self):
@@ -262,9 +264,8 @@ class test_torrent_info(unittest.TestCase):
             self.assertEqual(web_seeds[i]["type"], ws[i]["type"])
 
     def test_iterable_files(self):
-        # this detects whether libtorrent was built with deprecated APIs
         # the file_strage object is only iterable for backwards compatibility
-        if not hasattr(lt, 'version'):
+        if not HAVE_DEPRECATED_APIS:
             return
 
         lt.session({'alert_mask': lt.alert.category_t.all_categories,
@@ -323,7 +324,8 @@ class test_alerts(unittest.TestCase):
         print(st.progress)
         print(st.num_pieces)
         print(st.distributed_copies)
-        print(st.paused)
+        if HAVE_DEPRECATED_APIS:
+            print(st.paused)
         print(st.info_hash)
         print(st.seeding_duration)
         print(st.last_upload)

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -201,3 +201,4 @@ crypto
 uri
 infohashes
 rw
+0xffffffffffffffff

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -1495,7 +1495,14 @@ MAGNETURL is a magnet link
 				if (c == 's' && h.is_valid())
 				{
 					torrent_status const& ts = view.get_active_torrent();
-					h.set_sequential_download(!ts.sequential_download);
+					if (ts.flags & add_torrent_params::flag_sequential_download)
+					{
+						h.set_flags(add_torrent_params::flag_sequential_download);
+					}
+					else
+					{
+						h.unset_flags(add_torrent_params::flag_sequential_download);
+					}
 				}
 
 				if (c == 'R')
@@ -1531,13 +1538,14 @@ MAGNETURL is a magnet link
 				if (c == 'p' && h.is_valid())
 				{
 					torrent_status const& ts = view.get_active_torrent();
-					if (!ts.auto_managed && ts.paused)
+					if ((ts.flags & (add_torrent_params::flag_auto_managed |
+						add_torrent_params::flag_paused)) == add_torrent_params::flag_paused)
 					{
-						h.auto_managed(true);
+						h.set_flags(add_torrent_params::flag_auto_managed);
 					}
 					else
 					{
-						h.auto_managed(false);
+						h.unset_flags(add_torrent_params::flag_auto_managed);
 						h.pause(torrent_handle::graceful_pause);
 					}
 				}
@@ -1546,8 +1554,14 @@ MAGNETURL is a magnet link
 				if (c == 'k' && h.is_valid())
 				{
 					torrent_status const& ts = view.get_active_torrent();
-					h.auto_managed(!ts.auto_managed);
-					if (ts.auto_managed && ts.paused) h.resume();
+					h.set_flags(
+						~(ts.flags & add_torrent_params::flag_auto_managed),
+						add_torrent_params::flag_auto_managed);
+					if ((ts.flags & add_torrent_params::flag_auto_managed) &&
+						(ts.flags & add_torrent_params::flag_paused))
+					{
+						h.resume();
+					}
 				}
 
 				if (c == 'c' && h.is_valid())

--- a/examples/torrent_view.cpp
+++ b/examples/torrent_view.cpp
@@ -45,11 +45,15 @@ std::string torrent_state(lt::torrent_status const& s)
 
 	if (s.errc) return s.errc.message();
 	std::string ret;
+#ifndef TORRENT_NO_DEPRECATE
 	if (s.paused && !s.auto_managed) ret += "paused";
 	else if (s.paused && s.auto_managed) ret += "queued";
 	else if (s.upload_mode) ret += "upload mode";
 	else ret += state_str[s.state];
 	if (!s.paused && !s.auto_managed) ret += " [F]";
+#else
+	ret += state_str[s.state];
+#endif
 	char buf[10];
 	std::snprintf(buf, sizeof(buf), " (%.1f%%)", s.progress_ppm / 10000.f);
 	ret += buf;
@@ -337,7 +341,9 @@ void torrent_view::print_torrent(lt::torrent_status const& s, bool selected)
 
 	color_code progress_bar_color = col_yellow;
 	if (s.errc) progress_bar_color = col_red;
+#ifndef TORRENT_NO_DEPRECATE
 	else if (s.paused) progress_bar_color = col_blue;
+#endif
 	else if (s.state == lt::torrent_status::downloading_metadata)
 		progress_bar_color = col_magenta;
 	else if (s.current_tracker.empty())

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -401,8 +401,10 @@ namespace libtorrent {
 		// before disconnecting
 		bool graceful_pause() const { return m_graceful_pause_mode; }
 
-		boost::uint64_t get_flags() const;
-		void set_flags(boost::uint64_t mask, boost::uint64_t flags);
+		boost::uint64_t flags() const;
+		void set_flags(boost::uint64_t flags, boost::uint64_t mask);
+		void set_flags(boost::uint64_t flags) { set_flags(0xffffffffffffffff, flags); }
+		void unset_flags(boost::uint64_t flags) { set_flags(0, flags); }
 
 		void set_upload_mode(bool b);
 		bool upload_mode() const { return m_upload_mode || m_graceful_pause_mode; }

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -403,8 +403,6 @@ namespace libtorrent {
 
 		boost::uint64_t flags() const;
 		void set_flags(boost::uint64_t flags, boost::uint64_t mask);
-		void set_flags(boost::uint64_t flags) { set_flags(0xffffffffffffffff, flags); }
-		void unset_flags(boost::uint64_t flags) { set_flags(0, flags); }
 
 		void set_upload_mode(bool b);
 		bool upload_mode() const { return m_upload_mode || m_graceful_pause_mode; }

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -401,6 +401,9 @@ namespace libtorrent {
 		// before disconnecting
 		bool graceful_pause() const { return m_graceful_pause_mode; }
 
+		boost::uint64_t get_flags() const;
+		void set_flags(boost::uint64_t mask, boost::uint64_t flags);
+
 		void set_upload_mode(bool b);
 		bool upload_mode() const { return m_upload_mode || m_graceful_pause_mode; }
 		bool is_upload_only() const { return is_finished() || upload_mode(); }

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -243,14 +243,6 @@ namespace libtorrent { namespace aux {
 	//
 	struct TORRENT_EXPORT torrent_handle
 	{
-		// TODO: 3 consider replacing all the setters and getters for pause,
-		// resume, stop-when-ready, share-mode, upload-mode, super-seeding,
-		// apply-ip-filter, pinned, sequential-download,
-		// seed-mode
-		// with just set_flags() and clear_flags() using the flags from
-		// add_torrent_params. Perhaps those flags should have a more generic
-		// name.
-
 		friend struct aux::session_impl;
 		friend struct session_handle;
 		friend class torrent;
@@ -583,6 +575,26 @@ namespace libtorrent { namespace aux {
 		void pause(int flags = 0) const;
 		void resume() const;
 
+		// reflects the torrent's flags. The bits in the return value
+		// correspond to the flags found in
+		// ``add_torrent_params::flags_t``. The currently supported
+		// flags are:
+		// ``seed_mode``, ``upload_mode``, ``share_mode``,
+		// ``apply_ip_filter``, ``paused``,
+		// ``auto_managed``, ``super_seeding``,
+		// ``sequential_download``, ``pinned``, and
+		// ``stop_when_ready``.
+		boost::uint64_t get_flags() const;
+		// sets the ``add_torrent_params::flags_t`` flags
+		// reflected by ``torrent_handle::get_flags()``. For each bit
+		// set in the ``mask`` argument, that flag will be set to the
+		// value of the corresponding bit in the ``flags`` argument.
+		// Note that ``seed_mode`` can only be set when adding a
+		// torrent, and cannot be set with ``set_flags()``. Any
+		// unsupported flags will be silently ignored.
+		void set_flags(boost::uint64_t mask, boost::uint64_t flags = 0xffffffffffffffff) const;
+
+#ifndef TORRENT_NO_DEPRECATE
 		// set or clear the stop-when-ready flag. When this flag is set, the
 		// torrent will *force stop* whenever it transitions from a
 		// non-data-transferring state into a data-transferring state (referred to
@@ -612,6 +624,7 @@ namespace libtorrent { namespace aux {
 		// for the state_changed_alert and then call pause(). The download/seeding
 		// will most likely start in between posting the alert and receiving the
 		// call to pause.
+		TORRENT_DEPRECATED
 		void stop_when_ready(bool b) const;
 
 		// Explicitly sets the upload mode of the torrent. In upload mode, the
@@ -626,6 +639,7 @@ namespace libtorrent { namespace aux {
 		// To test if a torrent is in upload mode, call
 		// ``torrent_handle::status()`` and inspect
 		// ``torrent_status::upload_mode``.
+		TORRENT_DEPRECATED
 		void set_upload_mode(bool b) const;
 
 		// Enable or disable share mode for this torrent. When in share mode, the
@@ -633,7 +647,9 @@ namespace libtorrent { namespace aux {
 		// of it. Only parts that are likely to be distributed to more than 2
 		// other peers are downloaded, and only if the previous prediction was
 		// correct.
+		TORRENT_DEPRECATED
 		void set_share_mode(bool b) const;
+#endif
 
 		// Instructs libtorrent to flush all the disk caches for this torrent and
 		// close all file handles. This is done asynchronously and you will be
@@ -645,10 +661,13 @@ namespace libtorrent { namespace aux {
 		// ``torrent_handle::flush_cache()`` has been written to disk.
 		void flush_cache() const;
 
+#ifndef TORRENT_NO_DEPRECATE
 		// Set to true to apply the session global IP filter to this torrent
 		// (which is the default). Set to false to make this torrent ignore the
 		// IP filter.
+		TORRENT_DEPRECATED
 		void apply_ip_filter(bool b) const;
+#endif
 
 		// ``force_recheck`` puts the torrent back in a state where it assumes to
 		// have no resume data. All peers will be disconnected and the torrent
@@ -821,9 +840,12 @@ namespace libtorrent { namespace aux {
 		//	handled in order for this function to be meaningful.
 		bool need_save_resume_data() const;
 
+#ifndef TORRENT_NO_DEPRECATE
 		// changes whether the torrent is auto managed or not. For more info,
 		// see queuing_.
+		TORRENT_DEPRECATED
 		void auto_managed(bool m) const;
+#endif
 
 		// Every torrent that is added is assigned a queue position exactly one
 		// greater than the greatest queue position of all existing torrents.
@@ -1124,8 +1146,8 @@ namespace libtorrent { namespace aux {
 		// For more information about dynamically loading and unloading torrents,
 		// see dynamic-loading-of-torrent-files_.
 		//
+		TORRENT_DEPRECATED
 		void set_pinned(bool p) const;
-#endif
 
 		// ``set_sequential_download()`` enables or disables *sequential
 		// download*. When enabled, the piece picker will pick pieces in sequence
@@ -1135,7 +1157,9 @@ namespace libtorrent { namespace aux {
 		//
 		// Enabling sequential download will affect the piece distribution
 		// negatively in the swarm. It should be used sparingly.
+		TORRENT_DEPRECATED
 		void set_sequential_download(bool sd) const;
+#endif
 
 		// ``connect_peer()`` is a way to manually connect to peers that one
 		// believe is a part of the torrent. If the peer does not respond, or is
@@ -1261,11 +1285,12 @@ namespace libtorrent { namespace aux {
 		void move_storage(std::wstring const& save_path, int flags = 0) const;
 		TORRENT_DEPRECATED
 		void rename_file(file_index_t index, std::wstring const& new_name) const;
-#endif // TORRENT_NO_DEPRECATE
 
 		// Enables or disabled super seeding/initial seeding for this torrent.
 		// The torrent needs to be a seed for this to take effect.
+		TORRENT_DEPRECATED
 		void super_seeding(bool on) const;
+#endif // TORRENT_NO_DEPRECATE
 
 		// ``info_hash()`` returns the info-hash of the torrent. If this handle
 		// is to a torrent that hasn't loaded yet (for instance by being added)

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -584,15 +584,19 @@ namespace libtorrent { namespace aux {
 		// ``auto_managed``, ``super_seeding``,
 		// ``sequential_download``, ``pinned``, and
 		// ``stop_when_ready``.
-		boost::uint64_t get_flags() const;
+		boost::uint64_t flags() const;
 		// sets the ``add_torrent_params::flags_t`` flags
-		// reflected by ``torrent_handle::get_flags()``. For each bit
+		// reflected by ``torrent_handle::flags()``. For each bit
 		// set in the ``mask`` argument, that flag will be set to the
 		// value of the corresponding bit in the ``flags`` argument.
 		// Note that ``seed_mode`` can only be set when adding a
 		// torrent, and cannot be set with ``set_flags()``. Any
 		// unsupported flags will be silently ignored.
-		void set_flags(boost::uint64_t mask, boost::uint64_t flags = 0xffffffffffffffff) const;
+		void set_flags(boost::uint64_t flags, boost::uint64_t mask) const;
+		// an alias for ``set_flags(0xffffffffffffffff, flags)``
+		void set_flags(boost::uint64_t flags) const;
+		// an alias for ``set_flags(0, flags)``
+		void unset_flags(boost::uint64_t flags) const;
 
 #ifndef TORRENT_NO_DEPRECATE
 		// set or clear the stop-when-ready flag. When this flag is set, the

--- a/include/libtorrent/torrent_status.hpp
+++ b/include/libtorrent/torrent_status.hpp
@@ -460,6 +460,7 @@ namespace libtorrent {
 		// was saved.
 		bool need_save_resume = false;
 
+#ifndef TORRENT_NO_DEPRECATE
 		// true if the session global IP filter applies
 		// to this torrent. This defaults to true.
 		bool ip_filter_applies = false;
@@ -495,6 +496,16 @@ namespace libtorrent {
 		// true when the torrent is in sequential download mode. In this mode
 		// pieces are downloaded in order rather than rarest first.
 		bool sequential_download = false;
+#else
+		// hidden
+		bool deprecated_ip_filter_applies = false;
+		bool deprecated_upload_mode = false;
+		bool deprecated_share_mode = false;
+		bool deprecated_super_seeding = false;
+		bool deprecated_paused = false;
+		bool deprecated_auto_managed = false;
+		bool deprecated_sequential_download = false;
+#endif
 
 		// true if all pieces have been downloaded.
 		bool is_seeding = false;
@@ -515,10 +526,15 @@ namespace libtorrent {
 		// torrent.
 		bool has_incoming = false;
 
+#ifndef TORRENT_NO_DEPRECATE
 		// true if the torrent is in seed_mode. If the torrent was started in
 		// seed mode, it will leave seed mode once all pieces have been checked
 		// or as soon as one piece fails the hash check.
 		bool seed_mode = false;
+#else
+		// hidden
+		bool deprecated_seed_mode = false;
+#endif
 
 		// this is true if this torrent's storage is currently being moved from
 		// one location to another. This may potentially be a long operation
@@ -543,10 +559,15 @@ namespace libtorrent {
 		bool announcing_to_lsd = false;
 		bool announcing_to_dht = false;
 
+#ifndef TORRENT_NO_DEPRECATE
 		// this reflects whether the ``stop_when_ready`` flag is currently enabled
 		// on this torrent. For more information, see
 		// torrent_handle::stop_when_ready().
 		bool stop_when_ready = false;
+#else
+		// hidden
+		bool deprecated_stop_when_ready = false;
+#endif
 
 		// the info-hash for this torrent
 		sha1_hash info_hash;
@@ -559,6 +580,10 @@ namespace libtorrent {
 		seconds active_duration;
 		seconds finished_duration;
 		seconds seeding_duration;
+
+		// reflects several of the torrent's flags. For more
+		// information, see ``torrent_handle::get_flags()``.
+		boost::uint64_t flags = 0;
 	};
 }
 

--- a/include/libtorrent/torrent_status.hpp
+++ b/include/libtorrent/torrent_status.hpp
@@ -582,7 +582,7 @@ namespace libtorrent {
 		seconds seeding_duration;
 
 		// reflects several of the torrent's flags. For more
-		// information, see ``torrent_handle::get_flags()``.
+		// information, see ``torrent_handle::flags()``.
 		boost::uint64_t flags = 0;
 	};
 }

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10733,6 +10733,7 @@ namespace {
 #endif
 
 		st->state = static_cast<torrent_status::state_t>(m_state);
+		st->flags = this->flags();
 
 #if TORRENT_USE_ASSERTS
 		if (st->state == torrent_status::finished
@@ -10815,8 +10816,6 @@ namespace {
 		}
 
 		st->last_seen_complete = m_swarm_last_seen_complete;
-
-		st->flags = this->flags();
 	}
 
 	void torrent::add_redundant_bytes(int const b, waste_reason const reason)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -901,6 +901,82 @@ namespace libtorrent {
 #endif
 	}
 
+	boost::uint64_t torrent::get_flags() const
+	{
+		boost::uint64_t ret = 0;
+		if (m_seed_mode) {
+			ret |= add_torrent_params::flag_seed_mode;
+		}
+		if (m_upload_mode) {
+			ret |= add_torrent_params::flag_upload_mode;
+		}
+		if (m_share_mode) {
+			ret |= add_torrent_params::flag_share_mode;
+		}
+		if (m_apply_ip_filter) {
+			ret |= add_torrent_params::flag_apply_ip_filter;
+		}
+		if (is_torrent_paused()) {
+			ret |= add_torrent_params::flag_paused;
+		}
+		if (m_auto_managed) {
+			ret |= add_torrent_params::flag_auto_managed;
+		}
+		if (m_super_seeding) {
+			ret |= add_torrent_params::flag_super_seeding;
+		}
+		if (m_sequential_download) {
+			ret |= add_torrent_params::flag_sequential_download;
+		}
+		if (m_pinned) {
+			ret |= add_torrent_params::flag_pinned;
+		}
+		if (m_stop_when_ready) {
+			ret |= add_torrent_params::flag_stop_when_ready;
+		}
+		return ret;
+	}
+
+	void torrent::set_flags(boost::uint64_t mask, boost::uint64_t flags)
+	{
+		if (mask & add_torrent_params::flag_seed_mode) {
+			if ((flags & add_torrent_params::flag_seed_mode) == 0) {
+				leave_seed_mode(false);
+			}
+		}
+		if (mask & add_torrent_params::flag_upload_mode) {
+			set_upload_mode((flags & add_torrent_params::flag_upload_mode) != 0);
+		}
+		if (mask & add_torrent_params::flag_share_mode) {
+			set_share_mode((flags & add_torrent_params::flag_share_mode) != 0);
+		}
+		if (mask & add_torrent_params::flag_apply_ip_filter) {
+			set_apply_ip_filter((flags & add_torrent_params::flag_apply_ip_filter) != 0);
+		}
+		if (mask & add_torrent_params::flag_paused) {
+			if ((flags & add_torrent_params::flag_paused) != 0) {
+				graceful_pause();
+			} else {
+				resume();
+			}
+		}
+		if (mask & add_torrent_params::flag_auto_managed) {
+			auto_managed((flags & add_torrent_params::flag_auto_managed) != 0);
+		}
+		if (mask & add_torrent_params::flag_super_seeding) {
+			super_seeding((flags & add_torrent_params::flag_super_seeding) != 0);
+		}
+		if (mask & add_torrent_params::flag_sequential_download) {
+			set_sequential_download((flags & add_torrent_params::flag_sequential_download) != 0);
+		}
+		if (mask & add_torrent_params::flag_pinned) {
+			set_pinned((flags & add_torrent_params::flag_pinned) != 0);
+		}
+		if (mask & add_torrent_params::flag_stop_when_ready) {
+			stop_when_ready((flags & add_torrent_params::flag_stop_when_ready) != 0);
+		}
+	}
+
 	void torrent::set_share_mode(bool s)
 	{
 		if (s == m_share_mode) return;
@@ -10508,14 +10584,16 @@ namespace {
 #ifndef TORRENT_NO_DEPRECATE
 		if (m_error) st->error = convert_from_native(m_error.message())
 			+ ": " + resolve_filename(m_error_file);
-#endif
 		st->seed_mode = m_seed_mode;
+#endif
 		st->moving_storage = m_moving_storage;
 
 		st->announcing_to_trackers = m_announce_to_trackers;
 		st->announcing_to_lsd = m_announce_to_lsd;
 		st->announcing_to_dht = m_announce_to_dht;
+#ifndef TORRENT_NO_DEPRECATE
 		st->stop_when_ready = m_stop_when_ready;
+#endif
 
 		st->added_time = m_added_time;
 		st->completed_time = m_completed_time;
@@ -10525,8 +10603,10 @@ namespace {
 			: clamped_subtract_u16(m_ses.session_time(), m_last_scrape);
 #endif
 
+#ifndef TORRENT_NO_DEPRECATE
 		st->share_mode = m_share_mode;
 		st->upload_mode = m_upload_mode;
+#endif
 		st->up_bandwidth_queue = 0;
 		st->down_bandwidth_queue = 0;
 #ifndef TORRENT_NO_DEPRECATE
@@ -10575,12 +10655,16 @@ namespace {
 
 		st->num_complete = (m_complete == 0xffffff) ? -1 : m_complete;
 		st->num_incomplete = (m_incomplete == 0xffffff) ? -1 : m_incomplete;
+#ifndef TORRENT_NO_DEPRECATE
 		st->paused = is_torrent_paused();
 		st->auto_managed = m_auto_managed;
 		st->sequential_download = m_sequential_download;
+#endif
 		st->is_seeding = is_seed();
 		st->is_finished = is_finished();
+#ifndef TORRENT_NO_DEPRECATE
 		st->super_seeding = m_super_seeding;
+#endif
 		st->has_metadata = valid_metadata();
 		bytes_done(*st, (flags & torrent_handle::query_accurate_download_counters) != 0);
 		TORRENT_ASSERT(st->total_wanted_done >= 0);
@@ -10650,7 +10734,9 @@ namespace {
 
 		st->queue_position = queue_position();
 		st->need_save_resume = need_save_resume_data();
+#ifndef TORRENT_NO_DEPRECATE
 		st->ip_filter_applies = m_apply_ip_filter;
+#endif
 
 		st->state = static_cast<torrent_status::state_t>(m_state);
 
@@ -10735,6 +10821,8 @@ namespace {
 		}
 
 		st->last_seen_complete = m_swarm_last_seen_complete;
+
+		st->flags = get_flags();
 	}
 
 	void torrent::add_redundant_bytes(int const b, waste_reason const reason)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -928,9 +928,6 @@ namespace libtorrent {
 		if (m_sequential_download) {
 			ret |= add_torrent_params::flag_sequential_download;
 		}
-		if (m_pinned) {
-			ret |= add_torrent_params::flag_pinned;
-		}
 		if (m_stop_when_ready) {
 			ret |= add_torrent_params::flag_stop_when_ready;
 		}
@@ -964,13 +961,10 @@ namespace libtorrent {
 			auto_managed((flags & add_torrent_params::flag_auto_managed) != 0);
 		}
 		if (mask & add_torrent_params::flag_super_seeding) {
-			super_seeding((flags & add_torrent_params::flag_super_seeding) != 0);
+			set_super_seeding((flags & add_torrent_params::flag_super_seeding) != 0);
 		}
 		if (mask & add_torrent_params::flag_sequential_download) {
 			set_sequential_download((flags & add_torrent_params::flag_sequential_download) != 0);
-		}
-		if (mask & add_torrent_params::flag_pinned) {
-			set_pinned((flags & add_torrent_params::flag_pinned) != 0);
 		}
 		if (mask & add_torrent_params::flag_stop_when_ready) {
 			stop_when_ready((flags & add_torrent_params::flag_stop_when_ready) != 0);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -901,7 +901,7 @@ namespace libtorrent {
 #endif
 	}
 
-	boost::uint64_t torrent::get_flags() const
+	boost::uint64_t torrent::flags() const
 	{
 		boost::uint64_t ret = 0;
 		if (m_seed_mode) {
@@ -937,7 +937,7 @@ namespace libtorrent {
 		return ret;
 	}
 
-	void torrent::set_flags(boost::uint64_t mask, boost::uint64_t flags)
+	void torrent::set_flags(boost::uint64_t flags, boost::uint64_t mask)
 	{
 		if (mask & add_torrent_params::flag_seed_mode) {
 			if ((flags & add_torrent_params::flag_seed_mode) == 0) {
@@ -10822,7 +10822,7 @@ namespace {
 
 		st->last_seen_complete = m_swarm_last_seen_complete;
 
-		st->flags = get_flags();
+		st->flags = this->flags();
 	}
 
 	void torrent::add_redundant_bytes(int const b, waste_reason const reason)

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -272,12 +272,14 @@ namespace libtorrent {
 
 	void torrent_handle::set_flags(boost::uint64_t flags, boost::uint64_t mask) const
 	{
-		async_call(&torrent::set_flags, flags, mask);
+		void (torrent::*set_flags)(boost::uint64_t, boost::uint64_t) = &torrent::set_flags;
+		async_call(set_flags, flags, mask);
 	}
 
 	void torrent_handle::set_flags(boost::uint64_t flags) const
 	{
-		async_call(&torrent::set_flags, flags);
+		void (torrent::*set_flags)(boost::uint64_t) = &torrent::set_flags;
+		async_call(set_flags, flags);
 	}
 
 	void torrent_handle::unset_flags(boost::uint64_t flags) const

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -265,14 +265,24 @@ namespace libtorrent {
 		async_call(&torrent::pause, bool(flags & graceful_pause));
 	}
 
-	boost::uint64_t torrent_handle::get_flags() const
+	boost::uint64_t torrent_handle::flags() const
 	{
-		return sync_call_ret<boost::uint64_t>(0, &torrent::get_flags);
+		return sync_call_ret<boost::uint64_t>(0, &torrent::flags);
 	}
 
-	void torrent_handle::set_flags(boost::uint64_t mask, boost::uint64_t flags) const
+	void torrent_handle::set_flags(boost::uint64_t flags, boost::uint64_t mask) const
 	{
-		async_call(&torrent::set_flags, mask, flags);
+		async_call(&torrent::set_flags, flags, mask);
+	}
+
+	void torrent_handle::set_flags(boost::uint64_t flags) const
+	{
+		async_call(&torrent::set_flags, flags);
+	}
+
+	void torrent_handle::unset_flags(boost::uint64_t flags) const
+	{
+		async_call(&torrent::unset_flags, flags);
 	}
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -277,12 +277,12 @@ namespace libtorrent {
 
 	void torrent_handle::set_flags(boost::uint64_t flags) const
 	{
-		async_call(&torrent::set_flags, 0xffffffffffffffff, flags);
+		async_call(&torrent::set_flags, 0xffffffffffffffffull, flags);
 	}
 
 	void torrent_handle::unset_flags(boost::uint64_t flags) const
 	{
-		async_call(&torrent::set_flags, 0, flags);
+		async_call(&torrent::set_flags, 0ull, flags);
 	}
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -265,6 +265,17 @@ namespace libtorrent {
 		async_call(&torrent::pause, bool(flags & graceful_pause));
 	}
 
+	boost::uint64_t torrent_handle::get_flags() const
+	{
+		return sync_call_ret<boost::uint64_t>(0, &torrent::get_flags);
+	}
+
+	void torrent_handle::set_flags(boost::uint64_t mask, boost::uint64_t flags) const
+	{
+		async_call(&torrent::set_flags, mask, flags);
+	}
+
+#ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::stop_when_ready(bool b) const
 	{
 		async_call(&torrent::stop_when_ready, b);
@@ -284,6 +295,7 @@ namespace libtorrent {
 	{
 		async_call(&torrent::set_upload_mode, b);
 	}
+#endif
 
 	void torrent_handle::flush_cache() const
 	{
@@ -340,10 +352,12 @@ namespace libtorrent {
 		async_call(&torrent::resume);
 	}
 
+#ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::auto_managed(bool m) const
 	{
 		async_call(&torrent::auto_managed, m);
 	}
+#endif
 
 	int torrent_handle::queue_position() const
 	{
@@ -407,10 +421,12 @@ namespace libtorrent {
 		return st;
 	}
 
+#ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::set_sequential_download(bool sd) const
 	{
 		async_call(&torrent::set_sequential_download, sd);
 	}
+#endif
 
 	void torrent_handle::piece_availability(std::vector<int>& avail) const
 	{
@@ -697,12 +713,12 @@ namespace libtorrent {
 		async_call(&torrent::scrape_tracker, idx, true);
 	}
 
+#ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::super_seeding(bool on) const
 	{
 		async_call(&torrent::set_super_seeding, on);
 	}
 
-#ifndef TORRENT_NO_DEPRECATE
 	void torrent_handle::get_full_peer_list(std::vector<peer_list_entry>& v) const
 	{
 		auto vp = &v;

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -272,19 +272,17 @@ namespace libtorrent {
 
 	void torrent_handle::set_flags(boost::uint64_t flags, boost::uint64_t mask) const
 	{
-		void (torrent::*set_flags)(boost::uint64_t, boost::uint64_t) = &torrent::set_flags;
-		async_call(set_flags, flags, mask);
+		async_call(&torrent::set_flags, flags, mask);
 	}
 
 	void torrent_handle::set_flags(boost::uint64_t flags) const
 	{
-		void (torrent::*set_flags)(boost::uint64_t) = &torrent::set_flags;
-		async_call(set_flags, flags);
+		async_call(&torrent::set_flags, 0xffffffffffffffff, flags);
 	}
 
 	void torrent_handle::unset_flags(boost::uint64_t flags) const
 	{
-		async_call(&torrent::unset_flags, flags);
+		async_call(&torrent::set_flags, 0, flags);
 	}
 
 #ifndef TORRENT_NO_DEPRECATE

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -174,6 +174,7 @@ test-suite libtorrent :
 	[ run test_session_params.cpp ]
 	[ run test_read_piece.cpp ]
 	[ run test_remove_torrent.cpp ]
+	[ run test_flags.cpp ]
 
 	[ run test_file.cpp ]
 	[ run test_fast_extension.cpp ]

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -195,7 +195,8 @@ test_primitives_SOURCES = \
   test_settings_pack.cpp \
   test_fence.cpp \
   test_dos_blocker.cpp \
-  test_upnp.cpp
+  test_upnp.cpp \
+  test_flags.cpp
 
 test_recheck_SOURCES = test_recheck.cpp
 test_stat_cache_SOURCES = test_stat_cache.cpp

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -836,7 +836,10 @@ setup_transfer(lt::session* ses1, lt::session* ses2, lt::session* ses3
 		std::printf("ses1.add_torrent: %s\n", ec.message().c_str());
 		return std::make_tuple(torrent_handle(), torrent_handle(), torrent_handle());
 	}
-	tor1.super_seeding(super_seeding);
+	if (super_seeding)
+	{
+		tor1.set_flags(add_torrent_params::flag_super_seeding);
+	}
 
 	// the downloader cannot use seed_mode
 	param.flags &= ~add_torrent_params::flag_seed_mode;

--- a/test/swarm_suite.cpp
+++ b/test/swarm_suite.cpp
@@ -158,7 +158,7 @@ void test_swarm(int flags)
 		if (flags & super_seeding)
 		{
 			TEST_CHECK(st1.is_seeding);
-			TEST_CHECK(st1.super_seeding);
+			TEST_CHECK(tor1.get_flags() & add_torrent_params::flag_super_seeding);
 		}
 
 		if (st2.progress < 1.f && st2.progress > 0.5f)

--- a/test/swarm_suite.cpp
+++ b/test/swarm_suite.cpp
@@ -158,7 +158,7 @@ void test_swarm(int flags)
 		if (flags & super_seeding)
 		{
 			TEST_CHECK(st1.is_seeding);
-			TEST_CHECK(tor1.get_flags() & add_torrent_params::flag_super_seeding);
+			TEST_CHECK(tor1.flags() & add_torrent_params::flag_super_seeding);
 		}
 
 		if (st2.progress < 1.f && st2.progress > 0.5f)

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -31,13 +31,10 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "test.hpp"
-#include "setup_transfer.hpp"
-#include "libtorrent/magnet_uri.hpp"
+#include "libtorrent/add_torrent_params.hpp"
 #include "libtorrent/session.hpp"
 #include "libtorrent/torrent_handle.hpp"
-#include "libtorrent/bencode.hpp"
-#include "libtorrent/torrent_info.hpp" // for announce_entry
-#include "libtorrent/announce_entry.hpp"
+#include "libtorrent/torrent_info.hpp"
 #include "settings.hpp"
 
 using namespace libtorrent;

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -46,8 +46,8 @@ void test_add_and_get_flags(boost::uint64_t flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = boost::make_shared<torrent_info>("../test_torrents/base.torrent",
-		boost::ref(ec));
+	p.ti = std::make_shared<torrent_info>("../test_torrents/base.torrent",
+		std::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = flags;
 	const torrent_handle h = ses.add_torrent(p);
@@ -61,8 +61,8 @@ void test_set_after_add(boost::uint64_t flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = boost::make_shared<torrent_info>("../test_torrents/base.torrent",
-		boost::ref(ec));
+	p.ti = std::make_shared<torrent_info>("../test_torrents/base.torrent",
+		std::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = 0xffffffffffffffff & ~flags;
 	const torrent_handle h = ses.add_torrent(p);
@@ -78,8 +78,8 @@ void test_unset_after_add(boost::uint64_t flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = boost::make_shared<torrent_info>("../test_torrents/base.torrent",
-		boost::ref(ec));
+	p.ti = std::make_shared<torrent_info>("../test_torrents/base.torrent",
+		std::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = flags;
 	const torrent_handle h = ses.add_torrent(p);
@@ -151,14 +151,6 @@ TORRENT_TEST(flag_sequential_download)
 	test_add_and_get_flags(add_torrent_params::flag_sequential_download);
 	test_set_after_add(add_torrent_params::flag_sequential_download);
 	test_unset_after_add(add_torrent_params::flag_sequential_download);
-}
-
-TORRENT_TEST(flag_pinned)
-{
-	// pinned
-	test_add_and_get_flags(add_torrent_params::flag_pinned);
-	test_set_after_add(add_torrent_params::flag_pinned);
-	test_unset_after_add(add_torrent_params::flag_pinned);
 }
 
 TORRENT_TEST(flag_stop_when_ready)

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -46,13 +46,13 @@ void test_add_and_get_flags(boost::uint64_t flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = boost::shared_ptr<torrent_info>(
-		new torrent_info("../test_torrents/base.torrent", ec));
+	p.ti = boost::make_shared<torrent_info>("../test_torrents/base.torrent",
+		boost::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = flags;
-	torrent_handle h = ses.add_torrent(p);
+	const torrent_handle h = ses.add_torrent(p);
 	TEST_CHECK(h.is_valid());
-	TEST_EQUAL(h.get_flags() & flags, flags);
+	TEST_EQUAL(h.flags() & flags, flags);
 }
 
 void test_set_after_add(boost::uint64_t flags)
@@ -61,15 +61,15 @@ void test_set_after_add(boost::uint64_t flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = boost::shared_ptr<torrent_info>(
-		new torrent_info("../test_torrents/base.torrent", ec));
+	p.ti = boost::make_shared<torrent_info>("../test_torrents/base.torrent",
+		boost::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = 0xffffffffffffffff & ~flags;
-	torrent_handle h = ses.add_torrent(p);
+	const torrent_handle h = ses.add_torrent(p);
 	TEST_CHECK(h.is_valid());
-	TEST_EQUAL(h.get_flags() & flags, 0);
+	TEST_EQUAL(h.flags() & flags, 0);
 	h.set_flags(flags);
-	TEST_EQUAL(h.get_flags() & flags, flags);
+	TEST_EQUAL(h.flags() & flags, flags);
 }
 
 void test_unset_after_add(boost::uint64_t flags)
@@ -78,15 +78,15 @@ void test_unset_after_add(boost::uint64_t flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = boost::shared_ptr<torrent_info>(
-		new torrent_info("../test_torrents/base.torrent", ec));
+	p.ti = boost::make_shared<torrent_info>("../test_torrents/base.torrent",
+		boost::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = flags;
-	torrent_handle h = ses.add_torrent(p);
+	const torrent_handle h = ses.add_torrent(p);
 	TEST_CHECK(h.is_valid());
-	TEST_EQUAL(h.get_flags() & flags, flags);
-	h.set_flags(flags, 0);
-	TEST_EQUAL(h.get_flags() & flags, 0);
+	TEST_EQUAL(h.flags() & flags, flags);
+	h.unset_flags(flags);
+	TEST_EQUAL(h.flags() & flags, 0);
 }
 
 TORRENT_TEST(flag_seed_mode)

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -1,0 +1,175 @@
+/*
+
+Copyright (c) 2017, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "test.hpp"
+#include "setup_transfer.hpp"
+#include "libtorrent/magnet_uri.hpp"
+#include "libtorrent/session.hpp"
+#include "libtorrent/torrent_handle.hpp"
+#include "libtorrent/bencode.hpp"
+#include "libtorrent/torrent_info.hpp" // for announce_entry
+#include "libtorrent/announce_entry.hpp"
+#include "settings.hpp"
+
+using namespace libtorrent;
+namespace lt = libtorrent;
+
+void test_add_and_get_flags(boost::uint64_t flags)
+{
+	session ses(settings());
+	add_torrent_params p;
+	p.save_path = ".";
+	error_code ec;
+	p.ti = boost::shared_ptr<torrent_info>(
+		new torrent_info("../test_torrents/base.torrent", ec));
+	TEST_CHECK(!ec);
+	p.flags = flags;
+	torrent_handle h = ses.add_torrent(p);
+	TEST_CHECK(h.is_valid());
+	TEST_EQUAL(h.get_flags() & flags, flags);
+}
+
+void test_set_after_add(boost::uint64_t flags)
+{
+	session ses(settings());
+	add_torrent_params p;
+	p.save_path = ".";
+	error_code ec;
+	p.ti = boost::shared_ptr<torrent_info>(
+		new torrent_info("../test_torrents/base.torrent", ec));
+	TEST_CHECK(!ec);
+	p.flags = 0xffffffffffffffff & ~flags;
+	torrent_handle h = ses.add_torrent(p);
+	TEST_CHECK(h.is_valid());
+	TEST_EQUAL(h.get_flags() & flags, 0);
+	h.set_flags(flags);
+	TEST_EQUAL(h.get_flags() & flags, flags);
+}
+
+void test_unset_after_add(boost::uint64_t flags)
+{
+	session ses(settings());
+	add_torrent_params p;
+	p.save_path = ".";
+	error_code ec;
+	p.ti = boost::shared_ptr<torrent_info>(
+		new torrent_info("../test_torrents/base.torrent", ec));
+	TEST_CHECK(!ec);
+	p.flags = flags;
+	torrent_handle h = ses.add_torrent(p);
+	TEST_CHECK(h.is_valid());
+	TEST_EQUAL(h.get_flags() & flags, flags);
+	h.set_flags(flags, 0);
+	TEST_EQUAL(h.get_flags() & flags, 0);
+}
+
+TORRENT_TEST(flag_seed_mode)
+{
+	// seed-mode (can't be set after adding)
+	test_add_and_get_flags(add_torrent_params::flag_seed_mode);
+	test_unset_after_add(add_torrent_params::flag_seed_mode);
+}
+
+TORRENT_TEST(flag_upload_mode)
+{
+	// upload-mode
+	test_add_and_get_flags(add_torrent_params::flag_upload_mode);
+	test_set_after_add(add_torrent_params::flag_upload_mode);
+	test_unset_after_add(add_torrent_params::flag_upload_mode);
+}
+
+TORRENT_TEST(flag_share_mode)
+{
+	// share-mode
+	test_add_and_get_flags(add_torrent_params::flag_share_mode);
+	test_set_after_add(add_torrent_params::flag_share_mode);
+	test_unset_after_add(add_torrent_params::flag_share_mode);
+}
+
+TORRENT_TEST(flag_apply_ip_filter)
+{
+	// apply-ip-filter
+	test_add_and_get_flags(add_torrent_params::flag_apply_ip_filter);
+	test_set_after_add(add_torrent_params::flag_apply_ip_filter);
+	test_unset_after_add(add_torrent_params::flag_apply_ip_filter);
+}
+
+TORRENT_TEST(flag_paused)
+{
+	// paused
+	test_add_and_get_flags(add_torrent_params::flag_paused);
+	// TODO: change to a different test setup. currently always paused.
+	//test_set_after_add(add_torrent_params::flag_paused);
+	//test_unset_after_add(add_torrent_params::flag_paused);
+}
+
+TORRENT_TEST(flag_auto_managed)
+{
+	// auto-managed
+	test_add_and_get_flags(add_torrent_params::flag_auto_managed);
+	test_set_after_add(add_torrent_params::flag_auto_managed);
+	test_unset_after_add(add_torrent_params::flag_auto_managed);
+}
+
+TORRENT_TEST(flag_super_seeding)
+{
+	// super-seeding
+	test_add_and_get_flags(add_torrent_params::flag_super_seeding);
+	test_set_after_add(add_torrent_params::flag_super_seeding);
+	test_unset_after_add(add_torrent_params::flag_super_seeding);
+}
+
+TORRENT_TEST(flag_sequential_download)
+{
+	// sequential-download
+	test_add_and_get_flags(add_torrent_params::flag_sequential_download);
+	test_set_after_add(add_torrent_params::flag_sequential_download);
+	test_unset_after_add(add_torrent_params::flag_sequential_download);
+}
+
+TORRENT_TEST(flag_pinned)
+{
+	// pinned
+	test_add_and_get_flags(add_torrent_params::flag_pinned);
+	test_set_after_add(add_torrent_params::flag_pinned);
+	test_unset_after_add(add_torrent_params::flag_pinned);
+}
+
+TORRENT_TEST(flag_stop_when_ready)
+{
+	// stop-when-ready
+	test_add_and_get_flags(add_torrent_params::flag_stop_when_ready);
+	// setting stop-when-ready when already stopped has no effect.
+	// TODO: change to a different test setup. currently always paused.
+	//test_set_after_add(add_torrent_params::flag_stop_when_ready);
+	test_unset_after_add(add_torrent_params::flag_stop_when_ready);
+}

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -897,11 +897,11 @@ void test_seed_mode(test_mode_t const flags)
 		| test_mode_t::piece_prio
 		| test_mode_t::pieces_have)))
 	{
-		TEST_EQUAL(s.seed_mode, false);
+		TEST_CHECK(!(s.flags & add_torrent_params::flag_seed_mode));
 	}
 	else
 	{
-		TEST_EQUAL(s.seed_mode, true);
+		TEST_CHECK(s.flags & add_torrent_params::flag_seed_mode);
 	}
 }
 #ifndef TORRENT_NO_DEPRECATE
@@ -1047,14 +1047,14 @@ TORRENT_TEST(plain)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_sequential_download));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_paused));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_auto_managed));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_seed_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_super_seeding));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_share_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_upload_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -1070,14 +1070,14 @@ TORRENT_TEST(seed_mode)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, true);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_sequential_download));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_paused));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_auto_managed));
+	TEST_CHECK(s.flags & add_torrent_params::flag_seed_mode);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_super_seeding));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_share_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_upload_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -1092,14 +1092,14 @@ TORRENT_TEST(upload_mode)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, true);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_sequential_download));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_paused));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_auto_managed));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_seed_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_super_seeding));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_share_mode));
+	TEST_CHECK(s.flags & add_torrent_params::flag_upload_mode);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -1115,14 +1115,14 @@ TORRENT_TEST(share_mode)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, true);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_sequential_download));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_paused));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_auto_managed));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_seed_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_super_seeding));
+	TEST_CHECK(s.flags & add_torrent_params::flag_share_mode);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_upload_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -1138,14 +1138,14 @@ TORRENT_TEST(auto_managed)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, true);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_sequential_download));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_paused));
+	TEST_CHECK(s.flags & add_torrent_params::flag_auto_managed);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_seed_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_super_seeding));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_share_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_upload_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -1161,14 +1161,14 @@ TORRENT_TEST(paused)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, true);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_sequential_download));
+	TEST_CHECK(s.flags & add_torrent_params::flag_paused);
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_auto_managed));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_seed_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_super_seeding));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_share_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_upload_mode));
+	TEST_CHECK(!(s.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -432,14 +432,14 @@ TORRENT_TEST(plain_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -455,14 +455,14 @@ TORRENT_TEST(use_resume_save_path_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/resume_data save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -480,14 +480,15 @@ TORRENT_TEST(override_resume_data_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, true);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused,
+		add_torrent_params::flag_paused);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 2);
 	TEST_EQUAL(s.uploads_limit, 1);
 }
@@ -503,14 +504,15 @@ TORRENT_TEST(seed_mode_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, true);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode,
+		add_torrent_params::flag_seed_mode);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 2);
 	TEST_EQUAL(s.uploads_limit, 1);
 }
@@ -526,14 +528,15 @@ TORRENT_TEST(upload_mode_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, true);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode,
+		add_torrent_params::flag_upload_mode);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -550,14 +553,15 @@ TORRENT_TEST(share_mode_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, true);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode,
+		add_torrent_params::flag_share_mode);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 2);
 	TEST_EQUAL(s.uploads_limit, 1);
 }
@@ -574,14 +578,14 @@ TORRENT_TEST(auto_managed_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 }
@@ -597,14 +601,14 @@ TORRENT_TEST(paused_deprecated)
 #else
 	TEST_EQUAL(s.save_path, "/add_torrent_params save_path");
 #endif
-	TEST_EQUAL(s.sequential_download, false);
-	TEST_EQUAL(s.paused, false);
-	TEST_EQUAL(s.auto_managed, false);
-	TEST_EQUAL(s.seed_mode, false);
-	TEST_EQUAL(s.super_seeding, false);
-	TEST_EQUAL(s.share_mode, false);
-	TEST_EQUAL(s.upload_mode, false);
-	TEST_EQUAL(s.ip_filter_applies, false);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_sequential_download, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_auto_managed, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_seed_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_super_seeding, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_share_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_upload_mode, 0);
+	TEST_EQUAL(s.flags & add_torrent_params::flag_apply_ip_filter, 0);
 	TEST_EQUAL(s.connections_limit, 1345);
 	TEST_EQUAL(s.uploads_limit, 1346);
 

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -183,9 +183,6 @@ TORRENT_TEST(async_add_torrent_duplicate_back_to_back)
 	TEST_CHECK(!a->error);
 
 	torrent_status st = h.status();
-	std::printf("paused = %d\n", st.paused);
-	std::printf("flags = 0x%x\n", st.flags);
-	std::printf("flags & flag_paused = 0x%x\n", st.flags & add_torrent_params::flag_paused);
 	TEST_CHECK(st.flags & add_torrent_params::flag_paused);
 	TEST_CHECK(!(st.flags & add_torrent_params::flag_apply_ip_filter));
 	TEST_CHECK(!(st.flags & add_torrent_params::flag_auto_managed));

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -183,9 +183,12 @@ TORRENT_TEST(async_add_torrent_duplicate_back_to_back)
 	TEST_CHECK(!a->error);
 
 	torrent_status st = h.status();
-	TEST_CHECK(st.paused);
-	TEST_CHECK(!st.ip_filter_applies);
-	TEST_CHECK(!st.auto_managed);
+	std::printf("paused = %d\n", st.paused);
+	std::printf("flags = 0x%x\n", st.flags);
+	std::printf("flags & flag_paused = 0x%x\n", st.flags & add_torrent_params::flag_paused);
+	TEST_CHECK(st.flags & add_torrent_params::flag_paused);
+	TEST_CHECK(!(st.flags & add_torrent_params::flag_apply_ip_filter));
+	TEST_CHECK(!(st.flags & add_torrent_params::flag_auto_managed));
 }
 
 TORRENT_TEST(load_empty_file)

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -237,7 +237,7 @@ TORRENT_TEST(paused_session)
 	h.resume();
 	std::this_thread::sleep_for(lt::milliseconds(1000));
 
-	TEST_CHECK(!h.status().paused);
+	TEST_EQUAL(h.get_flags() & add_torrent_params::flag_paused, 0);
 }
 
 TORRENT_TEST(get_cache_info)

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -237,7 +237,7 @@ TORRENT_TEST(paused_session)
 	h.resume();
 	std::this_thread::sleep_for(lt::milliseconds(1000));
 
-	TEST_EQUAL(h.get_flags() & add_torrent_params::flag_paused, 0);
+	TEST_EQUAL(h.flags() & add_torrent_params::flag_paused, 0);
 }
 
 TORRENT_TEST(get_cache_info)

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -284,7 +284,9 @@ void test_transfer(int proxy_type, settings_pack const& sett
 		// back into upload mode) before we restart it.
 
 		// TODO: factor out the disk-full test into its own unit test
-		if (test_disk_full && st2.upload_mode && ++upload_mode_timer > 10)
+		if (test_disk_full &&
+				((tor2.get_flags() & add_torrent_params::flag_upload_mode) != 0) &&
+				++upload_mode_timer > 10)
 		{
 			test_disk_full = false;
 			((test_storage*)tor2.get_storage_impl())->set_limit(16 * 1024 * 1024);
@@ -303,7 +305,7 @@ void test_transfer(int proxy_type, settings_pack const& sett
 			lt::error_code err = tor2.status().errc;
 			std::printf("error: \"%s\"\n", err.message().c_str());
 			TEST_CHECK(!err);
-			tor2.set_upload_mode(false);
+			tor2.set_flags(add_torrent_params::flag_upload_mode, 0);
 
 			// at this point we probably disconnected the seed
 			// so we need to reconnect as well

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -285,7 +285,7 @@ void test_transfer(int proxy_type, settings_pack const& sett
 
 		// TODO: factor out the disk-full test into its own unit test
 		if (test_disk_full &&
-				((tor2.get_flags() & add_torrent_params::flag_upload_mode) != 0) &&
+				((tor2.flags() & add_torrent_params::flag_upload_mode) != 0) &&
 				++upload_mode_timer > 10)
 		{
 			test_disk_full = false;
@@ -305,7 +305,7 @@ void test_transfer(int proxy_type, settings_pack const& sett
 			lt::error_code err = tor2.status().errc;
 			std::printf("error: \"%s\"\n", err.message().c_str());
 			TEST_CHECK(!err);
-			tor2.set_flags(add_torrent_params::flag_upload_mode, 0);
+			tor2.unset_flags(add_torrent_params::flag_upload_mode);
 
 			// at this point we probably disconnected the seed
 			// so we need to reconnect as well


### PR DESCRIPTION
Per our discussions a while ago, I refactored several boolean fields into a single "flags" bitfield.

There's now `torrent_handle::get_flags()/set_flags()`. I wasn't quite sure if I should add `torrent_status::flags` in this commit -- I believe it would break the ABI so it shouldn't be in the 1.1 train. I included it in this PR so I could ask what you thought about it.

I also considered that maybe we should move the official definitions of `flags_t` to `torrent_handle`. The `add_torrent_params::flag_foo` definitions could be aliases for `torrent_handle::flag_foo`. Thoughts?

I refactored all tests to use flags, rather than the deprecated fields. Building and testing with `deprecated-functions=off` seems to work.