### PR TITLE
Use IFA_LOCAL address if present. Closes #3038.

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -363,6 +363,7 @@ namespace {
 			switch(rt_attr->rta_type)
 			{
 			case IFA_ADDRESS:
+			case IFA_LOCAL:
 #if TORRENT_USE_IPV6
 				if (addr_msg->ifa_family == AF_INET6)
 				{


### PR DESCRIPTION
With Point-to-Point interfaces, netlink sends interface IP in IFA_LOCAL
and IP of the remote peer in IFA_ADDRESS, and IFA_ADDRESS comes first.
Thus if the response contains IFA_LOCAL, we take that address overwriting
the value obtained from IFA_ADDRESS earlier.