### PR TITLE
ensure settings pack enums are 16bit long

### DIFF
--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -111,7 +111,7 @@ namespace libtorrent {
 
 		// setting names (indices) are 16 bits. The two most significant
 		// bits indicate what type the setting has. (string, int, bool)
-		enum type_bases
+		enum type_bases : std::uint16_t
 		{
 			string_type_base = 0x0000,
 			int_type_base =    0x4000,
@@ -120,7 +120,7 @@ namespace libtorrent {
 			index_mask =       0x3fff
 		};
 
-		enum string_types
+		enum string_types : std::uint16_t
 		{
 			// this is the client identification to the tracker. The recommended
 			// format of this string is: "ClientName/ClientVersion
@@ -240,7 +240,7 @@ namespace libtorrent {
 			max_string_setting_internal
 		};
 
-		enum bool_types
+		enum bool_types : std::uint16_t
 		{
 			// determines if connections from the same IP address as existing
 			// connections should be rejected or not. Multiple connections from
@@ -715,7 +715,7 @@ namespace libtorrent {
 			max_bool_setting_internal
 		};
 
-		enum int_types
+		enum int_types : std::uint16_t
 		{
 			// ``tracker_completion_timeout`` is the number of seconds the tracker
 			// connection will wait from when it sent the request until it


### PR DESCRIPTION
This is just me being paranoid (and still not knowing enough about C++ compilers)

When I read these declarations on how setting_packs stores settings in vector of `pairs<enum_for_type, value_of_type>`

```
std::vector<std::pair<std::uint16_t, std::string>> m_strings;
std::vector<std::pair<std::uint16_t, int>> m_ints;
std::vector<std::pair<std::uint16_t, bool>> m_bools;
```
I wondered why the programmer assumed that enums are by default 16-bits long, what if you had just a few enums and wanted less bits to be used, say `std::uint8_t` for less than 255 possibilities.

This assumes that all compilers will use 16bits for enums, but perhaps there's a guy out there that somehow has his compiler set to build enums of 8bits. I wonder if this helps in any way, or if in the Makefiles the size of enums has been specified to be by default 16bits.