### PR TITLE
Bump `file_error_alert` priority

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1158,7 +1158,7 @@ namespace libtorrent
 			, char const* op
 			, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT(file_error_alert, 43)
+		TORRENT_DEFINE_ALERT_PRIO(file_error_alert, 43, alert_priority_high)
 
 		static const int static_category = alert::status_notification
 			| alert::error_notification


### PR DESCRIPTION
This alert's priority must be higher than `block_downloading_alert`'s
to allow custom handling of file errors.

With progress notifications enabled, network thread might fully load
alerts queue, so file errors from disk thread won't have a chance to
be delivered.