### PR TITLE
simplify to_string to not apply unary - to an unsigned integer

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -39,7 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/assert.hpp"
 
 #include <cstdlib> // for malloc
-#include <cstring> // for memmov/strcpy/strlen
+#include <cstring> // for strlen
 #include <algorithm> // for search
 
 namespace libtorrent {
@@ -52,15 +52,12 @@ namespace libtorrent {
 		std::array<char, 4 + std::numeric_limits<std::int64_t>::digits10> ret;
 		char *p = &ret.back();
 		*p = '\0';
-		std::uint64_t un = std::uint64_t(n);
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4146 ) /* warning C4146: unary minus operator applied to unsigned type */
-#endif // _MSC_VER
-		if (n < 0)  un = -un;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER
+		// we want "un" to be the absolute value
+		// since the absolute of INT64_MIN cannot be represented by a signed
+		// int64, we calculate the abs in unsigned space
+		std::uint64_t un = n < 0
+			? std::numeric_limits<std::uint64_t>::max() - std::uint64_t(n) + 1
+			: std::uint64_t(n);
 		do {
 			*--p = '0' + un % 10;
 			un /= 10;

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -131,8 +131,79 @@ TORRENT_TEST(to_string)
 {
 	TEST_CHECK(to_string(345).data() == std::string("345"));
 	TEST_CHECK(to_string(-345).data() == std::string("-345"));
+	TEST_CHECK(to_string(std::numeric_limits<std::int64_t>::max()).data() == std::string("9223372036854775807"));
+	TEST_CHECK(to_string(std::numeric_limits<std::int64_t>::min()).data() == std::string("-9223372036854775808"));
+
 	TEST_CHECK(to_string(0).data() == std::string("0"));
+	TEST_CHECK(to_string(10).data() == std::string("10"));
+	TEST_CHECK(to_string(100).data() == std::string("100"));
+	TEST_CHECK(to_string(1000).data() == std::string("1000"));
+	TEST_CHECK(to_string(10000).data() == std::string("10000"));
+	TEST_CHECK(to_string(100000).data() == std::string("100000"));
+	TEST_CHECK(to_string(1000000).data() == std::string("1000000"));
+	TEST_CHECK(to_string(10000000).data() == std::string("10000000"));
+	TEST_CHECK(to_string(100000000).data() == std::string("100000000"));
 	TEST_CHECK(to_string(1000000000).data() == std::string("1000000000"));
+	TEST_CHECK(to_string(10000000000).data() == std::string("10000000000"));
+	TEST_CHECK(to_string(100000000000).data() == std::string("100000000000"));
+	TEST_CHECK(to_string(1000000000000).data() == std::string("1000000000000"));
+	TEST_CHECK(to_string(10000000000000).data() == std::string("10000000000000"));
+	TEST_CHECK(to_string(100000000000000).data() == std::string("100000000000000"));
+	TEST_CHECK(to_string(1000000000000000).data() == std::string("1000000000000000"));
+
+	TEST_CHECK(to_string(9).data() == std::string("9"));
+	TEST_CHECK(to_string(99).data() == std::string("99"));
+	TEST_CHECK(to_string(999).data() == std::string("999"));
+	TEST_CHECK(to_string(9999).data() == std::string("9999"));
+	TEST_CHECK(to_string(99999).data() == std::string("99999"));
+	TEST_CHECK(to_string(999999).data() == std::string("999999"));
+	TEST_CHECK(to_string(9999999).data() == std::string("9999999"));
+	TEST_CHECK(to_string(99999999).data() == std::string("99999999"));
+	TEST_CHECK(to_string(999999999).data() == std::string("999999999"));
+	TEST_CHECK(to_string(9999999999).data() == std::string("9999999999"));
+	TEST_CHECK(to_string(99999999999).data() == std::string("99999999999"));
+	TEST_CHECK(to_string(999999999999).data() == std::string("999999999999"));
+	TEST_CHECK(to_string(9999999999999).data() == std::string("9999999999999"));
+	TEST_CHECK(to_string(99999999999999).data() == std::string("99999999999999"));
+	TEST_CHECK(to_string(999999999999999).data() == std::string("999999999999999"));
+	TEST_CHECK(to_string(9999999999999999).data() == std::string("9999999999999999"));
+	TEST_CHECK(to_string(99999999999999999).data() == std::string("99999999999999999"));
+	TEST_CHECK(to_string(999999999999999999).data() == std::string("999999999999999999"));
+
+	TEST_CHECK(to_string(-10).data() == std::string("-10"));
+	TEST_CHECK(to_string(-100).data() == std::string("-100"));
+	TEST_CHECK(to_string(-1000).data() == std::string("-1000"));
+	TEST_CHECK(to_string(-10000).data() == std::string("-10000"));
+	TEST_CHECK(to_string(-100000).data() == std::string("-100000"));
+	TEST_CHECK(to_string(-1000000).data() == std::string("-1000000"));
+	TEST_CHECK(to_string(-10000000).data() == std::string("-10000000"));
+	TEST_CHECK(to_string(-100000000).data() == std::string("-100000000"));
+	TEST_CHECK(to_string(-1000000000).data() == std::string("-1000000000"));
+	TEST_CHECK(to_string(-10000000000).data() == std::string("-10000000000"));
+	TEST_CHECK(to_string(-100000000000).data() == std::string("-100000000000"));
+	TEST_CHECK(to_string(-1000000000000).data() == std::string("-1000000000000"));
+	TEST_CHECK(to_string(-10000000000000).data() == std::string("-10000000000000"));
+	TEST_CHECK(to_string(-100000000000000).data() == std::string("-100000000000000"));
+	TEST_CHECK(to_string(-1000000000000000).data() == std::string("-1000000000000000"));
+
+	TEST_CHECK(to_string(-9).data() == std::string("-9"));
+	TEST_CHECK(to_string(-99).data() == std::string("-99"));
+	TEST_CHECK(to_string(-999).data() == std::string("-999"));
+	TEST_CHECK(to_string(-9999).data() == std::string("-9999"));
+	TEST_CHECK(to_string(-99999).data() == std::string("-99999"));
+	TEST_CHECK(to_string(-999999).data() == std::string("-999999"));
+	TEST_CHECK(to_string(-9999999).data() == std::string("-9999999"));
+	TEST_CHECK(to_string(-99999999).data() == std::string("-99999999"));
+	TEST_CHECK(to_string(-999999999).data() == std::string("-999999999"));
+	TEST_CHECK(to_string(-9999999999).data() == std::string("-9999999999"));
+	TEST_CHECK(to_string(-99999999999).data() == std::string("-99999999999"));
+	TEST_CHECK(to_string(-999999999999).data() == std::string("-999999999999"));
+	TEST_CHECK(to_string(-9999999999999).data() == std::string("-9999999999999"));
+	TEST_CHECK(to_string(-99999999999999).data() == std::string("-99999999999999"));
+	TEST_CHECK(to_string(-999999999999999).data() == std::string("-999999999999999"));
+	TEST_CHECK(to_string(-9999999999999999).data() == std::string("-9999999999999999"));
+	TEST_CHECK(to_string(-99999999999999999).data() == std::string("-99999999999999999"));
+	TEST_CHECK(to_string(-999999999999999999).data() == std::string("-999999999999999999"));
 }
 
 TORRENT_TEST(base64)


### PR DESCRIPTION
use std::abs() instead