### PR TITLE
header fix for use of stringstream

### DIFF
--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -47,6 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <string>
 #include <algorithm>
+#include <sstream>
 
 using namespace std::placeholders;
 


### PR DESCRIPTION
Without this, android `clang` fails to compile with
```
error: implicit instantiation of undefined template 'std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >'
        std::stringstream request;
```