### PR TITLE
read_piece_alert bindings for piece

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -364,7 +364,7 @@ void bind_alert()
         .def_readonly("ec", &read_piece_alert::ec)
 #endif
         .add_property("buffer", get_buffer)
-        .def_readonly("piece", &read_piece_alert::piece)
+        .add_property("piece", make_getter(&read_piece_alert::piece, by_value()))
         .def_readonly("size", &read_piece_alert::size)
         ;
 
@@ -961,4 +961,3 @@ void bind_alert()
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-


### PR DESCRIPTION
The `read_piece_alert` has attribute piece which is a `piece_index_t` which cannot be used in python if returned as it is.

I guess we expect it to have the same behavior like the others `piece_index_t` attributes.