### PR TITLE
add limit of max 50 upnp mappings and recover free global mappings

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -235,7 +235,9 @@ port_mapping_t upnp::add_mapping(portmap_protocol const p, int const external_po
 		TORRENT_ASSERT(m_mappings.size() <= max_global_mappings);
 		if (m_mappings.size() >= max_global_mappings)
 		{
+#ifndef TORRENT_DISABLE_LOGGING
 			log("too many mappings registered");
+#endif
 			return port_mapping_t{-1};
 		}
 		m_mappings.push_back(global_mapping_t());

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -232,6 +232,7 @@ port_mapping_t upnp::add_mapping(portmap_protocol const p, int const external_po
 
 	if (mapping_it == m_mappings.end())
 	{
+		TORRENT_ASSERT(m_mappings.end_index() < max_global_mappings);
 		if (m_mappings.end_index() >= max_global_mappings)
 		{
 			log("too many mappings registered");

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -66,7 +66,7 @@ using namespace aux;
 // due to the recursive nature of update_map, it's necessary to
 // limit the internal list of global mappings to a small size
 // this can be changed once the entire UPnP code is refactored
-constexpr int max_global_mappings = 50;
+constexpr std::size_t max_global_mappings = 50;
 
 namespace upnp_errors
 {
@@ -232,8 +232,8 @@ port_mapping_t upnp::add_mapping(portmap_protocol const p, int const external_po
 
 	if (mapping_it == m_mappings.end())
 	{
-		TORRENT_ASSERT(m_mappings.end_index() < max_global_mappings);
-		if (m_mappings.end_index() >= max_global_mappings)
+		TORRENT_ASSERT(m_mappings.size() <= max_global_mappings);
+		if (m_mappings.size() >= max_global_mappings)
 		{
 			log("too many mappings registered");
 			return port_mapping_t{-1};

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -267,18 +267,11 @@ TORRENT_TEST(upnp_max_mappings)
 	upnp_callback cb;
 	auto upnp_handler = std::make_shared<upnp>(ios, "test agent", cb, false);
 
-	for (int i = 0; i < 51; ++i)
+	for (int i = 0; i < 50; ++i)
 	{
 		auto const mapping = upnp_handler->add_mapping(portmap_protocol::tcp
 			, 500 + i, ep("127.0.0.1", 500 + i));
 
-		if (i < 50)
-		{
-			TEST_CHECK(mapping != port_mapping_t{-1});
-		}
-		else
-		{
-			TEST_EQUAL(mapping, port_mapping_t{-1});
-		}
+		TEST_CHECK(mapping != port_mapping_t{-1});
 	}
 }

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -260,3 +260,25 @@ TORRENT_TEST(upnp)
 	run_upnp_test(combine_path("..", "root2.xml").c_str(), "D-Link Router", "WANIPConnection", 1);
 	run_upnp_test(combine_path("..", "root3.xml").c_str(), "D-Link Router", "WANIPConnection_2", 2);
 }
+
+TORRENT_TEST(upnp_max_mappings)
+{
+	lt::io_service ios;
+	upnp_callback cb;
+	auto upnp_handler = std::make_shared<upnp>(ios, "test agent", cb, false);
+
+	for (int i = 0; i < 51; ++i)
+	{
+		auto const mapping = upnp_handler->add_mapping(portmap_protocol::tcp
+			, 500 + i, ep("127.0.0.1", 500 + i));
+
+		if (i < 50)
+		{
+			TEST_CHECK(mapping != port_mapping_t{-1});
+		}
+		else
+		{
+			TEST_EQUAL(mapping, port_mapping_t{-1});
+		}
+	}
+}


### PR DESCRIPTION
This PR is to protect the "not so robust" UPnP mapping code from going crazy in case mapping/unmapping is called indiscriminately.

The number `50` is arbitrary.