### PR TITLE
enabled bigobj for msvc cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,8 @@ if (MSVC)
 	target_compile_options(torrent-rasterbar PUBLIC /Zc:wchar_t /Zc:forScope)
 	# for multi-core compilation
 	target_compile_options(torrent-rasterbar PUBLIC /MP)
+	# increase the number of sections for obj files
+	target_compile_options(torrent-rasterbar PUBLIC /bigobj)
 endif()
 
 target_compile_definitions(torrent-rasterbar PUBLIC _FILE_OFFSET_BITS=64)


### PR DESCRIPTION
bigobj is needed for msvc win builds