### PR TITLE
Stop using deprecated save_proxy in header files

### DIFF
--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -101,10 +101,10 @@ namespace libtorrent
 			save_feeds TORRENT_DEPRECATED_ENUM =        0x080,
 			save_proxy TORRENT_DEPRECATED_ENUM =        0x008,
 			save_i2p_proxy TORRENT_DEPRECATED_ENUM =    0x010,
-			save_dht_proxy TORRENT_DEPRECATED_ENUM = save_proxy,
-			save_peer_proxy TORRENT_DEPRECATED_ENUM = save_proxy,
-			save_web_proxy TORRENT_DEPRECATED_ENUM = save_proxy,
-			save_tracker_proxy TORRENT_DEPRECATED_ENUM = save_proxy
+			save_dht_proxy TORRENT_DEPRECATED_ENUM = 0x008, // save_proxy
+			save_peer_proxy TORRENT_DEPRECATED_ENUM = 0x008, // save_proxy
+			save_web_proxy TORRENT_DEPRECATED_ENUM = 0x008, // save_proxy
+			save_tracker_proxy TORRENT_DEPRECATED_ENUM = 0x008 // save_proxy
 #endif
 		};
 


### PR DESCRIPTION
Without this patch, compiler will warn about save_proxy being used by merely
including session_handle.hpp:

```
/tmp/include/libtorrent/session_handle.hpp:104:45: warning: ‘save_proxy’ is deprecated [-Wdeprecated-declarations]
    save_dht_proxy TORRENT_DEPRECATED_ENUM = save_proxy,
                                             ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:102:4: note: declared here
    save_proxy TORRENT_DEPRECATED_ENUM =        0x008,
    ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:105:46: warning: ‘save_proxy’ is deprecated [-Wdeprecated-declarations]
    save_peer_proxy TORRENT_DEPRECATED_ENUM = save_proxy,
                                              ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:102:4: note: declared here
    save_proxy TORRENT_DEPRECATED_ENUM =        0x008,
    ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:106:45: warning: ‘save_proxy’ is deprecated [-Wdeprecated-declarations]
    save_web_proxy TORRENT_DEPRECATED_ENUM = save_proxy,
                                             ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:102:4: note: declared here
    save_proxy TORRENT_DEPRECATED_ENUM =        0x008,
    ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:107:49: warning: ‘save_proxy’ is deprecated [-Wdeprecated-declarations]
    save_tracker_proxy TORRENT_DEPRECATED_ENUM = save_proxy
                                                 ^~~~~~~~~~
/tmp/include/libtorrent/session_handle.hpp:102:4: note: declared here
    save_proxy TORRENT_DEPRECATED_ENUM =        0x008,
    ^~~~~~~~~~
```