### PR TITLE
[WIP] Hide thread implementation and header

### DIFF
--- a/include/libtorrent/session.hpp
+++ b/include/libtorrent/session.hpp
@@ -33,8 +33,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_SESSION_HPP_INCLUDED
 #define TORRENT_SESSION_HPP_INCLUDED
 
-#include <thread>
-
 #include "libtorrent/config.hpp"
 #include "libtorrent/build_config.hpp"
 #include "libtorrent/io_service.hpp"
@@ -96,6 +94,7 @@ namespace libtorrent {
 namespace aux {
 
 		struct session_impl;
+		struct std_thread_impl;
 	}
 
 	struct disk_interface;
@@ -122,11 +121,11 @@ namespace aux {
 	private:
 		session_proxy(
 			std::shared_ptr<io_service> ios
-			, std::shared_ptr<std::thread> t
+			, std::shared_ptr<aux::std_thread_impl> t
 			, std::shared_ptr<aux::session_impl> impl);
 
 		std::shared_ptr<io_service> m_io_service;
-		std::shared_ptr<std::thread> m_thread;
+		std::shared_ptr<aux::std_thread_impl> m_thread;
 		std::shared_ptr<aux::session_impl> m_impl;
 	};
 
@@ -367,7 +366,7 @@ namespace aux {
 		// data shared between the main thread
 		// and the working thread
 		std::shared_ptr<io_service> m_io_service;
-		std::shared_ptr<std::thread> m_thread;
+		std::shared_ptr<aux::std_thread_impl> m_thread;
 		std::shared_ptr<aux::session_impl> m_impl;
 	};
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -30,6 +30,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <thread>
+
 #include "libtorrent/config.hpp"
 #include "libtorrent/extensions/ut_pex.hpp"
 #include "libtorrent/extensions/ut_metadata.hpp"
@@ -60,6 +62,12 @@ namespace aux {
 	constexpr torrent_list_index_t session_interface::torrent_downloading_auto_managed;
 	constexpr torrent_list_index_t session_interface::torrent_seeding_auto_managed;
 	constexpr torrent_list_index_t session_interface::torrent_checking_auto_managed;
+
+	struct std_thread_impl : public std::thread
+	{
+	public:
+		using std::thread::thread;
+	};
 }
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
@@ -369,7 +377,7 @@ namespace {
 		if (internal_executor)
 		{
 			// start a thread for the message pump
-			m_thread = std::make_shared<std::thread>(
+			m_thread = std::make_shared<aux::std_thread_impl>(
 				[&] { m_io_service->run(); });
 		}
 	}
@@ -428,7 +436,7 @@ namespace {
 
 	session_proxy::session_proxy() = default;
 	session_proxy::session_proxy(std::shared_ptr<io_service> ios
-		, std::shared_ptr<std::thread> t
+		, std::shared_ptr<aux::std_thread_impl> t
 		, std::shared_ptr<aux::session_impl> impl)
 		: m_io_service(std::move(ios))
 		, m_thread(std::move(t))


### PR DESCRIPTION
This is a simple change (I think) which moves the `#include <thread>` from `session.hpp` to `session.cpp`.

The reason is that I want to wrap libtorrent in C++/CLI and make it available to .NET, but C++/CLI doesn't support directly including headers which include `<thread>`.

I think there are a few other places where `<thread>` is included in the header, and if this change is something you'd consider accepting then I can make the change for the other headers as well.