### PR TITLE
keep updating aux::time_now() while there are announces

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3052,10 +3052,13 @@ retry:
 
 		// we have to keep ticking the utp socket manager
 		// until they're all closed
+		// we also have to keep updating the aux time while
+		// there are outstanding announces
 		if (m_abort)
 		{
 			if (m_utp_socket_manager.num_sockets() == 0
-				&& m_undead_peers.empty())
+				&& m_undead_peers.empty()
+				&& m_tracker_manager.empty())
 				return;
 #if defined TORRENT_ASIO_DEBUGGING
 			fprintf(stderr, "uTP sockets left: %d undead-peers left: %d\n"

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3206,7 +3206,7 @@ namespace {
 		req.num_want = (req.event == tracker_request::stopped)
 			? 0 : settings().get_int(settings_pack::num_want);
 
-		time_point now = clock_type::now();
+		time_point now = aux::time_now();
 
 		// the tier is kept as INT_MAX until we find the first
 		// tracker that works, then it's set to that tracker's


### PR DESCRIPTION
This fixes an infinite loop when an announce during shutown fails and
`aux::time_now()` has fallen behind `clock_type::now()` by more than the
delay calculated in `announce_entry::failed()`. If this happens,
`announce_entry::can_announce()` can forever return true when called from
`torrent::announce_with_tracker()` because that function uses
`clock_type::now()`.

Also change `torrent::announce_with_tracker()` to use `aux::time_now()` just
for consistency with the reset of the announce related functions.