### PR TITLE
make session_handle::get_torrent_status return the vector

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -1461,9 +1461,9 @@ MAGNETURL is a magnet link
 				if (c == 'R')
 				{
 					// save resume data for all torrents
-					std::vector<torrent_status> torr;
-					ses.get_torrent_status(&torr, [](torrent_status const& st)
-					{ return st.need_save_resume; }, {});
+					std::vector<torrent_status> const torr = ses.get_torrent_status(
+						[](torrent_status const& st)
+						{ return st.need_save_resume; }, {});
 					for (torrent_status const& st : torr)
 					{
 						st.handle.save_resume_data(torrent_handle::save_info_dict);
@@ -1906,14 +1906,14 @@ COLUMN OPTIONS
 	std::printf("saving resume data\n");
 
 	// get all the torrent handles that we need to save resume data for
-	std::vector<torrent_status> temp;
-	ses.get_torrent_status(&temp, [](torrent_status const& st)
-	{
-		if (!st.handle.is_valid()) return false;
-		if (!st.has_metadata) return false;
-		if (!st.need_save_resume) return false;
-		return true;
-	}, {});
+	std::vector<torrent_status> const temp = ses.get_torrent_status(
+		[](torrent_status const& st)
+		{
+			if (!st.handle.is_valid()) return false;
+			if (!st.has_metadata) return false;
+			if (!st.need_save_resume) return false;
+			return true;
+		}, {});
 
 	int idx = 0;
 	for (auto const& st : temp)

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -152,8 +152,8 @@ namespace libtorrent {
 		//
 		// Any torrent_status object whose ``handle`` member is not referring to
 		// a valid torrent are ignored.
-		void get_torrent_status(std::vector<torrent_status>* ret
-			, std::function<bool(torrent_status const&)> const& pred
+		std::vector<torrent_status> get_torrent_status(
+			std::function<bool(torrent_status const&)> const& pred
 			, status_flags_t flags = {}) const;
 		void refresh_torrent_status(std::vector<torrent_status>* ret
 			, status_flags_t flags = {}) const;
@@ -304,7 +304,13 @@ namespace libtorrent {
 		// For more information, see the cache_status type.
 		TORRENT_DEPRECATED
 		cache_status get_cache_status() const;
-#endif
+
+		// deprecated in 1.2
+		TORRENT_DEPRECATED
+		void get_torrent_status(std::vector<torrent_status>* ret
+			, std::function<bool(torrent_status const&)> const& pred
+			, status_flags_t flags = {}) const;
+#endif // TORRENT_NO_DEPRECATE
 
 		enum { disk_cache_no_pieces = 1 };
 

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -173,12 +173,23 @@ namespace libtorrent {
 		sync_call(&session_impl::load_state, &e, flags);
 	}
 
+	std::vector<torrent_status> session_handle::get_torrent_status(
+		std::function<bool(torrent_status const&)> const& pred
+		, status_flags_t const flags) const
+	{
+		std::vector<torrent_status> ret;
+		sync_call(&session_impl::get_torrent_status, &ret, pred, flags);
+		return ret;
+	}
+
+#ifndef TORRENT_NO_DEPRECATE
 	void session_handle::get_torrent_status(std::vector<torrent_status>* ret
 		, std::function<bool(torrent_status const&)> const& pred
 		, status_flags_t const flags) const
 	{
 		sync_call(&session_impl::get_torrent_status, ret, pred, flags);
 	}
+#endif
 
 	void session_handle::refresh_torrent_status(std::vector<torrent_status>* ret
 		, status_flags_t const flags) const


### PR DESCRIPTION
 instead of taking an out-parameter