### PR TITLE
python: return torrent handles in alerts by value

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -234,7 +234,7 @@ void bind_alert()
 
     class_<torrent_alert, bases<alert>, noncopyable>(
         "torrent_alert", no_init)
-        .def_readonly("handle", &torrent_alert::handle)
+        .add_property("handle", make_getter(&torrent_alert::handle, by_value()))
         ;
 
     class_<tracker_alert, bases<torrent_alert>, noncopyable>(


### PR DESCRIPTION
This is needed to avoid a dangling reference if the client stores a
reference to the handle.