### PR TITLE
Fix torrent files prioritization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix issue when subsequent file priority updates cause torrent to stop
+
 1.1.8 release
 
 	* coalesce reads and writes by default on windows

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -50,6 +50,8 @@ class test_torrent_handle(unittest.TestCase):
 		self.assertEqual(self.h.piece_priorities(), [4])
 
 		self.h.prioritize_files([0,1])
+		# workaround for asynchronous priority update
+		time.sleep(1)
 		self.assertEqual(self.h.file_priorities(), [0,1])
 
 		self.h.prioritize_pieces([0])

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -552,7 +552,6 @@ namespace libtorrent
 		void set_piece_deadline(int piece, int t, int flags);
 		void reset_piece_deadline(int piece);
 		void clear_time_critical();
-		void update_piece_priorities();
 
 		void status(torrent_status* st, boost::uint32_t flags);
 
@@ -1149,7 +1148,7 @@ namespace libtorrent
 
 		void ip_filter_updated();
 
-		void inc_stats_counter(int c, int value = 1);
+		void inc_stats_counter(int c, int value = 1) const;
 
 		// initialize the torrent_state structure passed to peer_list
 		// member functions. Don't forget to also call peers_erased()
@@ -1182,6 +1181,7 @@ namespace libtorrent
 		bool request_bandwidth_from_session(int channel) const;
 
 		void update_peer_interest(bool was_finished);
