### PR TITLE
don't change state to downloading if the torrent is finished

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8829,24 +8829,6 @@ namespace {
 			return;
 		}
 
-		// we might be finished already, in which case we should
-		// not switch to downloading mode. If all files are
-		// filtered, we're finished when we start.
-		if (m_state != torrent_status::finished
-			&& m_state != torrent_status::seeding
-			&& !m_seed_mode)
-		{
-			set_state(torrent_status::downloading);
-		}
-
-		INVARIANT_CHECK;
-
-		if (m_ses.alerts().should_post<torrent_checked_alert>())
-		{
-			m_ses.alerts().emplace_alert<torrent_checked_alert>(
-				get_handle());
-		}
-
 		// calling pause will also trigger the auto managed
 		// recalculation
 		// if we just got here by downloading the metadata,
@@ -8881,6 +8863,24 @@ namespace {
 			if (m_state != torrent_status::finished
 				&& m_state != torrent_status::seeding)
 				finished();
+		}
+
+		// we might be finished already, in which case we should
+		// not switch to downloading mode. If all files are
+		// filtered, we're finished when we start.
+		if (m_state != torrent_status::finished
+			&& m_state != torrent_status::seeding
+			&& !m_seed_mode)
+		{
+			set_state(torrent_status::downloading);
+		}
+
+		INVARIANT_CHECK;
+
+		if (m_ses.alerts().should_post<torrent_checked_alert>())
+		{
+			m_ses.alerts().emplace_alert<torrent_checked_alert>(
+				get_handle());
 		}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS


### PR DESCRIPTION
Move the transition to downloading after the torrent has been checked
for being finished. This prevents a spurious state_changed_alert when
adding a torrent which is already completed.

Also move the posting of the torrent_checked_alert to maintain the
historical ordering of that alert with respect to the transition out of
checking_resume_data.

Fixes #3042