### PR TITLE
fix m_in_constructor assert for peer_connection

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -184,6 +184,7 @@ namespace libtorrent {
 #endif
 #if TORRENT_USE_ASSERTS
 		piece_failed = false;
+		m_in_constructor = false;
 #endif
 	}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -869,6 +869,9 @@ namespace aux {
 			te.second->abort();
 		}
 		m_torrents.clear();
+		m_stats_counters.set_value(counters::num_peers_up_unchoked_all, 0);
+		m_stats_counters.set_value(counters::num_peers_up_unchoked, 0);
+		m_stats_counters.set_value(counters::num_peers_up_unchoked_optimistic, 0);
 
 #ifndef TORRENT_DISABLE_LOGGING
 		session_log(" aborting all tracker requests");
@@ -2941,9 +2944,6 @@ namespace {
 
 		std::shared_ptr<peer_connection> c
 			= std::make_shared<bt_peer_connection>(pack, get_peer_id());
-#if TORRENT_USE_ASSERTS
-		c->m_in_constructor = false;
-#endif
 
 		if (!c->is_disconnecting())
 		{

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -517,8 +517,8 @@ int EXPORT main(int argc, char const* argv[])
 			fclose(t.output);
 	}
 
-	if (redirect_stdout) dup2(old_stdout, fileno(stdout));
-	if (redirect_stderr) dup2(old_stderr, fileno(stderr));
+	if (redirect_stdout && old_stdout != -1) dup2(old_stdout, fileno(stdout));
+	if (redirect_stderr && old_stderr != -1) dup2(old_stderr, fileno(stderr));
 
 	if (!tests_to_run.empty())
 	{


### PR DESCRIPTION
if the peer connection is constructed, but bt_peer_connection constructor fails, it needs to be cleared. Fix an invariant in session on ungraceful shutdown. Make test framework a bit more robust.