### PR TITLE
making use of openssl API 1.1 compatible

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -68,8 +68,6 @@ rule linking ( properties * )
 			# system starting with OpenSSL 1.1
 			result += <library>crypto <library>ssl ;
 		}
-		# boost.asio use the pre-1.1 OpenSSL API
-		result += <define>OPENSSL_API_COMPAT=0x10000000L ;
 	}
 
 	if <crypto>libcrypto in $(properties)

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -139,6 +139,11 @@ namespace {
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 
+// by openssl changelog at https://www.openssl.org/news/changelog.html
+// Changes between 1.0.2h and 1.1.0  [25 Aug 2016]
+// - Most global cleanup functions are no longer required because they are handled
+//   via auto-deinit. Affected function CRYPTO_cleanup_all_ex_data()
+#if !defined(OPENSSL_API_COMPAT) || OPENSSL_API_COMPAT < 0x10100000L
 namespace {
 
 	// openssl requires this to clean up internal
@@ -155,6 +160,7 @@ namespace {
 #endif
 	} openssl_global_destructor;
 }
+#endif
 
 #endif // TORRENT_USE_OPENSSL
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1536,7 +1536,11 @@ namespace libtorrent {
 		using boost::asio::ssl::context;
 
 		// this is needed for openssl < 1.0 to decrypt keys created by openssl 1.0+
+#if !defined(OPENSSL_API_COMPAT) || (OPENSSL_API_COMPAT < 0x10100000L)
 		OpenSSL_add_all_algorithms();
+#else
+		OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS, nullptr);
+#endif
 
 		// create the SSL context for this torrent. We need to
 		// inject the root certificate, and no other, to


### PR DESCRIPTION
as a note, the macro `OPENSSL_API_COMPAT` is to be defined in the `openssl` compilation and use the value in the client code.