### PR TITLE
more message-sent hooks for extensions

### DIFF
--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -226,6 +226,9 @@ namespace libtorrent {
 		void on_extended_handshake();
 #endif
 
+		template<class F, typename... Args>
+		void extension_notify(F message, Args... args);
+
 		// the following functions appends messages
 		// to the send buffer
 		void write_choke() override;

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -449,7 +449,7 @@ namespace libtorrent {
 		virtual void sent_unchoke() {}
 		virtual void sent_interested() {}
 		virtual void sent_not_interested() {}
-		virtual void sent_have(int) {}
+		virtual void sent_have(piece_index_t) {}
 		virtual void sent_piece(peer_request const&) {}
 
 		// called after piece data has been sent to the peer

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -439,18 +439,18 @@ namespace libtorrent {
 
 		virtual void sent_have_all() {}
 		virtual void sent_have_none() {}
-		virtual void sent_reject_request(piece_index_t, int, int) {}
+		virtual void sent_reject_request(peer_request const&) {}
 		virtual void sent_allow_fast(piece_index_t) {}
 		virtual void sent_suggest(piece_index_t) {}
-		virtual void sent_cancel(piece_index_t, int, int) {}
-		virtual void sent_request(piece_index_t, int, int) {}
+		virtual void sent_cancel(peer_request const&) {}
+		virtual void sent_request(peer_request const&) {}
 		virtual void sent_choke() {}
 		// called after a choke message has been sent to the peer
 		virtual void sent_unchoke() {}
 		virtual void sent_interested() {}
 		virtual void sent_not_interested() {}
 		virtual void sent_have(int) {}
-		virtual void sent_piece(piece_index_t, int, int) {}
+		virtual void sent_piece(peer_request const&) {}
 
 		// called after piece data has been sent to the peer
 		// this can be used for stats book keeping

--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -437,8 +437,20 @@ namespace libtorrent {
 		virtual bool on_reject(peer_request const&) { return false; }
 		virtual bool on_suggest(piece_index_t) { return false; }
 
+		virtual void sent_have_all() {}
+		virtual void sent_have_none() {}
+		virtual void sent_reject_request(piece_index_t, int, int) {}
+		virtual void sent_allow_fast(piece_index_t) {}
+		virtual void sent_suggest(piece_index_t) {}
+		virtual void sent_cancel(piece_index_t, int, int) {}
+		virtual void sent_request(piece_index_t, int, int) {}
+		virtual void sent_choke() {}
 		// called after a choke message has been sent to the peer
 		virtual void sent_unchoke() {}
+		virtual void sent_interested() {}
+		virtual void sent_not_interested() {}
+		virtual void sent_have(int) {}
+		virtual void sent_piece(piece_index_t, int, int) {}
 
 		// called after piece data has been sent to the peer
 		// this can be used for stats book keeping

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -401,7 +401,7 @@ namespace {
 		send_message(msg_reject_request, counters::num_outgoing_reject, 0
 			, static_cast<int>(r.piece), r.start, r.length);
 
-		extension_notify(&peer_plugin::sent_reject_request, r.piece, r.start, r.length);
+		extension_notify(&peer_plugin::sent_reject_request, r);
 	}
 
 	void bt_peer_connection::write_allow_fast(piece_index_t const piece)
@@ -1971,7 +1971,7 @@ namespace {
 
 		if (!m_supports_fast) incoming_reject_request(r);
 
-		extension_notify(&peer_plugin::sent_cancel, r.piece, r.start, r.length);
+		extension_notify(&peer_plugin::sent_cancel, r);
 	}
 
 	void bt_peer_connection::write_request(peer_request const& r)
@@ -1981,7 +1981,7 @@ namespace {
 		send_message(msg_request, counters::num_outgoing_request, message_type_request
 			, static_cast<int>(r.piece), r.start, r.length);
 
-		extension_notify(&peer_plugin::sent_request, r.piece, r.start, r.length);
+		extension_notify(&peer_plugin::sent_request, r);
 	}
 
 	void bt_peer_connection::write_bitfield()
@@ -2372,7 +2372,7 @@ namespace {
 				remote(), pid(), r.start / t->block_size() , r.piece);
 		}
 
-		extension_notify(&peer_plugin::sent_piece, r.piece, r.start, r.length);
+		extension_notify(&peer_plugin::sent_piece, r);
 	}
 
 	// --------------------------


### PR DESCRIPTION
It's useful for a `peer_plugin` to know when messages of certain types have been sent. There was already `sent_unchoke`; I needed `sent_interested` and `sent_request`, so I added all the ones that I could imagine would be useful.

It's a fairly small patch, but maybe there is a simpler way than the `*e.*` part.