### PR TITLE
avoid calls to .address() when looking for endpoint protocol

### DIFF
--- a/include/libtorrent/broadcast_socket.hpp
+++ b/include/libtorrent/broadcast_socket.hpp
@@ -53,6 +53,18 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT bool is_teredo(address const& addr);
 	TORRENT_EXTRA_EXPORT bool is_ip_address(std::string const& host);
 
+	// TODO: refactor these out too
+	template <typename Endpoint>
+	bool is_v4(Endpoint const& ep)
+	{
+		return ep.protocol() == Endpoint::protocol_type::v4();
+	}
+	template <typename Endpoint>
+	bool is_v6(Endpoint const& ep)
+	{
+		return ep.protocol() == Endpoint::protocol_type::v6();
+	}
+
 	// determines if the operating system supports IPv6
 	TORRENT_EXTRA_EXPORT bool supports_ipv6();
 	address ensure_v6(address const& a);

--- a/include/libtorrent/broadcast_socket.hpp
+++ b/include/libtorrent/broadcast_socket.hpp
@@ -112,7 +112,7 @@ namespace libtorrent {
 				error_code ec;
 				return broadcast
 					&& netmask != address_v4()
-					&& socket->local_endpoint(ec).address().is_v4();
+					&& is_v4(socket->local_endpoint(ec));
 			}
 			address_v4 broadcast_address() const
 			{

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -58,6 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/peer_info.hpp" // for peer_source_flags_t
 #include "libtorrent/download_priority.hpp"
 #include "libtorrent/pex_flags.hpp"
+#include "libtorrent/broadcast_socket.hpp" // for is_v6
 
 namespace libtorrent {
 namespace aux {
@@ -125,7 +126,7 @@ namespace aux {
 		void set_peer(tcp::endpoint const& ep)
 		{
 #if TORRENT_USE_IPV6
-			is_v6_addr = ep.address().is_v6();
+			is_v6_addr = is_v6(ep);
 			if (is_v6_addr)
 				addr.v6 = ep.address().to_v6().to_bytes();
 			else

--- a/include/libtorrent/utp_stream.hpp
+++ b/include/libtorrent/utp_stream.hpp
@@ -40,6 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/time.hpp"
 #include "libtorrent/close_reason.hpp"
+#include "libtorrent/broadcast_socket.hpp" // for is_v4
 
 #include <functional>
 
@@ -299,7 +300,7 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 	template <class Handler>
 	void async_connect(endpoint_type const& endpoint, Handler const& handler)
 	{
-		if (!endpoint.address().is_v4())
+		if (!is_v4(endpoint))
 		{
 			m_io_service.post(std::bind<void>(handler, boost::asio::error::operation_not_supported));
 			return;

--- a/simulation/test_dht.cpp
+++ b/simulation/test_dht.cpp
@@ -66,7 +66,7 @@ void bootstrap_session(std::vector<dht_network*> networks, lt::session& ses)
 
 		char const* nodes_key;
 
-		if (is_v6(router_nodes.front()))
+		if (lt::is_v6(router_nodes.front()))
 			nodes_key = "nodes6";
 		else
 			nodes_key = "nodes";
@@ -184,8 +184,8 @@ TORRENT_TEST(dht_dual_stack_get_peers)
 				for (lt::tcp::endpoint const& peer : peers)
 				{
 					// TODO: verify that the endpoint matches the session's
-					got_peer_v4 |= is_v4(peer);
-					got_peer_v6 |= is_v6(peer);
+					got_peer_v4 |= lt::is_v4(peer);
+					got_peer_v6 |= lt::is_v6(peer);
 				}
 			}
 		}

--- a/simulation/test_dht.cpp
+++ b/simulation/test_dht.cpp
@@ -48,7 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/kademlia/ed25519.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/kademlia/item.hpp"
-
+#include "libtorrent/broadcast_socket.hpp"
 
 #ifndef TORRENT_DISABLE_DHT
 void bootstrap_session(std::vector<dht_network*> networks, lt::session& ses)
@@ -347,4 +347,3 @@ TORRENT_TEST(dht_dual_stack_mutable_item)
 
 #endif // TORRENT_DISABLE_DHT
 }
-

--- a/simulation/test_dht.cpp
+++ b/simulation/test_dht.cpp
@@ -66,7 +66,7 @@ void bootstrap_session(std::vector<dht_network*> networks, lt::session& ses)
 
 		char const* nodes_key;
 
-		if (router_nodes.front().address().is_v6())
+		if (is_v6(router_nodes.front()))
 			nodes_key = "nodes6";
 		else
 			nodes_key = "nodes";
@@ -184,8 +184,8 @@ TORRENT_TEST(dht_dual_stack_get_peers)
 				for (lt::tcp::endpoint const& peer : peers)
 				{
 					// TODO: verify that the endpoint matches the session's
-					got_peer_v4 |= peer.address().is_v4();
-					got_peer_v6 |= peer.address().is_v6();
+					got_peer_v4 |= is_v4(peer);
+					got_peer_v6 |= is_v6(peer);
 				}
 			}
 		}

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -473,7 +473,7 @@ void test_udpv6_support(char const* listen_interfaces
 						a->message().c_str());
 					if (auto tr = alert_cast<tracker_announce_alert>(a))
 					{
-						if (tr->local_endpoint.address().is_v4())
+						if (is_v4(tr->local_endpoint))
 							++v4_announces;
 						else
 							++v6_announces;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2071,7 +2071,7 @@ namespace {
 	{
 		for (auto const& endp : peers)
 		{
-			if (endp.protocol() == tcp::v4())
+			if (is_v4(endp))
 				m_v4_num_peers++;
 #if TORRENT_USE_IPV6
 			else
@@ -2088,7 +2088,7 @@ namespace {
 #endif
 		for (auto const& endp : peers)
 		{
-			if (endp.protocol() == tcp::v4())
+			if (is_v4(endp))
 				detail::write_endpoint(endp, v4_ptr);
 #if TORRENT_USE_IPV6
 			else
@@ -2304,7 +2304,7 @@ namespace {
 
 		for (auto const& n : nodes)
 		{
-			if (n.second.protocol() == udp::v4())
+			if (is_v4(n.second))
 				v4_num_nodes++;
 #if TORRENT_USE_IPV6
 			else
@@ -2322,7 +2322,7 @@ namespace {
 		for (auto const& n : nodes)
 		{
 			udp::endpoint const& endp = n.second;
-			if (endp.protocol() == udp::v4())
+			if (is_v4(endp))
 			{
 				detail::write_string(n.first.to_string(), v4_ptr);
 				detail::write_endpoint(endp, v4_ptr);

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -179,7 +179,7 @@ namespace libtorrent {
 		std::vector<ip_interface> interfaces = enum_net_interfaces(ios, ec);
 
 #if TORRENT_USE_IPV6
-		if (m_multicast_endpoint.protocol() == udp::v6())
+		if (is_v6(m_multicast_endpoint))
 			open_multicast_socket(ios, address_v6::any(), loopback, ec);
 		else
 #endif
@@ -188,7 +188,7 @@ namespace libtorrent {
 		for (auto const& i : interfaces)
 		{
 			// only multicast on compatible networks
-			if (i.interface_address.is_v4() != m_multicast_endpoint.address().is_v4()) continue;
+			if (i.interface_address.is_v4() != is_v4(m_multicast_endpoint)) continue;
 			// ignore any loopback interface
 			if (!loopback && is_loopback(i.interface_address)) continue;
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -123,7 +123,7 @@ namespace {
 	bool ut_pex_peer_store::was_introduced_by(tcp::endpoint const &ep)
 	{
 #if TORRENT_USE_IPV6
-		if (ep.protocol() == tcp::v4())
+		if (is_v4(ep))
 		{
 #endif
 			peers4_t::value_type const v(ep.address().to_v4().to_bytes(), ep.port());
@@ -1507,7 +1507,7 @@ namespace {
 		char buf[35];
 		char* ptr = buf + 6;
 		detail::write_uint8(type, ptr);
-		if (ep.address().is_v4()) detail::write_uint8(0, ptr);
+		if (is_v4(ep)) detail::write_uint8(0, ptr);
 		else detail::write_uint8(1, ptr);
 		detail::write_endpoint(ep, ptr);
 

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -530,11 +530,11 @@ void http_connection::on_resolve(error_code const& e
 		auto new_end = std::partition(m_endpoints.begin(), m_endpoints.end()
 			, [this] (tcp::endpoint const& ep)
 		{
-			if (ep.address().is_v4() != m_bind_addr->is_v4())
+			if (is_v4(ep) != m_bind_addr->is_v4())
 				return false;
-			if (ep.address().is_v4() && m_bind_addr->is_v4())
+			if (is_v4(ep) && m_bind_addr->is_v4())
 				return true;
-			TORRENT_ASSERT(ep.address().is_v6() && m_bind_addr->is_v6());
+			TORRENT_ASSERT(is_v6(ep) && m_bind_addr->is_v6());
 			// don't try to connect to a global address with a local source address
 			// this is mainly needed to prevent attempting to connect to a global
 			// address using a ULA as the source

--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -47,6 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/random.hpp>
 #include <libtorrent/aux_/vector.hpp>
 #include <libtorrent/aux_/numeric_cast.hpp>
+#include <libtorrent/broadcast_socket.hpp> // for ip_v4
 
 namespace libtorrent { namespace dht {
 namespace {
@@ -325,7 +326,7 @@ namespace {
 				v->name = name.substr(0, 100).to_string();
 			}
 
-			auto& peersv = endp.protocol() == tcp::v4() ? v->peers4 : v->peers6;
+			auto& peersv = is_v4(endp) ? v->peers4 : v->peers6;
 
 			peer_entry peer;
 			peer.addr = endp;

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -118,7 +118,7 @@ namespace libtorrent { namespace dht {
 	{
 		if (s.is_ssl()) return;
 
-		address local_address = s.get_local_endpoint().address();
+		address const local_address = s.get_local_endpoint().address();
 #if TORRENT_USE_IPV6
 		// don't try to start dht nodes on non-global IPv6 addresses
 		// with IPv4 the interface might be behind NAT so we can't skip them based on the scope of the local address
@@ -182,7 +182,7 @@ namespace libtorrent { namespace dht {
 			n.second.connection_timer.async_wait(
 				std::bind(&dht_tracker::connection_timeout, self(), n.first, _1));
 #if TORRENT_USE_IPV6
-			if (n.first.get_local_endpoint().protocol() == tcp::v6())
+			if (is_v6(n.first.get_local_endpoint()))
 				n.second.dht.bootstrap(concat(m_state.nodes6, m_state.nodes), f);
 			else
 #endif
@@ -510,10 +510,10 @@ namespace libtorrent { namespace dht {
 		m_counters.inc_stats_counter(counters::dht_bytes_in, buf_size);
 		// account for IP and UDP overhead
 		m_counters.inc_stats_counter(counters::recv_ip_overhead_bytes
-			, ep.address().is_v6() ? 48 : 28);
+			, is_v6(ep) ? 48 : 28);
 		m_counters.inc_stats_counter(counters::dht_messages_in);
 
-		if (m_settings.ignore_dark_internet && ep.address().is_v4())
+		if (m_settings.ignore_dark_internet && is_v4(ep))
 		{
 			address_v4::bytes_type b = ep.address().to_v4().to_bytes();
 
@@ -701,7 +701,7 @@ namespace libtorrent { namespace dht {
 		m_counters.inc_stats_counter(counters::dht_bytes_out, int(m_send_buf.size()));
 		// account for IP and UDP overhead
 		m_counters.inc_stats_counter(counters::sent_ip_overhead_bytes
-			, addr.address().is_v6() ? 48 : 28);
+			, is_v6(addr) ? 48 : 28);
 		m_counters.inc_stats_counter(counters::dht_messages_out);
 #ifndef TORRENT_DISABLE_LOGGING
 		m_log->log_packet(dht_logger::outgoing_message, m_send_buf, addr);

--- a/src/kademlia/get_peers.cpp
+++ b/src/kademlia/get_peers.cpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/kademlia/dht_observer.hpp>
 #include <libtorrent/socket_io.hpp>
 #include <libtorrent/performance_counters.hpp>
+#include <libtorrent/broadcast_socket.hpp> // for is_v4
 
 #ifndef TORRENT_DISABLE_LOGGING
 #include <libtorrent/hex.hpp> // to_hex
@@ -61,7 +62,7 @@ void get_peers_observer::reply(msg const& m)
 	{
 		std::vector<tcp::endpoint> peer_list;
 		if (n.list_size() == 1 && n.list_at(0).type() == bdecode_node::string_t
-			&& m.addr.protocol() == udp::v4())
+			&& is_v4(m.addr))
 		{
 			// assume it's mainline format
 			char const* peers = n.list_at(0).string_ptr();

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -111,13 +111,13 @@ node::node(aux::listen_socket_handle const& sock, socket_manager* sock_man
 	, dht_storage_interface& storage)
 	: m_settings(settings)
 	, m_id(calculate_node_id(nid, sock))
-	, m_table(m_id, sock.get_local_endpoint().protocol() == tcp::v4() ? udp::v4() : udp::v6(), 8, settings, observer)
+	, m_table(m_id, is_v4(sock.get_local_endpoint()) ? udp::v4() : udp::v6(), 8, settings, observer)
 	, m_rpc(m_id, m_settings, m_table, sock, sock_man, observer)
 	, m_sock(sock)
 	, m_sock_man(sock_man)
 	, m_get_foreign_node(std::move(get_foreign_node))
 	, m_observer(observer)
-	, m_protocol(map_protocol_to_descriptor(sock.get_local_endpoint().protocol() == tcp::v4() ? udp::v4() : udp::v6()))
+	, m_protocol(map_protocol_to_descriptor(is_v4(sock.get_local_endpoint()) ? udp::v4() : udp::v6()))
 	, m_last_tracker_tick(aux::time_now())
 	, m_last_self_refresh(min_time())
 	, m_counters(cnt)
@@ -224,7 +224,7 @@ void node::bootstrap(std::vector<udp::endpoint> const& nodes
 	for (auto const& n : nodes)
 	{
 #if !TORRENT_USE_IPV6
-		if (n.protocol() == udp::v6()) continue;
+		if (is_v6(n)) continue;
 #endif
 
 #ifndef TORRENT_DISABLE_LOGGING

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -49,6 +49,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/socket_io.hpp> // for print_endpoint
 #include <libtorrent/aux_/time.hpp> // for aux::time_now
 #include <libtorrent/aux_/aligned_union.hpp>
+#include <libtorrent/broadcast_socket.hpp> // for is_v6
 
 #include <type_traits>
 #include <functional>
@@ -83,7 +84,7 @@ void observer::set_target(udp::endpoint const& ep)
 
 	m_port = ep.port();
 #if TORRENT_USE_IPV6
-	if (ep.address().is_v6())
+	if (is_v6(ep))
 	{
 		flags |= flag_ipv6_address;
 		m_addr.v6 = ep.address().to_v6().to_bytes();

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -329,7 +329,7 @@ namespace libtorrent {
 				disconnect(ec, operation_t::getname);
 				return;
 			}
-			if (m_remote.address().is_v4() && m_settings.get_int(settings_pack::peer_tos) != 0)
+			if (is_v4(m_remote) && m_settings.get_int(settings_pack::peer_tos) != 0)
 			{
 				m_socket->set_option(type_of_service(char(m_settings.get_int(settings_pack::peer_tos))), ec);
 #ifndef TORRENT_DISABLE_LOGGING
@@ -341,7 +341,7 @@ namespace libtorrent {
 #endif
 			}
 #if TORRENT_USE_IPV6 && defined IPV6_TCLASS
-			else if (m_remote.address().is_v6() && m_settings.get_int(settings_pack::peer_tos) != 0)
+			else if (is_v6(m_remote) && m_settings.get_int(settings_pack::peer_tos) != 0)
 			{
 				m_socket->set_option(traffic_class(char(m_settings.get_int(settings_pack::peer_tos))), ec);
 			}
@@ -381,7 +381,7 @@ namespace libtorrent {
 		if (should_log(peer_log_alert::outgoing))
 		{
 			peer_log(peer_log_alert::outgoing, "OPEN", "protocol: %s"
-				, (m_remote.address().is_v4() ? "IPv4" : "IPv6"));
+				, (is_v4(m_remote) ? "IPv4" : "IPv6"));
 		}
 #endif
 		error_code ec;
@@ -430,7 +430,7 @@ namespace libtorrent {
 			, [conn](error_code const& e) { conn->wrap(&peer_connection::on_connection_complete, e); });
 		m_connect = aux::time_now();
 
-		sent_syn(m_remote.address().is_v6());
+		sent_syn(is_v6(m_remote));
 
 		if (t && t->alerts().should_post<peer_connect_alert>())
 		{
@@ -2656,7 +2656,7 @@ namespace libtorrent {
 
 #ifdef TORRENT_CORRUPT_DATA
 		// corrupt all pieces from certain peers
-		if (m_remote.address().is_v4()
+		if (is_v4(m_remote)
 			&& (m_remote.address().to_v4().to_ulong() & 0xf) == 0)
 		{
 			data[0] = ~data[0];
@@ -5791,7 +5791,7 @@ namespace libtorrent {
 		m_ses.received_buffer(bytes_transferred);
 
 		// estimate transport protocol overhead
-		trancieve_ip_packet(bytes_transferred, m_remote.address().is_v6());
+		trancieve_ip_packet(bytes_transferred, is_v6(m_remote));
 
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::incoming, "READ"
@@ -6088,7 +6088,7 @@ namespace libtorrent {
 
 		// this means the connection just succeeded
 
-		received_synack(m_remote.address().is_v6());
+		received_synack(is_v6(m_remote));
 
 		TORRENT_ASSERT(m_socket);
 #ifndef TORRENT_DISABLE_LOGGING
@@ -6120,7 +6120,7 @@ namespace libtorrent {
 			return;
 		}
 
-		if (m_remote.address().is_v4() && m_settings.get_int(settings_pack::peer_tos) != 0)
+		if (is_v4(m_remote) && m_settings.get_int(settings_pack::peer_tos) != 0)
 		{
 			error_code err;
 			m_socket->set_option(type_of_service(char(m_settings.get_int(settings_pack::peer_tos))), err);
@@ -6133,7 +6133,7 @@ namespace libtorrent {
 #endif
 		}
 #if TORRENT_USE_IPV6 && defined IPV6_TCLASS
-		else if (m_remote.address().is_v6() && m_settings.get_int(settings_pack::peer_tos) != 0)
+		else if (is_v6(m_remote) && m_settings.get_int(settings_pack::peer_tos) != 0)
 		{
 			error_code err;
 			m_socket->set_option(traffic_class(char(m_settings.get_int(settings_pack::peer_tos))), err);
@@ -6215,7 +6215,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(int(bytes_transferred) <= m_quota[upload_channel]);
 		m_quota[upload_channel] -= int(bytes_transferred);
 
-		trancieve_ip_packet(int(bytes_transferred), m_remote.address().is_v6());
+		trancieve_ip_packet(int(bytes_transferred), is_v6(m_remote));
 
 		if (m_send_barrier != INT_MAX)
 			m_send_barrier -= int(bytes_transferred);

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -48,6 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/torrent_peer_allocator.hpp"
 #include "libtorrent/ip_voter.hpp" // for external_ip
+#include "libtorrent/broadcast_socket.hpp" // for is_v6
 
 #if TORRENT_USE_ASSERTS
 #include "libtorrent/socket_io.hpp" // for print_endpoint
@@ -734,7 +735,7 @@ namespace libtorrent {
 			}
 
 #if TORRENT_USE_IPV6
-			bool const is_v6 = c.remote().address().is_v6();
+			bool const is_v6 = lt::is_v6(c.remote());
 #else
 			bool const is_v6 = false;
 #endif

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1408,7 +1408,7 @@ namespace aux {
 #endif // TORRENT_WINDOWS
 
 #if TORRENT_USE_IPV6
-			if (bind_ep.address().is_v6())
+			if (is_v6(bind_ep))
 			{
 				error_code err; // ignore errors here
 				ret->sock->set_option(boost::asio::ip::v6_only(true), err);
@@ -6099,7 +6099,7 @@ namespace aux {
 		void set_tos(Socket& s, int v, error_code& ec)
 		{
 #if TORRENT_USE_IPV6 && defined IPV6_TCLASS
-			if (s.local_endpoint(ec).address().is_v6())
+			if (is_v6(s.local_endpoint(ec)))
 				s.set_option(traffic_class(char(v)), ec);
 			else if (!ec)
 #endif
@@ -6829,7 +6829,7 @@ namespace aux {
 		// TODO: remove this function once all callers are updated to specify a listen socket
 		for (auto& i : m_listen_sockets)
 		{
-			if (i->local_endpoint.address().is_v4() != ip.is_v4())
+			if (is_v4(i->local_endpoint) != ip.is_v4())
 				continue;
 
 			set_external_address(i, ip, source_type, source);

--- a/src/session_udp_sockets.cpp
+++ b/src/session_udp_sockets.cpp
@@ -87,7 +87,7 @@ namespace libtorrent { namespace aux {
 			if (++idx >= sockets.size())
 				idx = 0;
 
-			if (sockets[idx]->local_endpoint().address().is_v4() != remote_address.is_v4()
+			if (is_v4(sockets[idx]->local_endpoint()) != remote_address.is_v4()
 				|| sockets[idx]->ssl != ssl)
 			{
 				if (idx == index_begin) break;

--- a/src/socks5_stream.cpp
+++ b/src/socks5_stream.cpp
@@ -244,8 +244,8 @@ namespace libtorrent {
 		{
 			// send SOCKS5 connect command
 			m_buffer.resize(6 + (!m_dst_name.empty()
-				?m_dst_name.size() + 1
-				:(m_remote_endpoint.address().is_v4()?4:16)));
+				? m_dst_name.size() + 1
+				:(is_v4(m_remote_endpoint) ? 4 : 16)));
 			char* p = &m_buffer[0];
 			write_uint8(5, p); // SOCKS VERSION 5
 			write_uint8(std::uint8_t(m_command), p); // CONNECT command
@@ -263,7 +263,7 @@ namespace libtorrent {
 				// we either need a hostname or a valid endpoint
 				TORRENT_ASSERT(m_remote_endpoint.address() != address());
 
-				write_uint8(m_remote_endpoint.address().is_v4()?1:4, p); // address type
+				write_uint8(is_v4(m_remote_endpoint) ? 1 : 4, p); // address type
 				write_address(m_remote_endpoint.address(), p);
 			}
 			write_uint16(m_remote_endpoint.port(), p);
@@ -271,7 +271,7 @@ namespace libtorrent {
 		else if (m_version == 4)
 		{
 			// SOCKS4 only supports IPv4
-			if (!m_remote_endpoint.address().is_v4())
+			if (!is_v4(m_remote_endpoint))
 			{
 				h(boost::asio::error::address_family_not_supported);
 				return;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2760,7 +2760,7 @@ bool is_downloading_state(int const st)
 			{
 				if (s.is_ssl() != is_ssl_torrent())
 					return;
-				if (!s.get_local_endpoint().address().is_v6())
+				if (!is_v6(s.get_local_endpoint()))
 					return;
 				req.ipv6.push_back(s.get_local_endpoint().address().to_v6());
 			});
@@ -5925,7 +5925,7 @@ bool is_downloading_state(int const st)
 		TORRENT_ASSERT(!web->resolving);
 		TORRENT_ASSERT(web->peer_info.connection == nullptr);
 
-		if (a.address().is_v4())
+		if (is_v4(a))
 		{
 			web->peer_info.addr = a.address().to_v4();
 			web->peer_info.port = a.port();
@@ -10066,7 +10066,7 @@ bool is_downloading_state(int const st)
 		TORRENT_ASSERT(is_single_thread());
 
 #if !TORRENT_USE_IPV6
-		if (!adr.address().is_v4())
+		if (!is_v4(adr))
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			error_code ec;

--- a/src/torrent_peer.cpp
+++ b/src/torrent_peer.cpp
@@ -73,7 +73,7 @@ namespace libtorrent {
 	// * all IP addresses are in network byte order when hashed
 	std::uint32_t peer_priority(tcp::endpoint e1, tcp::endpoint e2)
 	{
-		TORRENT_ASSERT(e1.address().is_v4() == e2.address().is_v4());
+		TORRENT_ASSERT(is_v4(e1) == is_v4(e2));
 
 		using std::swap;
 
@@ -89,7 +89,7 @@ namespace libtorrent {
 			ret = crc32c_32(p);
 		}
 #if TORRENT_USE_IPV6
-		else if (e1.address().is_v6())
+		else if (is_v6(e1))
 		{
 			static const std::uint8_t v6mask[][8] = {
 				{ 0xff, 0xff, 0xff, 0xff, 0x55, 0x55, 0x55, 0x55 },

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -267,7 +267,7 @@ namespace libtorrent {
 		if (bind_interface() != address_v4::any())
 		{
 			// find first endpoint that matches our bind interface type
-			for (; iter != m_endpoints.end() && iter->address().is_v4()
+			for (; iter != m_endpoints.end() && is_v4(*iter)
 				!= bind_interface().is_v4(); ++iter);
 
 			if (iter == m_endpoints.end())
@@ -276,7 +276,7 @@ namespace libtorrent {
 				std::shared_ptr<request_callback> cb = requester();
 				if (cb)
 				{
-					char const* tracker_address_type = target.address().is_v4() ? "IPv4" : "IPv6";
+					char const* tracker_address_type = is_v4(target) ? "IPv4" : "IPv6";
 					char const* bind_address_type = bind_interface().is_v4() ? "IPv4" : "IPv6";
 					char msg[200];
 					std::snprintf(msg, sizeof(msg)
@@ -623,7 +623,7 @@ namespace libtorrent {
 
 		std::size_t const ip_stride =
 #if TORRENT_USE_IPV6
-			m_target.address().is_v6() ? 18 :
+			is_v6(m_target) ? 18 :
 #endif
 			6;
 
@@ -649,7 +649,7 @@ namespace libtorrent {
 		}
 
 #if TORRENT_USE_IPV6
-		if (m_target.protocol() == udp::v6())
+		if (is_v6(m_target))
 		{
 			resp.peers6.reserve(std::size_t(num_peers));
 			for (int i = 0; i < num_peers; ++i)

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -174,7 +174,7 @@ namespace libtorrent {namespace {
 					flags |= p->supports_holepunch() ? pex_holepunch : pex_flags_t{};
 
 					// i->first was added since the last time
-					if (remote.address().is_v4())
+					if (is_v4(remote))
 					{
 						detail::write_endpoint(remote, pla_out);
 						detail::write_uint8(static_cast<std::uint8_t>(flags), plf_out);
@@ -199,7 +199,7 @@ namespace libtorrent {namespace {
 
 			for (auto const& i : dropped)
 			{
-				if (i.address().is_v4())
+				if (is_v4(i))
 					detail::write_endpoint(i, pld_out);
 #if TORRENT_USE_IPV6
 				else
@@ -568,7 +568,7 @@ namespace libtorrent {namespace {
 				}
 
 				// i->first was added since the last time
-				if (remote.address().is_v4())
+				if (is_v4(remote))
 				{
 					detail::write_endpoint(remote, pla_out);
 					detail::write_uint8(flags, plf_out);

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -196,7 +196,7 @@ namespace libtorrent {
 			for (auto const& p : atp.peers)
 			{
 #if TORRENT_USE_IPV6
-				if (p.address().is_v6())
+				if (is_v6(p))
 					write_endpoint(p, ptr6);
 				else
 #endif
@@ -213,7 +213,7 @@ namespace libtorrent {
 			for (auto const& p : atp.banned_peers)
 			{
 #if TORRENT_USE_IPV6
-				if (p.address().is_v6())
+				if (is_v6(p))
 					write_endpoint(p, ptr6);
 				else
 #endif

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -1054,7 +1054,7 @@ void test_id_enforcement(address(&rand_addr)())
 	t.sett.enforce_node_id = true;
 
 	node_id nid;
-	if (t.source.protocol() == udp::v4())
+	if (is_v4(t.source))
 	{
 		// this is one of the test vectors from:
 		// http://libtorrent.org/dht_sec.html
@@ -1103,7 +1103,7 @@ void test_id_enforcement(address(&rand_addr)())
 	TEST_EQUAL(std::get<0>(t.dht_node.size()), nodes_num);
 
 	// now the node-id is valid.
-	if (t.source.protocol() == udp::v4())
+	if (is_v4(t.source))
 		nid[0] = 0x5f;
 	else
 		nid[0] = 0x0a;
@@ -1604,7 +1604,7 @@ void test_routing_table(address(&rand_addr)())
 	address node_addr;
 	address node_near_addr;
 #if TORRENT_USE_IPV6
-	if (t.source.protocol() == udp::v6())
+	if (is_v6(t.source))
 	{
 		node_addr = addr6("2001:1111:1111:1111:1111:1111:1111:1111");
 		node_near_addr = addr6("2001:1111:1111:1111:eeee:eeee:eeee:eeee");
@@ -1861,7 +1861,7 @@ void test_bootstrap(address(&rand_addr)())
 	std::vector<node_entry> nodes;
 	nodes.push_back(node_entry{found_node});
 	g_sent_packets.clear();
-	if (initial_node.address().is_v4())
+	if (is_v4(initial_node))
 		send_dht_response(t.dht_node, response, initial_node, msg_args().nodes(nodes));
 	else
 		send_dht_response(t.dht_node, response, initial_node, msg_args().nodes6(nodes));
@@ -1935,7 +1935,7 @@ void test_bootstrap_want(address(&rand_addr)())
 	g_sent_packets.clear();
 
 	std::vector<udp::endpoint> nodesv;
-	if (t.source.address().is_v4())
+	if (is_v4(t.source))
 		nodesv.push_back(rand_udp_ep(rand_v6));
 	else
 		nodesv.push_back(rand_udp_ep(rand_v4));
@@ -1954,7 +1954,7 @@ void test_bootstrap_want(address(&rand_addr)())
 			|| find_node_keys[2].string_value() == "get_peers");
 
 		TEST_EQUAL(find_node_keys[7].list_size(), 1);
-		if (t.source.address().is_v4())
+		if (is_v4(t.source))
 		{
 			TEST_EQUAL(find_node_keys[7].list_string_value_at(0), "n4");
 		}
@@ -2042,7 +2042,7 @@ void test_short_nodes(address(&rand_addr)())
 	g_sent_packets.clear();
 	msg_args args;
 	// chop one byte off of the nodes string
-	if (initial_node.address().is_v4())
+	if (is_v4(initial_node))
 	{
 		args.nodes(nodes);
 		args.a["nodes"] = args.a["nodes"].string().substr(1);
@@ -2135,7 +2135,7 @@ void test_get_peers(address(&rand_addr)())
 	nodes.push_back(node_entry{next_node});
 
 	g_sent_packets.clear();
-	if (initial_node.address().is_v4())
+	if (is_v4(initial_node))
 	{
 		send_dht_response(t.dht_node, response, initial_node
 			, msg_args().nodes(nodes).token("10").port(1234).peers(peers[0]));

--- a/test/udp_tracker.cpp
+++ b/test/udp_tracker.cpp
@@ -39,6 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/socket_io.hpp"
 #include "libtorrent/io.hpp"
 #include "libtorrent/aux_/time.hpp"
+#include "libtorrent/broadcast_socket.hpp" // for is_v6
 #include "udp_tracker.hpp"
 #include "test_utils.hpp"
 
@@ -133,7 +134,7 @@ struct udp_tracker
 				detail::write_uint32(1, ptr); // complete
 				// 1 peers
 #if TORRENT_USE_IPV6
-				if (from->address().is_v6())
+				if (is_v6(*from))
 				{
 					detail::write_uint32(0, ptr);
 					detail::write_uint32(0, ptr);


### PR DESCRIPTION
I detected quite a few of these, but before going full in, I would like to have some opinions