### PR TITLE
introduce a fast-path for the hash disk job

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* fixed disk I/O performance of checking hashes and creating torrents
 	* fix race condition in part_file
 	* fix part_file open mode compatibility test
 	* fixed race condition in random number generator


### PR DESCRIPTION
This patch reads entire pieces at a time when hashing them, unless we already have some mixed in blocks already in the cache, in which case we use the existing (slow-path) that reads one block at a time