### PR TITLE
missing use of piece_refcount_holder before flush_iovec in unlocked scope

### DIFF
--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -544,6 +544,7 @@ constexpr disk_job_flags_t disk_interface::cache_hit;
 		{
 			// unlock while we're performing the actual disk I/O
 			// then lock again
+			piece_refcount_holder refcount_holder(first_piece);
 			auto unlock = scoped_unlock(l);
 			flush_iovec(first_piece, iov, flushing, iov_len, error);
 		}


### PR DESCRIPTION
Hi @arvidn, I'm not sure this is necessary (or right), that's why I'm skipping the CI, but take a look when you have a chance and let me know