### PR TITLE
removed leading :: in posix_fadvise to allow for fix in old android API build

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -651,7 +651,7 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 		if ((mode & open_mode::random_access))
 		{
 			// disable read-ahead
-			::posix_fadvise(native_handle(), 0, 0, POSIX_FADV_RANDOM);
+			posix_fadvise(native_handle(), 0, 0, POSIX_FADV_RANDOM);
 		}
 #endif
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -651,6 +651,9 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 		if ((mode & open_mode::random_access))
 		{
 			// disable read-ahead
+			// NOTE: in android this function was introduced in API 21,
+			// but the constant POSIX_FADV_RANDOM is there for lower
+			// API levels, just don't add :: to allow a macro workaround
 			posix_fadvise(native_handle(), 0, 0, POSIX_FADV_RANDOM);
 		}
 #endif


### PR DESCRIPTION
Hi @arvidn, this little change makes all the difference in the workaround I need to do for android API 16 