### PR TITLE
Autotools: Check if std::chrono and std::random are available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,17 +123,27 @@ AX_BOOST_SYSTEM()
 AS_IF([test -z "$BOOST_SYSTEM_LIB"],
       [AC_MSG_ERROR(Boost.System library not found. Try using --with-boost-system=lib)])
 
-AX_BOOST_CHRONO()
-AS_IF([test -z "$BOOST_CHRONO_LIB"],
-      [AC_MSG_ERROR(Boost.Chrono library not found. Try using --with-boost-chrono=lib)])
+AC_LANG_PUSH([C++])
+AC_CHECK_HEADERS([chrono])
+AC_CHECK_HEADERS([random])
+AC_LANG_POP
 
-AX_BOOST_RANDOM()
-AS_IF([test -z "$BOOST_RANDOM_LIB"],
-      [AC_MSG_ERROR(Boost.Random library not found. Try using --with-boost-random=lib)])
+AS_IF([test "x$ac_cv_header_chrono" = "xno"],
+      [AX_BOOST_CHRONO()
+       AS_IF([test -z "$BOOST_CHRONO_LIB"],
+             [AC_MSG_ERROR(Boost.Chrono library not found. Try using --with-boost-chrono=lib)])
+       LIBS="$BOOST_CHRONO_LIB $LIBS"
+      ])
+
+AS_IF([test "x$ac_cv_header_random" = "xno"],
+      [AX_BOOST_RANDOM()
+       AS_IF([test -z "$BOOST_RANDOM_LIB"],
+             [AC_MSG_ERROR(Boost.Random library not found. Try using --with-boost-random=lib)])
+       LIBS="$BOOST_RANDOM_LIB $LIBS"
+      ])
 
 CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
-LIBS="$BOOST_CHRONO_LIB $BOOST_RANDOM_LIB $LIBS"
 
 ###############################################################################
 # Checking for functions and other stuffs
@@ -642,9 +652,19 @@ Boost libraries:
   CPPFlags:             ${BOOST_CPPFLAGS}
   LDFlags:              ${BOOST_LDFLAGS}
   boost.system:         ${BOOST_SYSTEM_LIB}
+END
+
+AS_IF([test "x$ac_cv_header_chrono" = "xno"], [
+cat >> config.report << END
   boost.chrono:         ${BOOST_CHRONO_LIB}
+END
+])
+
+AS_IF([test "x$ac_cv_header_random" = "xno"], [
+cat >> config.report << END
   boost.random:         ${BOOST_RANDOM_LIB}
 END
+])
 
 AS_IF([test "x$ARG_ENABLE_PYTHON_BINDING" = "xyes"], [
 cat >> config.report << END


### PR DESCRIPTION
If yes, don't even try to find their Boost equivalents.

This way you avoid installing dev packages for Boost chrono/random.

I tested only on linux.

**I wanted to fix bjam too**. However, for the life of me, I can't find a suitable solution. The Boost.Build docs seem horribly inadequate. And bjam/b2 syntax/capabilities don't seem so powerful after all.
Please tell me that you can find a solution to this.
On Windows with msvc2017, **b2** copies boost.chrono and boost.random in the installation dir even though they aren't really needed. MSVC2017 has c++11 support always on.