### PR TITLE
Add 1.1.7 release in the ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,13 +1,16 @@
 
 	* set the hidden attribute when creating the part file
+	* fix tracker announces reporting more data downloaded than the size of the torrent
 	* fix recent regression with force_proxy setting
+
+1.1.7 release
+
 	* don't perform DNS lookups for the DHT bootstrap unless DHT is enabled
 	* fix issue where setting file/piece priority would stop checking
 	* expose post_dht_stats() to python binding
 	* fix backwards compatibility to downloads without partfiles
 	* improve part-file related error messages
 	* fix reporting &redundant= in tracker announces
-	* fix tracker announces reporting more data downloaded than the size of the torrent
 	* fix tie-break in duplicate peer connection disconnect logic
 	* fix issue with SSL tracker connections left in CLOSE_WAIT state
 	* defer truncating existing files until the first time we write to them


### PR DESCRIPTION
The tag was apparently forgotten. I realized it because I saw you're on the path for 1.1.8 already.