### PR TITLE
Remove twice assigned values

### DIFF
--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -302,8 +302,6 @@ namespace {
 		atp.num_complete = resume_data.num_complete;
 		atp.num_incomplete = resume_data.num_incomplete;
 		atp.num_downloaded = resume_data.num_downloaded;
-		atp.total_uploaded = resume_data.total_uploaded;
-		atp.total_downloaded = resume_data.total_downloaded;
 		atp.active_time = resume_data.active_time;
 		atp.finished_time = resume_data.finished_time;
 		atp.seeding_time = resume_data.seeding_time;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
libtorrent/src/session_handle.cpp   305     warn    V519 The 'atp.total_uploaded' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 300, 305.
libtorrent/src/session_handle.cpp   306     warn    V519 The 'atp.total_downloaded' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 301, 306.