### PR TITLE
fix alert_manager on_alert() race

### DIFF
--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -77,6 +77,14 @@ namespace libtorrent
 			|| a->type() == save_resume_data_alert::alert_type)
 			++m_num_queued_resume;
 
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		for (ses_extension_list_t::iterator i = m_ses_extensions.begin()
+			, end(m_ses_extensions.end()); i != end; ++i)
+		{
+			(*i)->on_alert(a);
+		}
+#endif
+
 		if (m_alerts[m_generation].size() == 1)
 		{
 			lock.unlock();
@@ -95,14 +103,6 @@ namespace libtorrent
 		{
 			lock.unlock();
 		}
-
-#ifndef TORRENT_DISABLE_EXTENSIONS
-		for (ses_extension_list_t::iterator i = m_ses_extensions.begin()
-			, end(m_ses_extensions.end()); i != end; ++i)
-		{
-			(*i)->on_alert(a);
-		}
-#endif
 	}
 
 #ifndef TORRENT_NO_DEPRECATE


### PR DESCRIPTION
make sure the alert_manager is still locked when calling the on_alert() hook on plugins, since they receive the alert, the storage of that alert is protected by the mutex and might otherwise be destroyed from another thread while the on_alert() callback is still running.

This is intended to fix https://github.com/arvidn/libtorrent/issues/2934