### PR TITLE
Make extension alerts reliable

### DIFF
--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -191,7 +191,7 @@ namespace libtorrent {
 		boost::function<void()> m_notify;
 
 		// the number of resume data alerts  in the alert queue
-		boost::atomic<int> m_num_queued_resume;
+		int m_num_queued_resume;
 
 		// this is either 0 or 1, it indicates which m_alerts and m_allocations
 		// the alert_manager is allowed to use right now. This is swapped when

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -114,7 +114,7 @@ namespace libtorrent {
 			T alert(m_allocations[m_generation], std::forward<Args>(args)...);
 			m_alerts[m_generation].push_back(alert);
 
-			maybe_notify(&alert, lock);
+			maybe_notify(&alert);
 		}
 
 #else
@@ -167,7 +167,7 @@ namespace libtorrent {
 		alert_manager(alert_manager const&);
 		alert_manager& operator=(alert_manager const&);
 
-		void maybe_notify(alert* a, mutex::scoped_lock& lock);
+		void maybe_notify(alert* const a);
 
 		mutable mutex m_mutex;
 		condition_variable m_condition;

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -103,7 +103,7 @@ namespace libtorrent {
 				if (m_ses_extensions_reliable.empty())
 					return;
 
-				mutex::scoped_lock lock(m_mutex_reliable);
+				mutex::scoped_lock reliable_lock(m_mutex_reliable);
 				T alert(m_allocator_reliable, std::forward<Args>(args)...);
 				notify_extensions(&alert, m_ses_extensions_reliable);
 				m_allocator_reliable.reset();
@@ -209,7 +209,7 @@ namespace libtorrent {
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		typedef std::list<boost::shared_ptr<plugin> > ses_extension_list_t;
-		void notify_extensions(alert * const a, ses_extension_list_t& extensions);
+		void notify_extensions(alert * const a, ses_extension_list_t const& extensions);
 		ses_extension_list_t m_ses_extensions;
 		ses_extension_list_t m_ses_extensions_reliable;
 		aux::stack_allocator m_allocator_reliable;

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -188,7 +188,7 @@ namespace libtorrent {
 		boost::function<void()> m_notify;
 
 		// the number of resume data alerts  in the alert queue
-		int m_num_queued_resume;
+		boost::atomic<int> m_num_queued_resume;
 
 		// this is either 0 or 1, it indicates which m_alerts and m_allocations
 		// the alert_manager is allowed to use right now. This is swapped when

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -138,7 +138,10 @@ namespace libtorrent {
 
 		void set_alert_mask(boost::uint32_t m)
 		{
-			m_alert_mask.store(m, boost::memory_order_relaxed);
+			// since this call may get inlined by external threads
+			// it can't be relaxed to ensure the update is done before
+			// returning
+			m_alert_mask = m;
 		}
 
 		boost::uint32_t alert_mask() const

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -138,10 +138,10 @@ namespace libtorrent {
 
 		void set_alert_mask(boost::uint32_t m)
 		{
-			// since this call may get inlined by external threads
-			// it can't be relaxed to ensure the update is done before
-			// returning
-			m_alert_mask = m;
+			// we don't care if this store happens immediately
+			// because it is guaranteed to happen before the caller
+			// makes any attempt to synchronize
+			m_alert_mask.store(m, boost::memory_order_relaxed);
 		}
 
 		boost::uint32_t alert_mask() const

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -61,7 +61,7 @@
 				BOOST_PP_ENUM_PARAMS(I, a));
 			m_alerts[m_generation].push_back(alert);
 
-			maybe_notify(&alert);
+			maybe_notify(&alert, lock);
 		}
 
 #undef I

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -39,7 +39,40 @@
 			// for high priority alerts, double the upper limit
 			if (m_alerts[m_generation].size() >= m_queue_size_limit
 				* (1 + T::priority))
+			{
+#ifndef TORRENT_DISABLE_EXTENSIONS
+				if (m_reliable_ext_alerts) {
+					// after we have a reference to the current allocator it
+					// is safe to unlock the mutex because m_allocations is protected
+					// by the fact that the client needs to pop alerts *twice* before
+					// it can free it and that's impossible until we emplace
+					// more alerts.
+					aux::stack_allocator& alloc = m_allocations[m_generation];
+					lock.unlock();
+
+					// save the state of the active allocator so that
+					// we can restore it when we're done
+					aux::stack_allocator_state_t state = alloc.save_state();
+					T alert(alloc
+						BOOST_PP_COMMA_IF(I)
+						BOOST_PP_ENUM_PARAMS(I, a));
+
+
+					for (ses_extension_list_t::iterator i = m_ses_extensions.begin()
+						, end(m_ses_extensions.end()); i != end; ++i)
+					{
+						if (((*i)->implemented_features() & plugin::reliable_alerts_feature) != 0)
+						{
+							(*i)->on_alert(&alert);
+						}
+					}
+
+					alloc.restore_state(state);
+				}
+#endif
+
 				return;
+			}
 
 			T alert(m_allocations[m_generation]
 				BOOST_PP_COMMA_IF(I)

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -46,7 +46,7 @@
 				if (m_ses_extensions_reliable.empty())
 					return;
 
-				mutex::scoped_lock lock(m_mutex_reliable);
+				mutex::scoped_lock reliable_lock(m_mutex_reliable);
 				T alert(m_allocator_reliable
 					BOOST_PP_COMMA_IF(I)
 					BOOST_PP_ENUM_PARAMS(I, a));
@@ -61,7 +61,7 @@
 				BOOST_PP_ENUM_PARAMS(I, a));
 			m_alerts[m_generation].push_back(alert);
 
-			maybe_notify(&alert, lock);
+			maybe_notify(&alert);
 		}
 
 #undef I

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -218,7 +218,11 @@ namespace libtorrent
 			optimistic_unchoke_feature = 1,
 
 			// include this bit if your plugin needs to have on_tick() called
-			tick_feature = 2
+			tick_feature = 2,
+
+			// include this bit if your plugin needs to have on_alert() called
+			// for all unmasked alerts, even after the queue is full.
+			reliable_alerts_feature = 4
 		};
 
 		// This function is expected to return a bitmask indicating which features

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -38,6 +38,8 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent { namespace aux
 {
 
+	typedef boost::uint32_t stack_allocator_state_t;
+
 	struct stack_allocator
 	{
 		stack_allocator() {}
@@ -98,6 +100,17 @@ namespace libtorrent { namespace aux
 		void reset()
 		{
 			m_storage.clear();
+		}
+
+		void restore_state(stack_allocator_state_t state)
+		{
+			TORRENT_ASSERT(state <= m_storage.size());
+			m_storage.resize(state);
+		}
+
+		stack_allocator_state_t save_state()
+		{
+			return m_storage.size();
 		}
 
 	private:

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -38,8 +38,6 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent { namespace aux
 {
 
-	typedef boost::uint32_t stack_allocator_state_t;
-
 	struct stack_allocator
 	{
 		stack_allocator() {}
@@ -100,17 +98,6 @@ namespace libtorrent { namespace aux
 		void reset()
 		{
 			m_storage.clear();
-		}
-
-		void restore_state(stack_allocator_state_t state)
-		{
-			TORRENT_ASSERT(state <= m_storage.size());
-			m_storage.resize(state);
-		}
-
-		stack_allocator_state_t save_state()
-		{
-			return m_storage.size();
 		}
 
 	private:

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -78,8 +78,6 @@ namespace libtorrent
 
 		if (m_alerts[m_generation].size() == 1)
 		{
-			lock.unlock();
-
 			// we just posted to an empty queue. If anyone is waiting for
 			// alerts, we need to notify them. Also (potentially) call the
 			// user supplied m_notify callback to let the client wake up its
@@ -90,14 +88,9 @@ namespace libtorrent
 			// > 0 notify them
 			m_condition.notify_all();
 		}
-		else
-		{
-			lock.unlock();
-		}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		notify_extensions(a, m_ses_extensions);
-		notify_extensions(a, m_ses_extensions_reliable);
 #endif
 	}
 
@@ -158,9 +151,9 @@ namespace libtorrent
 	}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-	void alert_manager::notify_extensions(alert * const alert, ses_extension_list_t& list)
+	void alert_manager::notify_extensions(alert * const alert, ses_extension_list_t const& list)
 	{
-		for (ses_extension_list_t::iterator i = list.begin(),
+		for (ses_extension_list_t::const_iterator i = list.begin(),
 			end(list.end()); i != end; ++i)
 		{
 			(*i)->on_alert(alert);
@@ -170,13 +163,8 @@ namespace libtorrent
 	void alert_manager::add_extension(boost::shared_ptr<plugin> ext)
 	{
 		if ((ext->implemented_features() & plugin::reliable_alerts_feature) != 0)
-		{
 			m_ses_extensions_reliable.push_back(ext);
-		}
-		else
-		{
-			m_ses_extensions.push_back(ext);
-		}
+		m_ses_extensions.push_back(ext);
 	}
 #endif
 

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -70,7 +70,7 @@ namespace libtorrent
 		return NULL;
 	}
 
-	void alert_manager::maybe_notify(alert* a, mutex::scoped_lock& lock)
+	void alert_manager::maybe_notify(alert* const a)
 	{
 		if (a->type() == save_resume_data_failed_alert::alert_type
 			|| a->type() == save_resume_data_alert::alert_type)

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -52,7 +52,8 @@ namespace libtorrent
 
 	int alert_manager::num_queued_resume() const
 	{
-		return m_num_queued_resume.load(boost::memory_order_consume);
+		mutex::scoped_lock lock(m_mutex);
+		return m_num_queued_resume;
 	}
 
 	alert* alert_manager::wait_for_alert(time_duration max_wait)
@@ -74,7 +75,7 @@ namespace libtorrent
 	{
 		if (a->type() == save_resume_data_failed_alert::alert_type
 			|| a->type() == save_resume_data_alert::alert_type)
-			m_num_queued_resume.fetch_add(1, boost::memory_order_relaxed);
+			++m_num_queued_resume;
 
 		if (m_alerts[m_generation].size() == 1)
 		{
@@ -177,13 +178,13 @@ namespace libtorrent
 	void alert_manager::get_all(std::vector<alert*>& alerts, int& num_resume)
 	{
 		mutex::scoped_lock lock(m_mutex);
-		TORRENT_ASSERT(m_num_queued_resume.load(boost::memory_order_relaxed) <= m_alerts[m_generation].size());
+		TORRENT_ASSERT(m_num_queued_resume <= m_alerts[m_generation].size());
 
 		alerts.clear();
 		if (m_alerts[m_generation].empty()) return;
 
 		m_alerts[m_generation].get_pointers(alerts);
-		num_resume = m_num_queued_resume.load(boost::memory_order_relaxed);
+		num_resume = m_num_queued_resume;
 		m_num_queued_resume = 0;
 
 		// swap buffers

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -46,6 +46,9 @@ namespace libtorrent
 		, m_queue_size_limit(queue_limit)
 		, m_num_queued_resume(0)
 		, m_generation(0)
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		, m_reliable_ext_alerts(false)
+#endif
 	{}
 
 	alert_manager::~alert_manager() {}
@@ -164,6 +167,8 @@ namespace libtorrent
 #ifndef TORRENT_DISABLE_EXTENSIONS
 	void alert_manager::add_extension(boost::shared_ptr<plugin> ext)
 	{
+		if ((ext->implemented_features() & plugin::reliable_alerts_feature) != 0)
+			m_reliable_ext_alerts = true;
 		m_ses_extensions.push_back(ext);
 	}
 #endif

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -52,7 +52,6 @@ namespace libtorrent
 
 	int alert_manager::num_queued_resume() const
 	{
-		mutex::scoped_lock lock(m_mutex);
 		return m_num_queued_resume;
 	}
 

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -219,23 +219,14 @@ struct test_plugin : libtorrent::plugin
 void
 alert_popper(alert_manager& mgr, bool& running)
 {
+	int num_resume;
 	std::vector<alert*> alerts;
-	int num_resume = 0, n_iters = 0;
-
-	running = true;
-
-	while (running)
+	for (running = true; running;)
 	{
-		/* wait for the next alert */
-		time_duration td = seconds(1);
+		time_duration td = milliseconds(10);
 		if (mgr.wait_for_alert(td) == NULL)
 			continue;
-
 		mgr.get_all(alerts, num_resume);
-
-		/* sleep every few iterations to simulate overrun */
-		if (++n_iters % 5 == 0)
-			test_sleep(500);
 	}
 }
 
@@ -296,6 +287,8 @@ TORRENT_TEST(extensions)
 	running = false;
 	t.join();
 
+	TEST_EQUAL(plugin_alerts[0] < 100000140, true);
+	TEST_EQUAL(plugin_alerts[1] < 100000140, true);
 	TEST_EQUAL(plugin_alerts[2], 100000140);
 
 #endif

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -216,20 +216,6 @@ struct test_plugin : libtorrent::plugin
 	boost::uint32_t m_features;
 };
 
-void
-alert_popper(alert_manager& mgr, bool& running)
-{
-	int num_resume;
-	std::vector<alert*> alerts;
-	for (running = true; running;)
-	{
-		time_duration td = milliseconds(10);
-		if (mgr.wait_for_alert(td) == NULL)
-			continue;
-		mgr.get_all(alerts, num_resume);
-	}
-}
-
 #endif
 
 TORRENT_TEST(extensions)
@@ -271,25 +257,6 @@ TORRENT_TEST(extensions)
 	TEST_EQUAL(plugin_alerts[0], 100);
 	TEST_EQUAL(plugin_alerts[1], 100);
 	TEST_EQUAL(plugin_alerts[2], 140);
-
-	bool running = false;
-	int num_resume = 0;
-	std::vector<alert*> alerts;
-	mgr.get_all(alerts, num_resume);
-	libtorrent::thread t(boost::bind(&alert_popper, boost::ref(mgr), boost::ref(running)));
-
-	/* make sure the thread is started */
-	while (!running) test_sleep(10);
-
-	for (int i = 0; i < 100000000; ++i)
-		mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
-
-	running = false;
-	t.join();
-
-	TEST_EQUAL(plugin_alerts[0] < 100000140, true);
-	TEST_EQUAL(plugin_alerts[1] < 100000140, true);
-	TEST_EQUAL(plugin_alerts[2], 100000140);
 
 #endif
 }

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -190,7 +190,7 @@ int plugin_alerts[3] = { 0, 0, 0 };
 
 struct test_plugin : libtorrent::plugin
 {
-	test_plugin(int index, bool reliable_alerts) : m_index(index),
+	test_plugin(int index, bool reliable_alerts = false) : m_index(index),
 		m_features(reliable_alerts ? libtorrent::plugin::reliable_alerts_feature  : 0) {}
 	boost::uint32_t implemented_features() { return m_features; }
 	virtual void on_alert(alert const* a)
@@ -210,9 +210,9 @@ TORRENT_TEST(extensions)
 	memset(plugin_alerts, 0, sizeof(plugin_alerts));
 	alert_manager mgr(100, 0xffffffff);
 
-	mgr.add_extension(boost::make_shared<test_plugin>(0, false));
-	mgr.add_extension(boost::make_shared<test_plugin>(1, false));
-	mgr.add_extension(boost::make_shared<test_plugin>(2, false));
+	mgr.add_extension(boost::make_shared<test_plugin>(0));
+	mgr.add_extension(boost::make_shared<test_plugin>(1));
+	mgr.add_extension(boost::make_shared<test_plugin>(2));
 
 	for (int i = 0; i < 53; ++i)
 		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
@@ -236,8 +236,8 @@ TORRENT_TEST(reliable_alerts)
 	memset(plugin_alerts, 0, sizeof(plugin_alerts));
 	alert_manager mgr(100, 0xffffffff);
 
-	mgr.add_extension(boost::make_shared<test_plugin>(0, false));
-	mgr.add_extension(boost::make_shared<test_plugin>(1, false));
+	mgr.add_extension(boost::make_shared<test_plugin>(0));
+	mgr.add_extension(boost::make_shared<test_plugin>(1));
 	mgr.add_extension(boost::make_shared<test_plugin>(2, true));
 
 	for (int i = 0; i < 105; ++i)


### PR DESCRIPTION
Add feature to make alerts sent to session extensions reliable (ie. the
alerts will be delivered even if the queue is full). Also make should_post
lockless.