### PR TITLE
utp retransmit and window size fix

### DIFF
--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -136,8 +136,6 @@ enum
 {
 	ACK_MASK = 0xffff,
 
-	// the number of packets that'll fit in the reorder buffer
-	max_packets_reorder = 4096,
 
 	// if a packet receives more than this number of
 	// duplicate acks, we'll trigger a fast re-send
@@ -2850,6 +2848,10 @@ bool utp_socket_impl::incoming_packet(boost::uint8_t const* buf, int size
 
 	if (ph->get_type() == ST_DATA)
 		m_sm->inc_stats_counter(counters::utp_payload_pkts_in);
+
+	// the number of packets that'll fit in the reorder buffer
+    // incoming MTU of 1100 and minimal size of 16 packets are chosen arbitrarly
+	const boost::uint32_t max_packets_reorder = std::max(16, m_in_buf_size / 1100);
 
 	if (m_state != UTP_STATE_NONE
 		&& m_state != UTP_STATE_SYN_SENT

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1827,8 +1827,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 	// if we have one MSS worth of data, make sure it fits in our
 	// congestion window and the advertised receive window from
 	// the other end.
-	if (m_bytes_in_flight + payload_size > (std::min)(int(m_cwnd >> 16)
-		, int(m_adv_wnd - m_bytes_in_flight)))
+	if (m_bytes_in_flight + payload_size > (std::min)(int(m_cwnd >> 16) , int(m_adv_wnd)))
 	{
 		// this means there's not enough room in the send window for
 		// another packet. We have to hold off sending this data.

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -137,7 +137,7 @@ enum
 	ACK_MASK = 0xffff,
 
 	// the number of packets that'll fit in the reorder buffer
-	max_packets_reorder = 512,
+	max_packets_reorder = 4096,
 
 	// if a packet receives more than this number of
 	// duplicate acks, we'll trigger a fast re-send
@@ -281,7 +281,7 @@ struct utp_socket_impl
 		, m_written(0)
 		, m_receive_buffer_size(0)
 		, m_read_buffer_size(0)
-		, m_in_buf_size(1024 * 1024)
+		, m_in_buf_size(8 * 1024 * 1024)
 		, m_in_packets(0)
 		, m_out_packets(0)
 		, m_send_delay(0)


### PR DESCRIPTION
This patch is the result of [work done by Tribler team](https://github.com/Tribler/tribler/issues/2620). It solves two problems:

1. uTP stream implementation has a bug that incorrectly counts `m_bytes_in_flight` twice when checking it against`m_adv_wnd`:
```
if (m_bytes_in_flight + payload_size > (std::min)(int(m_cwnd >> 16)
	, int(m_adv_wnd - m_bytes_in_flight)))
```
This results in _advertised window size_ effectively being cut in half, significantly reducing uTP performance on single-peer low-latency links. The patch fixes that problem. [Performance tests](https://github.com/Tribler/tribler/issues/2620#issuecomment-367688634) show immediate increase in uTP bandwidth usage.

2. uTP implementation parameters  `m_in_buf_size` and `max_packets_reorder` are too low for high-latency links. These set the limits of growth for `std::vector<packet*> m_receive_buffer`. 
As `m_receive_buffer` does not allocate any space by default, and is not affected in any way by `recv_socket_buffer_size` and `send_socket_buffer_size`, it is safe to increase `m_in_buf_size` and `max_packets_reorder` to better suit the high-latency, high-bandwidth links (such as satellite links and TOR-like tunnels). The [tests](https://github.com/Tribler/tribler/issues/2620#issuecomment-368549367) show immediate improvement of uTP performance on these kind of links.