### PR TITLE
using separated sockets in netlink based enum_net_interfaces

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1943,6 +1943,12 @@ namespace {
 		{
 			expand_unspecified_address(ifs, eps);
 		}
+#ifndef TORRENT_DISABLE_LOGGING
+		if (ec)
+			session_log("failed to enum net interfaces: %s", ec.message().c_str());
+		else
+			session_log("enum net found %d interfaces", int(ifs.size()));
+#endif
 #endif
 
 		auto remove_iter = partition_listen_sockets(eps, m_listen_sockets);


### PR DESCRIPTION
Hi @ssiloti, I appreciate if you can take a look at this.

The main problem is that for some reason, if the same socket is used for `RTM_GETLINK` and `RTM_GETADDR` it fails to work the second time (the one with `RTM_GETADDR `) in android.

The second problem was that `nl_dump_request` can return a negative number (`-1`) but not necessarily with an `errno` (see deep down in `read_nl_sock`).

I tried to touch as less as possible to easy the review, but if this PR is right, maybe two functions are better in a later refactor.