### PR TITLE
code refactor in torrent_handle::info_hash

### DIFF
--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -180,9 +180,7 @@ namespace libtorrent {
 	sha1_hash torrent_handle::info_hash() const
 	{
 		std::shared_ptr<torrent> t = m_torrent.lock();
-		static const sha1_hash empty;
-		if (!t) return empty;
-		return t->info_hash();
+		return t ? t->info_hash() : sha1_hash();
 	}
 
 	int torrent_handle::max_uploads() const


### PR DESCRIPTION
Hi @arvidn, unless I'm missing something, I think that this code save the thread guarantee from the compiler to `empty`, and of course save the tiny `empty` memory space. The CPU cost of memory copy can't be avoided and RVO should help.