### PR TITLE
Fix unserialization of "unfinished" resume field

### DIFF
--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -338,7 +338,15 @@ namespace {
 				bdecode_node const bitmask = e.dict_find_string("bitmask");
 				if (!bitmask || bitmask.string_length() == 0) continue;
 				bitfield& bf = ret.unfinished_pieces[piece];
-				bf.assign(bitmask.string_ptr(), bitmask.string_length());
+				char const* bitmask_str = bitmask.string_ptr();
+				bf.resize(bitmask.string_length());
+				for (int j = 0; j < bitmask.string_length(); ++j)
+				{
+					if (bitmask_str[j] == '1')
+					{
+						bf.set_bit(j);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
It seems a34ce0278e0ce4c3d62a632425add5b7fcdf5551 changed how "unfinished" pieces blocks bitmasks stored, but forgot to fix how to read these bitmasks.
One of negative effects due this error was unexpected income_piece->verify_piece->do_hash->read ->file_error_alert. Because after torrent resume some piece blocks were falsely marked as finished.