### PR TITLE
don't use the partfile for existing files when their priority is set to 0

### DIFF
--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -477,11 +477,10 @@ namespace libtorrent
 			{
 				// move stuff into the part file
 				// this is not implemented yet.
-				// pretend that we didn't set the priority to 0.
+				// so we just don't use a partfile for this file
 
-				std::string fp = fs.file_path(i, m_save_path);
-				if (exists(fp))
-					new_prio = 1;
+				std::string const fp = fs.file_path(i, m_save_path);
+				if (exists(fp)) use_partfile(i, false);
 /*
 				file_handle f = open_file(i, file::read_only, ec);
 				if (ec.ec != boost::system::errc::no_such_file_or_directory)


### PR DESCRIPTION
since moving an existing file into the part file isn't supported.