### PR TITLE
Revise alert priorities / torrent::on_resume_data_checked issue

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -85,7 +85,7 @@ namespace libtorrent
 	{
 		alert_priority_normal = 0,
 		alert_priority_high,
-		alert_priority_realtime
+		alert_priority_critical
 	};
 
 	// This is a base class for alerts that are associated with a
@@ -238,7 +238,7 @@ namespace libtorrent
 		torrent_removed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, sha1_hash const& ih);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_removed_alert, 4, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_removed_alert, 4, alert_priority_critical)
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
 		sha1_hash info_hash;
@@ -259,7 +259,7 @@ namespace libtorrent
 			, int p, boost::shared_array<char> d, int s);
 		read_piece_alert(aux::stack_allocator& alloc, torrent_handle h, int p, error_code e);
 
-		TORRENT_DEFINE_ALERT_PRIO(read_piece_alert, 5, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(read_piece_alert, 5, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -296,7 +296,7 @@ namespace libtorrent
 			, std::string const& n
 			, int idx);
 
-		TORRENT_DEFINE_ALERT_PRIO(file_renamed_alert, 7, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(file_renamed_alert, 7, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -321,7 +321,7 @@ namespace libtorrent
 			, torrent_handle const& h, int idx
 			, error_code ec);
 
-		TORRENT_DEFINE_ALERT_PRIO(file_rename_failed_alert, 8, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(file_rename_failed_alert, 8, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 
@@ -931,7 +931,7 @@ namespace libtorrent
 		storage_moved_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, std::string const& p);
 
-		TORRENT_DEFINE_ALERT_PRIO(storage_moved_alert, 33, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(storage_moved_alert, 33, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -958,7 +958,7 @@ namespace libtorrent
 			, std::string const& file
 			, char const* op);
 
-		TORRENT_DEFINE_ALERT_PRIO(storage_moved_failed_alert, 34, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(storage_moved_failed_alert, 34, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -995,7 +995,7 @@ namespace libtorrent
 		torrent_deleted_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, sha1_hash const& ih);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_deleted_alert, 35, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_deleted_alert, 35, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1012,7 +1012,7 @@ namespace libtorrent
 		torrent_delete_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, error_code const& e, sha1_hash const& ih);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_delete_failed_alert, 36, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_delete_failed_alert, 36, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification
 			| alert::error_notification;
@@ -1038,7 +1038,7 @@ namespace libtorrent
 			, boost::shared_ptr<entry> const& rd
 			, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_alert, 37, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_alert, 37, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1055,7 +1055,7 @@ namespace libtorrent
 		save_resume_data_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, error_code const& e);
 
-		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_failed_alert, 38, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_failed_alert, 38, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification
 			| alert::error_notification;
@@ -1303,7 +1303,7 @@ namespace libtorrent
 			, error_code const& ec
 			, socket_type_t t);
 
-		TORRENT_DEFINE_ALERT_PRIO(listen_failed_alert, 48, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(listen_failed_alert, 48, alert_priority_critical)
 
 		static const int static_category = alert::status_notification | alert::error_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1344,7 +1344,7 @@ namespace libtorrent
 		listen_succeeded_alert(aux::stack_allocator& alloc, tcp::endpoint const& ep
 			, socket_type_t t);
 
-		TORRENT_DEFINE_ALERT_PRIO(listen_succeeded_alert, 49, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(listen_succeeded_alert, 49, alert_priority_critical)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1801,7 +1801,7 @@ namespace libtorrent
 		torrent_need_cert_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_need_cert_alert, 65, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_need_cert_alert, 65, alert_priority_critical)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1856,7 +1856,7 @@ namespace libtorrent
 		add_torrent_alert(aux::stack_allocator& alloc, torrent_handle h
 			, add_torrent_params const& p, error_code ec);
 
-		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67, alert_priority_critical)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1913,7 +1913,7 @@ namespace libtorrent
 	struct TORRENT_EXPORT session_stats_alert TORRENT_FINAL : alert
 	{
 		session_stats_alert(aux::stack_allocator& alloc, counters const& cnt);
-		TORRENT_DEFINE_ALERT_PRIO(session_stats_alert, 70, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(session_stats_alert, 70, alert_priority_critical)
 
 		static const int static_category = alert::stats_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1944,7 +1944,7 @@ namespace libtorrent
 		torrent_update_alert(aux::stack_allocator& alloc, torrent_handle h
 			, sha1_hash const& old_hash, sha1_hash const& new_hash);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_update_alert, 71, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_update_alert, 71, alert_priority_critical)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -2008,7 +2008,7 @@ namespace libtorrent
 		dht_immutable_item_alert(aux::stack_allocator& alloc, sha1_hash const& t
 			, entry const& i);
 
-		TORRENT_DEFINE_ALERT_PRIO(dht_immutable_item_alert, 74, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(dht_immutable_item_alert, 74, alert_priority_critical)
 
 		static const int static_category = alert::dht_notification;
 
@@ -2034,7 +2034,7 @@ namespace libtorrent
 			, entry const& i
 			, bool a);
 
-		TORRENT_DEFINE_ALERT_PRIO(dht_mutable_item_alert, 75, alert_priority_realtime)
+		TORRENT_DEFINE_ALERT_PRIO(dht_mutable_item_alert, 75, alert_priority_critical)
 
 		static const int static_category = alert::dht_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -2443,7 +2443,7 @@ namespace libtorrent
 		dht_direct_response_alert(aux::stack_allocator& alloc, void* userdata
 			, udp::endpoint const& addr);
 
-		TORRENT_DEFINE_ALERT(dht_direct_response_alert, 88)
+		TORRENT_DEFINE_ALERT_PRIO(dht_direct_response_alert, 88, alert_priority_critical)
 
 		static const int static_category = alert::dht_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -278,7 +278,7 @@ namespace libtorrent
 		file_completed_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, int idx);
 
-		TORRENT_DEFINE_ALERT_PRIO(file_completed_alert, 6, alert_priority_high)
+		TORRENT_DEFINE_ALERT_PRIO(file_completed_alert, 6, alert_priority_normal)
 
 		static const int static_category = alert::progress_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -271,7 +271,7 @@ namespace libtorrent
 		file_completed_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, int idx);
 
-		TORRENT_DEFINE_ALERT(file_completed_alert, 6)
+		TORRENT_DEFINE_ALERT_PRIO(file_completed_alert, 6)
 
 		static const int static_category = alert::progress_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -799,7 +799,7 @@ namespace libtorrent
 		torrent_finished_alert(aux::stack_allocator& alloc,
 			torrent_handle h);
 
-		TORRENT_DEFINE_ALERT(torrent_finished_alert, 26)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_finished_alert, 26)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1070,7 +1070,7 @@ namespace libtorrent
 		// internal
 		torrent_paused_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT(torrent_paused_alert, 39)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_paused_alert, 39)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1083,7 +1083,7 @@ namespace libtorrent
 		// internal
 		torrent_resumed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT(torrent_resumed_alert, 40)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_resumed_alert, 40)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1096,7 +1096,7 @@ namespace libtorrent
 		// internal
 		torrent_checked_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT(torrent_checked_alert, 41)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_checked_alert, 41)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1764,7 +1764,7 @@ namespace libtorrent
 		torrent_error_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, error_code const& e, std::string const& f);
 
