### PR TITLE
don't hard-code the paths to find openssl on mac

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -61,34 +61,30 @@ VERSION = 1.1.5 ;
 
 # rule for linking the correct libraries depending
 # on features and target-os
-rule linking ( properties * )
+rule link-openssl ( properties * )
 {
 	local result ;
 
 	# openssl libraries, if enabled
 	# exclude gcc from a regular windows build to make mingw
 	# link against the regular unix library name
-	if <crypto>openssl in $(properties)
+	if <openssl-version>pre1.1 in $(properties)
+		&& <target-os>windows in $(properties)
+		&& ! <toolset>gcc in $(properties)
 	{
-		if <openssl-version>pre1.1 in $(properties)
-			&& <target-os>windows in $(properties)
-			&& ! <toolset>gcc in $(properties)
-		{
-			result += <library>ssleay32
-				<library>libeay32
-			;
-		}
-		else
-		{
-			# on windows the library names were changed to be in line with other
-			# system starting with OpenSSL 1.1
-			result += <library>crypto <library>ssl ;
-		}
+		result += <library>ssleay32
+			<library>libeay32
+		;
+	}
+	else
+	{
+		# on windows the library names were changed to be in line with other
+		# system starting with OpenSSL 1.1
+		result += <library>crypto <library>ssl ;
 	}
 
 	# windows needs some more libraries when using openSSL
-	if <crypto>openssl in $(properties)
-		&& <target-os>windows in $(properties)
+	if <target-os>windows in $(properties)
 		&& ! <toolset>gcc in $(properties)
 	{
 		result += <library>advapi32
@@ -97,7 +93,13 @@ rule linking ( properties * )
 			<library>gdi32
 		;
 	}
+	echo "link openssl = " $(result) ;
+	return $(result) ;
+}
 
