### PR TITLE
don't assert on an empty mapping

### DIFF
--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -135,7 +135,7 @@ namespace aux {
 		// the memory range this file has been mapped into
 		span<byte volatile> memory()
 		{
-			TORRENT_ASSERT(m_mapping);
+			TORRENT_ASSERT(m_mapping || m_size == 0);
 			return { static_cast<byte volatile*>(m_mapping), static_cast<std::size_t>(m_size) };
 		}
 


### PR DESCRIPTION
If the underlying file is empty then m_mapping is expected to be null.
It is the caller's responsibilty to notice that the region's size is
zero and not dereference it in that case.

Otherwise there is no good way for users of `default_storage::open_file`
to determine that the opened file is empty.