### PR TITLE
fix reporting &redundant= in tracker announces

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* fix reporting &redundant= in tracker announces
 	* fix tie-break in duplicate peer connection disconnect logic
 	* fix issue with SSL tracker connections left in CLOSE_WAIT state
 	* defer truncating existing files until the first time we write to them

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3203,6 +3203,8 @@ namespace {
 		// exclude redundant bytes if we should
 		if (!settings().get_bool(settings_pack::report_true_downloaded))
 			req.downloaded -= m_total_redundant_bytes;
+		if (settings().get_bool(settings_pack::report_redundant_bytes))
+			req.redundant = m_total_redundant_bytes;
 		if (req.downloaded < 0) req.downloaded = 0;
 
 		req.event = e;


### PR DESCRIPTION
discovered while investigating https://github.com/arvidn/libtorrent/issues/2724