### PR TITLE
make sure libtorrent_assert_log is exported

### DIFF
--- a/include/libtorrent/assert.hpp
+++ b/include/libtorrent/assert.hpp
@@ -73,7 +73,7 @@ TORRENT_EXPORT void assert_fail(const char* expr, int line
 #if TORRENT_USE_ASSERTS
 
 #ifdef TORRENT_PRODUCTION_ASSERTS
-extern char const* libtorrent_assert_log;
+extern TORRENT_EXPORT char const* libtorrent_assert_log;
 #endif
 
 #if TORRENT_USE_IOSTREAM


### PR DESCRIPTION
when production asserts are enabled