### PR TITLE
added friendly_name and description to ip_interface

### DIFF
--- a/include/libtorrent/enum_net.hpp
+++ b/include/libtorrent/enum_net.hpp
@@ -59,6 +59,8 @@ namespace libtorrent {
 		address interface_address;
 		address netmask;
 		char name[64];
+		char friendly_name[128];
+		char description[128];
 		// an interface is preferred if its address is
 		// not tentative/duplicate/deprecated
 		bool preferred = true;

--- a/test/enum_if.cpp
+++ b/test/enum_if.cpp
@@ -52,7 +52,7 @@ int main()
 	std::printf("Default gateway: %s\n", def_gw.to_string(ec).c_str());
 
 	std::printf("=========== Routes ===========\n");
-	std::vector<ip_route> routes = enum_routes(ios, ec);
+	auto const routes = enum_routes(ios, ec);
 	if (ec)
 	{
 		std::printf("%s\n", ec.message().c_str());
@@ -61,37 +61,36 @@ int main()
 
 	std::printf("%-18s%-18s%-35s%-7sinterface\n", "destination", "network", "gateway", "mtu");
 
-	for (std::vector<ip_route>::const_iterator i = routes.begin()
-		, end(routes.end()); i != end; ++i)
+	for (auto const& r : routes)
 	{
 		std::printf("%-18s%-18s%-35s%-7d%s\n"
-			, i->destination.to_string(ec).c_str()
-			, i->netmask.to_string(ec).c_str()
-			, i->gateway.to_string(ec).c_str()
-			, i->mtu
-			, i->name);
+			, r.destination.to_string(ec).c_str()
+			, r.netmask.to_string(ec).c_str()
+			, r.gateway.to_string(ec).c_str()
+			, r.mtu
+			, r.name);
 	}
 
 	std::printf("========= Interfaces =========\n");
 
-	std::vector<ip_interface> const& net = enum_net_interfaces(ios, ec);
+	auto const net = enum_net_interfaces(ios, ec);
 	if (ec)
 	{
 		std::printf("%s\n", ec.message().c_str());
 		return 1;
 	}
 
-	std::printf("%-34s%-45s%-20sflags\n", "address", "netmask", "name");
+	std::printf("%-34s%-45s%-20s%-20sdescription\n", "address", "netmask", "name", "flags");
 
-	for (std::vector<ip_interface>::const_iterator i = net.begin()
-		, end(net.end()); i != end; ++i)
+	for (auto const& i : net)
 	{
-		std::printf("%-34s%-45s%-20s%s%s%s\n"
-			, i->interface_address.to_string(ec).c_str()
-			, i->netmask.to_string(ec).c_str()
-			, i->name
-			, (i->interface_address.is_multicast()?"multicast ":"")
-			, (is_local(i->interface_address)?"local ":"")
-			, (is_loopback(i->interface_address)?"loopback ":""));
+		std::printf("%-34s%-45s%-20s%s%s%-20s%s %s\n"
+			, i.interface_address.to_string(ec).c_str()
+			, i.netmask.to_string(ec).c_str()
+			, i.name
+			, (i.interface_address.is_multicast()?"multicast ":"")
+			, (is_local(i.interface_address)?"local ":"")
+			, (is_loopback(i.interface_address)?"loopback ":"")
+			, i.friendly_name, i.description);
 	}
 }


### PR DESCRIPTION
The context of this change is:

1-) It's very useful in Windows to have this information to inspect while experimenting/debugging, because the device name is an ugly UUID.
2-) This `enum_net` code is very robust, in terms of multiplatform and security, compared to everything I see in other projects. Just adding this minimal change, allows me to use it in a particular way (to VPN detection heuristic) without repeating code.

It's possible to get a similar information in macOS with a combined use of `SCNetworkInterfaceGetLocalizedDisplayName` and `SCNetworkInterfaceGetBSDName`. I'm not changing any public API, and I'm fully aware of the risks if I insist in using it. Also, I don't discard that in the future this can be part of the public API.