### PR TITLE
fix typo in client.py. introduce parse_magnet_uri_dict to python bindings

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -146,7 +146,7 @@ def print_download_queue(console, download_queue):
 def add_torrent(ses, filename, options):
     atp = {}
     if filename.startswith('magnet:'):
-        atp = lt.parse_magnet_uti(filename)
+        atp = lt.parse_magnet_uri_dict(filename)
     else:
         atp['ti'] = lt.torrent_info(filename)
         try:

--- a/bindings/python/src/magnet_uri.cpp
+++ b/bindings/python/src/magnet_uri.cpp
@@ -37,7 +37,7 @@ namespace {
 	}
 #endif
 
-	dict parse_magnet_uri_wrap(std::string const& uri)
+	dict parse_magnet_uri_dict(std::string const& uri)
 	{
 		add_torrent_params p;
 		error_code ec;
@@ -81,6 +81,7 @@ void bind_magnet_uri()
 #endif
 	def("make_magnet_uri", make_magnet_uri0);
 	def("make_magnet_uri", make_magnet_uri1);
-	def("parse_magnet_uri", parse_magnet_uri_wrap);
+	def("parse_magnet_uri", parse_magnet_uri_dict);
+	def("parse_magnet_uri_dict", parse_magnet_uri_dict);
 }
 

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -305,6 +305,16 @@ class test_magnet_link(unittest.TestCase):
 		ses = lt.session({})
 		magnet = 'magnet:?xt=urn:btih:C6EIF4CCYDBTIJVG3APAGM7M4NDONCTI'
 		p = lt.parse_magnet_uri(magnet)
+		self.assertEqual(binascii.hexlify(p['info_hash']), '178882f042c0c33426a6d81e0333ece346e68a68')
+		p['save_path'] = '.'
+		h = ses.add_torrent(p)
+		self.assertEqual(str(h.info_hash()), '178882f042c0c33426a6d81e0333ece346e68a68')
+
+	def test_parse_magnet_uri_dict(self):
+		ses = lt.session({})
+		magnet = 'magnet:?xt=urn:btih:C6EIF4CCYDBTIJVG3APAGM7M4NDONCTI'
+		p = lt.parse_magnet_uri_dict(magnet)
+		self.assertEqual(binascii.hexlify(p['info_hash']), '178882f042c0c33426a6d81e0333ece346e68a68')
 		p['save_path'] = '.'
 		h = ses.add_torrent(p)
 		self.assertEqual(str(h.info_hash()), '178882f042c0c33426a6d81e0333ece346e68a68')


### PR DESCRIPTION
in preparation for next major version that will release an add_torrent_params object

Related to https://github.com/arvidn/libtorrent/pull/2971