### PR TITLE
Fix build on FreeBSD 11.1

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -173,7 +173,7 @@ POSSIBILITY OF SUCH DAMAGE.
 // FreeBSD has a reasonable iconv signature
 // unless we're on glibc
 #ifndef __GLIBC__
-# define TORRENT_ICONV_ARG(x) (x)
+# define TORRENT_ICONV_ARG(x) (const_cast<char**>(x))
 #endif
 #endif // __APPLE__
 


### PR DESCRIPTION
Build fails on FreeBSD 11.1-p1 using cmake and base clang compiler.
I'm not sure what the correct convention is here for this iconv for
all BSD version, but certainly casting it to non-const and then
passing it in should be safe even if some versions of iconv take
a const pointer.

With current master I get this build error:
```
[ 24%] Building CXX object CMakeFiles/torrent-rasterbar.dir/src/i2p_stream.cpp.o
/home/matt/libtorrent/include/libtorrent/config.hpp:176:31: note: expanded from macro 'TORRENT_ICONV_ARG'
# define TORRENT_ICONV_ARG(x) (x)
                              ^~~
/usr/local/include/iconv.h:85:43: note: passing argument to parameter 'inbuf' here
extern size_t iconv (iconv_t cd,  char* * inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
```