### PR TITLE
dynamically load getauxval so as to support older android devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,6 +619,10 @@ if (WIN32)
 	endif()
 endif()
 
+if(ANDROID)
+    target_link_libraries(torrent-rasterbar dl)
+endif()
+
 if(APPLE)
 	# for ip_notifier
 	target_link_libraries(torrent-rasterbar "-framework CoreFoundation" "-framework SystemConfiguration")

--- a/Jamfile
+++ b/Jamfile
@@ -88,6 +88,11 @@ rule linking ( properties * )
 		}
 	}
 
+	if <target-os>android in $(properties)
+	{
+		result += <library>dl ;
+	}
+
 	if <target-os>beos in $(properties)
 	{
 		result += <library>netkit <library>gcc ;

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,21 @@ AS_ECHO "Initializing Libtool:"
 LT_PREREQ([2.2.6])
 LT_INIT
 
+AS_IF([test "$SYS" = linux],[
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM(
+        [[#ifndef __ANDROID__
+         # error Not Android
+         #endif
+        ]],[[;]])
+    ],[
+      HAVE_ANDROID="1"
+      AC_MSG_RESULT([yes])
+    ],[
+      AC_MSG_RESULT([no])
+    ])
+])
+AM_CONDITIONAL(HAVE_ANDROID, test "${HAVE_ANDROID}" = "1")
+
 
 ###############################################################################
 # Checking for needed base libraries

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,10 @@ libtorrent_rasterbar_la_SOURCES = \
 libtorrent_rasterbar_la_LDFLAGS = -version-info $(INTERFACE_VERSION_INFO)
 libtorrent_rasterbar_la_LIBADD = @OPENSSL_LIBS@
 
+if HAVE_ANDROID
+libtorrent_rasterbar_la_LIBADD += -ldl
+endif
+
 AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY -I$(top_srcdir)/include -I$(top_srcdir)/ed25519/src @DEBUGFLAGS@ @OPENSSL_INCLUDES@
 AM_CFLAGS = -I$(top_srcdir)/ed25519/src -std=c99
 


### PR DESCRIPTION
Dynamically load getauxval just like android cpufeatures module does. It allows cpuid module to work on android even on older android sdk versions for which the ``sys/auxv.h`` header is not present.

See #2825 