+		void update_piece_priorities();
 		void prioritize_udp_trackers();
 
 		void update_tracker_timer(time_point now);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5650,9 +5650,9 @@ namespace {
 
 	namespace
 	{
-		std::vector<uint8_t> fix_priorities(std::vector<int> const& input, file_storage const& fs)
+		std::vector<boost::uint8_t> fix_priorities(std::vector<int> const& input, file_storage const& fs)
 		{
-			std::vector<uint8_t> files(input.begin(), input.end());
+			std::vector<boost::uint8_t> files(input.begin(), input.end());
 
 			for (int i = 0; i < std::min<int>(fs.num_files(), files.size()); ++i)
 			{
@@ -5663,7 +5663,6 @@ namespace {
 			}
 
 			files.resize(fs.num_files(), 4);
-
 			return files;
 		}
 
@@ -5711,7 +5710,7 @@ namespace {
 			return;
 		}
 
-		std::vector<uint8_t> const new_priority = fix_priorities(files, m_torrent_file->files());
+		std::vector<boost::uint8_t> const new_priority = fix_priorities(files, m_torrent_file->files());
 
 		if (!m_torrent_file->num_pieces() || is_seed() || new_priority == m_file_priority) { return; }
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5656,7 +5656,7 @@ namespace {
 
 			for (int i = 0; i < std::min<int>(fs.num_files(), files.size()); ++i)
 			{
-				if (files[i] < 0 || fs.pad_file_at(i))
+				if (files[i] > 0 && fs.pad_file_at(i))
 					files[i] = 0;
 				else if (files[i] > 7)
 					files[i] = 7;

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -306,8 +306,11 @@ TORRENT_TEST(torrent)
 			piece[i] = (i % 26) + 'A';
 
 		// calculate the hash for all pieces
-		TEST_CHECK(t.num_pieces() == 1);
-		t.set_hash(0, hasher(&piece[0], piece.size()).final());
+		sha1_hash const ph = hasher(&piece[0], piece.size()).final();
+		int const num = t.num_pieces();
+		TEST_CHECK(num > 0);
+		for (int i = 0; i < num; ++i)
+			t.set_hash(i, ph);
 
 		std::vector<char> tmp;
 		std::back_insert_iterator<std::vector<char> > out(tmp);

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -60,7 +60,11 @@ bool wait_priority(torrent_handle const& h, std::vector<int> const& prio)
 	{
 		if (h.file_priorities() == prio) { return true; }
 
+#ifdef NDEBUG
 		test_sleep(100);
+#else
+		test_sleep(300);
+#endif
 	}
 
 	return h.file_priorities() == prio;

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -52,110 +52,117 @@ POSSIBILITY OF SUCH DAMAGE.
 using namespace libtorrent;
 namespace lt = libtorrent;
 
-void test_running_torrent(boost::shared_ptr<torrent_info> info, boost::int64_t file_size)
-{
-	settings_pack pack = settings();
-	pack.set_int(settings_pack::alert_mask, alert::storage_notification);
-	pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:48130");
-	pack.set_int(settings_pack::max_retry_port_bind, 10);
-	lt::session ses(pack);
-
-	std::vector<boost::uint8_t> zeroes;
-	zeroes.resize(1000, 0);
-	add_torrent_params p;
-	p.flags &= ~add_torrent_params::flag_paused;
-	p.flags &= ~add_torrent_params::flag_auto_managed;
-	p.ti = info;
-	p.save_path = ".";
-
-	// make sure we correctly handle the case where we pass in
-	// more values than there are files
-	p.file_priorities = zeroes;
-
-	error_code ec;
-	torrent_handle h = ses.add_torrent(p, ec);
-	if (ec)
+namespace {
+	bool wait_priority(torrent_handle const& h, std::vector<int> const& prio)
 	{
-		fprintf(stdout, "add_torrent: %s\n", ec.message().c_str());
-		return;
+		for (int i = 0; i < 10; ++i)
+		{
+			if (h.file_priorities() == prio) { return true; }
+
+			test_sleep(100);
+		}
+
+		return h.file_priorities() == prio;
 	}
 
-	std::vector<int> ones(info->num_files(), 1);
-	h.prioritize_files(ones);
-
-//	test_sleep(500);
-	torrent_status st = h.status();
-
-	TEST_EQUAL(st.total_wanted, file_size); // we want the single file
-	TEST_EQUAL(st.total_wanted_done, 0);
-
-	std::vector<int> prio(info->num_files(), 1);
-	prio[0] = 0;
-	h.prioritize_files(prio);
-	st = h.status();
-
-	TEST_EQUAL(st.total_wanted, 0); // we don't want anything
-	TEST_EQUAL(st.total_wanted_done, 0);
-	TEST_EQUAL(int(h.file_priorities().size()), info->num_files());
-	if (!st.is_seeding)
+	bool prioritize_files(torrent_handle const& h, std::vector<int> const& prio)
 	{
-		TEST_EQUAL(h.file_priorities()[0], 0);
-		if (info->num_files() > 1)
-			TEST_EQUAL(h.file_priorities()[1], 1);
-		if (info->num_files() > 2)
-			TEST_EQUAL(h.file_priorities()[2], 1);
-	}
-
-	if (info->num_files() > 1)
-	{
-		prio[1] = 0;
 		h.prioritize_files(prio);
-		st = h.status();
-
-		TEST_EQUAL(st.total_wanted, file_size);
-		TEST_EQUAL(st.total_wanted_done, 0);
-		if (!st.is_seeding)
-		{
-			TEST_EQUAL(int(h.file_priorities().size()), info->num_files());
-			TEST_EQUAL(h.file_priorities()[0], 0);
-			if (info->num_files() > 1)
-				TEST_EQUAL(h.file_priorities()[1], 0);
-			if (info->num_files() > 2)
-				TEST_EQUAL(h.file_priorities()[2], 1);
-		}
+		return wait_priority(h, prio);
 	}
 
-	if (info->num_pieces() > 0)
+	void test_running_torrent(boost::shared_ptr<torrent_info> info, boost::int64_t file_size)
 	{
-		h.piece_priority(0, 1);
-		st = h.status();
-		TEST_CHECK(st.pieces.size() > 0 && st.pieces[0] == false);
-		std::vector<char> piece(info->piece_length());
-		for (int i = 0; i < int(piece.size()); ++i)
-			piece[i] = (i % 26) + 'A';
-		h.add_piece(0, &piece[0], torrent_handle::overwrite_existing);
+		settings_pack pack = settings();
+		pack.set_int(settings_pack::alert_mask, alert::progress_notification | alert::storage_notification);
+		pack.set_str(settings_pack::listen_interfaces, "0.0.0.0:48130");
+		pack.set_int(settings_pack::max_retry_port_bind, 10);
+		lt::session ses(pack);
 
-		// wait until the piece is done writing and hashing
-		wait_for_alert(ses, piece_finished_alert::alert_type, "piece_finished_alert");
-		st = h.status();
-		TEST_CHECK(st.pieces.size() > 0);
+		std::vector<boost::uint8_t> zeroes;
+		zeroes.resize(1000, 0);
+		add_torrent_params p;
+		p.flags &= ~add_torrent_params::flag_paused;
+		p.flags &= ~add_torrent_params::flag_auto_managed;
+		p.ti = info;
+		p.save_path = ".";
 
-		std::cout << "reading piece 0" << std::endl;
-		h.read_piece(0);
-		alert const* a = wait_for_alert(ses, read_piece_alert::alert_type, "read_piece");
-		TEST_CHECK(a);
-		read_piece_alert const* rpa = alert_cast<read_piece_alert>(a);
-		TEST_CHECK(rpa);
-		if (rpa)
+		// make sure we correctly handle the case where we pass in
+		// more values than there are files
+		p.file_priorities = zeroes;
+
+		error_code ec;
+		torrent_handle h = ses.add_torrent(p, ec);
+		if (ec)
 		{
-			std::cout << "SUCCEEDED!" << std::endl;
-			TEST_CHECK(memcmp(&piece[0], rpa->buffer.get(), info->piece_size(0)) == 0);
-			TEST_CHECK(rpa->size == info->piece_size(0));
-			TEST_CHECK(rpa->piece == 0);
-			TEST_CHECK(hasher(&piece[0], piece.size()).final() == info->hash_for_piece(0));
+			fprintf(stdout, "add_torrent: %s\n", ec.message().c_str());
+			return;
 		}
+
+		std::vector<int> ones(info->num_files(), 1);
+		TEST_CHECK(prioritize_files(h, ones))
+
+		// test_sleep(500);
+		torrent_status st = h.status();
+
+		TEST_EQUAL(st.total_wanted, file_size); // we want the single file
+		TEST_EQUAL(st.total_wanted_done, 0);
+
+		std::vector<int> prio(info->num_files(), 1);
+		prio[0] = 0;
+		TEST_CHECK(prioritize_files(h, prio))
+
+		st = h.status();
+		TEST_EQUAL(st.total_wanted, 0); // we don't want anything
+		TEST_EQUAL(st.total_wanted_done, 0);
+		TEST_EQUAL(int(h.file_priorities().size()), info->num_files());
+
+		if (info->num_files() > 1)
+		{
+			prio[1] = 0;
+			TEST_CHECK(prioritize_files(h, prio))
+
+			st = h.status();
+			TEST_EQUAL(st.total_wanted, file_size);
+			TEST_EQUAL(st.total_wanted_done, 0);
+		}
+
+		if (info->num_pieces() > 0)
+		{
+			h.piece_priority(0, 1);
+			st = h.status();
+			TEST_CHECK(st.pieces.size() > 0 && st.pieces[0] == false);
+			std::vector<char> piece(info->piece_length());
+			for (int i = 0; i < int(piece.size()); ++i)
+			{
+				piece[i] = (i % 26) + 'A';
+			}
+			h.add_piece(0, &piece[0], torrent_handle::overwrite_existing);
+
+			// wait until the piece is done writing and hashing
+			wait_for_alert(ses, piece_finished_alert::alert_type, "piece_finished_alert");
+			st = h.status();
+			TEST_CHECK(st.pieces.size() > 0);
+
+			std::cout << "reading piece 0" << std::endl;
+			h.read_piece(0);
+			alert const* a = wait_for_alert(ses, read_piece_alert::alert_type, "read_piece");
+			TEST_CHECK(a);
+			read_piece_alert const* rpa = alert_cast<read_piece_alert>(a);
+			TEST_CHECK(rpa);
+			if (rpa)
+			{
+				std::cout << "SUCCEEDED!" << std::endl;
+				TEST_CHECK(memcmp(&piece[0], rpa->buffer.get(), info->piece_size(0)) == 0);
+				TEST_CHECK(rpa->size == info->piece_size(0));
+				TEST_CHECK(rpa->piece == 0);
+				TEST_CHECK(hasher(&piece[0], piece.size()).final() == info->hash_for_piece(0));
+			}
+		}
+
+		TEST_CHECK(h.file_priorities() == prio);
 	}
-}
+} // namespace
 
 TORRENT_TEST(long_names)
 {
@@ -214,6 +221,11 @@ TORRENT_TEST(total_wanted)
 	TEST_EQUAL(st.total_wanted, 1024);
 	std::cout << "total_wanted_done: " << st.total_wanted_done << " : 0" << std::endl;
 	TEST_EQUAL(st.total_wanted_done, 0);
+
+	h.file_priority(1, 4);
+	h.file_priority(1, 0);
+	TEST_CHECK(wait_priority(h, std::vector<int>(fs.num_files())));
+	TEST_EQUAL(h.status(0).total_wanted, 0);
 }
 
 TORRENT_TEST(added_peers)
@@ -248,63 +260,26 @@ TORRENT_TEST(added_peers)
 
 TORRENT_TEST(torrent)
 {
-/*	{
-		remove("test_torrent_dir2/tmp1");
-		remove("test_torrent_dir2/tmp2");
-		remove("test_torrent_dir2/tmp3");
-		file_storage fs;
-		boost::int64_t file_size = 256 * 1024;
-		fs.add_file("test_torrent_dir2/tmp1", file_size);
-		fs.add_file("test_torrent_dir2/tmp2", file_size);
-		fs.add_file("test_torrent_dir2/tmp3", file_size);
-		libtorrent::create_torrent t(fs, 128 * 1024);
-		t.add_tracker("http://non-existing.com/announce");
+	int const file_size = 1024;
+	file_storage fs;
 
-		std::vector<char> piece(128 * 1024);
-		for (int i = 0; i < int(piece.size()); ++i)
-			piece[i] = (i % 26) + 'A';
+	fs.add_file("test_torrent_dir2/tmp1", file_size);
+	libtorrent::create_torrent t(fs, file_size, 6);
 
-		// calculate the hash for all pieces
-		sha1_hash ph = hasher(&piece[0], piece.size()).final();
-		int num = t.num_pieces();
-		TEST_CHECK(t.num_pieces() > 0);
-		for (int i = 0; i < num; ++i)
-			t.set_hash(i, ph);
+	std::vector<char> piece(file_size);
+	for (int i = 0; i < int(piece.size()); ++i)
+		piece[i] = (i % 26) + 'A';
 
-		std::vector<char> tmp;
-		std::back_insert_iterator<std::vector<char> > out(tmp);
-		bencode(out, t.generate());
-		error_code ec;
-		boost::shared_ptr<torrent_info> info(boost::make_shared<torrent_info>(&tmp[0], tmp.size(), boost::ref(ec), 0));
-		TEST_CHECK(info->num_pieces() > 0);
+	// calculate the hash for all pieces
+	TEST_CHECK(t.num_pieces() == 1);
+	t.set_hash(0, hasher(&piece[0], piece.size()).final());
 
-		test_running_torrent(info, file_size);
-	}
-*/
-	{
-		file_storage fs;
-
-		fs.add_file("test_torrent_dir2/tmp1", 1024);
-		libtorrent::create_torrent t(fs, 128 * 1024, 6);
-
-		std::vector<char> piece(128 * 1024);
-		for (int i = 0; i < int(piece.size()); ++i)
-			piece[i] = (i % 26) + 'A';
-
-		// calculate the hash for all pieces
-		sha1_hash ph = hasher(&piece[0], piece.size()).final();
-		int num = t.num_pieces();
-		TEST_CHECK(t.num_pieces() > 0);
-		for (int i = 0; i < num; ++i)
-			t.set_hash(i, ph);
-
-		std::vector<char> tmp;
-		std::back_insert_iterator<std::vector<char> > out(tmp);
-		bencode(out, t.generate());
-		error_code ec;
-		boost::shared_ptr<torrent_info> info(boost::make_shared<torrent_info>(&tmp[0], tmp.size(), boost::ref(ec), 0));
-		test_running_torrent(info, 1024);
-	}
+	std::vector<char> tmp;
+	std::back_insert_iterator<std::vector<char> > out(tmp);
+	bencode(out, t.generate());
+	error_code ec;
+	boost::shared_ptr<torrent_info> info(boost::make_shared<torrent_info>(&tmp[0], tmp.size(), boost::ref(ec), 0));
+	test_running_torrent(info, file_size);
 }
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
@@ -534,4 +509,3 @@ TORRENT_TEST(test_move_storage_no_metadata)
 
 	TEST_EQUAL(h.status().save_path, complete("save_path_1"));
 }
-

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -278,6 +278,7 @@ TORRENT_TEST(torrent)
 		std::vector<char> piece(128 * 1024);
 		for (int i = 0; i < int(piece.size()); ++i)
 			piece[i] = (i % 26) + 'A';
+
 		// calculate the hash for all pieces
 		sha1_hash ph = hasher(&piece[0], piece.size()).final();
 		int num = t.num_pieces();


### PR DESCRIPTION
After setting file priority, any subsequent attempt to set different
priorities will fail if there is a `file_priority` job running in in
disk thread. This happens because `torrent::m_file_priority` is being
updated before adding disk thread job. The problem is gone if the file
priority vector owned by the torrent object, is modified in the
`torrent::on_file_priority` callback, when disk job finishes.

* Fix torrent test
* Minor `torrent` class refactoring