### PR TITLE
Fix resuming partially checked torrent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8646,6 +8646,10 @@ namespace {
 		// to be in downloading state (which it will be set to shortly)
 //		INVARIANT_CHECK;
 
+		// workaround for torrent getting stuck in `downloading` state
+		if (!are_files_checked())
+			set_state(torrent_status::checking_files);
+
 		if (m_state == torrent_status::checking_resume_data
 			|| m_state == torrent_status::checking_files
 			|| m_state == torrent_status::allocating)

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -76,7 +76,7 @@ enum
 	force_recheck = 8,
 };
 
-void test_checking(int flags = 0)
+void test_checking(int flags)
 {
 	using namespace libtorrent;
 	namespace lt = libtorrent;
@@ -272,7 +272,7 @@ void test_checking(int flags = 0)
 
 TORRENT_TEST(checking)
 {
-	test_checking();
+	test_checking(0);
 }
 
 TORRENT_TEST(read_only_corrupt)

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -40,10 +40,43 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/torrent_status.hpp"
 
-static const int file_sizes[] =
-{ 0, 5, 16 - 5, 16000, 17, 10, 8000, 8000, 1,1,1,1,1,100,1,1,1,1,100,1,1,1,1,1,1
-	,1,1,1,1,1,1,13,65000,34,75,2,30,400,500,23000,900,43000,400,4300,6, 4};
-const int num_files = sizeof(file_sizes)/sizeof(file_sizes[0]);
+namespace
+{
+	const int file_sizes[] =
+	{ 0, 5, 16 - 5, 16000, 17, 10, 8000, 8000, 1,1,1,1,1,100,1,1,1,1,100,1,1,1,1,1,1
+		,1,1,1,1,1,1,13,65000,34,75,2,30,400,500,23000,900,43000,400,4300,6, 4 };
+	const int num_files = sizeof(file_sizes) / sizeof(file_sizes[0]);
+
+	bool is_checking(int const state)
+	{
+		return state == lt::torrent_status::checking_files
+#ifndef TORRENT_NO_DEPRECATE
+			|| state == lt::torrent_status::queued_for_checking
+#endif
+			|| state == lt::torrent_status::checking_resume_data;
+	};
+
+	lt::settings_pack test_settings()
+	{
+		using namespace lt;
+
+		int const mask = alert::all_categories
+			& ~(alert::progress_notification
+				| alert::performance_warning
+				| alert::stats_notification);
+
+		settings_pack pack;
+		pack.set_bool(settings_pack::enable_lsd, false);
+		pack.set_bool(settings_pack::enable_natpmp, false);
+		pack.set_bool(settings_pack::enable_upnp, false);
+		pack.set_bool(settings_pack::enable_dht, false);
+		pack.set_int(settings_pack::alert_mask, mask);
+		pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:48000");
+		pack.set_int(settings_pack::max_retry_port_bind, 1000);
+
+		return pack;
+	}
+}
 
 enum
 {
@@ -63,7 +96,7 @@ enum
 	force_recheck = 8,
 };
 
-void test_checking(int flags = read_only_files)
+void test_checking(int flags = 0)
 {
 	using namespace libtorrent;
 	namespace lt = libtorrent;
@@ -167,20 +200,7 @@ void test_checking(int flags = read_only_files)
 			, ec.value(), ec.message().c_str());
 	}
 
-	int const mask = alert::all_categories
-		& ~(alert::progress_notification
-			| alert::performance_warning
-			| alert::stats_notification);
-
-	settings_pack pack;
-	pack.set_bool(settings_pack::enable_lsd, false);
-	pack.set_bool(settings_pack::enable_natpmp, false);
-	pack.set_bool(settings_pack::enable_upnp, false);
-	pack.set_bool(settings_pack::enable_dht, false);
-	pack.set_int(settings_pack::alert_mask, mask);
-	pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:48000");
-	pack.set_int(settings_pack::max_retry_port_bind, 1000);
-	lt::session ses1(pack);
+	lt::session ses1(test_settings());
 
 	add_torrent_params p;
 	p.save_path = ".";
@@ -216,15 +236,7 @@ void test_checking(int flags = read_only_files)
 
 		printf("%d %f %s\n", st.state, st.progress_ppm / 10000.f, st.errc.message().c_str());
 
-		if (
-#ifndef TORRENT_NO_DEPRECATE
-			st.state != torrent_status::queued_for_checking &&
-#endif
-			st.state != torrent_status::checking_files
-			&& st.state != torrent_status::checking_resume_data)
-			break;
-
-		if (st.errc) break;
+		if (!is_checking(st.state) || st.errc) break;
 		test_sleep(500);
 	}
 
