### PR TITLE
fix port parameter in DHT announces on multi-homed hosts

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -66,6 +66,15 @@ rule linking ( properties * )
 	{
 		result += <library>gcrypt ;
 	}
+	else if <crypto>openssl in $(properties)
+	{
+		result += <library>ssl ;
+		result += <library>crypto ;
+	}
+	else if <crypto>libcrypto in $(properties)
+	{
+		result += <library>crypto ;
+	}
 
 	if <target-os>windows in $(properties)
 		|| <target-os>cygwin in $(properties)
@@ -809,9 +818,6 @@ lib torrent
 	<link>shared:<define>TORRENT_BUILDING_SHARED
 	<define>BOOST_NO_DEPRECATED
 	<link>shared:<define>BOOST_SYSTEM_SOURCE
-	<crypto>openssl:<library>ssl
-	<crypto>openssl:<library>crypto
-	<crypto>libcrypto:<library>crypto
 
 	<dht>on:<source>src/kademlia/$(KADEMLIA_SOURCES).cpp
 	<dht>on:<source>ed25519/src/$(ED25519_SOURCES).cpp

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -593,6 +593,8 @@ namespace aux {
 			std::uint16_t ssl_listen_port() const override;
 			std::uint16_t ssl_listen_port(listen_socket_t* sock) const;
 
+			int get_listen_port(transport ssl, aux::listen_socket_handle const& s) override;
+
 			std::uint32_t get_tracker_key(address const& iface) const;
 
 			void for_each_listen_socket(std::function<void(aux::listen_socket_handle const&)> f) override

--- a/include/libtorrent/kademlia/dht_observer.hpp
+++ b/include/libtorrent/kademlia/dht_observer.hpp
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/address.hpp"
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/kademlia/msg.hpp"
+#include "libtorrent/aux_/session_udp_sockets.hpp" // for transport
 
 namespace libtorrent {
 
@@ -78,6 +79,7 @@ namespace dht {
 	{
 		virtual void set_external_address(aux::listen_socket_handle const& iface
 			, address const& addr, address const& source) = 0;
+		virtual int get_listen_port(aux::transport ssl, aux::listen_socket_handle const& s) = 0;
 		virtual void get_peers(sha1_hash const& ih) = 0;
 		virtual void outgoing_get_peers(sha1_hash const& target
 			, sha1_hash const& sent_target, udp::endpoint const& ep) = 0;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -96,7 +96,7 @@ namespace libtorrent { namespace dht {
 
 		dht_state state() const;
 
-		enum flags_t { flag_seed = 1, flag_implied_port = 2 };
+		enum flags_t { flag_seed = 1, flag_implied_port = 2, flag_ssl_torrent = 4 };
 		void get_peers(sha1_hash const& ih
 			, std::function<void(std::vector<tcp::endpoint> const&)> f);
 		void announce(sha1_hash const& ih, int listen_port, int flags

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -132,7 +132,7 @@ public:
 	int data_size() const { return int(m_storage.num_torrents()); }
 #endif
 
-	enum flags_t { flag_seed = 1, flag_implied_port = 2 };
+	enum flags_t { flag_seed = 1, flag_implied_port = 2, flag_ssl_torrent = 4 };
 	void get_peers(sha1_hash const& info_hash
 		, std::function<void(std::vector<tcp::endpoint> const&)> dcallback
 		, std::function<void(std::vector<std::pair<node_entry, std::string>> const&)> ncallback

--- a/simulation/test_dht_rate_limit.cpp
+++ b/simulation/test_dht_rate_limit.cpp
@@ -60,6 +60,8 @@ struct obs : dht::dht_observer
 	void set_external_address(lt::aux::listen_socket_handle const&, address const& /* addr */
 		, address const& /* source */) override
 	{}
+	int get_listen_port(lt::aux::transport, lt::aux::listen_socket_handle const& s) override
+	{ return s.get()->udp_external_port; }
 	void get_peers(sha1_hash const&) override {}
 	void outgoing_get_peers(sha1_hash const& /* target */
 		, sha1_hash const& /* sent_target */, udp::endpoint const& /* ep */) override {}

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -441,7 +441,7 @@ void node::get_peers(sha1_hash const& info_hash
 	ta->start();
 }
 
-void node::announce(sha1_hash const& info_hash, int const listen_port, int const flags
+void node::announce(sha1_hash const& info_hash, int listen_port, int const flags
 	, std::function<void(std::vector<tcp::endpoint> const&)> f)
 {
 #ifndef TORRENT_DISABLE_LOGGING
@@ -451,6 +451,13 @@ void node::announce(sha1_hash const& info_hash, int const listen_port, int const
 			, aux::to_hex(info_hash).c_str(), listen_port);
 	}
 #endif
+
+	if (listen_port == 0)
+	{
+		listen_port = m_observer->get_listen_port(
+			flags & node::flag_ssl_torrent ? aux::transport::ssl : aux::transport::plaintext
+			, m_sock);
+	}
 
 	get_peers(info_hash, std::move(f)
 		, std::bind(&announce_fun, _1, std::ref(*this)

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5438,6 +5438,24 @@ namespace aux {
 		return 0;
 	}
 
+	int session_impl::get_listen_port(transport const ssl, aux::listen_socket_handle const& s)
+	{
+		auto socket = s.get();
+		if (socket->ssl != ssl)
+		{
+			auto alt_socket = std::find_if(m_listen_sockets.begin(), m_listen_sockets.end()
+				, [&](std::shared_ptr<listen_socket_t> const& e)
+			{
+				return e->ssl == ssl
+					&& e->external_address.external_address()
+						== socket->external_address.external_address();
+			});
+			if (alt_socket != m_listen_sockets.end())
+				socket = alt_socket->get();
+		}
+		return socket->udp_external_port;
+	}
+
 	void session_impl::announce_lsd(sha1_hash const& ih, int port, bool broadcast)
 	{
 		// use internal listen port for local peers

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2586,12 +2586,6 @@ bool is_downloading_state(int const st)
 
 		TORRENT_ASSERT(!m_paused);
 
-#ifdef TORRENT_USE_OPENSSL
-		int port = is_ssl_torrent() ? m_ses.ssl_listen_port() : m_ses.listen_port();
-#else
-		int port = m_ses.listen_port();
-#endif
-
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("START DHT announce");
 		m_dht_start_time = aux::time_now();
@@ -2606,9 +2600,11 @@ bool is_downloading_state(int const st)
 		if (settings().get_bool(settings_pack::enable_incoming_utp))
 			flags |= dht::dht_tracker::flag_implied_port;
 
+		if (is_ssl_torrent())
+			flags |= dht::dht_tracker::flag_ssl_torrent;
+
 		std::weak_ptr<torrent> self(shared_from_this());
-		m_ses.dht()->announce(m_torrent_file->info_hash()
-			, port, flags
+		m_ses.dht()->announce(m_torrent_file->info_hash(), 0, flags
 			, std::bind(&torrent::on_dht_announce_response_disp, self, _1));
 	}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2597,7 +2597,10 @@ bool is_downloading_state(int const st)
 		// argument in the announce, this will make the DHT node use
 		// our source port in the packet as our listen port, which is
 		// likely more accurate when behind a NAT
-		if (settings().get_bool(settings_pack::enable_incoming_utp))
+		// don't set this for SSL torrents because peers need
+		// to connect to the SSL listen port
+		if (settings().get_bool(settings_pack::enable_incoming_utp)
+			&& !is_ssl_torrent())
 			flags |= dht::dht_tracker::flag_implied_port;
 
 		if (is_ssl_torrent())

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -527,6 +527,9 @@ struct obs : dht::dht_observer
 			, aux::session_interface::source_dht, rand_v4());
 	}
 
+	int get_listen_port(aux::transport, aux::listen_socket_handle const& s) override
+	{ return s.get()->udp_external_port; }
+
 	void get_peers(sha1_hash const&) override {}
 	void outgoing_get_peers(sha1_hash const& /*target*/
 		, sha1_hash const& /*sent_target*/, udp::endpoint const&) override {}


### PR DESCRIPTION
Use the correct listen port for each DHT node's external address instead of using the same port for all nodes.