### PR TITLE
Add alert when piece passes hash check and is written to disk

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* add alert when a piece is written to disk and passed the hash check
 	* fix issue where setting file/piece priority would stop checking
 	* expose post_dht_stats() to python binding
 	* fix backwards compatibility to downloads without partfiles

--- a/include/libtorrent/alert.hpp
+++ b/include/libtorrent/alert.hpp
@@ -190,6 +190,9 @@ namespace libtorrent {
 			// enables verbose logging from the piece picker.
 			picker_log_notification       = 0x100000,
 
+			// alerts when pieces are verified and written to disk
+			piece_progress_notification   = 0x200000,
+
 			// The full bitmask, representing all available categories.
 			//
 			// since the enum is signed, make sure this isn't

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2516,9 +2516,9 @@ namespace libtorrent
 		piece_ready_alert(aux::stack_allocator& alloc, torrent_handle h
 			, int piece_num);
 
-		TORRENT_DEFINE_ALERT(piece_ready_alert, 90)
+		TORRENT_DEFINE_ALERT_PRIO(piece_ready_alert, 90)
 
-		static const int static_category = alert::progress_notification;
+		static const int static_category = alert::piece_progress_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
 
 		int piece_index;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2507,12 +2507,30 @@ namespace libtorrent
 #endif // TORRENT_DISABLE_LOGGING
 	};
 
+	// This alert is generated when a piece has passed the hash check and has
+	// been written to disk (so it can be safely read). This alert may be generated
+	// more than once for each piece.
+	struct TORRENT_EXPORT piece_ready_alert TORRENT_FINAL : torrent_alert
+	{
+		// internal
+		piece_ready_alert(aux::stack_allocator& alloc, torrent_handle h
+			, int piece_num);
+
+		TORRENT_DEFINE_ALERT(piece_ready_alert, 90)
+
+		static const int static_category = alert::progress_notification;
+		virtual std::string message() const TORRENT_OVERRIDE;
+
+		int piece_index;
+	};
+
+
 #undef TORRENT_DEFINE_ALERT_IMPL
 #undef TORRENT_DEFINE_ALERT
 #undef TORRENT_DEFINE_ALERT_PRIO
 #undef TORRENT_CLONE
 
-	enum { num_alert_types = 90 }; // this enum represents "max_alert_index" + 1
+	enum { num_alert_types = 91 }; // this enum represents "max_alert_index" + 1
 }
 
 

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -385,7 +385,7 @@ namespace libtorrent
 		// or if we have the piece
 		bool is_piece_finished(int index) const;
 
-		// returns true if all blocks in this piece are finished
+		// returns true if the piece has passed the hash check
 		// and have been written to disk
 		bool is_piece_ready(int index) const;
 

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -385,6 +385,10 @@ namespace libtorrent
 		// or if we have the piece
 		bool is_piece_finished(int index) const;
 
+		// returns true if all blocks in this piece are finished
+		// and have been written to disk
+		bool is_piece_ready(int index) const;
+
 		// returns true if we have the piece or if the piece
 		// has passed the hash check
 		bool has_piece_passed(int index) const;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -593,6 +593,22 @@ namespace libtorrent {
 		return ret;
 	}
 
+	piece_ready_alert::piece_ready_alert(aux::stack_allocator& alloc, torrent_handle h
+		, int piece_num)
+		: torrent_alert(alloc, h)
+		, piece_index(piece_num)
+	{
+		TORRENT_ASSERT(piece_index >= 0);
+	}
+
+	std::string piece_ready_alert::message() const
+	{
+		char ret[200];
+		snprintf(ret, sizeof(ret), "%s piece %i is ready"
+			, torrent_alert::message().c_str(), piece_index);
+		return ret;
+	}
+
 	block_downloading_alert::block_downloading_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep
 		, peer_id const& peer_id, int block_num, int piece_num)

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -3064,6 +3064,15 @@ namespace libtorrent
 //			, peer_info_struct(), block_finished.piece_index, block_finished.block_index);
 		picker.mark_as_finished(block_finished, peer_info_struct());
 
