### PR TITLE
strtoll() returns LLONG_MAX if the input overflows

### DIFF
--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -281,7 +281,8 @@ restart_response:
 				if (name == "content-length")
 				{
 					m_content_length = strtoll(value.c_str(), 0, 10);
-					if (m_content_length < 0)
+					if (m_content_length < 0
+						|| m_content_length == std::numeric_limits<boost::int64_t>::max())
 					{
 						m_state = error_state;
 						error = true;
@@ -304,7 +305,8 @@ restart_response:
 					if (string_begins_no_case("bytes ", ptr)) ptr += 6;
 					char* end;
 					m_range_start = strtoll(ptr, &end, 10);
-					if (m_range_start < 0)
+					if (m_range_start < 0
+						|| m_range_start == std::numeric_limits<boost::int64_t>::max())
 					{
 						m_state = error_state;
 						error = true;
@@ -316,7 +318,8 @@ restart_response:
 					{
 						ptr = end + 1;
 						m_range_end = strtoll(ptr, &end, 10);
-						if (m_range_end < 0)
+						if (m_range_end < 0
+							|| m_range_end == std::numeric_limits<boost::int64_t>::max())
 						{
 							m_state = error_state;
 							error = true;

--- a/test/test_http_parser.cpp
+++ b/test/test_http_parser.cpp
@@ -537,6 +537,48 @@ TORRENT_TEST(invalid_content_range_end)
 	TEST_CHECK(boost::get<2>(received) == true);
 }
 
+TORRENT_TEST(overflow_content_length)
+{
+	char const* chunked_input =
+		"HTTP/1.1 200 OK\r\n"
+		"Content-Length: 9999999999999999999999999999\r\n"
+		"\r\n";
+
+	http_parser parser;
+	boost::tuple<int, int, bool> const received
+		= feed_bytes(parser, chunked_input);
+
+	TEST_CHECK(boost::get<2>(received) == true);
+}
+
+TORRENT_TEST(overflow_content_range_end)
+{
+	char const* chunked_input =
+		"HTTP/1.1 206 OK\n"
+		"Content-Range: bytes 0-999999999999999999999999\n"
+		"\n";
+
+	http_parser parser;
+	boost::tuple<int, int, bool> const received
+		= feed_bytes(parser, chunked_input);
+
+	TEST_CHECK(boost::get<2>(received) == true);
+}
+
+TORRENT_TEST(overflow_content_range_begin)
+{
+	char const* chunked_input =
+		"HTTP/1.1 206 OK\n"
+		"Content-Range: bytes 999999999999999999999999-0\n"
+		"\n";
+
+	http_parser parser;
+	boost::tuple<int, int, bool> const received
+		= feed_bytes(parser, chunked_input);
+
+	TEST_CHECK(boost::get<2>(received) == true);
+}
+
 TORRENT_TEST(invalid_chunk_afl)
 {
 	boost::uint8_t const invalid_chunked_input[] = {


### PR DESCRIPTION
Handle this case properly in the http parser