-		TORRENT_DEFINE_ALERT(torrent_error_alert, 64)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_error_alert, 64)
 
 		static const int static_category = alert::error_notification | alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -85,7 +85,7 @@ namespace libtorrent
 	{
 		alert_priority_normal = 0,
 		alert_priority_high,
-		alert_priority_realtime,
+		alert_priority_realtime
 	};
 
 	// This is a base class for alerts that are associated with a

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -439,7 +439,7 @@ namespace libtorrent
 			, torrent_status::state_t st
 			, torrent_status::state_t prev_st);
 
-		TORRENT_DEFINE_ALERT(state_changed_alert, 10)
+		TORRENT_DEFINE_ALERT_PRIO(state_changed_alert, 10, alert_priority_high)
 
 		static const int static_category = alert::status_notification;
 

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -81,6 +81,13 @@ namespace libtorrent
 	// user defined alerts should use IDs greater than this
 	static const int user_alert_id = 10000;
 
+	enum alert_priority
+	{
+		alert_priority_normal = 0,
+		alert_priority_high,
+		alert_priority_realtime,
+	};
+
 	// This is a base class for alerts that are associated with a
 	// specific torrent. It contains a handle to the torrent.
 	struct TORRENT_EXPORT torrent_alert : alert
@@ -190,10 +197,10 @@ namespace libtorrent
 	virtual char const* what() const TORRENT_OVERRIDE { return #name; }
 
 #define TORRENT_DEFINE_ALERT(name, seq) \
-	TORRENT_DEFINE_ALERT_IMPL(name, seq, 0)
+	TORRENT_DEFINE_ALERT_IMPL(name, seq, alert_priority_normal)
 
-#define TORRENT_DEFINE_ALERT_PRIO(name, seq) \
-	TORRENT_DEFINE_ALERT_IMPL(name, seq, 1)
+#define TORRENT_DEFINE_ALERT_PRIO(name, seq, prio) \
+	TORRENT_DEFINE_ALERT_IMPL(name, seq, prio)
 
 #ifndef TORRENT_NO_DEPRECATE
 	// The ``torrent_added_alert`` is posted once every time a torrent is successfully
@@ -231,7 +238,7 @@ namespace libtorrent
 		torrent_removed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, sha1_hash const& ih);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_removed_alert, 4)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_removed_alert, 4, alert_priority_realtime)
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
 		sha1_hash info_hash;
