### PR TITLE
make listen_socket_t non-copyable and non-movable

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -133,7 +133,7 @@ namespace aux {
 		TORRENT_EXTRA_EXPORT entry save_dht_settings(dht_settings const& settings);
 #endif
 
-	struct listen_socket_t final : aux::session_listen_socket
+	struct listen_socket_impl : aux::session_listen_socket
 	{
 		address get_external_address() override
 		{ return external_address.external_address(); }
@@ -141,7 +141,7 @@ namespace aux {
 		tcp::endpoint get_local_endpoint() override
 		{ return local_endpoint; }
 
-		listen_socket_t()
+		listen_socket_impl()
 		{
 			tcp_port_mapping[0] = -1;
 			tcp_port_mapping[1] = -1;
@@ -190,6 +190,18 @@ namespace aux {
 		std::shared_ptr<tcp::acceptor> sock;
 		std::shared_ptr<aux::session_udp_socket> udp_sock;
 	};
+
+		struct listen_socket_t final : listen_socket_impl
+		{
+			listen_socket_t(listen_socket_t const&) = delete;
+			listen_socket_t(listen_socket_t&&) = delete;
+			listen_socket_t& operator=(listen_socket_t const&) = delete;
+			listen_socket_t& operator=(listen_socket_t&&) = delete;
+
+			listen_socket_t(listen_socket_impl const& i)
+				: listen_socket_impl(i)
+			{}
+		};
 
 		struct TORRENT_EXTRA_EXPORT listen_endpoint_t
 		{
@@ -954,7 +966,7 @@ namespace aux {
 				open_ssl_socket = 0x10
 			};
 
-			listen_socket_t setup_listener(std::string const& device
+			listen_socket_impl setup_listener(std::string const& device
 				, tcp::endpoint bind_ep, int flags, error_code& ec);
 
 #ifndef TORRENT_DISABLE_DHT

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -133,14 +133,8 @@ namespace aux {
 		TORRENT_EXTRA_EXPORT entry save_dht_settings(dht_settings const& settings);
 #endif
 
-	struct listen_socket_impl : aux::session_listen_socket
+	struct listen_socket_impl
 	{
-		address get_external_address() override
-		{ return external_address.external_address(); }
-
-		tcp::endpoint get_local_endpoint() override
-		{ return local_endpoint; }
-
 		listen_socket_impl()
 		{
 			tcp_port_mapping[0] = -1;
@@ -148,8 +142,6 @@ namespace aux {
 			udp_port_mapping[0] = -1;
 			udp_port_mapping[1] = -1;
 		}
-
-		virtual ~listen_socket_impl() = default;
 
 		// this may be empty but can be set
 		// to the WAN IP address of a NAT router
@@ -193,12 +185,18 @@ namespace aux {
 		std::shared_ptr<aux::session_udp_socket> udp_sock;
 	};
 
-		struct listen_socket_t final : listen_socket_impl
+		struct listen_socket_t final : listen_socket_impl, aux::session_listen_socket
 		{
 			listen_socket_t(listen_socket_t const&) = delete;
 			listen_socket_t(listen_socket_t&&) = delete;
 			listen_socket_t& operator=(listen_socket_t const&) = delete;
 			listen_socket_t& operator=(listen_socket_t&&) = delete;
+
+			address get_external_address() override
+			{ return external_address.external_address(); }
+
+			tcp::endpoint get_local_endpoint() override
+			{ return local_endpoint; }
 
 			listen_socket_t(listen_socket_impl const& i) // NOLINT
 				: listen_socket_impl(i)

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -149,6 +149,8 @@ namespace aux {
 			udp_port_mapping[1] = -1;
 		}
 
+		virtual ~listen_socket_impl() = default;
+
 		// this may be empty but can be set
 		// to the WAN IP address of a NAT router
 		ip_voter external_address;
@@ -198,7 +200,7 @@ namespace aux {
 			listen_socket_t& operator=(listen_socket_t const&) = delete;
 			listen_socket_t& operator=(listen_socket_t&&) = delete;
 
-			listen_socket_t(listen_socket_impl const& i)
+			listen_socket_t(listen_socket_impl const& i) // NOLINT
 				: listen_socket_impl(i)
 			{}
 		};

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1447,7 +1447,7 @@ namespace {
 
 	enum { listen_no_system_port = 0x02 };
 
-	listen_socket_t session_impl::setup_listener(std::string const& device
+	listen_socket_impl session_impl::setup_listener(std::string const& device
 		, tcp::endpoint bind_ep, int flags, error_code& ec)
 	{
 		int retries = m_settings.get_int(settings_pack::max_retry_port_bind);
@@ -1460,7 +1460,7 @@ namespace {
 		}
 #endif
 
-		listen_socket_t ret;
+		listen_socket_impl ret;
 		ret.ssl = (flags & open_ssl_socket) != 0 ? transport::ssl : transport::plaintext;
 		ret.original_port = bind_ep.port();
 		operation_t last_op = operation_t::unknown;
@@ -1975,13 +1975,13 @@ namespace {
 		// an existing socket
 		for (auto const& ep : eps)
 		{
-			listen_socket_t const s = setup_listener(ep.device
+			listen_socket_impl const s = setup_listener(ep.device
 				, tcp::endpoint(ep.addr, std::uint16_t(ep.port))
 				, flags | (ep.ssl == transport::ssl ? open_ssl_socket : 0), ec);
 
 			if (!ec && (s.sock || s.udp_sock))
 			{
-				m_listen_sockets.push_back(s);
+				m_listen_sockets.emplace_back(s);
 
 #ifndef TORRENT_DISABLE_DHT
 				if (m_dht)

--- a/test/test_listen_socket.cpp
+++ b/test/test_listen_socket.cpp
@@ -61,10 +61,10 @@ namespace
 		return aux::listen_endpoint_t(address::from_string(ip), port, device, ssl);
 	}
 
-	aux::listen_socket_t sock(char const* ip, int const port
+	aux::listen_socket_impl sock(char const* ip, int const port
 		, int const original_port, char const* device = "", tp ssl = tp::plaintext)
 	{
-		aux::listen_socket_t s;
+		aux::listen_socket_impl s;
 		s.local_endpoint = tcp::endpoint(address::from_string(ip), port);
 		s.original_port = original_port;
 		s.device = device;
@@ -72,13 +72,13 @@ namespace
 		return s;
 	}
 
-	aux::listen_socket_t sock(char const* ip, int const port, tp ssl)
+	aux::listen_socket_impl sock(char const* ip, int const port, tp ssl)
 	{ return sock(ip, port, port, "", ssl); }
 
-	aux::listen_socket_t sock(char const* ip, int const port, char const* dev)
+	aux::listen_socket_impl sock(char const* ip, int const port, char const* dev)
 	{ return sock(ip, port, port, dev); }
 
-	aux::listen_socket_t sock(char const* ip, int const port)
+	aux::listen_socket_impl sock(char const* ip, int const port)
 	{ return sock(ip, port, port); }
 
 } // anonymous namespace


### PR DESCRIPTION
The DHT stores a pointer to this struct so it must not be copied or moved once
it is stored in m_listen_sockets.