### PR TITLE
Make emplace_alert() lock-free (almost)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ target_compile_definitions(torrent-rasterbar PRIVATE TORRENT_BUILDING_LIBRARY)
 
 # Boost
 if(NOT DEFINED Boost_INCLUDE_DIR OR NOT DEFINED Boost_LIBRARIES)
-	FIND_PACKAGE(Boost REQUIRED COMPONENTS system chrono random)
+	FIND_PACKAGE(Boost REQUIRED COMPONENTS system chrono random thread)
 endif()
 include_directories(${Boost_INCLUDE_DIRS})
 target_link_libraries(torrent-rasterbar ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/Jamfile
+++ b/Jamfile
@@ -25,6 +25,7 @@ if $(BOOST_ROOT)
 	alias boost_chrono : /boost/chrono//boost_chrono : : : <include>$(BOOST_ROOT) ;
 	alias boost_system : /boost/system//boost_system : : : <include>$(BOOST_ROOT) ;
 	alias boost_random : /boost/random//boost_random : : : <include>$(BOOST_ROOT) ;
+	alias boost_thread : /boost/thread//boost_thread : : : <include>$(BOOST_ROOT) ;
 }
 else
 {
@@ -48,12 +49,16 @@ else
 		: : $(boost-include-path) ;
 	lib boost_random : : <target-os>darwin <name>boost_random-mt $(boost-lib-search-path)
 		: : $(boost-include-path) ;
+	lib boost_thread : : <target-os>darwin <name>boost_thread-mt $(boost-lib-search-path)
+		: : $(boost-include-path) ;
 
 	lib boost_chrono : : <name>boost_chrono $(boost-lib-search-path)
 		: : $(boost-include-path) ;
 	lib boost_system : : <name>boost_system $(boost-lib-search-path)
 		: : $(boost-include-path) ;
 	lib boost_random : : <name>boost_random $(boost-lib-search-path)
+		: : $(boost-include-path) ;
+	lib boost_thread : : <name>boost_thread $(boost-lib-search-path)
 		: : $(boost-include-path) ;
 }
 
@@ -152,12 +157,14 @@ rule linking ( properties * )
 			result += <library>boost_system/<link>static/<define>BOOST_ALL_DYN_LINK ;
 			result += <library>boost_chrono/<link>static/<define>BOOST_ALL_DYN_LINK ;
 			result += <library>boost_random/<link>static/<define>BOOST_ALL_DYN_LINK ;
+			result += <library>boost_thread/<link>static/<define>BOOST_ALL_DYN_LINK ;
 		}
 		else
 		{
 			result += <library>boost_system/<link>static ;
 			result += <library>boost_chrono/<link>static ;
 			result += <library>boost_random/<link>static ;
+			result += <library>boost_thread/<link>static ;
 		}
 
 		if <toolset>gcc in $(properties)
@@ -173,12 +180,14 @@ rule linking ( properties * )
 		result += <library>boost_system/<link>shared ;
 		result += <library>boost_chrono/<link>shared ;
 		result += <library>boost_random/<link>shared ;
+		result += <library>boost_thread/<link>shared ;
 	}
 	else
 	{
 		result += <library>boost_system ;
 		result += <library>boost_chrono ;
 		result += <library>boost_random ;
+		result += <library>boost_thread ;
 	}
 
 	result += <define>BOOST_ALL_NO_LIB

--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,10 @@ AX_BOOST_RANDOM()
 AS_IF([test -z "$BOOST_RANDOM_LIB"],
       [AC_MSG_ERROR(Boost.Random library not found. Try using --with-boost-random=lib)])
 
+AX_BOOST_THREAD()
+AS_IF([test -z "$BOOST_THREAD_LIB"],
+      [AC_MSG_ERROR(Boost.Random library not found. Try using --with-boost-thread=lib)])
+
 CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 LIBS="$BOOST_CHRONO_LIB $BOOST_RANDOM_LIB $LIBS"
@@ -644,6 +648,7 @@ Boost libraries:
   boost.system:         ${BOOST_SYSTEM_LIB}
   boost.chrono:         ${BOOST_CHRONO_LIB}
   boost.random:         ${BOOST_RANDOM_LIB}