+		if (picker.is_piece_ready(block_finished.piece_index))
+		{
+			if (t->alerts().should_post<piece_ready_alert>())
+			{
+				t->alerts().emplace_alert<piece_ready_alert>(t->get_handle(),
+					int(block_finished.piece_index));
+			}
+		}
+
 		t->maybe_done_flushing();
 
 		if (t->alerts().should_post<block_finished_alert>())

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -3064,9 +3064,9 @@ namespace libtorrent
 //			, peer_info_struct(), block_finished.piece_index, block_finished.block_index);
 		picker.mark_as_finished(block_finished, peer_info_struct());
 
-		if (picker.is_piece_ready(block_finished.piece_index))
+		if (t->alerts().should_post<piece_ready_alert>())
 		{
-			if (t->alerts().should_post<piece_ready_alert>())
+			if (picker.is_piece_ready(block_finished.piece_index))
 			{
 				t->alerts().emplace_alert<piece_ready_alert>(t->get_handle(),
 					int(block_finished.piece_index));

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -2921,6 +2921,26 @@ get_out:
 		return true;
 	}
 
+	bool piece_picker::is_piece_ready(int index) const
+	{
+		if (!is_piece_finished(index))
+			return false;
+
+		piece_pos const& p = m_piece_map[index];
+		int state = p.download_queue();
+
+		if (state < piece_pos::num_download_categories)
+		{
+			std::vector<downloading_piece>::const_iterator i =
+				find_dl_piece(state, index);
+			TORRENT_ASSERT(i != m_downloads[state].end());
+			if (int(i->finished) < blocks_in_piece(index))
+				return false;
+		}
+
+		return true;
+	}
+
 	bool piece_picker::has_piece_passed(int index) const
 	{
 		TORRENT_ASSERT(index < int(m_piece_map.size()));

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1523,6 +1523,16 @@ namespace libtorrent
 		if (picker().is_finished(block_finished)) return;
 
 		picker().mark_as_finished(block_finished, 0);
+
+		if (picker().is_piece_ready(block_finished.piece_index))
+		{
+			if (alerts().should_post<piece_ready_alert>())
+			{
+				alerts().emplace_alert<piece_ready_alert>(get_handle(),
+					block_finished.piece_index);
+			}
+		}
+
 		maybe_done_flushing();
 	}
 
@@ -4381,6 +4391,14 @@ namespace {
 
 		if (m_ses.alerts().should_post<piece_finished_alert>())
 			m_ses.alerts().emplace_alert<piece_finished_alert>(get_handle(), index);
+
+		if (has_picker() && picker().is_piece_ready(index))
+		{
+			if (alerts().should_post<piece_ready_alert>())
+			{
+				alerts().emplace_alert<piece_ready_alert>(get_handle(), index);
+			}
+		}
 
 		// update m_file_progress (if we have one)
 		m_file_progress.update(m_torrent_file->files(), index

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1524,9 +1524,9 @@ namespace libtorrent
 
 		picker().mark_as_finished(block_finished, 0);
 
-		if (picker().is_piece_ready(block_finished.piece_index))
+		if (alerts().should_post<piece_ready_alert>())
 		{
-			if (alerts().should_post<piece_ready_alert>())
+			if (picker().is_piece_ready(block_finished.piece_index))
 			{
 				alerts().emplace_alert<piece_ready_alert>(get_handle(),
 					block_finished.piece_index);
@@ -4392,9 +4392,9 @@ namespace {
 		if (m_ses.alerts().should_post<piece_finished_alert>())
 			m_ses.alerts().emplace_alert<piece_finished_alert>(get_handle(), index);
 
-		if (has_picker() && picker().is_piece_ready(index))
+		if (alerts().should_post<piece_ready_alert>())
 		{
-			if (alerts().should_post<piece_ready_alert>())
+			if (has_picker() && picker().is_piece_ready(index))
 			{
 				alerts().emplace_alert<piece_ready_alert>(get_handle(), index);
 			}


### PR DESCRIPTION
Add a new alert, piece_ready_alert, that is generated when a piece has
passed the hash check and has been written to disk. This alert may be
generated more than once for some pieces.