### PR TITLE
fix conversions of resume_data field of save_resume_data_alert.

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -344,7 +344,7 @@ def main():
         for a in alerts:
             if type(a) == lt.save_resume_data_alert:
                 print(a)
-                data = lt.bencode(a.resume_data)
+                data = lt.write_resume_data_buf(a.params)
                 h = a.handle
                 if h in torrents:
                     open(os.path.join(options.save_path, torrents[h].name + '.fastresume'), 'wb').write(data)

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -135,6 +135,13 @@ dict session_stats_values(session_stats_alert const& alert)
     return d;
 }
 
+#ifndef TORRENT_NO_DEPRECATE
+entry const& get_resume_data_entry(save_resume_data_alert const& self)
+{
+	return *self.resume_data;
+}
+#endif
+
 namespace boost
 {
 	// some older compilers (like msvc-12.0) end up using
@@ -676,7 +683,7 @@ void bind_alert()
         "save_resume_data_alert", no_init)
         .def_readonly("params", &save_resume_data_alert::params)
 #ifndef TORRENT_NO_DEPRECATE
-        .def_readonly("resume_data", &save_resume_data_alert::resume_data)
+        .add_property("resume_data", make_function(get_resume_data_entry, by_value()))
 #endif
         ;
 

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -634,6 +634,15 @@ namespace
 		 return lt::find_metric_idx(name);
 	 }
 
+	bytes write_resume_data_buf_(add_torrent_params const& atp)
+	{
+		bytes ret;
+		auto buf = write_resume_data_buf(atp);
+		ret.arr.resize(buf.size());
+		std::copy(buf.begin(), buf.end(), ret.arr.begin());
+		return ret;
+	}
+
 } // anonymous namespace
 
 struct dummy1 {};
@@ -1098,7 +1107,7 @@ void bind_session()
     def("default_settings", default_settings_wrapper);
     def("read_resume_data", read_resume_data_wrapper);
     def("write_resume_data", write_resume_data);
-    def("write_resume_data_buf", write_resume_data_buf);
+    def("write_resume_data_buf", write_resume_data_buf_);
 
 	class_<stats_metric>("stats_metric")
 		.def_readonly("name", &stats_metric::name)


### PR DESCRIPTION
make write_resume_data_buf return a byte-array. use write_resume_data_buf() in client.py instead of, the deprecated, resume_data