### PR TITLE
remove support for using a pool allocator for disk buffers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@
 	* added support for retrieval of DHT live nodes
 	* complete UNC path support
 	* add packets pool allocator
+	* remove disk buffer pool allocator
 	* fix last_upload and last_download overflow after 9 hours in past
 	* python binding add more add_torrent_params fields and an invalid key check
 	* introduce introduce distinct types for peer_class_t, piece_index_t and

--- a/include/libtorrent/disk_buffer_pool.hpp
+++ b/include/libtorrent/disk_buffer_pool.hpp
@@ -35,15 +35,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-
-#ifndef TORRENT_DISABLE_POOL_ALLOCATOR
-#include "libtorrent/allocator.hpp" // for page_aligned_allocator
-#include <boost/pool/pool.hpp>
-#endif
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #if TORRENT_USE_INVARIANT_CHECKS
 #include <set>
 #endif
@@ -86,8 +77,6 @@ namespace libtorrent {
 		void free_iovec(span<iovec_t const> iov);
 
 		int block_size() const { return m_block_size; }
-
-		void release_memory();
 
 		int in_use() const
 		{
@@ -143,28 +132,6 @@ namespace libtorrent {
 		mutable std::mutex m_pool_mutex;
 
 		int m_cache_buffer_chunk_size;
-
-#ifndef TORRENT_DISABLE_POOL_ALLOCATOR
-		// if this is true, all buffers are allocated
-		// from m_pool. If this is false, all buffers
-		// are allocated using page_aligned_allocator.
-		// if the settings change to prefer the other
-		// allocator, this bool will not switch over
-		// to match the settings until all buffers have
-		// been freed. That way, we never have a mixture
-		// of buffers allocated from different sources.
-		// in essence, this make the setting only take
-		// effect after a restart (which seems fine).
-		// or once the client goes idle for a while.
-		bool m_using_pool_allocator;
-
-		// this is the actual user setting
-		bool m_want_pool_allocator;
-
-		// memory pool for read and write operations
-		// and disk cache
-		boost::pool<page_aligned_allocator> m_pool;
-#endif
 
 		// this is specifically exempt from release_asserts
 		// since it's a quite costly check. Only for debug

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -642,11 +642,15 @@ namespace libtorrent {
 			// failure is preferred, set this to false.
 			listen_system_port_fallback,
 
+#ifndef TORRENT_NO_DEPRECATE
 			// ``use_disk_cache_pool`` enables using a pool allocator for disk
 			// cache blocks. Enabling it makes the cache perform better at high
 			// throughput. It also makes the cache less likely and slower at
 			// returning memory back to the system, once allocated.
 			use_disk_cache_pool,
+#else
+			deprecated24,
+#endif
 
 			// when this is true, and incoming encrypted connections are enabled,
 			// &supportcrypt=1 is included in http tracker announces

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -293,7 +293,6 @@ namespace libtorrent {
 		//
 		//			int block_size() const { return m_block_size; }
 		//
-		//			void release_memory();
 		//		};
 		virtual void delete_files(remove_flags_t options, storage_error& ec) = 0;
 

--- a/src/block_cache.cpp
+++ b/src/block_cache.cpp
@@ -692,9 +692,6 @@ cached_piece_entry* block_cache::allocate_piece(disk_io_job const* j, std::uint1
 
 cached_piece_entry* block_cache::add_dirty_block(disk_io_job* j)
 {
-#if !defined TORRENT_DISABLE_POOL_ALLOCATOR
-	TORRENT_ASSERT(is_disk_buffer(boost::get<disk_buffer_holder>(j->argument).get()));
-#endif
 #ifdef TORRENT_EXPENSIVE_INVARIANT_CHECKS
 	INVARIANT_CHECK;
 #endif
@@ -1616,14 +1613,6 @@ void block_cache::check_invariant() const
 		{
 			if (p.blocks[k].buf)
 			{
-#if !defined TORRENT_DISABLE_POOL_ALLOCATOR && defined TORRENT_EXPENSIVE_INVARIANT_CHECKS
-				TORRENT_PIECE_ASSERT(is_disk_buffer(p.blocks[k].buf), &p);
-
-				// make sure we don't have the same buffer
-				// in the cache twice
-				TORRENT_PIECE_ASSERT(buffers.count(p.blocks[k].buf) == 0, &p);
-				buffers.insert(p.blocks[k].buf);
-#endif
 				++num_blocks;
 				if (p.blocks[k].dirty)
 				{

--- a/src/disk_buffer_pool.cpp
+++ b/src/disk_buffer_pool.cpp
@@ -141,6 +141,7 @@ namespace libtorrent {
 #elif defined TORRENT_DEBUG_BUFFERS
 		return page_aligned_allocator::in_use(buffer);
 #else
+		TORRENT_UNUSED(buffer);
 		return true;
 #endif
 	}

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -2569,8 +2569,6 @@ namespace libtorrent {
 			, completed_jobs, l);
 		l.unlock();
 
-		m_disk_cache.release_memory();
-
 		j->storage->release_files(j->error);
 		return j->error ? status_t::fatal_disk_error : status_t::no_error;
 	}

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -240,8 +240,6 @@ namespace libtorrent {
 		// of a resumed file
 		set.set_int(settings_pack::checking_mem_usage, 320);
 
-		// the disk cache performs better with the pool allocator
-		set.set_bool(settings_pack::use_disk_cache_pool, true);
 		return set;
 	}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3547,8 +3547,6 @@ namespace {
 				}
 			}
 		}
-
-//		m_peer_pool.release_memory();
 	}
 
 	namespace {

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -189,7 +189,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		SET(support_merkle_torrents, true, nullptr),
 		SET(report_redundant_bytes, true, nullptr),
 		SET(listen_system_port_fallback, true, nullptr),
-		SET(use_disk_cache_pool, true, nullptr),
+		DEPRECATED_SET(use_disk_cache_pool, false, nullptr),
 		SET(announce_crypto_support, true, nullptr),
 		SET(enable_upnp, true, &session_impl::update_upnp),
 		SET(enable_natpmp, true, &session_impl::update_natpmp),


### PR DESCRIPTION
The pool allocator has known issues with not releasing memory when it should
and is of dubious benefit.

Fixes #2251