### PR TITLE
Use settings_pack::urlseed_wait_retry for default retry with http seeds.

### DIFF
--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -812,7 +812,7 @@ namespace libtorrent {
 			// low number, like 5
 			urlseed_pipeline_size,
 
-			// time to wait until a new retry of a url-seed takes place.
+			// number of seconds until a new retry of a url-seed takes place.
 			// Default retry value for http-seeds that don't provide a valid 'retry-after' header.
 			urlseed_wait_retry,
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -806,13 +806,14 @@ namespace libtorrent {
 			// reliable.
 			urlseed_timeout,
 
-			// controls the pipelining size of url-seeds. i.e. the number of HTTP
+			// controls the pipelining size of url and http seeds. i.e. the number of HTTP
 			// request to keep outstanding before waiting for the first one to
 			// complete. It's common for web servers to limit this to a relatively
 			// low number, like 5
 			urlseed_pipeline_size,
 
-			// time to wait until a new retry of a web seed takes place
+			// time to wait until a new retry of a url-seed takes place.
+			// Default retry value for http-seeds that don't provide a valid 'retry-after' header.
 			urlseed_wait_retry,
 
 			// sets the upper limit on the total number of files this session will

--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -275,7 +275,7 @@ namespace libtorrent {
 				if (!is_ok_status(m_parser.status_code()))
 				{
 					auto const retry_time = value_or(m_parser.header_duration("retry-after")
-						, minutes32(5));
+						, seconds32(m_settings.get_int(settings_pack::urlseed_wait_retry)));
 
 					// temporarily unavailable, retry later
 					t->retry_web_seed(this, retry_time);


### PR DESCRIPTION
Currently there is no way to configure the default retry time for http_seeds.
I looked through the history and can see no signs this is intentional.

This change will result in a default of 30 seconds instead of 5 minutes, but since the example in the BEP17 spec uses a 30 second retry time as the default I don't think it's a major issue.

Potentially this would be better as a separate setting, but I see http_seeds already share a few of the url_seed settings.