### PR TITLE
remove use of deprecated function readdir_r

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -762,13 +762,10 @@ std::vector<std::string> list_dir(std::string path
 		return ret;
 	}
 
-	struct dirent de;
-	dirent* dummy;
-	while (readdir_r(handle, &de, &dummy) == 0)
+	struct dirent* de;
+	while ((de = readdir(handle)))
 	{
-		if (dummy == 0) break;
-
-		std::string p = de.d_name;
+		std::string p = de->d_name;
 		if (filter_fun(p))
 			ret.push_back(p);
 	}

--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -193,11 +193,8 @@ namespace libtorrent
 #endif
 #else
 		DIR* m_handle;
-		// the dirent struct contains a zero-sized
-		// array at the end, it will end up referring
-		// to the m_name field
-		struct dirent m_dirent;
-		char m_name[TORRENT_MAX_PATH + 1]; // +1 to make room for null
+		ino_t m_inode;
+		std::string m_name;
 #endif
 		bool m_done;
 	};


### PR DESCRIPTION
Ports 140b8ace onto RC_1_1 branch

Compilation with GCC 8 fails without such change.