### PR TITLE
remove call _strchr

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -81,8 +81,7 @@ namespace libtorrent {
 
 	bool is_space(char c)
 	{
-		static const char* ws = " \t\n\r\f\v";
-		return strchr(ws, c) != nullptr;
+		return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
 	}
 
 	char to_lower(char c)

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -91,6 +91,8 @@ TORRENT_TEST(is_space)
 	TEST_CHECK(is_space('\t'));
 	TEST_CHECK(is_space('\n'));
 	TEST_CHECK(is_space('\r'));
+	TEST_CHECK(is_space('\f'));
+	TEST_CHECK(is_space('\v'));
 }
 
 TORRENT_TEST(to_lower)


### PR DESCRIPTION
_TEXT	SEGMENT
_c$ = 8							; size = 1
?is_space@@YA_ND@Z PROC					; is_space, COMDAT

; 8    : 	static const char* ws = " \t\n\r\f\v";
; 9    : 	return strchr(ws, c) != nullptr;

	movsx	eax, BYTE PTR _c$[esp-4]
	push	eax
	push	DWORD PTR ?ws@?1??is_space@@YA_ND@Z@4PBDB
	call	_strchr
	add	esp, 8
	neg	eax
	sbb	eax, eax
	neg	eax

; 10   : }