### PR TITLE
Improve SSL performance by avoiding excessive memory allocations

### DIFF
--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -91,7 +91,7 @@ namespace libtorrent
 		// enough room, returns 0
 		char* allocate_appendix(int s);
 
-		std::list<asio::const_buffer> const& build_iovec(int to_send);
+		std::vector<asio::const_buffer> const& build_iovec(int to_send);
 
 		~chained_buffer();
 
@@ -103,7 +103,7 @@ namespace libtorrent
 
 		// this is the vector of buffers used when
 		// invoking the async write call
-		std::list<asio::const_buffer> m_tmp_vec;
+		std::vector<asio::const_buffer> m_tmp_vec;
 
 		// this is the number of bytes in the send buf.
 		// this will always be equal to the sum of the

--- a/src/chained_buffer.cpp
+++ b/src/chained_buffer.cpp
@@ -115,7 +115,7 @@ namespace libtorrent
 		return insert;
 	}
 
-	std::list<asio::const_buffer> const& chained_buffer::build_iovec(int to_send)
+	std::vector<asio::const_buffer> const& chained_buffer::build_iovec(int to_send)
 	{
 		m_tmp_vec.clear();
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4987,7 +4987,7 @@ namespace libtorrent
 #ifdef TORRENT_VERBOSE_LOGGING
 		peer_log(">>> ASYNC_WRITE [ bytes: %d ]", amount_to_send);
 #endif
-		std::list<asio::const_buffer> const& vec = m_send_buffer.build_iovec(amount_to_send);
+		std::vector<asio::const_buffer> const& vec = m_send_buffer.build_iovec(amount_to_send);
 #if defined TORRENT_ASIO_DEBUGGING
 		add_outstanding_async("peer_connection::on_send_data");
 #endif

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -202,7 +202,7 @@ bool compare_chained_buffer(chained_buffer& b, char const* mem, int size)
 {
 	if (size == 0) return true;
 	std::vector<char> flat(size);
-	std::list<libtorrent::asio::const_buffer> const& iovec2 = b.build_iovec(size);
+	std::vector<libtorrent::asio::const_buffer> const& iovec2 = b.build_iovec(size);
 	int copied = copy_buffers(iovec2, &flat[0]);
 	TEST_CHECK(copied == size);
 	return std::memcmp(&flat[0], mem, size) == 0;


### PR DESCRIPTION
Boost.Asio moves the io_op object multiple times per async SSL read/write operation: https://github.com/boostorg/asio/blob/develop/include/boost/asio/ssl/detail/io.hpp#L187
Move constuctor makes a **copy** of the internal op_ object: https://github.com/boostorg/asio/blob/develop/include/boost/asio/ssl/detail/io.hpp#L118
That in turn involves copying the container with memory buffers: https://github.com/boostorg/asio/blob/develop/include/boost/asio/ssl/detail/write_op.hpp#L59
With the container being an std::list, this causes a very large number of memory allocations for each write operation.
Replacing the container with a vector reduces the overhead by a factor of O(iovec.size()).
In my application this improved upload speed for SSL-enabled torrents by 7x (from 50MB/s to 350MB/s).