### PR TITLE
Add missing define for old android sdk

### DIFF
--- a/include/libtorrent/socket.hpp
+++ b/include/libtorrent/socket.hpp
@@ -68,6 +68,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef SOL_NETLINK
 #define SOL_NETLINK 270
 #endif
+
+// NETLINK_NO_ENOBUFS exists at least since android 2.3, but is not exposed
+#if TORRENT_ANDROID && !defined NETLINK_NO_ENOBUFS
+#define NETLINK_NO_ENOBUFS 5
+#endif
 #endif
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -92,6 +92,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
+
+#if TORRENT_ANDROID && !defined IFA_F_DADFAILED
+#define IFA_F_DADFAILED 8
+#endif
+
 #endif
 
 #if TORRENT_USE_IFADDRS


### PR DESCRIPTION
On old android SDK, before unified header, NETLINK_NO_ENOBUFS and IFA_D_DADFAILED don't exist, but seems to be supported. Define them with their known values in that case.

See #2825