@@ -252,7 +259,7 @@ namespace libtorrent
 			, int p, boost::shared_array<char> d, int s);
 		read_piece_alert(aux::stack_allocator& alloc, torrent_handle h, int p, error_code e);
 
-		TORRENT_DEFINE_ALERT_PRIO(read_piece_alert, 5)
+		TORRENT_DEFINE_ALERT_PRIO(read_piece_alert, 5, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -271,7 +278,7 @@ namespace libtorrent
 		file_completed_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, int idx);
 
-		TORRENT_DEFINE_ALERT_PRIO(file_completed_alert, 6)
+		TORRENT_DEFINE_ALERT_PRIO(file_completed_alert, 6, alert_priority_high)
 
 		static const int static_category = alert::progress_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -289,7 +296,7 @@ namespace libtorrent
 			, std::string const& n
 			, int idx);
 
-		TORRENT_DEFINE_ALERT_PRIO(file_renamed_alert, 7)
+		TORRENT_DEFINE_ALERT_PRIO(file_renamed_alert, 7, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -314,7 +321,7 @@ namespace libtorrent
 			, torrent_handle const& h, int idx
 			, error_code ec);
 
-		TORRENT_DEFINE_ALERT_PRIO(file_rename_failed_alert, 8)
+		TORRENT_DEFINE_ALERT_PRIO(file_rename_failed_alert, 8, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 
@@ -799,7 +806,7 @@ namespace libtorrent
 		torrent_finished_alert(aux::stack_allocator& alloc,
 			torrent_handle h);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_finished_alert, 26)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_finished_alert, 26, alert_priority_high)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -924,7 +931,7 @@ namespace libtorrent
 		storage_moved_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, std::string const& p);
 
-		TORRENT_DEFINE_ALERT_PRIO(storage_moved_alert, 33)
+		TORRENT_DEFINE_ALERT_PRIO(storage_moved_alert, 33, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -951,7 +958,7 @@ namespace libtorrent
 			, std::string const& file
 			, char const* op);
 
