### PR TITLE
using make_address instead of deprecated from_string when boost>=1.66

### DIFF
--- a/include/libtorrent/address.hpp
+++ b/include/libtorrent/address.hpp
@@ -65,13 +65,10 @@ namespace libtorrent {
 // the from_string member functions are deprecated starting
 // in boost 1.66.0
 #if BOOST_VERSION >= 106600 && !defined TORRENT_BUILD_SIMULATOR
-	inline address make_address(string_view str, boost::system::error_code& ec)
-	{ return boost::asio::ip::make_address(str.data(), ec); }
-	inline address_v4 make_address_v4(string_view str, boost::system::error_code& ec)
-	{ return boost::asio::ip::make_address_v4(str.data(), ec); }
+	using boost::asio::ip::make_address;
+	using boost::asio::ip::make_address_v4;
 #if TORRENT_USE_IPV6
-	inline address_v6 make_address_v6(string_view str, boost::system::error_code& ec)
-	{ return boost::asio::ip::make_address_v6(str.data(), ec); }
+	using boost::asio::ip::make_address_v6;
 #endif
 #else
 	inline address make_address(string_view str, boost::system::error_code& ec)

--- a/include/libtorrent/address.hpp
+++ b/include/libtorrent/address.hpp
@@ -33,7 +33,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_ADDRESS_HPP_INCLUDED
 #define TORRENT_ADDRESS_HPP_INCLUDED
 
+#include <boost/version.hpp>
+
 #include "libtorrent/config.hpp"
+#include "libtorrent/string_view.hpp"
 
 #if defined TORRENT_BUILD_SIMULATOR
 #include "simulator/simulator.hpp"
@@ -58,6 +61,28 @@ namespace libtorrent {
 	using address_v6 = boost::asio::ip::address_v6;
 #endif
 #endif // SIMULATOR
+
+// the from_string member functions are deprecated starting
+// in boost 1.66.0
+#if BOOST_VERSION >= 106600 && !defined TORRENT_BUILD_SIMULATOR
+	inline address make_address(string_view str, boost::system::error_code& ec)
+	{ return boost::asio::ip::make_address(str.data(), ec); }
+	inline address_v4 make_address_v4(string_view str, boost::system::error_code& ec)
+	{ return boost::asio::ip::make_address_v4(str.data(), ec); }
+#if TORRENT_USE_IPV6
+	inline address_v6 make_address_v6(string_view str, boost::system::error_code& ec)
+	{ return boost::asio::ip::make_address_v6(str.data(), ec); }
+#endif
+#else
+	inline address make_address(string_view str, boost::system::error_code& ec)
+	{ return address::from_string(str.data(), ec); }
+	inline address_v4 make_address_v4(string_view str, boost::system::error_code& ec)
+	{ return address_v4::from_string(str.data(), ec); }
+#if TORRENT_USE_IPV6
+	inline address_v6 make_address_v6(string_view str, boost::system::error_code& ec)
+	{ return address_v6::from_string(str.data(), ec); }
+#endif
+#endif
 }
 
 #endif

--- a/include/libtorrent/enum_net.hpp
+++ b/include/libtorrent/enum_net.hpp
@@ -110,7 +110,7 @@ namespace libtorrent {
 	{
 		tcp::endpoint bind_ep(address_v4::any(), std::uint16_t(port));
 
-		address ip = address::from_string(device_name, ec);
+		address ip = make_address(device_name, ec);
 		if (!ec)
 		{
 #if TORRENT_USE_IPV6

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -59,7 +59,7 @@ namespace libtorrent {
 	bool is_ip_address(std::string const& host)
 	{
 		error_code ec;
-		address::from_string(host, ec);
+		make_address(host, ec);
 		return !ec;
 	}
 
@@ -148,7 +148,7 @@ namespace libtorrent {
 #elif defined TORRENT_WINDOWS
 		TORRENT_TRY {
 			error_code ec;
-			address::from_string("::1", ec);
+			make_address("::1", ec);
 			return !ec;
 		} TORRENT_CATCH(std::exception const&) { return false; }
 #else
@@ -157,7 +157,8 @@ namespace libtorrent {
 		error_code ec;
 		test.open(tcp::v6(), ec);
 		if (ec) return false;
-		test.bind(tcp::endpoint(address_v6::from_string("::1"), 0), ec);
+		error_code ignore;
+		test.bind(tcp::endpoint(make_address_v6("::1", ignore), 0), ec);
 		return !bool(ec);
 #endif
 	}

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -568,7 +568,7 @@ void http_connection::connect()
 		// is, ec will be represent "success". If so, don't set it as the socks5
 		// hostname, just connect to the IP
 		error_code ec;
-		address adr = address::from_string(m_hostname, ec);
+		address adr = make_address(m_hostname, ec);
 
 		if (ec)
 		{

--- a/src/lsd.cpp
+++ b/src/lsd.cpp
@@ -68,9 +68,9 @@ static error_code dummy;
 
 lsd::lsd(io_service& ios, aux::lsd_callback& cb)
 	: m_callback(cb)
-	, m_socket(udp::endpoint(address_v4::from_string("239.192.152.143", dummy), 6771))
+	, m_socket(udp::endpoint(make_address_v4("239.192.152.143", dummy), 6771))
 #if TORRENT_USE_IPV6
-	, m_socket6(udp::endpoint(address_v6::from_string("ff15::efc0:988f", dummy), 6771))
+	, m_socket6(udp::endpoint(make_address_v6("ff15::efc0:988f", dummy), 6771))
 #endif
 	, m_broadcast_timer(ios)
 	, m_cookie((random(0x7fffffff) ^ std::uintptr_t(this)) & 0x7fffffff)

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -93,7 +93,7 @@ namespace libtorrent {
 		// special handling for raw IP addresses. There's no need to get in line
 		// behind actual lookups if we can just resolve it immediately.
 		error_code ec;
-		address const ip = address::from_string(host, ec);
+		address const ip = make_address(host, ec);
 		if (!ec)
 		{
 			std::vector<address> addresses;

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -892,7 +892,7 @@ namespace {
 		if (net_interface == nullptr || strlen(net_interface) == 0)
 			net_interface = "0.0.0.0";
 
-		interfaces_str = print_endpoint(tcp::endpoint(address::from_string(net_interface, ec), std::uint16_t(port_range.first)));
+		interfaces_str = print_endpoint(tcp::endpoint(make_address(net_interface, ec), std::uint16_t(port_range.first)));
 		if (ec) return;
 
 		p.set_str(settings_pack::listen_interfaces, interfaces_str);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -318,8 +318,8 @@ namespace aux {
 		for (int i = 0; i < len; ++i)
 		{
 			error_code ec;
-			address_v4 begin = address_v4::from_string(p[i].first, ec);
-			address_v4 end = address_v4::from_string(p[i].last, ec);
+			address_v4 begin = make_address_v4(p[i].first, ec);
+			address_v4 end = make_address_v4(p[i].last, ec);
 			if (ec) continue;
 			m_peer_class_filter.add_rule(begin, end, p[i].filter);
 		}
@@ -330,8 +330,8 @@ namespace aux {
 		for (int i = 0; i < len; ++i)
 		{
 			error_code ec;
-			address_v6 begin = address_v6::from_string(p[i].first, ec);
-			address_v6 end = address_v6::from_string(p[i].last, ec);
+			address_v6 begin = make_address_v6(p[i].first, ec);
+			address_v6 end = make_address_v6(p[i].last, ec);
 			if (ec) continue;
 			m_peer_class_filter.add_rule(begin, end, p[i].filter);
 		}
@@ -1751,7 +1751,7 @@ namespace {
 	{
 		// First, check to see if it's an IP address
 		error_code err;
-		address const adr = address::from_string(device.c_str(), err);
+		address const adr = make_address(device.c_str(), err);
 		if (!err)
 		{
 #if !TORRENT_USE_IPV6
@@ -5090,7 +5090,7 @@ namespace {
 		for (auto const& s : m_outgoing_interfaces)
 		{
 			error_code err;
-			address const ip = address::from_string(s.c_str(), err);
+			address const ip = make_address(s.c_str(), err);
 			if (err) continue;
 			if (ip == addr) return true;
 		}

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -121,7 +121,7 @@ namespace libtorrent {
 			// shave off the ':'
 			port = port.substr(1);
 #if TORRENT_USE_IPV6
-			ret.address(address_v6::from_string(addr.to_string(), ec));
+			ret.address(make_address_v6(addr.to_string(), ec));
 #else
 			ec = boost::asio::error::address_family_not_supported;
 #endif
@@ -137,7 +137,7 @@ namespace libtorrent {
 			}
 			addr = str.substr(0, port_pos);
 			port = str.substr(port_pos + 1);
-			ret.address(address_v4::from_string(addr.to_string(), ec));
+			ret.address(make_address_v4(addr.to_string(), ec));
 			if (ec) return ret;
 		}
 

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -179,7 +179,7 @@ namespace libtorrent {
 
 #if TORRENT_USE_IPV6
 			error_code ec;
-			address_v6::from_string(i.device, ec);
+			make_address_v6(i.device, ec);
 			if (!ec)
 			{
 				// IPv6 addresses must be wrapped in square brackets

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5916,7 +5916,7 @@ namespace libtorrent {
 		}
 
 		bool const is_ip = is_ip_address(hostname);
-		if (is_ip) a.address(address::from_string(hostname, ec));
+		if (is_ip) a.address(make_address(hostname, ec));
 		bool const proxy_hostnames = settings().get_bool(settings_pack::proxy_hostnames)
 			&& !is_ip;
 

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -249,7 +249,7 @@ void udp_socket::send_hostname(char const* hostname, int const port
 
 	// the overload that takes a hostname is really only supported when we're
 	// using a proxy
-	address target = address::from_string(hostname, ec);
+	address target = make_address(hostname, ec);
 	if (!ec) send(udp::endpoint(target, std::uint16_t(port)), p, ec, flags);
 }
 
@@ -378,7 +378,7 @@ bool udp_socket::unwrap(udp::endpoint& from, span<char>& buf)
 		if (len > buf.end() - p) return false;
 		std::string hostname(p, p + len);
 		error_code ec;
-		address addr = address::from_string(hostname, ec);
+		address addr = make_address(hostname, ec);
 		// we only support "hostnames" that are a dotted decimal IP
 		if (ec) return false;
 		p += len;

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -770,7 +770,7 @@ namespace libtorrent {
 			&& !settings.get_str(settings_pack::announce_ip).empty())
 		{
 			error_code ec;
-			address ip = address::from_string(settings.get_str(settings_pack::announce_ip).c_str(), ec);
+			address ip = make_address(settings.get_str(settings_pack::announce_ip).c_str(), ec);
 			if (!ec && ip.is_v4()) announce_ip = ip.to_v4();
 		}
 		aux::write_uint32(announce_ip.to_ulong(), out);

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -105,7 +105,7 @@ upnp::upnp(io_service& ios
 	, m_retry_count(0)
 	, m_io_service(ios)
 	, m_resolver(ios)
-	, m_socket(udp::endpoint(address_v4::from_string("239.255.255.250"
+	, m_socket(udp::endpoint(make_address_v4("239.255.255.250"
 		, ignore_error), 1900))
 	, m_broadcast_timer(ios)
 	, m_refresh_timer(ios)
@@ -1315,7 +1315,7 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 #ifndef TORRENT_DISABLE_LOGGING
 		log("got router external IP address %s", s.ip_address.c_str());
 #endif
-		d.external_ip = address::from_string(s.ip_address.c_str(), ignore_error);
+		d.external_ip = make_address(s.ip_address.c_str(), ignore_error);
 	}
 	else
 	{


### PR DESCRIPTION
I wanted to change the code only inside core libtorrent, and not in tests and bindings to easy the diff