### PR TITLE
Bump `cache_flushed_alert` priority

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1630,7 +1630,7 @@ namespace libtorrent
 		// internal
 		cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT(cache_flushed_alert, 58)
+		TORRENT_DEFINE_ALERT_PRIO(cache_flushed_alert, 58, alert_priority_critical)
 
 		static const int static_category = alert::storage_notification;
 	};


### PR DESCRIPTION
A call to `torrent_handle::flush_cache` must result in `cache_flushed_alert` being posted.