### PR TITLE
fix if defined TORRENT_ANDROID

### DIFF
--- a/include/libtorrent/socket.hpp
+++ b/include/libtorrent/socket.hpp
@@ -70,7 +70,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 // NETLINK_NO_ENOBUFS exists at least since android 2.3, but is not exposed
-#if TORRENT_ANDROID && !defined NETLINK_NO_ENOBUFS
+#if defined TORRENT_ANDROID && !defined NETLINK_NO_ENOBUFS
 #define NETLINK_NO_ENOBUFS 5
 #endif
 #endif

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -93,7 +93,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <sys/types.h>
 
-#if TORRENT_ANDROID && !defined IFA_F_DADFAILED
+#if defined TORRENT_ANDROID && !defined IFA_F_DADFAILED
 #define IFA_F_DADFAILED 8
 #endif
 


### PR DESCRIPTION
Fix malformed TORRENT_ANDROID macroprocessor tests, related to #2831 

Sorry for disturbance, I need to write proper test for android so that I don't fail my build test again.

It definitely fixes #2825 