### PR TITLE
Fix pkg-config branch in the example CMake find module

### DIFF
--- a/examples/cmake/FindLibtorrentRasterbar.cmake
+++ b/examples/cmake/FindLibtorrentRasterbar.cmake
@@ -108,7 +108,7 @@ else()
 	if(LibtorrentRasterbar_ENCRYPTION_INDEX GREATER -1)
 		find_package(OpenSSL QUIET REQUIRED)
 		set(LibtorrentRasterbar_LIBRARIES ${LibtorrentRasterbar_LIBRARIES} ${OPENSSL_LIBRARIES})
-		set(LibtorrentRasterbar_INCLUDE_DIRS ${LibtorrentRasterbar_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIRS})
+		set(LibtorrentRasterbar_INCLUDE_DIRS ${LibtorrentRasterbar_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
 		set(LibtorrentRasterbar_OPENSSL_ENABLED ON)
 	endif()
 
@@ -128,13 +128,23 @@ else()
 	if (LibtorrentRasterbar_FOUND AND NOT TARGET LibtorrentRasterbar::torrent-rasterbar)
 		add_library(LibtorrentRasterbar::torrent-rasterbar SHARED IMPORTED)
 
+		# LibtorrentRasterbar_DEFINITIONS var contains a mix of -D, -f, and possible -std options
+		# let's split them into definitions and options (that are not definitions)
+		set(LibtorrentRasterbar_defines "${LibtorrentRasterbar_DEFINITIONS}")
+		set(LibtorrentRasterbar_options "${LibtorrentRasterbar_DEFINITIONS}")
+		list(FILTER LibtorrentRasterbar_defines INCLUDE REGEX "(^|;)-D.+")
+		list(FILTER LibtorrentRasterbar_options EXCLUDE REGEX "(^|;)-D.+")
+		# remove '-D' from LibtorrentRasterbar_defines
+		string(REGEX REPLACE "(^|;)(-D)" "\\1" LibtorrentRasterbar_defines "${LibtorrentRasterbar_defines}")
+
 		set_target_properties(LibtorrentRasterbar::torrent-rasterbar PROPERTIES
 			IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
 			IMPORTED_LOCATION "${LibtorrentRasterbar_LIBRARY}"
 			INTERFACE_INCLUDE_DIRECTORIES "${LibtorrentRasterbar_INCLUDE_DIRS}"
 			INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${LibtorrentRasterbar_INCLUDE_DIRS}"
 			INTERFACE_LINK_LIBRARIES "${LibtorrentRasterbar_LIBRARIES}"
-			INTERFACE_COMPILE_DEFINITIONS "${LibtorrentRasterbar_DEFINITIONS}"
+			INTERFACE_COMPILE_DEFINITIONS "${LibtorrentRasterbar_defines}"
+			INTERFACE_COMPILE_OPTIONS "${LibtorrentRasterbar_options}"
 		)
 	endif()
 endif()


### PR DESCRIPTION
1. The imported target properties may not contain -D switches in the
INTERFACE_COMPILE_DEFINITIONS property, because CMake will always
prepend them to each item. Therefore we have to remove those switches
and also pass other options (e.g. -fexceptions) in INTERFACE_COMPILE_OPTIONS
property, otherwise CMake creates "mutants" '-D-fexceptions' alike.

2. FindOpenSSL.cmake variable for include directory is
OPENSSL_INCLUDE_DIR, not OPENSSL_INCLUDE_DIRS.