### PR TITLE
Windows async read EOF handling

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -212,7 +212,7 @@ namespace {
 				{
 					num_waits = i;
 					break;
-				} 
+				}
 				else if (last_error != ERROR_IO_PENDING
 #ifdef ERROR_CANT_WAIT
 					&& last_error != ERROR_CANT_WAIT

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -201,42 +201,60 @@ namespace {
 		}
 
 		int ret = 0;
+		int num_waits = num_bufs;
 		for (int i = 0; i < num_bufs; ++i)
 		{
 			DWORD num_read;
-			if (ReadFile(fd, bufs[i].iov_base, DWORD(bufs[i].iov_len), &num_read, &ol[i]) == FALSE
-				&& GetLastError() != ERROR_IO_PENDING
-#ifdef ERROR_CANT_WAIT
-				&& GetLastError() != ERROR_CANT_WAIT
-#endif
-				)
+			if (ReadFile(fd, bufs[i].iov_base, DWORD(bufs[i].iov_len), &num_read, &ol[i]) == FALSE)
 			{
-				ret = -1;
-				goto done;
+				DWORD last_error = GetLastError();
+				if (last_error == ERROR_HANDLE_EOF)
+				{
+					num_waits = i;
+					break;
+				} 
+				else if (last_error != ERROR_IO_PENDING
+#ifdef ERROR_CANT_WAIT
+					&& last_error != ERROR_CANT_WAIT
+#endif
+					)
+				{
+					ret = -1;
+					goto done;
+				}
 			}
 		}
 
-		if (wait_for_multiple_objects(int(h.size()), h.data()) == WAIT_FAILED)
+		if (num_waits == 0)
+		{
+			goto done;
+		}
+
+		if (wait_for_multiple_objects(num_waits, h.data()) == WAIT_FAILED)
 		{
 			ret = -1;
 			goto done;
 		}
 
-		for (auto& o : ol)
+		for (int i = 0; i < num_waits; ++i)
 		{
-			if (WaitForSingleObject(o.hEvent, INFINITE) == WAIT_FAILED)
+			if (WaitForSingleObject(ol[i].hEvent, INFINITE) == WAIT_FAILED)
 			{
 				ret = -1;
 				break;
 			}
 			DWORD num_read;
-			if (GetOverlappedResult(fd, &o, &num_read, FALSE) == FALSE)
+			if (GetOverlappedResult(fd, &ol[i], &num_read, FALSE) == FALSE)
 			{
+				DWORD last_error = GetLastError();
+				if (last_error != ERROR_HANDLE_EOF)
+				{
 #ifdef ERROR_CANT_WAIT
-				TORRENT_ASSERT(GetLastError() != ERROR_CANT_WAIT);
+					TORRENT_ASSERT(last_error != ERROR_CANT_WAIT);
 #endif
-				ret = -1;
-				break;
+					ret = -1;
+					break;
+				}
 			}
 			ret += num_read;
 		}

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -207,7 +207,7 @@ namespace {
 			DWORD num_read;
 			if (ReadFile(fd, bufs[i].iov_base, DWORD(bufs[i].iov_len), &num_read, &ol[i]) == FALSE)
 			{
-				DWORD last_error = GetLastError();
+				DWORD const last_error = GetLastError();
 				if (last_error == ERROR_HANDLE_EOF)
 				{
 					num_waits = i;
@@ -236,17 +236,17 @@ namespace {
 			goto done;
 		}
 
-		for (int i = 0; i < num_waits; ++i)
+		for (auto& o : libtorrent::span<OVERLAPPED>(ol).first(num_waits))
 		{
-			if (WaitForSingleObject(ol[i].hEvent, INFINITE) == WAIT_FAILED)
+			if (WaitForSingleObject(o.hEvent, INFINITE) == WAIT_FAILED)
 			{
 				ret = -1;
 				break;
 			}
 			DWORD num_read;
-			if (GetOverlappedResult(fd, &ol[i], &num_read, FALSE) == FALSE)
+			if (GetOverlappedResult(fd, &o, &num_read, FALSE) == FALSE)
 			{
-				DWORD last_error = GetLastError();
+				DWORD const last_error = GetLastError();
 				if (last_error != ERROR_HANDLE_EOF)
 				{
 #ifdef ERROR_CANT_WAIT

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1,4 +1,4 @@
- /*
+/*
 
 Copyright (c) 2012, Arvid Norberg
 All rights reserved.

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1,4 +1,4 @@
-/*
+ /*
 
 Copyright (c) 2012, Arvid Norberg
 All rights reserved.
@@ -287,25 +287,48 @@ TORRENT_TEST(file)
 {
 	error_code ec;
 	file f;
-	TEST_CHECK(f.open("test_file", open_mode::read_write, ec));
+	std::string test_file_name = "test_file";
+	TEST_CHECK(f.open(test_file_name, open_mode::read_write, ec));
 	if (ec)
 		std::printf("open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 	if (ec) std::printf("%s\n", ec.message().c_str());
 	char test[] = "test";
-	iovec_t b = {test, 4};
-	TEST_EQUAL(f.writev(0, b, ec), 4);
+	size_t const test_word_size = sizeof(test) - 1;
+	iovec_t b = {test, test_word_size};
+	TEST_EQUAL(f.writev(0, b, ec), test_word_size);
 	if (ec)
 		std::printf("writev failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_CHECK(!ec);
-	char test_buf[5] = {0};
-	b = { test_buf, 4 };
-	TEST_EQUAL(f.readv(0, b, ec), 4);
+	char test_buf[test_word_size + 1] = {0};
+	b = { test_buf, test_word_size };
+	TEST_EQUAL(f.readv(0, b, ec), test_word_size);
 	if (ec)
 		std::printf("readv failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
 	TEST_EQUAL(ec, error_code());
 	TEST_CHECK(test_buf == "test"_sv);
 	f.close();
+
+	TEST_CHECK(f.open(test_file_name, open_mode::read_only, ec));
+	if (ec)
+		std::printf("open failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+	TEST_EQUAL(ec, error_code());
+	if (ec) std::printf("%s\n", ec.message().c_str());
+
+	char test_buf2[test_word_size + 1] = {0};
+	std::memset(test_buf, 0, sizeof(test_buf));
+	iovec_t two_buffers[2] {
+			{test_buf, test_word_size},
+			{test_buf2, test_word_size}
+	};
+
+	TEST_EQUAL(f.readv(0, two_buffers, ec), test_word_size);
+	if (ec)
+		std::printf("readv failed: [%s] %s\n", ec.category().name(), ec.message().c_str());
+	TEST_EQUAL(ec, error_code());
+	TEST_CHECK(test_buf == "test"_sv);
+	f.close();
+
 }
 
 TORRENT_TEST(hard_link)


### PR DESCRIPTION
Windows "preadv" emulation uses overlapped ReadFile API.
This async read API may throw ERROR_HANDLE_EOF (https://docs.microsoft.com/en-us/windows/desktop/fileio/testing-for-the-end-of-a-file).
There are several issues with this error code handling:
- if "preadv" has multiple input bufs and only one of them reaches EOF then all data will be discarded and windows sepcific system_error will be raised
- *nix "preadv" and old windows "readv" does not generate error upon reaching EOF (they simply returns 0 while reading after EOF)

PR should fix these issues.