### PR TITLE
fix iOS compile: <net/route.h> not available on iOS

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -193,7 +193,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_HAS_FALLOCATE 0
 
 #define TORRENT_USE_IFADDRS 1
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE == 1
+#define TORRENT_USE_SYSCTL 0
+#else
 #define TORRENT_USE_SYSCTL 1
+#endif
 #define TORRENT_USE_IFCONF 1
 
 


### PR DESCRIPTION
for a while, <net/route.h> was in the simulator header files but not in the device header files. a lot of people used to copy it from the simulator header files to make things compile. but since Xcode 9, it has been removed altogether. a recent [discussion](https://forums.developer.apple.com/thread/84607) on the apple developer forums