### PR TITLE
DHT nodes should only handle requests on their socket

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -1102,6 +1102,7 @@ namespace aux {
 			void on_udp_writeable(std::weak_ptr<session_udp_socket> s, error_code const& ec);
 
 			void on_udp_packet(std::weak_ptr<session_udp_socket> s
+				, std::weak_ptr<listen_socket_t> ls
 				, transport ssl, error_code const& ec);
 
 			libtorrent::utp_socket_manager m_utp_socket_manager;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -141,7 +141,8 @@ namespace libtorrent { namespace dht {
 		void update_stats_counters(counters& c) const;
 
 		void incoming_error(error_code const& ec, udp::endpoint const& ep);
-		bool incoming_packet(udp::endpoint const& ep, span<char const> buf);
+		bool incoming_packet(aux::listen_socket_handle const& s
+			, udp::endpoint const& ep, span<char const> buf);
 
 		std::vector<std::pair<node_id, udp::endpoint>> live_nodes(node_id const& nid);
 

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -110,7 +110,7 @@ public:
 	void add_router_node(udp::endpoint const& router);
 
 	void unreachable(udp::endpoint const& ep);
-	void incoming(msg const& m);
+	void incoming(aux::listen_socket_handle const& s, msg const& m);
 
 #ifndef TORRENT_NO_DEPRECATE
 	int num_torrents() const { return int(m_storage.num_torrents()); }
@@ -241,6 +241,7 @@ private:
 public:
 	routing_table m_table;
 	rpc_manager m_rpc;
+	aux::listen_socket_handle const m_sock;
 
 private:
 
@@ -252,6 +253,8 @@ private:
 	};
 
 	static protocol_descriptor const& map_protocol_to_descriptor(udp protocol);
+
+	socket_manager* m_sock_man;
 
 	get_foreign_node_t m_get_foreign_node;
 
@@ -268,8 +271,6 @@ private:
 	// secret random numbers used to create write tokens
 	std::uint32_t m_secret[2];
 
-	socket_manager* m_sock_man;
-	aux::listen_socket_handle m_sock;
 	counters& m_counters;
 
 	dht_storage_interface& m_storage;

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -145,7 +145,7 @@ struct dht_node final : lt::dht::socket_manager
 		if (msg.type() != bdecode_node::dict_t) return;
 
 		lt::dht::msg m(msg, m_ep);
-		dht().incoming(m);
+		dht().incoming(m_ls, m);
 
 		sock().async_receive_from(asio::mutable_buffers_1(m_buffer, sizeof(m_buffer))
 			, m_ep, [&](lt::error_code const& ec, std::size_t bytes_transferred)

--- a/simulation/test_dht_rate_limit.cpp
+++ b/simulation/test_dht_rate_limit.cpp
@@ -132,7 +132,7 @@ TORRENT_TEST(dht_rate_limit)
 		udp_socket::packet p;
 		error_code err;
 		int const num = int(sock.read(lt::span<udp_socket::packet>(&p, 1), err));
-		if (num) dht->incoming_packet(p.from, p.data);
+		if (num) dht->incoming_packet(ls, p.from, p.data);
 		if (stop || err) return;
 		sock.async_read(on_read);
 	};

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -498,8 +498,8 @@ namespace libtorrent { namespace dht {
 		}
 	}
 
-	bool dht_tracker::incoming_packet(udp::endpoint const& ep
-		, span<char const> const buf)
+	bool dht_tracker::incoming_packet(aux::listen_socket_handle const& s
+		, udp::endpoint const& ep, span<char const> const buf)
 	{
 		int const buf_size = int(buf.size());
 		if (buf_size <= 20
@@ -564,7 +564,7 @@ namespace libtorrent { namespace dht {
 
 		libtorrent::dht::msg const m(m_msg, ep);
 		for (auto& n : m_nodes)
-			n.second.dht.incoming(m);
+			n.second.dht.incoming(s, m);
 		return true;
 	}
 

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -2765,6 +2765,31 @@ TORRENT_TEST(dht_dual_stack)
 }
 #endif
 
+TORRENT_TEST(multi_home)
+{
+	// send a request with a different listen socket and make sure the node ignores it
+	dht_test_setup t(udp::endpoint(rand_v4(), 20));
+	bdecode_node response;
+
+	entry e;
+	e["q"] = "ping";
+	e["t"] = "10";
+	e["y"] = "q";
+	e["a"].dict().insert(std::make_pair("id", generate_next().to_string()));
+	char msg_buf[1500];
+	int size = bencode(msg_buf, e);
+
+	bdecode_node decoded;
+	error_code ec;
+	bdecode(msg_buf, msg_buf + size, decoded, ec);
+	if (ec) std::printf("bdecode failed: %s\n", ec.message().c_str());
+
+	dht::msg m(decoded, t.source);
+	t.dht_node.incoming(dummy_listen_socket(udp::endpoint(rand_v4(), 21)), m);
+	TEST_CHECK(g_sent_packets.empty());
+	g_sent_packets.clear();
+}
+
 TORRENT_TEST(signing_test1)
 {
 	// test vector 1

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -288,7 +288,7 @@ void send_dht_request(node& node, char const* msg, udp::endpoint const& ep
 	if (ec) std::printf("bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, ep);
-	node.incoming(m);
+	node.incoming(node.m_sock, m);
 
 	// If the request is supposed to get a response, by now the node should have
 	// invoked the send function and put the response in g_sent_packets
@@ -333,7 +333,7 @@ void send_dht_response(node& node, bdecode_node const& request, udp::endpoint co
 	if (ec) std::printf("bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, ep);
-	node.incoming(m);
+	node.incoming(node.m_sock, m);
 }
 
 struct announce_item
@@ -3254,7 +3254,7 @@ TORRENT_TEST(invalid_error_msg)
 	if (ec) std::printf("bdecode failed: %s\n", ec.message().c_str());
 
 	dht::msg m(decoded, source);
-	node.incoming(m);
+	node.incoming(node.m_sock, m);
 
 	bool found = false;
 	for (int i = 0; i < int(observer.m_log.size()); ++i)


### PR DESCRIPTION
Go through the trouble of passing the listen socket through
session_impl::on_udp_packet because otherwise we'd have to match by comparing
a tcp::endpoint with a udp::endpoint which is surprisingly expensive.