### PR TITLE
don't create web seed connections if the torrent is upload only

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6605,6 +6605,7 @@ namespace {
 
 		if (is_paused()) return;
 		if (m_ses.is_aborted()) return;
+		if (is_upload_only()) return;
 
 		boost::shared_ptr<socket_type> s
 			= boost::make_shared<socket_type>(boost::ref(m_ses.get_io_service()));

--- a/src/web_connection_base.cpp
+++ b/src/web_connection_base.cpp
@@ -77,6 +77,8 @@ namespace libtorrent
 
 		TORRENT_ASSERT(is_outgoing());
 
+		TORRENT_ASSERT(!m_torrent.lock()->is_upload_only());
+
 		// we only want left-over bandwidth
 		// TODO: introduce a web-seed default class which has a low download priority
 
@@ -117,9 +119,10 @@ namespace libtorrent
 		// which fails because the m_num_connecting count is not consistent until
 		// after we call peer_connection::start
 		m_upload_only = true;
-		disconnect_if_redundant();
-		if (is_disconnecting()) return;
 		peer_connection::start();
+		// disconnect_if_redundant must be called after start to keep
+		// m_num_connecting consistent
+		disconnect_if_redundant();
 	}
 
 	web_connection_base::~web_connection_base()


### PR DESCRIPTION
The fix in 9a63d4696ebec5743418181ef3411371d8e31b04 was imcomplete.
It turns out disconnect_if_redundant decrements the connection count
which unballances the count if we do end up disconnecting the peer.

This change avoids the problem by checking if the torrent is
upload only much sooner, before the connection object is even created.
We still do a redundancy check just-in-case, but it is not expected to
trigger.