### PR TITLE
Fix parts file i/o errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 
+	* fix race condition during part_file export
+	* fix part_file open mode compatibility test
 	* fixed race condition in random number generator
 	* fix race condition in stat_cache (disk storage)
 	* improve error handling of failing to change file priority

--- a/include/libtorrent/part_file.hpp
+++ b/include/libtorrent/part_file.hpp
@@ -73,6 +73,9 @@ namespace libtorrent
 		void open_file(int mode, error_code& ec);
 		void flush_metadata_impl(error_code& ec);
 
+		boost::int64_t slot_offset(boost::int64_t const slot) const
+		{ return m_header_size + slot * m_piece_size; }
+
 		std::string m_path;
 		std::string m_name;
 

--- a/include/libtorrent/part_file.hpp
+++ b/include/libtorrent/part_file.hpp
@@ -77,7 +77,7 @@ namespace libtorrent
 		{ return m_header_size + slot * m_piece_size; }
 
 		std::string m_path;
-		std::string m_name;
+		std::string const m_name;
 
 		// allocate a slot and return the slot index
 		int allocate_slot(int piece);

--- a/include/libtorrent/part_file.hpp
+++ b/include/libtorrent/part_file.hpp
@@ -93,15 +93,15 @@ namespace libtorrent
 
 		// the max number of pieces in the torrent this part file is
 		// backing
-		int m_max_pieces;
+		int const m_max_pieces;
 
 		// number of bytes each piece contains
-		int m_piece_size;
+		int const m_piece_size;
 
 		// this is the size of the part_file header, it is added
 		// to offsets when calculating the offset to read and write
 		// payload data from
-		int m_header_size;
+		int const m_header_size;
 
 		// if this is true, the metadata in memory has changed since
 		// we last saved or read it from disk. It means that we

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -314,9 +314,6 @@ namespace libtorrent
 
 				if (!buf) buf.reset(new char[m_piece_size]);
 
-				// don't hold the lock during disk I/O
-				l.unlock();
-
 				file::iovec_t v = { buf.get(), size_t(block_to_copy) };
 				v.iov_len = m_file.readv(slot_offset(slot) + piece_offset, &v, 1, ec);
 				TORRENT_ASSERT(!ec);
@@ -325,10 +322,6 @@ namespace libtorrent
 				boost::int64_t ret = f.writev(file_offset, &v, 1, ec);
 				TORRENT_ASSERT(ec || ret == v.iov_len);
 				if (ec || ret != v.iov_len) return;
-
-				// we're done with the disk I/O, grab the lock again to update
-				// the slot map
-				l.lock();
 
 				if (block_to_copy == m_piece_size)
 				{

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -226,8 +226,8 @@ namespace libtorrent
 
 	void part_file::open_file(int mode, error_code& ec)
 	{
-		if (m_file.is_open() && mode == file::read_only
-			|| (m_file.open_mode() & file::rw_mask) == (mode & file::rw_mask))
+		if (m_file.is_open() && (mode == file::read_only
+			|| (m_file.open_mode() & file::rw_mask) == (mode & file::rw_mask)))
 			return;
 
 		std::string const fn = combine_path(m_path, m_name);


### PR DESCRIPTION
Since i/o operations are not synchronized, it is possible that one
thread closes file handle, opened by another thread. With addition
of `hidden` file attribute, an old bug in `part_file::open_file()`
revealed both problems, causing a lot of random i/o errors in parts
file. Fixing `open_file` bug should reduce the number of such errors
back to 'normal'.

* Add more const
* Extract slot offset calculation to separate function