### PR TITLE
enable/disable the internal ip notifier with new setting

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -614,10 +614,12 @@ namespace aux {
 				, error_code const& e);
 #endif
 
+			void start_ip_notifier();
 			void start_lsd();
 			natpmp* start_natpmp();
 			upnp* start_upnp();
 
+			void stop_ip_notifier();
 			void stop_lsd();
 			void stop_natpmp();
 			void stop_upnp();
@@ -715,6 +717,7 @@ namespace aux {
 			void update_max_failcount();
 			void update_resolver_cache_timeout();
 
+			void update_ip_notifier();
 			void update_upnp();
 			void update_natpmp();
 			void update_lsd();

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -716,6 +716,16 @@ namespace libtorrent {
 			// any.
 			proxy_tracker_connections,
 
+			// Starts and stops the internal IP table route changes notifier.
+			//
+			// The current implementation supports multiple platforms, and it is
+			// recommended to have it enable, but you may want to disable it if
+			// it's supported but unreliable, or if you have a better way to
+			// detect the changes. In the later case, you should manually call
+			// ``session_handle::reopen_network_sockets`` to ensure network
+			// changes are taken in consideration.
+			enable_ip_notifier,
+
 			max_bool_setting_internal
 		};
 

--- a/simulation/test_session.cpp
+++ b/simulation/test_session.cpp
@@ -67,7 +67,7 @@ TORRENT_TEST(seed_mode)
 TORRENT_TEST(ip_notifier_setting)
 {
 	int s_tick = 0;
-	bool working = false;
+	int working_count = 0;
 
 	setup_swarm(1, swarm_test::upload
 		// add session
@@ -79,13 +79,13 @@ TORRENT_TEST(ip_notifier_setting)
 		// add torrent
 		, [](lt::add_torrent_params& params) {}
 		// on alert
-		, [&s_tick, &working](lt::alert const* a, lt::session& ses)
+		, [&s_tick, &working_count](lt::alert const* a, lt::session& ses)
 		{
 			std::string const msg = a->message();
 			if (msg.find("received error on_ip_change:") != std::string::npos)
 			{
 				TEST_CHECK(s_tick == 0 || s_tick == 2);
-				working = true;
+				working_count++;
 			}
 		}
 		// terminate
@@ -110,5 +110,5 @@ TORRENT_TEST(ip_notifier_setting)
 			return ticks > 3;
 		});
 
-	TEST_CHECK(working);
+	TEST_EQUAL(working_count, 2);
 }

--- a/simulation/test_session.cpp
+++ b/simulation/test_session.cpp
@@ -64,3 +64,51 @@ TORRENT_TEST(seed_mode)
 		});
 }
 
+TORRENT_TEST(ip_notifier_setting)
+{
+	int s_tick = 0;
+	bool working = false;
+
+	setup_swarm(1, swarm_test::upload
+		// add session
+		, [](lt::settings_pack& pack)
+		{
+			pack.set_int(settings_pack::tick_interval, 1000);
+			pack.set_int(settings_pack::alert_mask, alert::all_categories);
+		}
+		// add torrent
+		, [](lt::add_torrent_params& params) {}
+		// on alert
+		, [&s_tick, &working](lt::alert const* a, lt::session& ses)
+		{
+			std::string const msg = a->message();
+			if (msg.find("received error on_ip_change:") != std::string::npos)
+			{
+				TEST_CHECK(s_tick == 0 || s_tick == 2);
+				working = true;
+			}
+		}
+		// terminate
+		, [&s_tick](int ticks, lt::session& ses) -> bool {
+
+			if (ticks == 1)
+			{
+				settings_pack sp;
+				sp.set_bool(settings_pack::enable_ip_notifier, false);
+				ses.apply_settings(sp);
+			}
+			else if (ticks == 2)
+			{
+				settings_pack sp;
+				sp.set_bool(settings_pack::enable_ip_notifier, true);
+				ses.apply_settings(sp);
+			}
+
+			s_tick = ticks;
+
+			// exit after 3 seconds
+			return ticks > 3;
+		});
+
+	TEST_CHECK(working);
+}

--- a/src/ip_notifier.cpp
+++ b/src/ip_notifier.cpp
@@ -91,7 +91,7 @@ struct ip_change_notifier_impl final : ip_change_notifier
 	{
 		using namespace std::placeholders;
 		m_socket.async_receive(boost::asio::buffer(m_buf)
-			, std::bind(&ip_change_notifier_impl::on_notify, this, _1, _2, std::move(cb)));
+			, std::bind(&ip_change_notifier_impl::on_notify, _1, _2, std::move(cb)));
 	}
 
 	void cancel() override
@@ -101,7 +101,7 @@ private:
 	netlink::socket m_socket;
 	std::array<char, 4096> m_buf;
 
-	void on_notify(error_code const& ec, std::size_t bytes_transferred
+	static void on_notify(error_code const& ec, std::size_t bytes_transferred
 		, std::function<void(error_code const&)> const& cb)
 	{
 		TORRENT_UNUSED(bytes_transferred);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -6624,9 +6624,8 @@ namespace {
 
 	void session_impl::stop_lsd()
 	{
-		if (!m_lsd) return;
-
-		m_lsd->close();
+		if (m_lsd)
+			m_lsd->close();
 		m_lsd.reset();
 	}
 

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -199,6 +199,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		SET(proxy_peer_connections, true, nullptr),
 		SET(auto_sequential, true, &session_impl::update_auto_sequential),
 		SET(proxy_tracker_connections, true, nullptr),
+		SET(enable_ip_notifier, true, &session_impl::update_ip_notifier),
 	}});
 
 	aux::array<int_setting_entry_t, settings_pack::num_int_settings> const int_settings


### PR DESCRIPTION
This helps to avoid the issue that in some android phones, netlink notifies with high frecuency even if no actual changes happened.