### PR TITLE
use the official boost.config header

### DIFF
--- a/include/libtorrent/export.hpp
+++ b/include/libtorrent/export.hpp
@@ -33,19 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_EXPORT_HPP_INCLUDED
 #define TORRENT_EXPORT_HPP_INCLUDED
 
-#if !defined(BOOST_COMPILER_CONFIG) && !defined(BOOST_NO_COMPILER_CONFIG)
-#  include <boost/config/select_compiler_config.hpp>
-#endif
-#ifdef BOOST_COMPILER_CONFIG
-#  include BOOST_COMPILER_CONFIG
-#endif
-
-#if !defined(BOOST_PLATFORM_CONFIG) && !defined(BOOST_NO_PLATFORM_CONFIG)
-#  include <boost/config/select_platform_config.hpp>
-#endif
-#ifdef BOOST_PLATFORM_CONFIG
-#  include BOOST_PLATFORM_CONFIG
-#endif
+#include <boost/config.hpp>
 
 // backwards compatibility with older versions of boost
 #if !defined BOOST_SYMBOL_EXPORT && !defined BOOST_SYMBOL_IMPORT


### PR DESCRIPTION
Just to have RC_1_0 work with boost 1.65+

(cherry-picked from RC_1_1)