### PR TITLE
fix issue querying block size from torrent

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -846,7 +846,7 @@ namespace libtorrent {
 
 		int block_size() const
 		{
-			return m_torrent_file
+			return valid_metadata()
 				? (std::min)(m_torrent_file->piece_length(), default_block_size)
 				: default_block_size;
 		}


### PR DESCRIPTION
before metadata has been received. Addresses https://github.com/arvidn/libtorrent/issues/2771