### PR TITLE
reserve space in the undead peers list up-front

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -370,7 +370,7 @@ namespace aux {
 
 			peer_id const& get_peer_id() const override { return m_peer_id; }
 
-			void close_connection(peer_connection* p) override;
+			void close_connection(peer_connection* p) noexcept override;
 
 			void apply_settings_pack(std::shared_ptr<settings_pack> pack) override;
 			void apply_settings_pack_impl(settings_pack const& pack);

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -204,7 +204,7 @@ namespace libtorrent { namespace aux {
 
 		virtual peer_id const& get_peer_id() const = 0;
 
-		virtual void close_connection(peer_connection* p) = 0;
+		virtual void close_connection(peer_connection* p) noexcept = 0;
 		virtual int num_connections() const = 0;
 
 		virtual void deferred_submit_jobs() = 0;


### PR DESCRIPTION
to not have to allocate memory when disconnecting