### PR TITLE
Fix building on FreeBSD

### DIFF
--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -47,6 +47,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <malloc.h>
 #elif defined _MSC_VER
 #include <malloc.h>
+#elif defined __FreeBSD__
+#include <malloc_np.h>
 #elif defined TORRENT_BSD
 #include <malloc/malloc.h>
 #endif
@@ -81,7 +83,7 @@ public:
 
 		// the actual allocation may be larger than we requested. If so, let the
 		// user take advantage of every single byte
-#if defined __GLIBC__
+#if defined __GLIBC__ || defined __FreeBSD__
 		m_size = ::malloc_usable_size(m_begin);
 #elif defined _MSC_VER
 		m_size = ::_msize(m_begin);

--- a/src/ip_notifier.cpp
+++ b/src/ip_notifier.cpp
@@ -376,6 +376,23 @@ private:
 	OVERLAPPED m_ovl = {};
 	boost::asio::windows::object_handle m_hnd;
 };
+#else
+struct ip_change_notifier_impl final : ip_change_notifier
+{
+	explicit ip_change_notifier_impl(io_service& ios)
+		: m_ios(ios) {}
+
+	void async_wait(std::function<void(error_code const&)> cb) override
+	{
+		m_ios.post([cb]()
+		{ cb(make_error_code(boost::system::errc::not_supported)); });
+	}
+
+	void cancel() override {}
+
+private:
+	io_service& m_ios;
+};
 #endif
 
 } // anonymous namespace


### PR DESCRIPTION
These changes were necessary to build libtorrent on FreeBSD 10/11.

The default ip_change_notifier (which will be used on FreeBSD) always fails with not_supported.