### PR TITLE
complete the error handling test and make it part of the default simulation test suite

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -519,12 +519,12 @@ variant test_release : release
 variant test_debug : debug
 	: <logging>on
 	<invariant-checks>full <boost-link>shared
-	<export-extra>on <debug-iterators>on <threading>multi <asserts>on
+	<export-extra>on <threading>multi <asserts>on
 	;
 variant test_barebones : debug
 	: <ipv6>off <dht>off <extensions>off <logging>off <boost-link>shared
 	<deprecated-functions>off <invariant-checks>off
-	<export-extra>on <debug-iterators>on <threading>multi <asserts>on
+	<export-extra>on <threading>multi <asserts>on
 	;
 variant test_arm : debug
 	: <ipv6>off <dht>off <extensions>off <logging>off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ build_script:
 # simulations
 - cd %ROOT_DIRECTORY%\simulation
 - if defined sim (
-  b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% deprecated-functions=off %linkflags% %include% link=shared crypto=built-in testing.execute=off
+  b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP testing.execute=off
   )
 
 test_script:
@@ -107,7 +107,9 @@ test_script:
 # specifiers when debug iterators are enabled. Specifically, constructors that
 # allocate memory are still marked as noexcept. That results in program
 # termination
+# the IOCP backend in asio appears to have an issue where it hangs under
+# certain unexpected terminations (through exceptions)
 - cd %ROOT_DIRECTORY%\simulation
 - if defined sim (
-  b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in
+  b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP
   )

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -1261,7 +1261,7 @@ namespace aux {
 
 #ifndef TORRENT_DISABLE_LOGGING
 			bool should_log() const override;
-			void session_log(char const* fmt, ...) const override TORRENT_FORMAT(2,3);
+			void session_log(char const* fmt, ...) const noexcept override TORRENT_FORMAT(2,3);
 #endif
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
@@ -1314,7 +1314,7 @@ namespace aux {
 				, error_code const& ec, const std::string& str
 				, seconds32 retry_interval) override;
 			bool should_log() const override;
-			void debug_log(const char* fmt, ...) const override TORRENT_FORMAT(2,3);
+			void debug_log(const char* fmt, ...) const noexcept override TORRENT_FORMAT(2,3);
 			session_interface& m_ses;
 		private:
 			// explicitly disallow assignment, to silence msvc warning

--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -286,7 +286,9 @@ namespace aux {
 		, buffer_allocator_interface
 	{
 		disk_io_thread(io_service& ios, counters& cnt);
+#if TORRENT_USE_ASSERTS
 		~disk_io_thread();
+#endif
 
 		void set_settings(settings_pack const* sett);
 

--- a/include/libtorrent/packet_pool.hpp
+++ b/include/libtorrent/packet_pool.hpp
@@ -160,6 +160,16 @@ namespace libtorrent {
 	// can handle common cases of packet size by 3 pools
 	struct TORRENT_EXTRA_EXPORT packet_pool : private single_threaded
 	{
+		// there's a bug in GCC where allocating these in
+		// member initializer expressions won't propagate exceptions.
+		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80683
+		packet_pool()
+			: m_syn_slab(TORRENT_UTP_HEADER)
+			, m_mtu_floor_slab(mtu_floor_size)
+			, m_mtu_ceiling_slab(mtu_ceiling_size)
+		{}
+		packet_pool(packet_pool&&) = default;
+
 		packet_ptr acquire(int const allocate)
 		{
 			TORRENT_ASSERT(is_single_thread());
@@ -202,9 +212,9 @@ namespace libtorrent {
 		}
 		static int const mtu_floor_size = TORRENT_INET_MIN_MTU - TORRENT_IPV4_HEADER - TORRENT_UDP_HEADER;
 		static int const mtu_ceiling_size = TORRENT_ETHERNET_MTU - TORRENT_IPV4_HEADER - TORRENT_UDP_HEADER;
-		packet_slab m_syn_slab{ TORRENT_UTP_HEADER };
-		packet_slab m_mtu_floor_slab{ mtu_floor_size };
-		packet_slab m_mtu_ceiling_slab{ mtu_ceiling_size };
+		packet_slab m_syn_slab;
+		packet_slab m_mtu_floor_slab;
+		packet_slab m_mtu_ceiling_slab;
 	};
 }
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -526,9 +526,9 @@ namespace aux {
 #ifndef TORRENT_DISABLE_LOGGING
 		bool should_log(peer_log_alert::direction_t direction) const override;
 		void peer_log(peer_log_alert::direction_t direction
-			, char const* event, char const* fmt, ...) const override TORRENT_FORMAT(4,5);
+			, char const* event, char const* fmt, ...) const noexcept override TORRENT_FORMAT(4,5);
 		void peer_log(peer_log_alert::direction_t direction
-			, char const* event) const;
+			, char const* event) const noexcept;
 
 		time_point m_connect_time;
 		time_point m_bitfield_time;

--- a/include/libtorrent/peer_connection_interface.hpp
+++ b/include/libtorrent/peer_connection_interface.hpp
@@ -65,7 +65,7 @@ namespace libtorrent {
 #ifndef TORRENT_DISABLE_LOGGING
 		virtual bool should_log(peer_log_alert::direction_t direction) const = 0;
 		virtual void peer_log(peer_log_alert::direction_t direction
-			, char const* event, char const* fmt = "", ...) const TORRENT_FORMAT(4,5) = 0;
+			, char const* event, char const* fmt = "", ...) const noexcept TORRENT_FORMAT(4,5) = 0;
 #endif
 	protected:
 		~peer_connection_interface() {}

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1023,7 +1023,7 @@ namespace libtorrent {
 		// LOGGING
 #ifndef TORRENT_DISABLE_LOGGING
 		bool should_log() const override;
-		void debug_log(const char* fmt, ...) const override TORRENT_FORMAT(2,3);
+		void debug_log(const char* fmt, ...) const noexcept override TORRENT_FORMAT(2,3);
 
 		void log_to_all_peers(char const* message);
 		time_point m_dht_start_time;

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -249,7 +249,7 @@ namespace libtorrent {
 
 #ifndef TORRENT_DISABLE_LOGGING
 		virtual bool should_log() const = 0;
-		virtual void debug_log(const char* fmt, ...) const TORRENT_FORMAT(2,3) = 0;
+		virtual void debug_log(const char* fmt, ...) const noexcept TORRENT_FORMAT(2,3) = 0;
 #endif
 	};
 

--- a/simulation/Jamfile
+++ b/simulation/Jamfile
@@ -51,8 +51,6 @@ alias libtorrent-sims :
 	[ run test_fast_extensions.cpp ]
 	[ run test_file_pool.cpp ]
 	[ run test_save_resume.cpp ]
+	[ run test_error_handling.cpp ]
 	;
-
-run test_error_handling.cpp ;
-explicit test_error_handling ;
 

--- a/src/block_cache.cpp
+++ b/src/block_cache.cpp
@@ -329,7 +329,6 @@ cached_piece_entry::~cached_piece_entry()
 	{
 		for (int i = 0; i < blocks_in_piece; ++i)
 		{
-			TORRENT_ASSERT(blocks[i].buf == nullptr);
 			TORRENT_ASSERT(!blocks[i].pending);
 			TORRENT_ASSERT(blocks[i].refcount == 0);
 			TORRENT_ASSERT(blocks[i].hashing_count == 0);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4361,8 +4361,23 @@ namespace libtorrent {
 		// the torrent object from there
 		if (m_storage)
 		{
-			m_ses.disk_thread().async_stop_torrent(m_storage
-				, std::bind(&torrent::on_torrent_aborted, shared_from_this()));
+			try {
+				m_ses.disk_thread().async_stop_torrent(m_storage
+					, std::bind(&torrent::on_torrent_aborted, shared_from_this()));
+			}
+			catch (std::exception const& e)
+			{
+				TORRENT_UNUSED(e);
+				m_storage.reset();
+#ifndef TORRENT_DISABLE_LOGGING
+				debug_log("Failed to flush disk cache: %s", e.what());
+#endif
+				// clients may rely on this alert to be posted, so it's probably a
+				// good idea to post it here, even though we failed
+				// TODO: 3 should this alert have an error code in it?
+				if (alerts().should_post<cache_flushed_alert>())
+					alerts().emplace_alert<cache_flushed_alert>(get_handle());
+			}
 		}
 		else
 		{
@@ -4401,6 +4416,10 @@ namespace libtorrent {
 		// have been destructed
 		if (m_peer_list) m_peer_list->clear();
 		m_connections.clear();
+		m_peers_to_disconnect.clear();
+		m_num_uploads = 0;
+		m_num_connecting = 0;
+		m_num_connecting_seeds = 0;
 	}
 
 	void torrent::set_super_seeding(bool on)
@@ -6877,22 +6896,7 @@ namespace libtorrent {
 		peers_erased(st.erased);
 
 		m_peers_to_disconnect.reserve(m_connections.size() + 1);
-
-		TORRENT_ASSERT(sorted_find(m_connections, p) == m_connections.end());
-		TORRENT_ASSERT(m_iterating_connections == 0);
-		sorted_insert(m_connections, p);
-		update_want_peers();
-		update_want_tick();
-
-		if (p->peer_info_struct() && p->peer_info_struct()->seed)
-		{
-			TORRENT_ASSERT(m_num_seeds < 0xffff);
-			++m_num_seeds;
-		}
-
-#ifndef TORRENT_DISABLE_LOGGING
-		debug_log("incoming peer (%d)", num_peers());
-#endif
+		m_connections.reserve(m_connections.size() + 1);
 
 #if TORRENT_USE_ASSERTS
 		error_code ec;
@@ -6956,13 +6960,33 @@ namespace libtorrent {
 		if (m_share_mode)
 			recalc_share_mode();
 
+		// once we add the peer to our m_connections list, we can't throw an
+		// exception. That will end up violating an invariant between the session,
+		// torrent and peers
+		TORRENT_ASSERT(sorted_find(m_connections, p) == m_connections.end());
+		TORRENT_ASSERT(m_iterating_connections == 0);
+		sorted_insert(m_connections, p);
+		update_want_peers();
+		update_want_tick();
+
+		if (p->peer_info_struct() && p->peer_info_struct()->seed)
+		{
+			TORRENT_ASSERT(m_num_seeds < 0xffff);
+			++m_num_seeds;
+		}
+
 #ifndef TORRENT_DISABLE_LOGGING
-		if (should_log())
+		debug_log("incoming peer (%d)", num_peers());
+#endif
+
+#ifndef TORRENT_DISABLE_LOGGING
+		if (should_log()) try
 		{
 			debug_log("ATTACHED CONNECTION \"%s\" connections: %d limit: %d"
 				, print_endpoint(p->remote()).c_str(), num_peers()
 				, m_max_connections);
 		}
+		catch (std::exception const&) {}
 #endif
 
 		return true;
@@ -7775,7 +7799,7 @@ namespace libtorrent {
 
 		TORRENT_ASSERT(is_single_thread());
 		// this fires during disconnecting peers
-//		if (is_paused()) TORRENT_ASSERT(num_peers() == 0 || m_graceful_pause_mode);
+		if (is_paused()) TORRENT_ASSERT(num_peers() == 0 || m_graceful_pause_mode);
 
 		int seeds = 0;
 		int num_uploads = 0;
@@ -7784,10 +7808,6 @@ namespace libtorrent {
 		std::map<piece_block, int> num_requests;
 		for (peer_connection const* peer : *this)
 		{
-#ifdef TORRENT_EXPENSIVE_INVARIANT_CHECKS
-			// make sure this peer is not a dangling pointer
-			TORRENT_ASSERT(m_ses.has_peer(peer));
-#endif
 			peer_connection const& p = *peer;
 
 			if (p.is_connecting()) ++num_connecting;
@@ -7813,16 +7833,19 @@ namespace libtorrent {
 			if (associated_torrent != this && associated_torrent != nullptr)
 				TORRENT_ASSERT_FAIL();
 		}
-		TORRENT_ASSERT(num_uploads == int(m_num_uploads));
-		TORRENT_ASSERT(seeds == int(m_num_seeds));
-		TORRENT_ASSERT(num_connecting == int(m_num_connecting));
-		TORRENT_ASSERT(num_connecting_seeds == int(m_num_connecting_seeds));
-		TORRENT_ASSERT(int(m_num_uploads) <= num_peers());
-		TORRENT_ASSERT(int(m_num_seeds) <= num_peers());
-		TORRENT_ASSERT(int(m_num_connecting) <= num_peers());
-		TORRENT_ASSERT(int(m_num_connecting_seeds) <= num_peers());
-		TORRENT_ASSERT(int(m_num_connecting) + int(m_num_seeds) >= int(m_num_connecting_seeds));
-		TORRENT_ASSERT(int(m_num_connecting) + int(m_num_seeds) - int(m_num_connecting_seeds) <= num_peers());
+		TORRENT_ASSERT_VAL(num_uploads == int(m_num_uploads), int(m_num_uploads) - num_uploads);
+		TORRENT_ASSERT_VAL(seeds == int(m_num_seeds), int(m_num_seeds) - seeds);
+		TORRENT_ASSERT_VAL(num_connecting == int(m_num_connecting), int(m_num_connecting) - num_connecting);
+		TORRENT_ASSERT_VAL(num_connecting_seeds == int(m_num_connecting_seeds)
+			, int(m_num_connecting_seeds) - num_connecting_seeds);
+		TORRENT_ASSERT_VAL(int(m_num_uploads) <= num_peers(), m_num_uploads - num_peers());
+		TORRENT_ASSERT_VAL(int(m_num_seeds) <= num_peers(), m_num_seeds - num_peers());
+		TORRENT_ASSERT_VAL(int(m_num_connecting) <= num_peers(), int(m_num_connecting) - num_peers());
+		TORRENT_ASSERT_VAL(int(m_num_connecting_seeds) <= num_peers(), int(m_num_connecting_seeds) - num_peers());
+		TORRENT_ASSERT_VAL(int(m_num_connecting) + int(m_num_seeds) >= int(m_num_connecting_seeds)
+			, int(m_num_connecting_seeds) - (int(m_num_connecting) + int(m_num_seeds)));
+		TORRENT_ASSERT_VAL(int(m_num_connecting) + int(m_num_seeds) - int(m_num_connecting_seeds) <= num_peers()
+			, num_peers() - (int(m_num_connecting) + int(m_num_seeds) - int(m_num_connecting_seeds)));
 
 		if (has_picker())
 		{
@@ -10979,7 +11002,7 @@ namespace {
 	}
 
 	TORRENT_FORMAT(2,3)
-	void torrent::debug_log(char const* fmt, ...) const
+	void torrent::debug_log(char const* fmt, ...) const noexcept try
 	{
 		if (!alerts().should_post<torrent_log_alert>()) return;
 
@@ -10989,6 +11012,7 @@ namespace {
 			const_cast<torrent*>(this)->get_handle(), fmt, v);
 		va_end(v);
 	}
+	catch (std::exception const&) {}
 #endif
 
 }

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -70,11 +70,11 @@ struct mock_peer_connection
 	virtual ~mock_peer_connection() = default;
 
 #if !defined TORRENT_DISABLE_LOGGING
-	bool should_log(peer_log_alert::direction_t) const override
+	bool should_log(peer_log_alert::direction_t) const noexcept override
 	{ return true; }
 
 	void peer_log(peer_log_alert::direction_t dir, char const* event
-		, char const* fmt, ...) const override
+		, char const* fmt, ...) const noexcept override
 	{
 		va_list v;
 		va_start(v, fmt);


### PR DESCRIPTION
It will run a file transfer between two clients repeatedly, each time cause another memory allocation fail, until every single memory allocation has failed once. Any invariant check failure, assertion or signal will cause the test to fail