### PR TITLE
fix recent patch to support setting file priorities on torrents that don't have metadata

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5650,20 +5650,21 @@ namespace {
 
 	namespace
 	{
-		std::vector<boost::uint8_t> fix_priorities(std::vector<int> const& input, file_storage const& fs)
+		std::vector<boost::uint8_t> fix_priorities(std::vector<int> const& input
+			, file_storage const* fs)
 		{
 			std::vector<boost::uint8_t> files(input.begin(), input.end());
+			if (fs) files.resize(fs->num_files(), 4);
 
-			for (int i = 0; i < std::min<int>(fs.num_files(), files.size()); ++i)
+			for (int i = 0; i < int(files.size()); ++i)
 			{
 				// initialize pad files to priority 0
-				if (files[i] > 0 && fs.pad_file_at(i))
+				if (files[i] > 0 && fs && fs->pad_file_at(i))
 					files[i] = 0;
 				else if (files[i] > 7)
 					files[i] = 7;
 			}
 
-			files.resize(fs.num_files(), 4);
 			return files;
 		}
 
@@ -5705,7 +5706,8 @@ namespace {
 
 		if (is_seed()) return;
 
-		std::vector<boost::uint8_t> const new_priority = fix_priorities(files, m_torrent_file->files());
+		std::vector<boost::uint8_t> const new_priority = fix_priorities(files
+			, valid_metadata() ? &m_torrent_file->files() : NULL);
 
 		// storage may be NULL during shutdown
 		if (m_storage)

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -381,6 +381,34 @@ TORRENT_TEST(priority)
 
 // test to set piece and file priority on a torrent that doesn't have metadata
 // yet
+TORRENT_TEST(no_metadata_prioritize_files)
+{
+	settings_pack pack = settings();
+	lt::session ses(pack);
+
+	add_torrent_params addp;
+	addp.flags &= ~add_torrent_params::flag_paused;
+	addp.flags &= ~add_torrent_params::flag_auto_managed;
+	addp.info_hash = sha1_hash("abababababababababab");
+	addp.save_path = ".";
+	torrent_handle h = ses.add_torrent(addp);
+
+	std::vector<int> prios(3);
+	prios[0] = 0;
+
+	h.prioritize_files(prios);
+	// TODO 2: this should wait for an alert instead of just sleeping
+	test_sleep(100);
+	TEST_CHECK(h.file_priorities() == prios);
+
+	prios[0] = 1;
+	h.prioritize_files(prios);
+	test_sleep(100);
+	TEST_CHECK(h.file_priorities() == prios);
+
+	ses.remove_torrent(h);
+}
+
 TORRENT_TEST(no_metadata_file_prio)
 {
 	settings_pack pack = settings();


### PR DESCRIPTION
@d-komarov could you please take a look? I broke this in one of my last changes on that previous patch. I discovered this when merging it into master