+  boost.thread:         ${BOOST_THREAD_LIB}
 END
 
 AS_IF([test "x$ARG_ENABLE_PYTHON_BINDING" = "xyes"], [

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -191,7 +191,7 @@ namespace libtorrent {
 		boost::function<void()> m_notify;
 
 		// the number of resume data alerts  in the alert queue
-		boost::atomic<int> m_num_queued_resume;
+		int m_num_queued_resume;
 
 		// this is either 0 or 1, it indicates which m_alerts and m_allocations
 		// the alert_manager is allowed to use right now. This is swapped when

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -114,7 +114,7 @@ namespace libtorrent {
 			T alert(m_allocations[m_generation], std::forward<Args>(args)...);
 			m_alerts[m_generation].push_back(alert);
 
-			maybe_notify(&alert, lock);
+			maybe_notify(&alert);
 		}
 
 #else
@@ -167,7 +167,7 @@ namespace libtorrent {
 		alert_manager(alert_manager const&);
 		alert_manager& operator=(alert_manager const&);
 
-		void maybe_notify(alert* a, mutex::scoped_lock& lock);
+		void maybe_notify(alert* const a);
 
 		mutable mutex m_mutex;
 		condition_variable m_condition;

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -103,7 +103,7 @@ namespace libtorrent {
 				if (m_ses_extensions_reliable.empty())
 					return;
 
-				mutex::scoped_lock lock(m_mutex_reliable);
+				mutex::scoped_lock reliable_lock(m_mutex_reliable);
 				T alert(m_allocator_reliable, std::forward<Args>(args)...);
 				notify_extensions(&alert, m_ses_extensions_reliable);
 				m_allocator_reliable.reset();
@@ -209,7 +209,7 @@ namespace libtorrent {
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		typedef std::list<boost::shared_ptr<plugin> > ses_extension_list_t;
-		void notify_extensions(alert * const a, ses_extension_list_t& extensions);
+		void notify_extensions(alert * const a, ses_extension_list_t const& extensions);
 		ses_extension_list_t m_ses_extensions;
 		ses_extension_list_t m_ses_extensions_reliable;
 		aux::stack_allocator m_allocator_reliable;

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -188,7 +188,7 @@ namespace libtorrent {
 		boost::function<void()> m_notify;
 
 		// the number of resume data alerts  in the alert queue
-		int m_num_queued_resume;
+		boost::atomic<int> m_num_queued_resume;
 
 		// this is either 0 or 1, it indicates which m_alerts and m_allocations
 		// the alert_manager is allowed to use right now. This is swapped when

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -138,7 +138,10 @@ namespace libtorrent {
 
 		void set_alert_mask(boost::uint32_t m)
 		{
-			m_alert_mask.store(m, boost::memory_order_relaxed);
+			// since this call may get inlined by external threads
+			// it can't be relaxed to ensure the update is done before
+			// returning
+			m_alert_mask = m;
 		}
 
 		boost::uint32_t alert_mask() const

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -138,10 +138,10 @@ namespace libtorrent {
 
 		void set_alert_mask(boost::uint32_t m)
 		{
-			// since this call may get inlined by external threads
-			// it can't be relaxed to ensure the update is done before
-			// returning
-			m_alert_mask = m;
+			// we don't care if this store happens immediately
+			// because it is guaranteed to happen before the caller
+			// makes any attempt to synchronize
+			m_alert_mask.store(m, boost::memory_order_relaxed);
 		}
 
 		boost::uint32_t alert_mask() const

--- a/include/libtorrent/alert_manager.hpp
+++ b/include/libtorrent/alert_manager.hpp
@@ -135,7 +135,8 @@ namespace libtorrent {
 				if (!m_ses_extensions_reliable.empty())
 				{
 					aux::stack_allocator::scoped_lock lock(*m_allocations[gen]);
-					T alert(lock.allocator(), std::forward<Args>(args)...);
+					T alert(lock.allocator()
+						, std::forward<Args>(args)...);
 					notify_extensions(&alert, m_ses_extensions_reliable);
 				}
 #endif
@@ -145,8 +146,8 @@ namespace libtorrent {
 			do
 			{
 				bool aborted;
-				T* alert = new T(*m_allocations[gen],
-					std::forward<Args>(args)...);
+				T* alert = new T(*m_allocations[gen]
+					, std::forward<Args>(args)...);
 
 				if (!do_emplace_alert(alert, T::priority, gen, aborted))
 				{
@@ -161,7 +162,8 @@ namespace libtorrent {
 					if (!m_ses_extensions_reliable.empty())
 					{
 						aux::stack_allocator::scoped_lock lock(*m_allocations[gen]);
-						T alert(lock.allocator(), std::forward<Args>(args)...);
+						T alert(lock.allocator()
+							, std::forward<Args>(args)...);
 						notify_extensions(&alert, m_ses_extensions_reliable);
 					}
 #endif

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -24,76 +24,63 @@
 			BOOST_PP_ENUM_PARAMS(I, typename A)>
 		bool emplace_alert(BOOST_PP_ENUM_BINARY_PARAMS(I, A, const& a) )
 		{
+			// acquire a shared lock
+			shared_lock::scoped_lock lock(m_shared_lock, shared_lock::shared);
+
 			// allocate thread specific storage the first time the thread runs
 			// this will be freed automagically by boost::thread_specific_ptr
-			if (m_allocations[0].get() == NULL)
-				init_thread_specific_storage();
+			if (m_thread_storage.get() == NULL)
+				init_thread_storage();
 
-			const int gen = (*m_generation).load();
+			// get the thread specific storage
+			thread_storage*const ts = m_thread_storage.get();
 
 #ifndef TORRENT_NO_DEPRECATE
-			if (m_dispatch.load(boost::memory_order_relaxed))
+			if (m_dispatch)
 			{
-				aux::stack_allocator::scoped_lock lock(*m_allocations[gen]);
-				(*m_dispatch.load(boost::memory_order_relaxed))(std::auto_ptr<alert>(new T(lock.allocator()
+				m_dispatch(std::auto_ptr<alert>(new T(ts->current_allocator()
 					BOOST_PP_COMMA_IF(I)
 					BOOST_PP_ENUM_PARAMS(I, a))));
 				return false;
 			}
 #endif
+			int index;
+			T* alert;
+			alert = m_alerts_pool.acquire(alert);
+			new (alert) T(ts->current_allocator()
+					BOOST_PP_COMMA_IF(I)
+					BOOST_PP_ENUM_PARAMS(I, a));
+			TORRENT_ASSERT(alert != NULL);
 
-			// don't add more than this number of alerts, unless it's a
-			// high priority alert, in which case we try harder to deliver it
-			// for high priority alerts, double the upper limit
-			if (m_queue_size.load(boost::memory_order_relaxed) >=
-				(m_queue_size_limit.load(boost::memory_order_relaxed) * (1 + T::priority)))
+			if ((index = m_alerts.push(alert, T::priority)) == -1)
 			{
 #ifndef TORRENT_DISABLE_EXTENSIONS
 				if (!m_ses_extensions_reliable.empty())
-				{
-					aux::stack_allocator::scoped_lock lock(*m_allocations[gen]);
-					T alert(lock.allocator()
-						BOOST_PP_COMMA_IF(I)
-						BOOST_PP_ENUM_PARAMS(I, a));
-
-					notify_extensions(&alert, m_ses_extensions_reliable);
-				}
+					notify_extensions(alert, m_ses_extensions_reliable);
 #endif
+				// free the alert
+				m_alerts_pool.release(alert);
 				return false;
 			}
 
-			do
+			if (index == 0)
 			{
-				bool aborted;
-				T* alert = new T(*m_allocations[gen]
-					BOOST_PP_COMMA_IF(I)
-					BOOST_PP_ENUM_PARAMS(I, a));
+				// we just posted to an empty queue. If anyone is waiting for
+				// alerts, we need to notify them. Also (potentially) call the
+				// user supplied m_notify callback to let the client wake up its
+				// message loop to poll for alerts.
+				if (m_notify) m_notify();
 
-				if (!do_emplace_alert(alert, T::priority, gen, aborted))
-				{
-					// free the alert
-					delete alert;
-
-					// this is just a safety net in case alerts where
-					// popped twice while do_emplace_alert() was running.
-					if (aborted) continue;
+				// wake any threads waiting for alerts
+				mutex::scoped_lock lock(m_mutex);
+				m_condition.notify_all();
+			}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-					if (!m_ses_extensions_reliable.empty())
-					{
-						aux::stack_allocator::scoped_lock lock(*m_allocations[gen]);
-						T alert(lock.allocator()
-							BOOST_PP_COMMA_IF(I)
-							BOOST_PP_ENUM_PARAMS(I, a));
-
-						notify_extensions(&alert, m_ses_extensions_reliable);
-					}
+			notify_extensions(alert, m_ses_extensions);
 #endif
-					return false;
-				}
-				return true;
-			}
-			while (1);
+
+			return true;
 		}
 
 #undef I

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -61,7 +61,7 @@
 				BOOST_PP_ENUM_PARAMS(I, a));
 			m_alerts[m_generation].push_back(alert);
 
-			maybe_notify(&alert);
+			maybe_notify(&alert, lock);
 		}
 
 #undef I

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -39,7 +39,40 @@
 			// for high priority alerts, double the upper limit
 			if (m_alerts[m_generation].size() >= m_queue_size_limit
 				* (1 + T::priority))
+			{
+#ifndef TORRENT_DISABLE_EXTENSIONS
+				if (m_reliable_ext_alerts) {
+					// after we have a reference to the current allocator it
+					// is safe to unlock the mutex because m_allocations is protected
+					// by the fact that the client needs to pop alerts *twice* before
+					// it can free it and that's impossible until we emplace
+					// more alerts.
+					aux::stack_allocator& alloc = m_allocations[m_generation];
+					lock.unlock();
+
+					// save the state of the active allocator so that
+					// we can restore it when we're done
+					aux::stack_allocator_state_t state = alloc.save_state();
+					T alert(alloc
+						BOOST_PP_COMMA_IF(I)
+						BOOST_PP_ENUM_PARAMS(I, a));
+
+
+					for (ses_extension_list_t::iterator i = m_ses_extensions.begin()
+						, end(m_ses_extensions.end()); i != end; ++i)
+					{
+						if (((*i)->implemented_features() & plugin::reliable_alerts_feature) != 0)
+						{
+							(*i)->on_alert(&alert);
+						}
+					}
+
+					alloc.restore_state(state);
+				}
+#endif
+
 				return;
+			}
 
 			T alert(m_allocations[m_generation]
 				BOOST_PP_COMMA_IF(I)

--- a/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
+++ b/include/libtorrent/aux_/alert_manager_variadic_emplace.hpp
@@ -46,7 +46,7 @@
 				if (m_ses_extensions_reliable.empty())
 					return;
 
-				mutex::scoped_lock lock(m_mutex_reliable);
+				mutex::scoped_lock reliable_lock(m_mutex_reliable);
 				T alert(m_allocator_reliable
 					BOOST_PP_COMMA_IF(I)
 					BOOST_PP_ENUM_PARAMS(I, a));
@@ -61,7 +61,7 @@
 				BOOST_PP_ENUM_PARAMS(I, a));
 			m_alerts[m_generation].push_back(alert);
 
-			maybe_notify(&alert, lock);
+			maybe_notify(&alert);
 		}
 
 #undef I

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -798,6 +798,9 @@ namespace libtorrent
 			// outstanding
 			int m_num_save_resume;
 
+			// the number of queued resume???
+			int m_num_queued_resume;
+
 			// peer connections are put here when disconnected to avoid
 			// race conditions with the disk thread. It's important that
 			// peer connections are destructed from the network thread,

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -218,7 +218,11 @@ namespace libtorrent
 			optimistic_unchoke_feature = 1,
 
 			// include this bit if your plugin needs to have on_tick() called
-			tick_feature = 2
+			tick_feature = 2,
+
+			// include this bit if your plugin needs to have on_alert() called
+			// for all unmasked alerts, even after the queue is full.
+			reliable_alerts_feature = 4
 		};
 
 		// This function is expected to return a bitmask indicating which features

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -138,39 +138,32 @@ namespace libtorrent { namespace aux
 
 		int copy_string(std::string const& str)
 		{
-			mutex::scoped_lock lock(m_mutex);
 			int ret = int(m_storage.size());
 			m_storage.resize(ret + str.length() + 1);
-			lock.unlock();
 			strcpy(&m_storage[ret], str.c_str());
 			return ret;
 		}
 
 		int copy_string(char const* str)
 		{
-			mutex::scoped_lock lock(m_mutex);
 			int ret = int(m_storage.size());
 			int len = strlen(str);
 			m_storage.resize(ret + len + 1);
-			lock.unlock();
 			strcpy(&m_storage[ret], str);
 			return ret;
 		}
 
 		int copy_buffer(char const* buf, int size)
 		{
-			mutex::scoped_lock lock(m_mutex);
 			int ret = int(m_storage.size());
 			if (size < 1) return -1;
 			m_storage.resize(ret + size);
-			lock.unlock();
 			memcpy(&m_storage[ret], buf, size);
 			return ret;
 		}
 
 		int allocate(int bytes)
 		{
-			mutex::scoped_lock lock(m_mutex);
 			if (bytes < 1) return -1;
 			int ret = int(m_storage.size());
 			m_storage.resize(ret + bytes);

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -38,6 +38,8 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent { namespace aux
 {
 
+	typedef boost::uint32_t stack_allocator_state_t;
+
 	struct stack_allocator
 	{
 		stack_allocator() {}
@@ -98,6 +100,17 @@ namespace libtorrent { namespace aux
 		void reset()
 		{
 			m_storage.clear();
+		}
+
+		void restore_state(stack_allocator_state_t state)
+		{
+			TORRENT_ASSERT(state <= m_storage.size());
+			m_storage.resize(state);
+		}
+
+		stack_allocator_state_t save_state()
+		{
+			return m_storage.size();
 		}
 
 	private:

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -38,8 +38,6 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent { namespace aux
 {
 
-	typedef boost::uint32_t stack_allocator_state_t;
-
 	struct stack_allocator
 	{
 		stack_allocator() {}
@@ -100,17 +98,6 @@ namespace libtorrent { namespace aux
 		void reset()
 		{
 			m_storage.clear();
-		}
-
-		void restore_state(stack_allocator_state_t state)
-		{
-			TORRENT_ASSERT(state <= m_storage.size());
-			m_storage.resize(state);
-		}
-
-		stack_allocator_state_t save_state()
-		{
-			return m_storage.size();
 		}
 
 	private:

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -134,7 +134,10 @@ namespace libtorrent { namespace aux
 			scoped_lock& operator=(scoped_lock const&);
 		};
 
-		stack_allocator() {}
+		stack_allocator() : m_locks(0)
+			, m_consec_locks(0)
+			, m_saved_size(-1)
+			, m_reset_pending(false) {}
 
 		int copy_string(std::string const& str)
 		{
@@ -209,10 +212,10 @@ namespace libtorrent { namespace aux
 		stack_allocator(stack_allocator const&);
 		stack_allocator& operator=(stack_allocator const&);
 
-		int m_locks = 0;
-		int m_consec_locks = 0;
-		int m_saved_size = -1;
-		bool m_reset_pending = false;
+		int m_locks;
+		int m_consec_locks;
+		int m_saved_size;
+		bool m_reset_pending;
 		mutable mutex m_mutex;
 		buffer m_storage;
 	};

--- a/include/libtorrent/thread.hpp
+++ b/include/libtorrent/thread.hpp
@@ -69,7 +69,7 @@ namespace libtorrent
 	namespace this_thread
 	{
 		void yield();
-	};
+	}
 
 	struct TORRENT_EXTRA_EXPORT condition_variable
 	{

--- a/include/libtorrent/thread.hpp
+++ b/include/libtorrent/thread.hpp
@@ -50,18 +50,17 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory> // for auto_ptr required by asio
 
-#include <boost/asio/detail/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/asio/detail/mutex.hpp>
 #include <boost/asio/detail/event.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/atomic.hpp>
-#include <thread>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 namespace libtorrent
 {
-	typedef boost::asio::detail::thread thread;
+	typedef boost::thread thread;
 	typedef boost::asio::detail::mutex mutex;
 	typedef boost::asio::detail::event event;
 
@@ -124,7 +123,7 @@ namespace libtorrent
 
 				// wait for all shared locks to be released
 				while (m_shared_locks.load() > 0)
-					std::this_thread::yield();
+					boost::this_thread::yield();
 			}
 			else
 			{

--- a/include/libtorrent/thread.hpp
+++ b/include/libtorrent/thread.hpp
@@ -66,6 +66,11 @@ namespace libtorrent
 	// internal
 	void sleep(int milliseconds);
 
+	namespace this_thread
+	{
+		void yield();
+	};
+
 	struct TORRENT_EXTRA_EXPORT condition_variable
 	{
 		condition_variable();

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -295,7 +295,8 @@ namespace libtorrent
 
 		torrent(aux::session_interface& ses, int block_size
 			, int seq, add_torrent_params const& p
-			, sha1_hash const& info_hash);
+			, sha1_hash const& info_hash
+			, int& num_queued_resume);
 		~torrent();
 
 		// This may be called from multiple threads
@@ -803,6 +804,10 @@ namespace libtorrent
 		}
 
 	private:
+		// this field lives on session_impl and it's incremented
+		// when save_resume_data_alert or save_resume_data_failed_alert
+		// is successfully enqueued
+		int& m_num_queued_resume;
 
 		// called when we learn that we have a piece
 		// only once per piece

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -158,7 +158,7 @@ libtorrent_rasterbar_la_SOURCES = \
   $(BUILTIN_CRYPTO_SOURCES)
 
 libtorrent_rasterbar_la_LDFLAGS = -version-info $(INTERFACE_VERSION_INFO)
-libtorrent_rasterbar_la_LIBADD = @BOOST_SYSTEM_LIB@ @OPENSSL_LIBS@
+libtorrent_rasterbar_la_LIBADD = @BOOST_SYSTEM_LIB@ @BOOST_THREAD_LIB@ @OPENSSL_LIBS@
 
 AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY -I$(top_srcdir)/include -I$(top_srcdir)/ed25519/src @DEBUGFLAGS@ @OPENSSL_INCLUDES@
 AM_CFLAGS = -I$(top_srcdir)/ed25519/src -std=c99

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -63,14 +63,14 @@ namespace libtorrent
 
 		// release alerts in the pending deletes list
 		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
-			delete m_alerts_pending_delete[i];
+			m_alerts_pool.release(m_alerts_pending_delete[i]);
 
 		// free alerts already in the queue
 		for (int i = 0; i < n_alerts; i++)
 		{
 			alert * const alert = pop_alert();
 			TORRENT_ASSERT(alert != NULL);
-			delete alert;
+			m_alerts_pool.release(alert);
 		}
 	}
 
@@ -222,7 +222,7 @@ namespace libtorrent
 
 		// release alerts in the pending deletes list
 		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
-			delete m_alerts_pending_delete[i];
+			m_alerts_pool.release(m_alerts_pending_delete[i]);
 		m_alerts_pending_delete.clear();
 		alerts.clear();
 

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -78,8 +78,6 @@ namespace libtorrent
 
 		if (m_alerts[m_generation].size() == 1)
 		{
-			lock.unlock();
-
 			// we just posted to an empty queue. If anyone is waiting for
 			// alerts, we need to notify them. Also (potentially) call the
 			// user supplied m_notify callback to let the client wake up its
@@ -90,14 +88,9 @@ namespace libtorrent
 			// > 0 notify them
 			m_condition.notify_all();
 		}
-		else
-		{
-			lock.unlock();
-		}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 		notify_extensions(a, m_ses_extensions);
-		notify_extensions(a, m_ses_extensions_reliable);
 #endif
 	}
 
@@ -158,9 +151,9 @@ namespace libtorrent
 	}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-	void alert_manager::notify_extensions(alert * const alert, ses_extension_list_t& list)
+	void alert_manager::notify_extensions(alert * const alert, ses_extension_list_t const& list)
 	{
-		for (ses_extension_list_t::iterator i = list.begin(),
+		for (ses_extension_list_t::const_iterator i = list.begin(),
 			end(list.end()); i != end; ++i)
 		{
 			(*i)->on_alert(alert);
@@ -170,13 +163,8 @@ namespace libtorrent
 	void alert_manager::add_extension(boost::shared_ptr<plugin> ext)
 	{
 		if ((ext->implemented_features() & plugin::reliable_alerts_feature) != 0)
-		{
 			m_ses_extensions_reliable.push_back(ext);
-		}
-		else
-		{
-			m_ses_extensions.push_back(ext);
-		}
+		m_ses_extensions.push_back(ext);
 	}
 #endif
 

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -40,7 +40,9 @@ namespace libtorrent
 	alert_manager::alert_manager(int queue_limit, boost::uint32_t alert_mask)
 		: m_alert_mask(alert_mask)
 		, m_queue_size_limit(queue_limit)
+#ifndef TORRENT_NO_DEPRECATE
 		, m_dispatch(NULL)
+#endif
 		, m_notify(NULL)
 		, m_alerts(queue_limit * 2)
 		, m_queue_size(0)

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -70,7 +70,7 @@ namespace libtorrent
 		return NULL;
 	}
 
-	void alert_manager::maybe_notify(alert* a, mutex::scoped_lock& lock)
+	void alert_manager::maybe_notify(alert* const a)
 	{
 		if (a->type() == save_resume_data_failed_alert::alert_type
 			|| a->type() == save_resume_data_alert::alert_type)

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -62,11 +62,11 @@ namespace libtorrent
 		const int n_alerts = m_queue_size;
 
 		// release alerts in the pending deletes list
-		for (int i = 0; i < m_alerts_pending_delete.size(); i++)
+		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
 			delete m_alerts_pending_delete[i];
 
 		// free alerts already in the queue
-		for (int i = 0; i < m_queue_size; i++)
+		for (int i = 0; i < n_alerts; i++)
 		{
 			alert * const alert = pop_alert();
 			TORRENT_ASSERT(alert != NULL);
@@ -157,7 +157,7 @@ namespace libtorrent
 		// unlock mutex and call dispatch function
 		lock.unlock();
 
-		for (int i = 0; i < alerts.size(); i++)
+		for (unsigned int i = 0; i < alerts.size(); i++)
 		{
 			TORRENT_ASSERT(alerts[i] != NULL);
 			(*m_dispatch.load(boost::memory_order_relaxed))(alerts[i]->clone());
@@ -245,11 +245,13 @@ namespace libtorrent
 			this_thread::yield();
 		}
 
-		const int n_pending = m_alerts_pending_delete.size();
-		const int size_limit = m_queue_size_limit;
+		//const int size_limit = m_queue_size_limit;
 
-		alerts.clear();
+		// release alerts in the pending deletes list
+		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
+			delete m_alerts_pending_delete[i];
 		m_alerts_pending_delete.clear();
+		alerts.clear();
 
 		// after this libtorrent threads can begin work on posting
 		// new alerts if the queue was full.
@@ -274,7 +276,7 @@ namespace libtorrent
 		maybe_resize_buffer();
 
 		// free the storage for each thread
-		for (int i = 0; i < m_threads.size(); i++)
+		for (unsigned int i = 0; i < m_threads.size(); i++)
 		{
 			thread_state& ts = m_threads[i];
 

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -52,7 +52,8 @@ namespace libtorrent
 
 	int alert_manager::num_queued_resume() const
 	{
-		return m_num_queued_resume.load(boost::memory_order_consume);
+		mutex::scoped_lock lock(m_mutex);
+		return m_num_queued_resume;
 	}
 
 	alert* alert_manager::wait_for_alert(time_duration max_wait)
@@ -74,7 +75,7 @@ namespace libtorrent
 	{
 		if (a->type() == save_resume_data_failed_alert::alert_type
 			|| a->type() == save_resume_data_alert::alert_type)
-			m_num_queued_resume.fetch_add(1, boost::memory_order_relaxed);
+			++m_num_queued_resume;
 
 		if (m_alerts[m_generation].size() == 1)
 		{
@@ -177,13 +178,13 @@ namespace libtorrent
 	void alert_manager::get_all(std::vector<alert*>& alerts, int& num_resume)
 	{
 		mutex::scoped_lock lock(m_mutex);
-		TORRENT_ASSERT(m_num_queued_resume.load(boost::memory_order_relaxed) <= m_alerts[m_generation].size());
+		TORRENT_ASSERT(m_num_queued_resume <= m_alerts[m_generation].size());
 
 		alerts.clear();
 		if (m_alerts[m_generation].empty()) return;
 
 		m_alerts[m_generation].get_pointers(alerts);
-		num_resume = m_num_queued_resume.load(boost::memory_order_relaxed);
+		num_resume = m_num_queued_resume;
 		m_num_queued_resume = 0;
 
 		// swap buffers

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -39,39 +39,24 @@ namespace libtorrent
 
 	alert_manager::alert_manager(int queue_limit, boost::uint32_t alert_mask)
 		: m_alert_mask(alert_mask)
-		, m_queue_size_limit(queue_limit)
-#ifndef TORRENT_NO_DEPRECATE
-		, m_dispatch(NULL)
-#endif
-		, m_notify(NULL)
-		, m_alerts(queue_limit * 2)
-		, m_queue_size(0)
-		, m_queue_write_slot(-1)
-		, m_queue_read_slot(0)
-		, m_queue_limit_requested(-1)
-	{
-		for (int i = 0; i < queue_limit * 2; i++)
-			m_alerts[i] = NULL;
-	}
+		, m_alerts(queue_limit)
+		, m_queue_limit_requested(-1) {}
 
 	alert_manager::~alert_manager()
 	{
 		mutex::scoped_lock lock(m_mutex);
 		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
+		std::vector<alert*> alerts;
 
-		const int n_alerts = m_queue_size;
+		// pop and free enqueued alerts
+		const int n_alerts = m_alerts.pop_all(alerts);
+		for (int i = 0; i < n_alerts; i++)
+			m_alerts_pool.release(alerts[i]);
 
-		// release alerts in the pending deletes list
+		// free alerts in the pending deletes list
 		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
 			m_alerts_pool.release(m_alerts_pending_delete[i]);
 
-		// free alerts already in the queue
-		for (int i = 0; i < n_alerts; i++)
-		{
-			alert * const alert = pop_alert();
-			TORRENT_ASSERT(alert != NULL);
-			m_alerts_pool.release(alert);
-		}
 	}
 
 	alert* alert_manager::wait_for_alert(time_duration max_wait)
@@ -79,46 +64,18 @@ namespace libtorrent
 		mutex::scoped_lock lock(m_mutex);
 		shared_lock::scoped_lock rlock(m_shared_lock, shared_lock::shared);
 
-		if (m_queue_size > 0)
-			return m_alerts[m_queue_read_slot];
+		if (m_alerts.front() != NULL)
+			return m_alerts.front();
 
 		// this call can be interrupted prematurely by other signals
 		rlock.unlock();
 		m_condition.wait_for(lock, max_wait);
 		rlock.lock();
 
-		if (m_queue_size > 0)
-			return m_alerts[m_queue_read_slot];
+		if (m_alerts.front())
+			return m_alerts.front();
 
 		return NULL;
-	}
-
-	// pops the next alert from the ring buffer. The caller of
-	// this function must ensure that there is at least one alert
-	// in the ring buffer before making this call
-	alert * alert_manager::pop_alert()
-	{
-		const int size_limit = m_queue_size_limit;
-		int slot = m_queue_read_slot;
-
-		// with multiple threads postings alerts slots may be written
-		// out of sequence so we must check that the alert is there
-		// before popping it.
-		for (int spins = 0; m_alerts[slot] == NULL; spins++)
-			if (spins > TORRENT_ALERT_MANAGER_SPIN_MAX) std::this_thread::yield();
-
-		alert * const alert = m_alerts[slot].load(boost::memory_order_relaxed);
-		TORRENT_ASSERT(alert != NULL);
-		m_alerts[slot++] = NULL;
-
-		if (slot == (size_limit * 2))
-			slot = 0;
-
-		TORRENT_ASSERT(slot >= 0 && slot < (size_limit * 2));
-
-		m_queue_read_slot = slot;
-
-		return alert;
 	}
 
 #ifndef TORRENT_NO_DEPRECATE
@@ -134,26 +91,25 @@ namespace libtorrent
 		mutex::scoped_lock lock(m_mutex);
 		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
 
-		std::vector<alert*> alerts;
+		std::vector<alert*> alerts, tmp;
+		const int n_alerts = m_alerts.pop_all(alerts);
 
-		for (int i = 0; i < m_queue_size; i++)
-		{
-			alert*const alert = pop_alert();
-			TORRENT_ASSERT(alert != NULL);
-			alerts.push_back(alert);
-		}
+		for (int i = 0; i < n_alerts; i++)
+			tmp.push_back(alerts[i]);
 
-		// clear the queue size and free ring buffer
-		m_queue_size = 0;
-		m_alerts = std::vector<boost::atomic<alert*>>(0);
+		// clear the queue and free ring buffer
+		m_alerts = lockfree_queue(0);
 		m_dispatch = fun;
 
 		// unlock mutex and call dispatch function
 		wlock.unlock();
 		lock.unlock();
 
-		for (unsigned int i = 0; i < alerts.size(); i++)
-			m_dispatch(alerts[i]->clone());
+		for (unsigned int i = 0; i < tmp.size(); i++)
+		{
+			m_dispatch(tmp[i]->clone());
+			m_alerts_pool.release(tmp[i]);
+		}
 	}
 
 #ifdef __GNUC__
@@ -171,7 +127,7 @@ namespace libtorrent
 
 		// this load can be relaxed because it is guaranteed to happen
 		// after the synchronized store above.
-		if (m_queue_size.load(boost::memory_order_relaxed) != 0)
+		if (m_alerts.size() != 0)
 			if (m_notify) m_notify();
 	}
 
@@ -191,17 +147,12 @@ namespace libtorrent
 
 		// we can only resize if there is no other thread posting alerts
 		// and if no thread posted an alert since we popped them
-		if (new_limit < 0 || m_queue_size > 0)
+		if (new_limit < 0 || m_alerts.size() > 0)
 			return;
 
 		// resize the queue
-		m_alerts = std::vector<boost::atomic<alert*>>(new_limit * 2);
-		for (int i = 0; i < new_limit * 2; i++)
-			m_alerts[i].store(NULL, boost::memory_order_relaxed);
-
-		m_queue_size_limit = new_limit;
-		m_queue_write_slot = -1;
-		m_queue_read_slot = 0;
+		if (new_limit != m_alerts.size_limit())
+			m_alerts = lockfree_queue(new_limit);
 		m_queue_limit_requested = -1;
 	}
 
@@ -214,35 +165,19 @@ namespace libtorrent
 		if (m_queue_limit_requested != -1)
 			wlock.lock();
 
-		// yield the cpu at least once before to ensure that
-		// this function cannot be called twice in the timespan
-		// between the alert contruction and it being placed in the
-		// queue (and available to us).
-		std::this_thread::yield();
-
 		// release alerts in the pending deletes list
 		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
 			m_alerts_pool.release(m_alerts_pending_delete[i]);
 		m_alerts_pending_delete.clear();
 		alerts.clear();
 
-		// after this libtorrent threads can begin work on posting
-		// new alerts if the queue was full.
-		const int n_alerts = m_queue_size.exchange(0);
+		// pop the alerts
+		const int n_alerts = m_alerts.pop_all(alerts);
 		if (n_alerts == 0) return;
 
-		// pop n_alerts
+		// copy the alerts to the pending deletes queue
 		for (int i = 0; i < n_alerts; i++)
-		{
-			// remove the alert and mark the ring buffer slot as free
-			alert * const alert = pop_alert();
-			TORRENT_ASSERT(alert != NULL);
-
-			// copy the alerts to the user's vector and to the
-			// pending delete list
-			m_alerts_pending_delete.push_back(alert);
-			alerts.push_back(alert);
-		}
+			m_alerts_pending_delete.push_back(alerts[i]);
 
 		// if a buffer resize is pending do it now
 		if (m_queue_limit_requested != -1)

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -46,6 +46,9 @@ namespace libtorrent
 		, m_queue_size_limit(queue_limit)
 		, m_num_queued_resume(0)
 		, m_generation(0)
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		, m_reliable_ext_alerts(false)
+#endif
 	{}
 
 	alert_manager::~alert_manager() {}
@@ -164,6 +167,8 @@ namespace libtorrent
 #ifndef TORRENT_DISABLE_EXTENSIONS
 	void alert_manager::add_extension(boost::shared_ptr<plugin> ext)
 	{
+		if ((ext->implemented_features() & plugin::reliable_alerts_feature) != 0)
+			m_reliable_ext_alerts = true;
 		m_ses_extensions.push_back(ext);
 	}
 #endif

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -52,7 +52,6 @@ namespace libtorrent
 
 	int alert_manager::num_queued_resume() const
 	{
-		mutex::scoped_lock lock(m_mutex);
 		return m_num_queued_resume;
 	}
 

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -49,7 +49,6 @@ namespace libtorrent
 		, m_queue_write_slot(-1)
 		, m_queue_read_slot(0)
 		, m_queue_limit_requested(-1)
-		, m_buffer_refs(0)
 	{
 		for (int i = 0; i < queue_limit * 2; i++)
 			m_alerts[i] = NULL;
@@ -58,8 +57,7 @@ namespace libtorrent
 	alert_manager::~alert_manager()
 	{
 		mutex::scoped_lock lock(m_mutex);
-
-		TORRENT_ASSERT(m_buffer_refs == 0);
+		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
 
 		const int n_alerts = m_queue_size;
 
@@ -79,12 +77,15 @@ namespace libtorrent
 	alert* alert_manager::wait_for_alert(time_duration max_wait)
 	{
 		mutex::scoped_lock lock(m_mutex);
+		shared_lock::scoped_lock rlock(m_shared_lock, shared_lock::shared);
 
 		if (m_queue_size > 0)
 			return m_alerts[m_queue_read_slot];
 
 		// this call can be interrupted prematurely by other signals
+		rlock.unlock();
 		m_condition.wait_for(lock, max_wait);
+		rlock.lock();
 
 		if (m_queue_size > 0)
 			return m_alerts[m_queue_read_slot];
@@ -97,14 +98,14 @@ namespace libtorrent
 	// in the ring buffer before making this call
 	alert * alert_manager::pop_alert()
 	{
-		const int size_limit = m_queue_size_limit.load(boost::memory_order_relaxed);
+		const int size_limit = m_queue_size_limit;
 		int slot = m_queue_read_slot;
 
 		// with multiple threads postings alerts slots may be written
 		// out of sequence so we must check that the alert is there
 		// before popping it.
 		for (int spins = 0; m_alerts[slot] == NULL; spins++)
-			if (spins > TORRENT_ALERT_MANAGER_SPIN_MAX) this_thread::yield();
+			if (spins > TORRENT_ALERT_MANAGER_SPIN_MAX) std::this_thread::yield();
 
 		alert * const alert = m_alerts[slot].load(boost::memory_order_relaxed);
 		TORRENT_ASSERT(alert != NULL);
@@ -131,23 +132,13 @@ namespace libtorrent
 		boost::function<void(std::auto_ptr<alert>)> const& fun)
 	{
 		mutex::scoped_lock lock(m_mutex);
+		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
 
 		std::vector<alert*> alerts;
 
-		// in order to make boost:function<> atomic we use two separate
-		// fields in a ping-pong fashion and update the pointer to it
-		// atomically
-		const int index = (&m_dispatch_storage[0] == m_dispatch) ? 1 : 0;
-		m_dispatch_storage[index] = fun;
-		m_dispatch.store(&m_dispatch_storage[index]);
-
-		// wait until all ring buffer refs are released
-		while (m_buffer_refs > 0)
-			this_thread::yield();
-
 		for (int i = 0; i < m_queue_size; i++)
 		{
-			alert * const alert = pop_alert();
+			alert*const alert = pop_alert();
 			TORRENT_ASSERT(alert != NULL);
 			alerts.push_back(alert);
 		}
@@ -155,15 +146,14 @@ namespace libtorrent
 		// clear the queue size and free ring buffer
 		m_queue_size = 0;
 		m_alerts = std::vector<boost::atomic<alert*>>(0);
+		m_dispatch = fun;
 
 		// unlock mutex and call dispatch function
+		wlock.unlock();
 		lock.unlock();
 
 		for (unsigned int i = 0; i < alerts.size(); i++)
-		{
-			TORRENT_ASSERT(alerts[i] != NULL);
-			(*m_dispatch.load(boost::memory_order_relaxed))(alerts[i]->clone());
-		}
+			m_dispatch(alerts[i]->clone());
 	}
 
 #ifdef __GNUC__
@@ -175,32 +165,20 @@ namespace libtorrent
 	void alert_manager::set_notify_function(boost::function<void()> const& fun)
 	{
 		mutex::scoped_lock lock(m_mutex);
+		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
 
-		// in order to make boost:function<> atomic we use two separate
-		// fields in a ping-pong fashion and update the pointer to it
-		// atomically
-		if (fun)
-		{
-			const int index = (m_notify == &m_notify_storage[0]) ? 1 : 0;
-			m_notify_storage[index] = fun;
-			m_notify.store(&m_notify_storage[index]);
-		}
-		else
-		{
-			m_notify.store(NULL);
-		}
+		m_notify = fun;
 
-		if (m_queue_size != 0)
-		{
-			// never call a callback with the lock held!
-			if (m_notify)
-				(*m_notify.load(boost::memory_order_relaxed))();
-		}
+		// this load can be relaxed because it is guaranteed to happen
+		// after the synchronized store above.
+		if (m_queue_size.load(boost::memory_order_relaxed) != 0)
+			if (m_notify) m_notify();
 	}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
 	void alert_manager::add_extension(boost::shared_ptr<plugin> ext)
 	{
+		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
 		if ((ext->implemented_features() & plugin::reliable_alerts_feature) != 0)
 			m_ses_extensions_reliable.push_back(ext);
 		m_ses_extensions.push_back(ext);
@@ -213,7 +191,7 @@ namespace libtorrent
 
 		// we can only resize if there is no other thread posting alerts
 		// and if no thread posted an alert since we popped them
-		if (new_limit < 0 || m_buffer_refs > 0 || m_queue_size > 0)
+		if (new_limit < 0 || m_queue_size > 0)
 			return;
 
 		// resize the queue
@@ -230,24 +208,17 @@ namespace libtorrent
 	void alert_manager::get_all(std::vector<alert*>& alerts)
 	{
 		mutex::scoped_lock lock(m_mutex);
+		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive, false);
 
+		// if a queue resize has been requested acquire an exclusive lock
 		if (m_queue_limit_requested != -1)
-		{
-			// if a buffer resize has been requested wait until all
-			// buffer references have been released to ensure that
-			// maybe_resize_buffer() succeeds
-			while (m_buffer_refs > 0) this_thread::yield();
-		}
-		else
-		{
-			// yield the cpu at least once before to ensure that
-			// this function cannot be called twice in the timespan
-			// between the alert contruction and it being placed in the
-			// queue (and available to us).
-			this_thread::yield();
-		}
+			wlock.lock();
 
-		//const int size_limit = m_queue_size_limit;
+		// yield the cpu at least once before to ensure that
+		// this function cannot be called twice in the timespan
+		// between the alert contruction and it being placed in the
+		// queue (and available to us).
+		std::this_thread::yield();
 
 		// release alerts in the pending deletes list
 		for (unsigned int i = 0; i < m_alerts_pending_delete.size(); i++)
@@ -258,7 +229,6 @@ namespace libtorrent
 		// after this libtorrent threads can begin work on posting
 		// new alerts if the queue was full.
 		const int n_alerts = m_queue_size.exchange(0);
-
 		if (n_alerts == 0) return;
 
 		// pop n_alerts
@@ -275,40 +245,18 @@ namespace libtorrent
 		}
 
 		// if a buffer resize is pending do it now
-		maybe_resize_buffer();
+		if (m_queue_limit_requested != -1)
+			maybe_resize_buffer();
 
-		// free the storage for each thread
-		for (unsigned int i = 0; i < m_threads.size(); i++)
-		{
-			thread_state& ts = m_threads[i];
-
-			int gen = ts.youngest_generation
-				->load(boost::memory_order_relaxed);
-
-			// swap buffers
-			gen = (gen == TORRENT_ALERT_MANAGER_N_GENERATIONS - 1) ? 0 : (gen + 1);
-			ts.youngest_generation->store(gen);
-			ts.n_generations++;
-
-			TORRENT_ASSERT(gen < TORRENT_ALERT_MANAGER_N_GENERATIONS);
-			TORRENT_ASSERT(ts.oldest_generation <= TORRENT_ALERT_MANAGER_N_GENERATIONS);
-
-			// delete the oldest generation
-			if (ts.n_generations == TORRENT_ALERT_MANAGER_N_GENERATIONS)
-			{
-				ts.allocators[ts.oldest_generation]->reset();
-				ts.oldest_generation = (ts.oldest_generation == TORRENT_ALERT_MANAGER_N_GENERATIONS - 1) ? 0
-					: ts.oldest_generation + 1;
-				ts.n_generations--;
-			}
-
-			TORRENT_ASSERT(ts.n_generations <= TORRENT_ALERT_MANAGER_N_GENERATIONS);
-		}
+		// reset thread specific storage
+		for (unsigned int i = 0; i < m_threads_storage.size(); i++)
+			m_threads_storage[i]->swap_allocators();
 	}
 
 	int alert_manager::set_alert_queue_size_limit(int queue_size_limit_)
 	{
-		mutex::scoped_lock resize_lock(m_mutex);
+		mutex::scoped_lock lock(m_mutex);
+		shared_lock::scoped_lock wlock(m_shared_lock, shared_lock::exclusive);
 		m_queue_limit_requested = queue_size_limit_;
 
 		// try to resize the queue. If it can't be done now it

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -79,7 +79,7 @@ namespace libtorrent
 			if (attr.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) return file_storage::attribute_hidden;
 			return 0;
 #else
-			struct stat s;
+			struct ::stat s;
 			if (lstat(convert_to_native(p).c_str(), &s) < 0) return 0;
 			int file_attr = 0;
 			if (s.st_mode & S_IXUSR)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -32,6 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/thread.hpp"
 #include "libtorrent/assert.hpp"
+#include <thread>
 
 #ifdef TORRENT_BEOS
 #include <kernel/OS.h>
@@ -46,6 +47,11 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
+
+	void this_thread::yield()
+	{
+		std::this_thread::yield();
+	}
 
 	void sleep(int milliseconds)
 	{

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/thread.hpp"
 #include "libtorrent/assert.hpp"
-#include <boost/thread/thread.hpp>
 
 #ifdef TORRENT_BEOS
 #include <kernel/OS.h>
@@ -47,12 +46,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
-
-	void this_thread::yield()
-	{
-		boost::this_thread::yield();
-	}
-
 	void sleep(int milliseconds)
 	{
 #if defined TORRENT_WINDOWS || defined TORRENT_CYGWIN

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -32,7 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/thread.hpp"
 #include "libtorrent/assert.hpp"
-#include <thread>
+#include <boost/thread/thread.hpp>
 
 #ifdef TORRENT_BEOS
 #include <kernel/OS.h>
@@ -50,7 +50,7 @@ namespace libtorrent
 
 	void this_thread::yield()
 	{
-		std::this_thread::yield();
+		boost::this_thread::yield();
 	}
 
 	void sleep(int milliseconds)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -247,5 +247,5 @@ LDADD = libtest.la $(top_builddir)/src/libtorrent-rasterbar.la
 AM_CPPFLAGS=-ftemplate-depth-50 -I$(top_srcdir)/include @DEBUGFLAGS@ @OPENSSL_INCLUDES@
 
 AM_LDFLAGS=@BOOST_SYSTEM_LIB@ @PTHREAD_LIBS@ @OPENSSL_LDFLAGS@ @OPENSSL_LIBS@ \
-	@BOOST_CHRONO_LIB@
+	@BOOST_CHRONO_LIB@ @BOOST_THREAD_LIB@
 

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -219,23 +219,14 @@ struct test_plugin : libtorrent::plugin
 void
 alert_popper(alert_manager& mgr, bool& running)
 {
+	int num_resume;
 	std::vector<alert*> alerts;
-	int num_resume = 0, n_iters = 0;
-
-	running = true;
-
-	while (running)
+	for (running = true; running;)
 	{
-		/* wait for the next alert */
-		time_duration td = seconds(1);
+		time_duration td = milliseconds(10);
 		if (mgr.wait_for_alert(td) == NULL)
 			continue;
-
 		mgr.get_all(alerts, num_resume);
-
-		/* sleep every few iterations to simulate overrun */
-		if (++n_iters % 5 == 0)
-			test_sleep(500);
 	}
 }
 
@@ -296,6 +287,8 @@ TORRENT_TEST(extensions)
 	running = false;
 	t.join();
 
+	TEST_EQUAL(plugin_alerts[0] < 100000140, true);
+	TEST_EQUAL(plugin_alerts[1] < 100000140, true);
 	TEST_EQUAL(plugin_alerts[2], 100000140);
 
 #endif

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -216,20 +216,6 @@ struct test_plugin : libtorrent::plugin
 	boost::uint32_t m_features;
 };
 
-void
-alert_popper(alert_manager& mgr, bool& running)
-{
-	int num_resume;
-	std::vector<alert*> alerts;
-	for (running = true; running;)
-	{
-		time_duration td = milliseconds(10);
-		if (mgr.wait_for_alert(td) == NULL)
-			continue;
-		mgr.get_all(alerts, num_resume);
-	}
-}
-
 #endif
 
 TORRENT_TEST(extensions)
@@ -271,25 +257,6 @@ TORRENT_TEST(extensions)
 	TEST_EQUAL(plugin_alerts[0], 100);
 	TEST_EQUAL(plugin_alerts[1], 100);
 	TEST_EQUAL(plugin_alerts[2], 140);
-
-	bool running = false;
-	int num_resume = 0;
-	std::vector<alert*> alerts;
-	mgr.get_all(alerts, num_resume);
-	libtorrent::thread t(boost::bind(&alert_popper, boost::ref(mgr), boost::ref(running)));
-
-	/* make sure the thread is started */
-	while (!running) test_sleep(10);
-
-	for (int i = 0; i < 100000000; ++i)
-		mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
-
-	running = false;
-	t.join();
-
-	TEST_EQUAL(plugin_alerts[0] < 100000140, true);
-	TEST_EQUAL(plugin_alerts[1] < 100000140, true);
-	TEST_EQUAL(plugin_alerts[2], 100000140);
 
 #endif
 }

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -290,7 +290,7 @@ TORRENT_TEST(alert_mask_response)
 	std::vector<alert*> alerts;
 	boost::atomic<bool> emplacer_running(true);
 	alert_manager mgr(100, lt::alert::status_notification);
-	std::vector<boost::shared_ptr<libtorrent::thread>> threads;
+	std::vector<boost::shared_ptr<libtorrent::thread> > threads;
 
 	// start some threads to emplace alerts
 	for (int i = 0; i < n_threads; i++)
@@ -334,7 +334,7 @@ TORRENT_TEST(thread_safety)
 	std::vector<alert*> alerts;
 	boost::atomic<bool> emplacer_running(true);
 	alert_manager mgr(100, lt::alert::status_notification);
-	std::vector<boost::shared_ptr<libtorrent::thread>> threads;
+	std::vector<boost::shared_ptr<libtorrent::thread> > threads;
 
 	// start some threads to emplace alerts
 	for (int i = 0; i < n_threads; i++)

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -190,7 +190,7 @@ int plugin_alerts[3] = { 0, 0, 0 };
 
 struct test_plugin : libtorrent::plugin
 {
-	test_plugin(int index, bool reliable_alerts) : m_index(index),
+	test_plugin(int index, bool reliable_alerts = false) : m_index(index),
 		m_features(reliable_alerts ? libtorrent::plugin::reliable_alerts_feature  : 0) {}
 	boost::uint32_t implemented_features() { return m_features; }
 	virtual void on_alert(alert const* a)
@@ -210,9 +210,9 @@ TORRENT_TEST(extensions)
 	memset(plugin_alerts, 0, sizeof(plugin_alerts));
 	alert_manager mgr(100, 0xffffffff);
 
-	mgr.add_extension(boost::make_shared<test_plugin>(0, false));
-	mgr.add_extension(boost::make_shared<test_plugin>(1, false));
-	mgr.add_extension(boost::make_shared<test_plugin>(2, false));
+	mgr.add_extension(boost::make_shared<test_plugin>(0));
+	mgr.add_extension(boost::make_shared<test_plugin>(1));
+	mgr.add_extension(boost::make_shared<test_plugin>(2));
 
 	for (int i = 0; i < 53; ++i)
 		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
@@ -236,8 +236,8 @@ TORRENT_TEST(reliable_alerts)
 	memset(plugin_alerts, 0, sizeof(plugin_alerts));
 	alert_manager mgr(100, 0xffffffff);
 
-	mgr.add_extension(boost::make_shared<test_plugin>(0, false));
-	mgr.add_extension(boost::make_shared<test_plugin>(1, false));
+	mgr.add_extension(boost::make_shared<test_plugin>(0));
+	mgr.add_extension(boost::make_shared<test_plugin>(1));
 	mgr.add_extension(boost::make_shared<test_plugin>(2, true));
 
 	for (int i = 0; i < 105; ++i)


### PR DESCRIPTION
This is a work in progress and I may not be able to finish it anytime soon, so if you like the idea feel free to finish it. I will answer any questions and help fix bugs if I can. I have not done any real testing but it passes all tests. I think all that's left is testing and cleanup, and maybe allocate the alerts from pooled memory. It cannot reallocate and I think some alerts are much larger than others so it may be a bit tricky.

The main benefit of this patch is that it de-couples the library's
internal threads from the user threads by making emplace_alert() not
longer mutually exclusive with pop_alerts() and wait_for_alert(), except
for a short period after a call to set_queue_size_limit() until it takes
effect on or before the next call to pop_alerts(). So it eliminates
contention and makes wait_for_alert() more deterministic.

It also makes emplace_alert() completely thread-safe and replaces the
coarse locking mechanism with very fine-grained locking so that many
threads can safely make progress through emplace_alert()

To allow concurrent access the alerts themselves are allocated on the
heap and pointers are stored on a ring buffer atomically
