### PR TITLE
fix inconsistency in file_priorities and override_resume_data behavior

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix inconsistency in file_priorities and override_resume_data behavior
+
 1.1.4 release
 
 	* corrected missing const qualifiers on bdecode_node

--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -157,8 +157,7 @@ namespace libtorrent
 			// add_torrent_params configuring the torrent override the corresponding
 			// configuration from the resume file, with the one exception of save
 			// resume data, which has its own flag (for historic reasons).
-			// If this flag is set, but file_priorities is empty, file priorities
-			// are still loaded from the resume data, if present.
+			// "file_priorities" and "save_path" are not affected by this flag.
 			flag_override_resume_data = 0x002,
 
 			// If ``flag_upload_mode`` is set, the torrent will be initialized in
@@ -347,7 +346,9 @@ namespace libtorrent
 
 		// can be set to control the initial file priorities when adding a
 		// torrent. The semantics are the same as for
-		// ``torrent_handle::prioritize_files()``.
+		// ``torrent_handle::prioritize_files()``. The file priorities specified
+		// in here take precedence over those specified in the resume data, if
+		// any.
 		std::vector<boost::uint8_t> file_priorities;
 
 		// torrent extension construction functions can be added to this vector

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -308,6 +308,45 @@ TORRENT_TEST(file_priorities_default)
 	TEST_EQUAL(file_priorities[2], 4);
 }
 
+// As long as the add_torrent_params priorities are empty, the file_priorities
+// from the resume data should take effect
+TORRENT_TEST(file_priorities_in_resume)
+{
+	lt::session ses(settings());
+	std::vector<int> file_priorities = test_resume_flags(ses, 0, "", "123").file_priorities();
+
+	TEST_EQUAL(file_priorities.size(), 3);
+	TEST_EQUAL(file_priorities[0], 1);
+	TEST_EQUAL(file_priorities[1], 2);
+	TEST_EQUAL(file_priorities[2], 3);
+}
+
+// if both resume data and add_torrent_params has file_priorities, the
+// add_torrent_params one take precedence
+TORRENT_TEST(file_priorities_in_resume_and_params)
+{
+	lt::session ses(settings());
+	std::vector<int> file_priorities = test_resume_flags(ses, 0, "456", "123").file_priorities();
+
+	TEST_EQUAL(file_priorities.size(), 3);
+	TEST_EQUAL(file_priorities[0], 4);
+	TEST_EQUAL(file_priorities[1], 5);
+	TEST_EQUAL(file_priorities[2], 6);
+}
+
+// if we set flag_override_resume_data, it should no affect file priorities
+TORRENT_TEST(file_priorities_override_resume)
+{
+	lt::session ses(settings());
+	std::vector<int> file_priorities = test_resume_flags(ses
+		, add_torrent_params::flag_override_resume_data, "", "123").file_priorities();
+
+	TEST_EQUAL(file_priorities.size(), 3);
+	TEST_EQUAL(file_priorities[0], 1);
+	TEST_EQUAL(file_priorities[1], 2);
+	TEST_EQUAL(file_priorities[2], 3);
+}
+
 TORRENT_TEST(file_priorities_resume_seed_mode)
 {
 	// in share mode file priorities should always be 0


### PR DESCRIPTION
file_priorities are not subject to the override_resume_data flag