### PR TITLE
use info hash from params instead of passing it separately

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -330,8 +330,7 @@ namespace libtorrent {
 	public:
 
 		torrent(aux::session_interface& ses, int block_size
-			, bool session_paused, add_torrent_params const& p
-			, sha1_hash const& info_hash);
+			, bool session_paused, add_torrent_params const& p);
 		~torrent() override;
 
 		// This may be called from multiple threads

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4954,7 +4954,7 @@ namespace {
 
 		torrent_ptr = std::make_shared<torrent>(*this
 			, 16 * 1024, m_paused
-			, params, params.info_hash);
+			, params);
 		torrent_ptr->set_queue_position(m_download_queue.end_index());
 
 		return std::make_pair(torrent_ptr, true);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -163,8 +163,7 @@ namespace libtorrent {
 		aux::session_interface& ses
 		, int const block_size
 		, bool const session_paused
-		, add_torrent_params const& p
-		, sha1_hash const& info_hash)
+		, add_torrent_params const& p)
 		: torrent_hot_members(ses, p, block_size, session_paused)
 		, m_tracker_timer(ses.get_io_service())
 		, m_inactivity_timer(ses.get_io_service())
@@ -179,7 +178,7 @@ namespace libtorrent {
 		, m_storage_constructor(p.storage)
 		, m_added_time(p.added_time ? p.added_time : std::time(nullptr))
 		, m_completed_time(p.completed_time)
-		, m_info_hash(info_hash)
+		, m_info_hash(p.info_hash)
 		, m_error_file(torrent_status::error_file_none)
 		, m_sequence_number(-1)
 		, m_announce_to_trackers(!(p.flags & torrent_flags::paused))
@@ -244,7 +243,7 @@ namespace libtorrent {
 		}
 
 		if (!m_torrent_file)
-			m_torrent_file = (p.ti ? p.ti : std::make_shared<torrent_info>(info_hash));
+			m_torrent_file = (p.ti ? p.ti : std::make_shared<torrent_info>(m_info_hash));
 
 		// --- WEB SEEDS ---
 


### PR DESCRIPTION
A minor cleanup I spotted while working on v2 support.