### PR TITLE
pick standard std::aligned_union if using clang

### DIFF
--- a/include/libtorrent/aux_/aligned_storage.hpp
+++ b/include/libtorrent/aux_/aligned_storage.hpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-#if defined __GNUC__ && __GNUC__ < 5
+#if defined __GNUC__ && __GNUC__ < 5 && !defined(_LIBCPP_VERSION)
 
 // this is for backwards compatibility with not-quite C++11 compilers
 template <std::size_t Len, std::size_t Align = alignof(void*)>

--- a/include/libtorrent/aux_/aligned_union.hpp
+++ b/include/libtorrent/aux_/aligned_union.hpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-#if defined __GNUC__ && __GNUC__ < 5
+#if defined __GNUC__ && __GNUC__ < 5 && !defined(__clang__)
 
 constexpr std::size_t max(std::size_t a)
 { return a; }

--- a/include/libtorrent/aux_/aligned_union.hpp
+++ b/include/libtorrent/aux_/aligned_union.hpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-#if defined __GNUC__ && __GNUC__ < 5 && !defined(__clang__)
+#if defined __GNUC__ && __GNUC__ < 5 && !defined(_LIBCPP_VERSION)
 
 constexpr std::size_t max(std::size_t a)
 { return a; }


### PR DESCRIPTION
Since in clang `__GNUC__` is `4`, the custom defined `aux::aligned_union` was used.

btw, this code `unsigned char __data[(_Len + _Align - 1)/_Align * _Align];` from the standard `type_traits` seems a little more sophisticated than the one defined in `aligned_union.hpp`