### PR TITLE
Revert "use existing mapping if insert fails"

### DIFF
--- a/src/file_view_pool.cpp
+++ b/src/file_view_pool.cpp
@@ -107,9 +107,12 @@ namespace libtorrent { namespace aux {
 		l.unlock();
 		file_entry e({st, file_index}, fs.file_path(file_index, p), m
 			, fs.file_size(file_index));
+		auto ret = e.mapping->view();
+
 		l.lock();
 		auto& key_view2 = m_files.get<0>();
-		return key_view2.insert(std::move(e)).first->mapping->view();
+		key_view2.insert(std::move(e));
+		return ret;
 	}
 
 namespace {


### PR DESCRIPTION
This reverts commit 9594a3df261f36b5accb4318eafeee0dae82cb26.
That commit could result in an access violation if the existing mapping was read-only but the caller requested write access.