### PR TITLE
don't treat a short read in a hash job as a fatal error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ set(sources
 	disk_buffer_holder
 	entry
 	error_code
+	file_view_pool
 	file_storage
 	file_progress
 	lazy_bdecode

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -659,14 +659,6 @@ namespace libtorrent {
 				ret += file_range.size();
 			}
 
-			if (ret == 0)
-			{
-				ec.operation = operation_t::file_read;
-				ec.ec = boost::asio::error::eof;
-				ec.file(file_index);
-				return -1;
-			}
-
 			return static_cast<int>(ret);
 		});
 	}

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -192,6 +192,8 @@ namespace libtorrent { namespace aux {
 				{
 					// fill in this information in case the caller wants to treat
 					// a short-read as an error
+					ec.operation = operation_t::file_read;
+					ec.ec = boost::asio::error::eof;
 					ec.file(file_index);
 				}
 				return size - bytes_left;

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -496,7 +496,7 @@ TORRENT_TEST(unc_paths)
 	error_code ec;
 	{
 		file f;
-		TEST_CHECK(f.open(reserved_name, open_mode::read_write, ec) && !ec);
+		TEST_CHECK(f.open(reserved_name, aux::open_mode::write, ec) && !ec);
 	}
 	remove(reserved_name, ec);
 	TEST_CHECK(!ec);


### PR DESCRIPTION
The eof error code will still be communicated to the handler so this
doesn't change behavior with the current code. This will become
important with v2 support where we may be doing multiple hash operations
in the same hash job. If the first hash op gets an eof we still want to
perform the second hash to keep the results consistent.