### PR TITLE
avoid listening in addresses that are not suitable for bittorrent protocol

### DIFF
--- a/include/libtorrent/broadcast_socket.hpp
+++ b/include/libtorrent/broadcast_socket.hpp
@@ -51,6 +51,7 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT bool is_any(address const& addr);
 	TORRENT_EXTRA_EXPORT bool is_teredo(address const& addr);
 	TORRENT_EXTRA_EXPORT bool is_ip_address(std::string const& host);
+	TORRENT_EXTRA_EXPORT bool is_non_useful(address const& a);
 
 	// determines if the operating system supports IPv6
 	TORRENT_EXTRA_EXPORT bool supports_ipv6();

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -139,6 +139,32 @@ namespace libtorrent {
 #endif
 	}
 
+	TORRENT_EXTRA_EXPORT bool is_non_useful(address const& a)
+	{
+		TORRENT_TRY {
+#if TORRENT_USE_IPV6
+			error_code ec;
+			std::string s = a.to_string(ec);
+			if (ec) return true;
+			if (s.find("%dummy") != std::string::npos) return true;
+			// Android Wi-Fi Direct
+			if (s.find("%p2p") != std::string::npos) return true;
+			// Apple Wireless Direct Link
+			if (s.find("%awdl") != std::string::npos) return true;
+			// TODO: study more about
+			// - rmnet_data
+			// - sit
+			// - upnlink
+			// - svnet
+			// - ip6tnl
+			return false;
+#else
+			TORRENT_UNUSED(a);
+			return false;
+#endif
+		} TORRENT_CATCH(std::exception const&) { return false; }
+	}
+
 	bool supports_ipv6()
 	{
 #if !TORRENT_USE_IPV6

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1880,6 +1880,8 @@ namespace {
 		// an existing socket
 		for (auto const& ep : eps)
 		{
+			if (is_non_useful(ep.addr)) continue;
+
 			std::shared_ptr<listen_socket_t> s = setup_listener(ep.device
 				, tcp::endpoint(ep.addr, std::uint16_t(ep.port)), ep.ssl, ec);
 


### PR DESCRIPTION
Hi @ssiloti, I agree with the rationale of keeping the link local ones, but I find these particular addresses (the ones that I'm filtering out) unsuitable for bittorrent. What do you think?