### PR TITLE
scrape_reply_alert should be high priority

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -552,7 +552,7 @@ TORRENT_VERSION_NAMESPACE_2
 			, torrent_handle const& h, tcp::endpoint const& ep
 			, int incomp, int comp, string_view u);
 
-		TORRENT_DEFINE_ALERT(scrape_reply_alert, 13)
+		TORRENT_DEFINE_ALERT_PRIO(scrape_reply_alert, 13, alert_priority_critical)
 
 		static constexpr alert_category_t static_category = alert::tracker_notification;
 		std::string message() const override;
@@ -576,7 +576,7 @@ TORRENT_VERSION_NAMESPACE_2
 			, torrent_handle const& h, tcp::endpoint const& ep
 			, string_view u, string_view m);
 
-		TORRENT_DEFINE_ALERT(scrape_failed_alert, 14)
+		TORRENT_DEFINE_ALERT_PRIO(scrape_failed_alert, 14, alert_priority_critical)
 
 		static constexpr alert_category_t static_category = alert::tracker_notification | alert::error_notification;
 		std::string message() const override;

--- a/test/test_alert_types.cpp
+++ b/test/test_alert_types.cpp
@@ -82,8 +82,8 @@ TORRENT_TEST(alerts_types)
 	TEST_ALERT_TYPE(state_changed_alert, 10, 1, alert::status_notification);
 	TEST_ALERT_TYPE(tracker_error_alert, 11, 1, alert::tracker_notification | alert::error_notification);
 	TEST_ALERT_TYPE(tracker_warning_alert, 12, 0, alert::tracker_notification | alert::error_notification);
-	TEST_ALERT_TYPE(scrape_reply_alert, 13, 0, alert::tracker_notification);
-	TEST_ALERT_TYPE(scrape_failed_alert, 14, 0, alert::tracker_notification | alert::error_notification);
+	TEST_ALERT_TYPE(scrape_reply_alert, 13, 2, alert::tracker_notification);
+	TEST_ALERT_TYPE(scrape_failed_alert, 14, 2, alert::tracker_notification | alert::error_notification);
 	TEST_ALERT_TYPE(tracker_reply_alert, 15, 0, alert::tracker_notification);
 	TEST_ALERT_TYPE(dht_reply_alert, 16, 0, alert::dht_notification | alert::tracker_notification);
 	TEST_ALERT_TYPE(tracker_announce_alert, 17, 0, alert::tracker_notification);


### PR DESCRIPTION
since it's triggered by the client