-		TORRENT_DEFINE_ALERT_PRIO(storage_moved_failed_alert, 34)
+		TORRENT_DEFINE_ALERT_PRIO(storage_moved_failed_alert, 34, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -988,7 +995,7 @@ namespace libtorrent
 		torrent_deleted_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, sha1_hash const& ih);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_deleted_alert, 35)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_deleted_alert, 35, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1005,7 +1012,7 @@ namespace libtorrent
 		torrent_delete_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, error_code const& e, sha1_hash const& ih);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_delete_failed_alert, 36)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_delete_failed_alert, 36, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification
 			| alert::error_notification;
@@ -1031,7 +1038,7 @@ namespace libtorrent
 			, boost::shared_ptr<entry> const& rd
 			, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_alert, 37)
+		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_alert, 37, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1048,7 +1055,7 @@ namespace libtorrent
 		save_resume_data_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, error_code const& e);
 
-		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_failed_alert, 38)
+		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_failed_alert, 38, alert_priority_realtime)
 
 		static const int static_category = alert::storage_notification
 			| alert::error_notification;
@@ -1070,7 +1077,7 @@ namespace libtorrent
 		// internal
 		torrent_paused_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_paused_alert, 39)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_paused_alert, 39, alert_priority_high)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1083,7 +1090,7 @@ namespace libtorrent
 		// internal
 		torrent_resumed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_resumed_alert, 40)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_resumed_alert, 40, alert_priority_high)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1096,7 +1103,7 @@ namespace libtorrent
 		// internal
 		torrent_checked_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_checked_alert, 41)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_checked_alert, 41, alert_priority_high)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1296,7 +1303,7 @@ namespace libtorrent
 			, error_code const& ec
 			, socket_type_t t);
 
-		TORRENT_DEFINE_ALERT_PRIO(listen_failed_alert, 48)
+		TORRENT_DEFINE_ALERT_PRIO(listen_failed_alert, 48, alert_priority_realtime)
 
 		static const int static_category = alert::status_notification | alert::error_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1337,7 +1344,7 @@ namespace libtorrent
 		listen_succeeded_alert(aux::stack_allocator& alloc, tcp::endpoint const& ep
 			, socket_type_t t);
 
-		TORRENT_DEFINE_ALERT_PRIO(listen_succeeded_alert, 49)
+		TORRENT_DEFINE_ALERT_PRIO(listen_succeeded_alert, 49, alert_priority_realtime)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1764,7 +1771,7 @@ namespace libtorrent
 		torrent_error_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, error_code const& e, std::string const& f);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_error_alert, 64)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_error_alert, 64, alert_priority_high)
 
 		static const int static_category = alert::error_notification | alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1794,7 +1801,7 @@ namespace libtorrent
 		torrent_need_cert_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_need_cert_alert, 65)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_need_cert_alert, 65, alert_priority_realtime)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1849,7 +1856,7 @@ namespace libtorrent
 		add_torrent_alert(aux::stack_allocator& alloc, torrent_handle h
 			, add_torrent_params const& p, error_code ec);
 
-		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67)
+		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67, alert_priority_realtime)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1872,7 +1879,7 @@ namespace libtorrent
 		state_update_alert(aux::stack_allocator& alloc
 			, std::vector<torrent_status> st);
 
