### PR TITLE
Use _CFLAGS_OTHER for compiler definitions

### DIFF
--- a/examples/cmake/FindLibtorrentRasterbar.cmake
+++ b/examples/cmake/FindLibtorrentRasterbar.cmake
@@ -24,7 +24,7 @@ if(LibtorrentRasterbar_USE_STATIC_LIBS)
 endif()
 
 if(PC_LIBTORRENT_RASTERBAR_FOUND)
-    set(LibtorrentRasterbar_DEFINITIONS ${PC_LIBTORRENT_RASTERBAR_CFLAGS})
+    set(LibtorrentRasterbar_DEFINITIONS ${PC_LIBTORRENT_RASTERBAR_CFLAGS_OTHER})
 else()
     if(LibtorrentRasterbar_CUSTOM_DEFINITIONS)
         set(LibtorrentRasterbar_DEFINITIONS ${LibtorrentRasterbar_CUSTOM_DEFINITIONS})


### PR DESCRIPTION
`PC_LIBTORRENT_RASTERBAR_CFLAGS` not only gives you the definitions, but
also includes the include path flags (`-I...`).

This causes problesm when passing the result to
`target_compile_definitions`. The resulting compiler command would then
look something like this:

    /usr/bin/c++   -D-I/home/...

This change uses `PC_LIBTORRENT_RASTERBAR_CFLAGS_OTHER` instead which
does not contain the include path flags.

An example of this can be seen here:
https://github.com/IT-Syndikat/arr-torrent/tree/8703fc63354f1e3e0de2e8ee05f23e550b335a86