### PR TITLE
don't specialize standard type trait is_integral

### DIFF
--- a/include/libtorrent/aux_/numeric_cast.hpp
+++ b/include/libtorrent/aux_/numeric_cast.hpp
@@ -54,8 +54,7 @@ namespace libtorrent { namespace aux {
 	}
 
 	// in C++ 17 you can use std::clamp
-	template <class T, typename Cond = typename std::enable_if<
-		std::is_integral<T>::value>::type>
+	template <class T>
 	T clamp(T v, T lo, T hi)
 	{
 		TORRENT_ASSERT(lo <= hi);

--- a/include/libtorrent/units.hpp
+++ b/include/libtorrent/units.hpp
@@ -136,10 +136,6 @@ namespace libtorrent { namespace aux {
 namespace std {
 
 	template<typename UnderlyingType, typename Tag>
-	struct is_integral<libtorrent::aux::strong_typedef<UnderlyingType, Tag>>
-		: std::is_integral<UnderlyingType> {};
-
-	template<typename UnderlyingType, typename Tag>
 	class numeric_limits<libtorrent::aux::strong_typedef<UnderlyingType, Tag>> : public std::numeric_limits<UnderlyingType>
 	{
 		using type = libtorrent::aux::strong_typedef<UnderlyingType, Tag>;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4900,7 +4900,7 @@ bool is_downloading_state(int const st)
 		bool const was_finished = is_finished();
 		for (auto const& p : pieces)
 		{
-			static_assert(std::is_unsigned<decltype(p.second)>::value
+			static_assert(std::is_unsigned<decltype(p.second)::underlying_type>::value
 				, "we need assert p.second >= dont_download");
 			TORRENT_ASSERT(p.second <= top_priority);
 			TORRENT_ASSERT(p.first >= piece_index_t(0));
@@ -4910,7 +4910,7 @@ bool is_downloading_state(int const st)
 				|| p.first >= m_torrent_file->end_piece()
 				|| p.second > top_priority)
 			{
-				static_assert(std::is_unsigned<decltype(p.second)>::value
+				static_assert(std::is_unsigned<decltype(p.second)::underlying_type>::value
 					, "we need additional condition: p.second < dont_download");
 				continue;
 			}
@@ -4953,7 +4953,7 @@ bool is_downloading_state(int const st)
 		bool const was_finished = is_finished();
 		for (auto prio : pieces)
 		{
-			static_assert(std::is_unsigned<decltype(prio)>::value
+			static_assert(std::is_unsigned<decltype(prio)::underlying_type>::value
 				, "we need assert prio >= dont_download");
 			TORRENT_ASSERT(prio <= top_priority);
 			filter_updated |= m_picker->set_piece_priority(index, prio);


### PR DESCRIPTION
Concerning type traits, the C++ standard states: "The behavior of a program
that adds specializations for any of the templates defined in this subclause is
undefined unless otherwise specified."

There is no exception for is_integral.

Fixes #3012