### PR TITLE
fix empty outgoing interfaces for UDP sockets

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -691,6 +691,7 @@ namespace aux {
 			mutable std::condition_variable cond;
 
 			// implements session_interface
+			bool has_udp_outgoing_sockets() const override;
 			tcp::endpoint bind_outgoing_socket(socket_type& s, address
 				const& remote_address, error_code& ec) const override;
 			bool verify_incoming_interface(address const& addr);

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -211,6 +211,7 @@ namespace aux {
 		virtual void for_each_listen_socket(std::function<void(aux::listen_socket_handle const&)> f) = 0;
 
 		// ask for which interface and port to bind outgoing peer connections on
+		virtual bool has_udp_outgoing_sockets() const = 0;
 		virtual tcp::endpoint bind_outgoing_socket(socket_type& s, address const&
 			remote_address, error_code& ec) const = 0;
 		virtual bool verify_bound_address(address const& addr, bool utp

--- a/include/libtorrent/aux_/session_udp_sockets.hpp
+++ b/include/libtorrent/aux_/session_udp_sockets.hpp
@@ -89,7 +89,8 @@ namespace libtorrent { namespace aux {
 		std::vector<std::shared_ptr<outgoing_udp_socket>>::iterator
 		partition_outgoing_sockets(std::vector<listen_endpoint_t>& eps);
 
-		tcp::endpoint bind(socket_type& s, address const& remote_address) const;
+		tcp::endpoint bind(socket_type& s, address const& remote_address
+			, error_code& ec) const;
 
 		void update_proxy(proxy_settings const& settings);
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4964,6 +4964,11 @@ namespace aux {
 #endif
 	}
 
+	bool session_impl::has_udp_outgoing_sockets() const
+	{
+		return !m_outgoing_sockets.sockets.empty();
+	}
+
 	tcp::endpoint session_impl::bind_outgoing_socket(socket_type& s, address
 		const& remote_address, error_code& ec) const
 	{

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4988,8 +4988,8 @@ namespace aux {
 
 		if (is_utp(s))
 		{
-			auto ep = m_outgoing_sockets.bind(s, remote_address);
-			if (ep.port() != 0)
+			auto ep = m_outgoing_sockets.bind(s, remote_address, ec);
+			if (ep.port() != 0 || ec)
 				return ep;
 		}
 

--- a/src/session_udp_sockets.cpp
+++ b/src/session_udp_sockets.cpp
@@ -32,6 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/session_udp_sockets.hpp"
 #include "libtorrent/aux_/session_impl.hpp"
+#include "libtorrent/error_code.hpp"
 
 namespace libtorrent { namespace aux {
 
@@ -63,9 +64,14 @@ namespace libtorrent { namespace aux {
 		});
 	}
 
-	tcp::endpoint outgoing_sockets::bind(socket_type& s, address const& remote_address) const
+	tcp::endpoint outgoing_sockets::bind(socket_type& s
+		, address const& remote_address, error_code& ec) const
 	{
-		TORRENT_ASSERT(!sockets.empty());
+		if (sockets.empty())
+		{
+			ec.assign(boost::system::errc::not_supported, generic_category());
+			return tcp::endpoint();
+		}
 
 		utp_socket_impl* impl = nullptr;
 		transport ssl = transport::plaintext;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6563,8 +6563,11 @@ bool is_downloading_state(int const st)
 			if (settings().get_bool(settings_pack::enable_outgoing_utp)
 				&& (!settings().get_bool(settings_pack::enable_outgoing_tcp)
 					|| peerinfo->supports_utp
-					|| peerinfo->confirmed_supports_utp))
+					|| peerinfo->confirmed_supports_utp)
+				&& m_ses.has_udp_outgoing_sockets())
+			{
 				sm = m_ses.utp_socket_manager();
+			}
 
 			// don't make a TCP connection if it's disabled
 			if (sm == nullptr && !settings().get_bool(settings_pack::enable_outgoing_tcp))


### PR DESCRIPTION
@ssiloti would you mind taking a look?
I ran into this problem when setting `outgoing_interfaces` to something that failed to resolve to any valid address, so (I think) no UDP sockets were opened