### PR TITLE
fix issue of null m_part_file in default_storage readv/writev

### DIFF
--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -89,6 +89,13 @@ namespace libtorrent {
 		TORRENT_ASSERT(files().num_files() > 0);
 		m_save_path = complete(params.path);
 		m_part_file_name = "." + aux::to_hex(params.info_hash) + ".parts";
+
+		file_storage const& fs = files();
+		for (file_index_t i(0); i < m_file_priority.end_index(); ++i)
+		{
+			if (m_file_priority[i] == 0 && !fs.pad_file_at(i))
+				need_partfile();
+		}
 	}
 
 	default_storage::~default_storage()

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -94,7 +94,10 @@ namespace libtorrent {
 		for (file_index_t i(0); i < m_file_priority.end_index(); ++i)
 		{
 			if (m_file_priority[i] == 0 && !fs.pad_file_at(i))
+			{
 				need_partfile();
+				break;
+			}
 		}
 	}
 
@@ -389,7 +392,6 @@ namespace libtorrent {
 		{
 			error_code ignore;
 			m_part_file->flush_metadata(ignore);
-			m_part_file.reset();
 		}
 
 		// make sure we don't have the files open

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -123,7 +123,7 @@ void test_transfer(settings_pack const& sett, bool test_deprecated = false)
 	file.close();
 
 	wait_for_listen(ses1, "ses1");
-	wait_for_listen(ses2, "ses1");
+	wait_for_listen(ses2, "ses2");
 
 	peer_disconnects = 0;
 


### PR DESCRIPTION
@arvidn this is the missing part in the constructor (as you mentioned in https://github.com/arvidn/libtorrent/issues/2489).

In case you want to merge it, I still have plans to create some unit tests to cover the issue