### PR TITLE
fix compilation with android SDK < 21

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -193,11 +193,17 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #define TORRENT_HAVE_MMAP 1
-#define TORRENT_USE_NETLINK 1
 #define TORRENT_USE_IFADDRS 0
 #define TORRENT_USE_IFCONF 1
 #define TORRENT_HAS_SALEN 0
 #define TORRENT_USE_FDATASYNC 1
+
+// Android doesn't have NETLINK_ENOBUFS until API 21
+#if !defined __ANDROID_API__ || __ANDROID_API__ >= 21
+#define TORRENT_USE_NETLINK 1
+#else
+#define TORRENT_USE_NETLINK 0
+#endif
 
 // ===== ANDROID ===== (almost linux, sort of)
 #if defined __ANDROID__

--- a/src/cpuid.cpp
+++ b/src/cpuid.cpp
@@ -48,7 +48,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #if defined __GLIBC__ && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 16))
 #define TORRENT_HAS_AUXV 1
-#elif defined TORRENT_ANDROID
+#elif defined __ANDROID_API__ && __ANDROID_API__ >= 21
+// sys/auxv.h has been added in sdk 21
 #define TORRENT_HAS_AUXV 1
 #else
 #define TORRENT_HAS_AUXV 0


### PR DESCRIPTION
As explained in #2825, ``sys/auxv.h`` and ``NETLINK_ENOBUFS`` are not available until API 21. They were added quite late in the SDK, see for example this patch:
https://android.googlesource.com/platform/bionic/+/2c5153b043b44e9935a334ae9b2d5a4bc5258b40

This PR adds checks so that it enables netlink and auxv only if ``ANDROID_API`` is greater or equal than 21.

Maybe the part about defining ``TORRENT_HAS_AUXV`` should be moved to the ``include/libtorrent/config.hpp`` file. If so, I can make the change.