### PR TITLE
Fix typo in ufloat16

### DIFF
--- a/include/libtorrent/policy.hpp
+++ b/include/libtorrent/policy.hpp
@@ -84,7 +84,7 @@ namespace libtorrent
 					++exp;
 				}
 				TORRENT_ASSERT(exp <= 7);
-				m_val = (v << 3) || (exp & 7);
+				m_val = (v << 3) | (exp & 7);
 			}
 			return *this;
 		}


### PR DESCRIPTION
gcc 7 prints this warning without the patch:

```
In file included from /tmp/include/libtorrent/torrent_info.hpp:61:0,
                 from test.cc:38:
/tmp/include/libtorrent/policy.hpp: In member function ‘libtorrent::ufloat16& libtorrent::ufloat16::operator=(int)’:
/tmp/include/libtorrent/policy.hpp:87:16: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
     m_val = (v << 3) || (exp & 7);
             ~~~^~~~~
```