### PR TITLE
Fix deadlock when loading libtorrent DLL

### DIFF
--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -341,10 +341,6 @@ namespace libtorrent
 #endif
 
 		int m_open_mode;
-#if defined TORRENT_WINDOWS
-		static bool has_manage_volume_privs;
-#endif
-
 #ifdef TORRENT_DEBUG_FILE_LEAKS
 		std::string m_file_path;
 #endif


### PR DESCRIPTION
Definition of `bool file::has_manage_volume_privs` involves a call to
`get_manage_volume_privs()`, causing restricted tasks to be performed
from within `DllMain` function. They introduce possibility that client
application deadlocks or crashes.

You should never perform the following tasks from within DllMain:

* Call `LoadLibrary` or `LoadLibraryEx` (either directly or indirectly).
  This can cause a deadlock or a crash.

* Call the registry functions. These functions are implemented in
  'Advapi32.dll'. If not initialized before your DLL, it can access
  uninitialized memory and cause the process to crash.

See [Dynamic-Link Library Best Practices](https://docs.microsoft.com/en-us/windows/desktop/dlls/dynamic-link-library-best-practices).