@@ -308,3 +320,46 @@ TORRENT_TEST(force_recheck)
 	test_checking(force_recheck);
 }
 
+TORRENT_TEST(discrete_checking)
+{
+	using namespace lt;
+	printf("\n==== TEST CHECKING discrete =====\n\n");
+	error_code ec;
+	create_directory("test_torrent_dir", ec);
+	if (ec) printf("ERROR: creating directory test_torrent_dir: (%d) %s\n", ec.value(), ec.message().c_str());
+
+	int const megabyte = 0x100000;
+	int const piece_size = 2 * megabyte;
+	int const file_sizes[] = { 25 * megabyte, 15 * megabyte };
+	int const num_files = sizeof(file_sizes) / sizeof(file_sizes[0]);
+
+	file_storage fs;
+	create_random_files("test_torrent_dir", file_sizes, num_files, &fs);
+	lt::create_torrent t(fs, piece_size, 0, lt::create_torrent::optimize_alignment);
+	set_piece_hashes(t, ".", ec);
+	if (ec) printf("ERROR: set_piece_hashes: (%d) %s\n", ec.value(), ec.message().c_str());
+
+	std::vector<char> buf;
+	bencode(std::back_inserter(buf), t.generate());
+	boost::shared_ptr<torrent_info> ti(new torrent_info(&buf[0], buf.size(), ec));
+	printf("generated torrent: %s test_torrent_dir\n", to_hex(ti->info_hash().to_string()).c_str());
+	TEST_EQUAL(ti->num_files(), 3);
+	{
+		session ses1(test_settings());
+		add_torrent_params p;
+		p.file_priorities.resize(ti->num_files());
+		p.file_priorities[0] = 1;
+		p.save_path = ".";
+		p.ti = ti;
+		torrent_handle tor1 = ses1.add_torrent(p, ec);
+		TEST_CHECK(wait_for_alert(ses1, torrent_finished_alert::alert_type, "checking file 0"));
+		std::vector<int> prio(ti->num_files(), 0);
+		prio[2] = 1;
+		tor1.prioritize_files(prio);
+		TEST_CHECK(wait_for_alert(ses1, torrent_finished_alert::alert_type, "checking file 1"));
+		TEST_CHECK(wait_for_alert(ses1, torrent_checked_alert::alert_type, "torrent checked"));
+		TEST_CHECK(tor1.status(0).is_seeding);
+	}
+	remove_all("test_torrent_dir", ec);
+	if (ec) fprintf(stdout, "ERROR: removing test_torrent_dir: (%d) %s\n", ec.value(), ec.message().c_str());
+}

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "test.hpp"
+#include "settings.hpp"
 #include "setup_transfer.hpp"
 #include "libtorrent/create_torrent.hpp"
 #include "libtorrent/alert_types.hpp"
@@ -55,27 +56,6 @@ namespace
 #endif
 			|| state == lt::torrent_status::checking_resume_data;
 	};
-
-	lt::settings_pack test_settings()
-	{
-		using namespace lt;
-
-		int const mask = alert::all_categories
-			& ~(alert::progress_notification
-				| alert::performance_warning
-				| alert::stats_notification);
-
-		settings_pack pack;
-		pack.set_bool(settings_pack::enable_lsd, false);
-		pack.set_bool(settings_pack::enable_natpmp, false);
-		pack.set_bool(settings_pack::enable_upnp, false);
-		pack.set_bool(settings_pack::enable_dht, false);
-		pack.set_int(settings_pack::alert_mask, mask);
-		pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:48000");
-		pack.set_int(settings_pack::max_retry_port_bind, 1000);
-
-		return pack;
-	}
 }
 
 enum
@@ -200,7 +180,7 @@ void test_checking(int flags = 0)
 			, ec.value(), ec.message().c_str());
 	}
 
-	lt::session ses1(test_settings());
+	lt::session ses1(settings());
 
 	add_torrent_params p;
 	p.save_path = ".";
@@ -345,7 +325,7 @@ TORRENT_TEST(discrete_checking)
 	printf("generated torrent: %s test_torrent_dir\n", to_hex(ti->info_hash().to_string()).c_str());
 	TEST_EQUAL(ti->num_files(), 3);
 	{
-		session ses1(test_settings());
+		session ses1(settings());
 		add_torrent_params p;
 		p.file_priorities.resize(ti->num_files());
 		p.file_priorities[0] = 1;


### PR DESCRIPTION
Torrent can't resume downloading when file priorities prevent the full
check. If file priorities are changed and torrent has unverified piece
hashes, then it will stuck in downloading state. The only way to handle
this is to perform a `force_recheck`.

* Add .editorconfig file to enforce code style
* Fix TORRENT_TEST(checking) <=> TORRENT_TEST(read_only)