-		TORRENT_DEFINE_ALERT_PRIO(state_update_alert, 68)
+		TORRENT_DEFINE_ALERT_PRIO(state_update_alert, 68, alert_priority_high)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1906,7 +1913,7 @@ namespace libtorrent
 	struct TORRENT_EXPORT session_stats_alert TORRENT_FINAL : alert
 	{
 		session_stats_alert(aux::stack_allocator& alloc, counters const& cnt);
-		TORRENT_DEFINE_ALERT_PRIO(session_stats_alert, 70)
+		TORRENT_DEFINE_ALERT_PRIO(session_stats_alert, 70, alert_priority_realtime)
 
 		static const int static_category = alert::stats_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -1937,7 +1944,7 @@ namespace libtorrent
 		torrent_update_alert(aux::stack_allocator& alloc, torrent_handle h
 			, sha1_hash const& old_hash, sha1_hash const& new_hash);
 
-		TORRENT_DEFINE_ALERT_PRIO(torrent_update_alert, 71)
+		TORRENT_DEFINE_ALERT_PRIO(torrent_update_alert, 71, alert_priority_realtime)
 
 		static const int static_category = alert::status_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;
@@ -2001,7 +2008,7 @@ namespace libtorrent
 		dht_immutable_item_alert(aux::stack_allocator& alloc, sha1_hash const& t
 			, entry const& i);
 
-		TORRENT_DEFINE_ALERT_PRIO(dht_immutable_item_alert, 74)
+		TORRENT_DEFINE_ALERT_PRIO(dht_immutable_item_alert, 74, alert_priority_realtime)
 
 		static const int static_category = alert::dht_notification;
 
@@ -2027,7 +2034,7 @@ namespace libtorrent
 			, entry const& i
 			, bool a);
 
-		TORRENT_DEFINE_ALERT_PRIO(dht_mutable_item_alert, 75)
+		TORRENT_DEFINE_ALERT_PRIO(dht_mutable_item_alert, 75, alert_priority_realtime)
 
 		static const int static_category = alert::dht_notification;
 		virtual std::string message() const TORRENT_OVERRIDE;

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1086,7 +1086,7 @@ namespace libtorrent
 		void lsd_announce();
 
 		void update_last_upload()
-		{ m_last_upload = total_seconds(clock_type::now().time_since_epoch()); }
+		{ m_last_upload = static_cast<boost::uint32_t>(total_seconds(clock_type::now().time_since_epoch())); }
 
 		void set_apply_ip_filter(bool b);
 		bool apply_ip_filter() const { return m_apply_ip_filter; }

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -54,7 +54,7 @@ TORRENT_TEST(limit)
 	// try add 600 torrent_add_alert to make sure we honor the limit of 500
 	// alerts.
 	for (int i = 0; i < 600; ++i)
-		mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
 
 	TEST_EQUAL(mgr.pending(), true);
 
@@ -71,7 +71,7 @@ TORRENT_TEST(limit)
 	mgr.set_alert_queue_size_limit(200);
 
 	for (int i = 0; i < 600; ++i)
-		mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
 
 	TEST_EQUAL(mgr.pending(), true);
 

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -87,21 +87,24 @@ TORRENT_TEST(priority_limit)
 
 	TEST_EQUAL(mgr.alert_queue_size_limit(), 100);
 
+	std::vector<alert*> alerts;
+	int num_resume = 0;
+
 	// this should only add 100 because of the limit
 	for (int i = 0; i < 200; ++i)
-		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
 
-	// the limit is twice as high for priority alerts
-	for (int i = 0; i < 200; ++i)
+	mgr.get_all(alerts, num_resume);
+	TEST_EQUAL(alerts.size(), 100);
+
+	// the limit is higher for priority alerts
+	for (int i = 0; i < 300; ++i)
 		mgr.emplace_alert<file_rename_failed_alert>(torrent_handle(), i, error_code());
 
-	std::vector<alert*> alerts;
-	int num_resume;
 	mgr.get_all(alerts, num_resume);
-
-	// even though we posted 400, the limit was 100 for half of them and
-	// 200 for the other half, meaning we should have 200 alerts now
-	TEST_EQUAL(alerts.size(), 200);
+	// even though we posted 500, the limit was 100 for half of them and
+	// 100 + 200 for the other half, meaning we should have 300 alerts now
+	TEST_EQUAL(alerts.size(), 300);
 }
 
 void test_dispatch_fun(int& cnt, std::auto_ptr<alert> const& a)


### PR DESCRIPTION
Most status alerts should have priorities above normal level.
Good reason for this is resume data verification issue. For a large
torrent(having lots of pieces) whole alert queue will be overflowed
with a `piece_finished_alert` right after resume data has been verified.
Thus alerts like `torrent_checked_alert`, `torrent_finished`,
`state_changed_alert` will not get to the alerts queue.