+rule linking ( properties * )
+{
+	local result ;
 	if <simulator>on in $(properties)
 	{
 		result += <library>/libsimulator//simulator ;
@@ -369,7 +371,7 @@ rule building ( properties * )
 	return $(result) ;
 }
 
-rule tag ( name : type  ? : property-set )
+rule tag ( name : type ? : property-set )
 {
 	name = [ virtual-target.add-prefix-and-suffix $(name) : $(type) : $(property-set) ] ;
 
@@ -381,6 +383,78 @@ rule tag ( name : type  ? : property-set )
 
 	return $(name) ;
 }
+
+# the search path to pick up the openssl libraries from. This is the <search>
+# property of those libraries
+rule openssl-lib-path ( properties * )
+{
+	local OPENSSL_LIB = [ feature.get-values <openssl-lib> : $(properties) ] ;
+
+	if <target-os>darwin in $(properties) && $(OPENSSL_LIB) = ""
+	{
+		# on macOS, default to pick up openssl from the homebrew installation
+		# brew install openssl
+		OPENSSL_LIB = /usr/local/opt/openssl/lib ;
+	}
+	else if <target-os>windows in $(properties)
+		&& <toolset>gcc in $(properties)
+		&& $(OPENSSL_LIB) = ""
+	{
+		# on mingw, assume openssl is installed in c:\OpenSSL-Win32 by default
+		OPENSSL_LIB = c:\\OpenSSL-Win32\\lib ;
+	}
+	else if <target-os>windows in $(properties) && $(OPENSSL_LIB) = ""
+	{
+		# on windows, just assume openssl is installed to c:\openssl
+		if <address-model>64 in $(properties)
+		{ OPENSSL_LIB = c:\\openssl\\lib64 ; }
+		else
+		{ OPENSSL_LIB = c:\\openssl\\lib ; }
+	}
+
+	local result ;
+	result += <search>$(OPENSSL_LIB) ;
+	echo "openssl-lib-path = " $(result) ;
+	return $(result) ;
+}
+
+# the include path to pick up openssl headers from. This is the
+# usage-requirement for the openssl-related libraries
+rule openssl-include-path ( properties * )
+{
+	local OPENSSL_INCLUDE = [ feature.get-values <openssl-include> : $(properties) ] ;
+
+	if <target-os>darwin in $(properties) && $(OPENSSL_INCLUDE) = ""
+	{
+		# on macOS, default to pick up openssl from the homebrew installation
+		# brew install openssl
+		OPENSSL_INCLUDE = /usr/local/opt/openssl/include ;
+	}
+	else if <target-os>windows in $(properties)
+		&& <toolset>gcc in $(properties)
+		&& $(OPENSSL_INCLUDE) = ""
+	{
+		# on mingw, assume openssl is installed in c:\OpenSSL-Win32 by default
+		OPENSSL_INCLUDE = c:\\OpenSSL-Win32\\include ;
+	}
+	else if <target-os>windows in $(properties) && $(OPENSSL_INCLUDE) = ""
+	{
+		# on windows, just assume openssl is installed to c:\openssl
+		# not sure if there's a better way to find out where it may be
+		if <address-model>64 in $(properties)
+		{ OPENSSL_INCLUDE = c:\\openssl\\include64 ; }
+		else
+		{ OPENSSL_INCLUDE = c:\\openssl\\include ; }
+	}
+
+	local result ;
+	result += <include>$(OPENSSL_INCLUDE) ;
+	echo "openssl-include-path = " $(result) ;
+	return $(result) ;
+}
+
+feature openssl-lib : : free path ;
+feature openssl-include : : free path ;
 
 feature ipv6 : on off : composite propagated link-incompatible ;
 feature.compose <ipv6>off : <define>TORRENT_USE_IPV6=0 ;
@@ -527,9 +601,12 @@ variant test_barebones : debug
 	  <export-extra>on <debug-iterators>on <threading>multi <asserts>on
 	;
 
+lib crypto : : <name>crypto <use>z <conditional>@openssl-lib-path : : <conditional>@openssl-include-path ;
+lib ssl : : <name>ssl <use>crypto <conditional>@openssl-lib-path : : <conditional>@openssl-include-path ;
+
 # required for openssl on windows
-lib ssleay32 : : <name>ssleay32 ;
-lib libeay32 : : <name>libeay32 ;
+lib ssleay32 : : <name>ssleay32 <conditional>@openssl-lib-path : : <conditional>@openssl-include-path ;
+lib libeay32 : : <name>libeay32 <conditional>@openssl-lib-path : : <conditional>@openssl-include-path ;
 lib advapi32 : : <name>advapi32 ;
 lib user32 : : <name>user32 ;
 lib shell32 : : <name>shell32 ;
@@ -548,12 +625,7 @@ lib gcrypt : : <name>gcrypt <link>shared <search>/opt/local/lib ;
 lib z : : <link>shared <name>z ;
 lib dl : : <link>shared <name>dl ;
 
-# pick up openssl on macos from brew
-lib crypto : : <name>crypto <use>z <target-os>darwin <search>/usr/local/opt/openssl/lib : <link>shared : <include>/usr/local/opt/openssl/include ;
-lib ssl : : <name>ssl <use>crypto <target-os>darwin <search>/usr/local/opt/openssl/lib : <link>shared : <include>/usr/local/opt/openssl/include ;
-
-lib crypto : : <name>crypto <use>z : <link>shared ;
-lib ssl : : <name>ssl <use>crypto : <link>shared ;
+alias openssl-libraries : : : : <conditional>@link-openssl ;
 
 # time functions used on linux require librt
 lib librt : : <name>rt <link>shared ;
@@ -758,6 +830,7 @@ lib torrent
 	<link>shared:<define>TORRENT_BUILDING_SHARED
 	<define>BOOST_NO_DEPRECATED
 	<link>shared:<define>BOOST_SYSTEM_SOURCE
+	<crypto>openssl:<library>openssl-libraries
 
 	<dht>on:<source>src/kademlia/$(KADEMLIA_SOURCES).cpp
 	<dht>on:<source>ed25519/src/$(ED25519_SOURCES).cpp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,30 +10,20 @@ environment:
     compiler: msvc-14.0
     os: Visual Studio 2015
     sim: 1
-    linkflags: '"/LIBPATH:C:\\openssl-1.0.1p-vs2015\\lib"'
-    include: '"c:\\openssl-1.0.1p-vs2015\\include"'
   - variant: test_debug
     compiler: msvc-12.0
     os: Visual Studio 2013
     x64: 1
-    linkflags: '"/LIBPATH:C:\\openssl-1.0.1p-vs2013\\lib64"'
-    include: '"c:\\openssl-1.0.1p-vs2013\\include"'
   - variant: test_debug
     python_package: 1
     compiler: msvc-10.0
     os: Visual Studio 2015
-    linkflags: '"/LIBPATH:C:\\openssl-1.0.1p-vs2010\\lib"'
-    include: '"c:\\openssl-1.0.1p-vs2010\\include"'
   - variant: test_barebones
     compiler: msvc-12.0
     os: Visual Studio 2013
-    linkflags: '"/LIBPATH:C:\\openssl-1.0.1p-vs2013\\lib"'
-    include: '"c:\\openssl-1.0.1p-vs2013\\include"'
   - variant: test_release
     compiler: msvc-12.0
     os: Visual Studio 2013
-    linkflags: '"/LIBPATH:C:\\openssl-1.0.1p-vs2013\\lib"'
-    include: '"c:\\openssl-1.0.1p-vs2013\\include"'
 
 # mingw and boost.random don't like each other. Comment this back in once there
 # is support
@@ -55,10 +45,11 @@ install:
 - if %compiler% == msvc-12.0 (
     echo extracting openssl-2013
     & 7z x -oc:\ -aoa openssl-1.0.1p-vs2013.7z > nul
-    & copy c:\openssl-1.0.1p-vs2013\lib64\ssleay32MT.lib c:\openssl-1.0.1p-vs2013\lib64\ssleay32.lib
-    & copy c:\openssl-1.0.1p-vs2013\lib64\libeay32MT.lib c:\openssl-1.0.1p-vs2013\lib64\libeay32.lib
-    & copy c:\openssl-1.0.1p-vs2013\lib\ssleay32MT.lib c:\openssl-1.0.1p-vs2013\lib\ssleay32.lib
-    & copy c:\openssl-1.0.1p-vs2013\lib\libeay32MT.lib c:\openssl-1.0.1p-vs2013\lib\libeay32.lib
+    & rename c:\openssl-1.0.1p-vs2013 openssl
+    & copy c:\openssl\lib64\ssleay32MT.lib c:\openssl\lib64\ssleay32.lib
+    & copy c:\openssl\lib64\libeay32MT.lib c:\openssl\lib64\libeay32.lib
+    & copy c:\openssl\lib\ssleay32MT.lib c:\openssl\lib\ssleay32.lib
+    & copy c:\openssl\lib\libeay32MT.lib c:\openssl\lib\libeay32.lib
   )
 - if %compiler% == msvc-10.0 (
     if not exist openssl-1.0.1p-vs2010.7z (
@@ -69,10 +60,11 @@ install:
 - if %compiler% == msvc-10.0 (
     echo extracting openssl-2010
     & 7z x -oc:\ -aoa openssl-1.0.1p-vs2010.7z > nul
-    & copy c:\openssl-1.0.1p-vs2010\lib64\ssleay32MT.lib c:\openssl-1.0.1p-vs2010\lib64\ssleay32.lib
-    & copy c:\openssl-1.0.1p-vs2010\lib64\libeay32MT.lib c:\openssl-1.0.1p-vs2010\lib64\libeay32.lib
-    & copy c:\openssl-1.0.1p-vs2010\lib\ssleay32MT.lib c:\openssl-1.0.1p-vs2010\lib\ssleay32.lib
-    & copy c:\openssl-1.0.1p-vs2010\lib\libeay32MT.lib c:\openssl-1.0.1p-vs2010\lib\libeay32.lib
+    & rename c:\openssl-1.0.1p-vs2010 openssl
+    & copy c:\openssl\lib64\ssleay32MT.lib c:\openssl\lib64\ssleay32.lib
+    & copy c:\openssl\lib64\libeay32MT.lib c:\openssl\lib64\libeay32.lib
+    & copy c:\openssl\lib\ssleay32MT.lib c:\openssl\lib\ssleay32.lib
+    & copy c:\openssl\lib\libeay32MT.lib c:\openssl\lib\libeay32.lib
   )
 - if %compiler% == msvc-14.0 (
     if not exist openssl-1.0.1p-vs2015.7z (
@@ -83,10 +75,11 @@ install:
 - if %compiler% == msvc-14.0 (
     echo extracting openssl-2015
     & 7z x -oc:\ -aoa openssl-1.0.1p-vs2015.7z > nul
-    & copy c:\openssl-1.0.1p-vs2015\lib64\ssleay32MT.lib c:\openssl-1.0.1p-vs2015\lib64\ssleay32.lib
-    & copy c:\openssl-1.0.1p-vs2015\lib64\libeay32MT.lib c:\openssl-1.0.1p-vs2015\lib64\libeay32.lib
-    & copy c:\openssl-1.0.1p-vs2015\lib\ssleay32MT.lib c:\openssl-1.0.1p-vs2015\lib\ssleay32.lib
-    & copy c:\openssl-1.0.1p-vs2015\lib\libeay32MT.lib c:\openssl-1.0.1p-vs2015\lib\libeay32.lib
+    & rename c:\openssl-1.0.1p-vs2015 openssl
+    & copy c:\openssl\lib64\ssleay32MT.lib c:\openssl\lib64\ssleay32.lib
+    & copy c:\openssl\lib64\libeay32MT.lib c:\openssl\lib64\libeay32.lib
+    & copy c:\openssl\lib\ssleay32MT.lib c:\openssl\lib\ssleay32.lib
+    & copy c:\openssl\lib\libeay32MT.lib c:\openssl\lib\libeay32.lib
   )
 - cd %ROOT_DIRECTORY%
 - set BOOST_ROOT=c:\Libraries\boost_1_63_0
@@ -117,12 +110,12 @@ build_script:
 - if not defined x64 (
   cd %ROOT_DIRECTORY%\examples
   & if %compiler% == msvc-14.0 (
-    b2.exe --hash -j2 openssl-version=pre1.1 address-model=32 %compiler% variant=%variant% debug-iterators=on picker-debugging=on invariant-checks=full linkflags=%linkflags% include=%include% link=shared bt-get bt-get2
+    b2.exe --hash -j2 crypto=openssl openssl-version=pre1.1 address-model=32 %compiler% variant=%variant% debug-iterators=on picker-debugging=on invariant-checks=full link=shared bt-get bt-get2
   ) else (
-    b2.exe --hash -j2 openssl-version=pre1.1 address-model=32 %compiler% variant=%variant% debug-iterators=on picker-debugging=on invariant-checks=full linkflags=%linkflags% include=%include% link=shared
+    b2.exe --hash -j2 crypto=openssl openssl-version=pre1.1 address-model=32 %compiler% variant=%variant% debug-iterators=on picker-debugging=on invariant-checks=full link=shared
   )
   & cd %ROOT_DIRECTORY%\bindings\python
-  & b2.exe --hash -j2 openssl-version=pre1.1 %compiler% stage_module install-dependencies=on variant=%variant% libtorrent-link=shared linkflags=%linkflags% include=%include%
+  & b2.exe --hash -j2 openssl-version=pre1.1 %compiler% stage_module install-dependencies=on variant=%variant% libtorrent-link=shared crypto=openssl
   & python test.py
   & if defined python_package ( python setup.py --bjam bdist_msi )
   )
@@ -130,9 +123,9 @@ build_script:
 test_script:
 - cd %ROOT_DIRECTORY%\test
 - if defined x64 (
-  appveyor-retry b2.exe --hash -j2 openssl-version=pre1.1 address-model=64 win-tests %compiler% variant=%variant% link=shared linkflags=%linkflags% include=%include%
+  appveyor-retry b2.exe --hash -j2 openssl-version=pre1.1 address-model=64 win-tests %compiler% variant=%variant% link=shared
   ) else (
-  appveyor-retry b2.exe --hash -j2 openssl-version=pre1.1 address-model=32 win-tests %compiler% variant=%variant% link=shared linkflags=%linkflags% include=%include%
+  appveyor-retry b2.exe --hash -j2 openssl-version=pre1.1 address-model=32 win-tests %compiler% variant=%variant% link=shared
   )
 - if defined sim (
   cd %ROOT_DIRECTORY%\simulation

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -237,6 +237,14 @@ windows format (``c:/boost_1_64_0``).
 The ``Jamfile`` will define ``NDEBUG`` when it's building a release build.
 For more build configuration flags see `Build configurations`_.
 
+When enabling linking against openssl (by setting the ``crypto`` feature to
+``openssl``) the Jamfile will look in some default directory for the openssl
+headers and libraries. On macOS, it will look for the homebrew openssl package.
+On windows it will look in ``c:\openssl`` and mingw in ``c:\OpenSSL-Win32``.
+
+To customize the library path and include path for openssl, set the features
+``openssl-lib`` and ``openssl-include`` respectively.
+
 Build features:
 
 +--------------------------+----------------------------------------------------+
@@ -246,6 +254,13 @@ Build features:
 |                          |   libraries.                                       |
 |                          | * ``shared`` - links dynamically against the boost |
 |                          |   libraries.                                       |
++--------------------------+----------------------------------------------------+
+| ``openssl-lib``          | can be used to specify the directory where libssl  |
+|                          | and libcrypto are installed (or the windows        |
+|                          | counterparts).                                     |
++--------------------------+----------------------------------------------------+
+| ``openssl-include``      | can be used to specify the include directory where |
+|                          | the openssl headers are installed.                 |
 +--------------------------+----------------------------------------------------+
 | ``logging``              | * ``off`` - logging alerts disabled. The           |
 |                          |   reason to disable logging is to keep the binary  |
@@ -282,6 +297,8 @@ Build features:
 |                          |   implementation.                                  |
 |                          | * ``openssl`` - links against openssl and          |
 |                          |   libcrypto to use for SHA-1 hashing.              |
+|                          |   This also enables HTTPS-tracker support and      |
+|                          |   support for bittorrent over SSL.                 |
 |                          | * ``gcrypt`` - links against libgcrypt to use for  |
 |                          |   SHA-1 hashing.                                   |
 +--------------------------+----------------------------------------------------+


### PR DESCRIPTION
default to picking up brew. Add two new jam features, openssl-lib and openssl-include that can be used to specify which openssl to link against.

@aldenml does this look good to you?
I will update this PR with documentation as well