### PR TITLE
remove the global cache of the current time

### DIFF
--- a/include/libtorrent/aux_/time.hpp
+++ b/include/libtorrent/aux_/time.hpp
@@ -42,9 +42,6 @@ namespace libtorrent { namespace aux {
 	// resolution of this timer is about 100 ms.
 	TORRENT_EXTRA_EXPORT time_point time_now();
 	TORRENT_EXTRA_EXPORT time_point32 time_now32();
-
-	TORRENT_EXTRA_EXPORT void update_time_now();
-
 } }
 
 #endif

--- a/simulation/test_dht_storage.cpp
+++ b/simulation/test_dht_storage.cpp
@@ -84,7 +84,6 @@ void timer_tick(dht_storage_interface* s
 	, dht_storage_counters const& c
 	, boost::system::error_code const&)
 {
-	lt::aux::update_time_now();
 	s->tick();
 
 	TEST_EQUAL(s->counters().peers, c.peers);
@@ -200,7 +199,6 @@ TORRENT_TEST(dht_storage_infohashes_sample)
 	timer.expires_from_now(hours(1)); // expiration of torrents
 	timer.async_wait([&s](boost::system::error_code const& ec)
 	{
-		lt::aux::update_time_now();
 		// tick here to trigger the torrents expiration
 		s->tick();
 

--- a/simulation/test_torrent_status.cpp
+++ b/simulation/test_torrent_status.cpp
@@ -90,7 +90,7 @@ TORRENT_TEST(status_timers)
 			{
 				lt::time_point32 const now = time_now();
 				// finish is 1 tick after start
-				auto const since_finish = duration_cast<seconds>(now - start_time) - lt::seconds(1);
+				auto const since_finish = duration_cast<seconds>(now - start_time);
 				torrent_status st = handle.status();
 				TEST_EQUAL(st.active_duration.count(), since_finish.count());
 				TEST_EQUAL(st.seeding_duration.count(), since_finish.count());

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -445,7 +445,6 @@ namespace aux {
 		, m_lsd_announce_timer(m_io_service)
 		, m_close_file_timer(m_io_service)
 	{
-		update_time_now();
 		m_disk_thread.set_settings(&pack);
 	}
 
@@ -3116,8 +3115,7 @@ namespace aux {
 		// submit all disk jobs when we leave this function
 		deferred_submit_jobs();
 
-		aux::update_time_now();
-		time_point now = aux::time_now();
+		time_point const now = aux::time_now();
 
 		// remove undead peers that only have this list as their reference keeping them alive
 		if (!m_undead_peers.empty())

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -31,18 +31,10 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/aux_/time.hpp"
-#include <atomic>
 
 namespace libtorrent { namespace aux {
 
-	// used to cache the current time regularly (update_time_now() is called by
-	// the session_impl main thread). This is cheaper than a system call and can
-	// be used where more accurate time is not necessary
-	namespace {
-		std::atomic<time_point> g_current_time(clock_type::now());
-	}
-	time_point time_now() { return aux::g_current_time.load(); }
+	time_point time_now() { return clock_type::now(); }
 	time_point32 time_now32() { return time_point_cast<seconds32>(clock_type::now()); }
-	void update_time_now() { g_current_time.store(clock_type::now()); }
 
 } }


### PR DESCRIPTION
just use clock::now() instead