### PR TITLE
raise priority of cache_flushed_alert

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1630,7 +1630,7 @@ namespace libtorrent
 		// internal
 		cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
 
-		TORRENT_DEFINE_ALERT(cache_flushed_alert, 58)
+		TORRENT_DEFINE_ALERT_PRIO(cache_flushed_alert, 58, alert_priority_high)
 
 		static const int static_category = alert::storage_notification;
 	};

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1164,7 +1164,7 @@ namespace libtorrent
 		void on_storage_moved(disk_io_job const* j);
 		void on_save_resume_data(disk_io_job const* j);
 		void on_file_renamed(disk_io_job const* j);
-		void on_cache_flushed(disk_io_job const* j);
+		void on_cache_flushed(disk_io_job const* j, bool manually_triggered);
 
 		// this is used when a torrent is being removed.It synchronizes with the
 		// disk thread

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8701,7 +8701,7 @@ namespace {
 			// we need to keep the object alive during this operation
 			inc_refcount("release_files");
 			m_ses.disk_thread().async_release_files(m_storage.get()
-				, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1));
+				, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1, false));
 		}
 
 		// this torrent just completed downloads, which means it will fall
@@ -9881,17 +9881,17 @@ namespace {
 		}
 		inc_refcount("release_files");
 		m_ses.disk_thread().async_release_files(m_storage.get()
-			, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1));
+			, boost::bind(&torrent::on_cache_flushed, shared_from_this(), _1, true));
 	}
 
-	void torrent::on_cache_flushed(disk_io_job const*)
+	void torrent::on_cache_flushed(disk_io_job const*, bool const manually_triggered)
 	{
 		dec_refcount("release_files");
 		TORRENT_ASSERT(is_single_thread());
 
 		if (m_ses.is_aborted()) return;
 
-		if (alerts().should_post<cache_flushed_alert>())
+		if (manually_triggered || alerts().should_post<cache_flushed_alert>())
 			alerts().emplace_alert<cache_flushed_alert>(get_handle());
 	}
 


### PR DESCRIPTION
and post it unconditionally when triggered explicitly by the client. This gives the alert the same priority as `torrent_finished_alert`