### PR TITLE
stop posting alerts when the session is shutting down

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5957,6 +5957,10 @@ namespace {
 
 	session_impl::~session_impl()
 	{
+		// since we're destructing the session, no more alerts will make it out to
+		// the user. So stop posting them now
+		m_alerts.set_alert_mask({});
+
 		// this is not allowed to be the network thread!
 //		TORRENT_ASSERT(is_not_thread());
 // TODO: asserts that no outstanding async operations are still in flight

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4373,6 +4373,9 @@ namespace libtorrent {
 		update_gauge();
 		stop_announcing();
 
+		// remove from download queue
+		m_ses.set_queue_position(this, queue_position_t{-1});
+
 		if (m_peer_class > peer_class_t{0})
 		{
 			remove_class(m_ses.peer_classes(), m_peer_class);


### PR DESCRIPTION
Nobody will be able to see them anyway. It also solves some issues around destruction order where posting alerts require certain things to still be around in the session_impl object.
Also remove torrent from download queue when shutting it down.