### PR TITLE
add windows socket libraries in Makefile.am

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,13 @@ AS_IF([test "$SYS" = linux],[
 ])
 AM_CONDITIONAL(HAVE_ANDROID, test "${HAVE_ANDROID}" = "1")
 
+HAVE_WINDOWS=0
+case "${host_os}" in
+    *mingw32* | *cygwin*)
+        HAVE_WINDOWS=1
+        ;;
+esac
+AM_CONDITIONAL(HAVE_WINDOWS, test "${HAVE_WINDOWS}" = "1")
 
 ###############################################################################
 # Checking for needed base libraries

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -171,15 +171,21 @@ libtorrent_rasterbar_la_SOURCES = \
   \
   $(BUILTIN_CRYPTO_SOURCES)
 
+AM_CFLAGS = -I$(top_srcdir)/ed25519/src -std=c99
+AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY -I$(top_srcdir)/include -I$(top_srcdir)/ed25519/src @DEBUGFLAGS@ @OPENSSL_INCLUDES@
+AM_LDFLAGS = @OPENSSL_LDFLAGS@
+
 libtorrent_rasterbar_la_LDFLAGS = -version-info $(INTERFACE_VERSION_INFO)
 libtorrent_rasterbar_la_LIBADD = @OPENSSL_LIBS@
+libtorrent_rasterbar_la_CPPFLAGS = $(AM_CPPFLAGS)
 
 if HAVE_ANDROID
 libtorrent_rasterbar_la_LIBADD += -ldl
 endif
 
-AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY -I$(top_srcdir)/include -I$(top_srcdir)/ed25519/src @DEBUGFLAGS@ @OPENSSL_INCLUDES@
-AM_CFLAGS = -I$(top_srcdir)/ed25519/src -std=c99
+if HAVE_WINDOWS
+libtorrent_rasterbar_la_LIBADD += -liphlpapi -lws2_32 -lwsock32
+libtorrent_rasterbar_la_CPPFLAGS += -DWIN32_LEAN_AND_MEAN -D__USE_W32_SOCKETS -DWIN32 -D_WIN32
+endif
 
-AM_LDFLAGS = @OPENSSL_LDFLAGS@
 


### PR DESCRIPTION
Fix link issues when cross compiling for windows with mingw.

I don't know if autotools' scripts are also expected to work with MSVC, but as they are linked in the other build scripts, I think it's ok.

Fixes #2833