### PR TITLE
restore aspects of the previous behavior of force-proxy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* fix recent regression with force_proxy setting
 	* don't perform DNS lookups for the DHT bootstrap unless DHT is enabled
 	* fix issue where setting file/piece priority would stop checking
 	* expose post_dht_stats() to python binding

--- a/simulation/test_session.cpp
+++ b/simulation/test_session.cpp
@@ -79,8 +79,9 @@ TORRENT_TEST(force_proxy)
 	// create session
 	std::shared_ptr<lt::session> ses = std::make_shared<lt::session>(pack, *ios);
 
-	// disable force proxy in 3 seconds (this should make us open up listen
-	// sockets)
+	// disable force proxy in 3 seconds. this won't make us open up listen
+	// sockets, since force proxy rejects incoming connections, it doesn't
+	// prevent the listen sockets from opening
 	sim::timer t1(sim, lt::seconds(3), [&](boost::system::error_code const& ec)
 	{
 		lt::settings_pack p;
@@ -111,6 +112,6 @@ TORRENT_TEST(force_proxy)
 	sim.run();
 
 	TEST_EQUAL(num_listen_tcp, 1);
-	TEST_EQUAL(num_listen_udp, 2);
+	TEST_EQUAL(num_listen_udp, 1);
 }
 


### PR DESCRIPTION
Instead of not opening any TCP listen sockets at all, open them but reject any incoming connection. This is because in RC_1_1, the UDP and TCP sockets are tied in subtle and unintuitive ways. This is much cleaner in the next major release and this patch will not need to be merged