### PR TITLE
apply piece priorities immediately

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 1.1.9 release
 
+	* save both file and piece priorities in resume file
 	* added missing stats_metric python binding
 	* uTP connections are no longer exempt from rate limits by default
 	* fix exporting files from partfile while seeding

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -552,7 +552,7 @@ namespace libtorrent
 		void set_piece_deadline(int piece, int t, int flags);
 		void reset_piece_deadline(int piece);
 		void clear_time_critical();
-		void update_piece_priorities();
+		void update_piece_priorities(std::vector<boost::uint8_t> const& file_prio);
 
 		void status(torrent_status* st, boost::uint32_t flags);
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1022,9 +1022,8 @@ namespace libtorrent
 		// The default priority of pieces is 4.
 		// 
 		// Piece priorities can not be changed for torrents that have not
-		// downloaded the metadata yet. For instance, magnet links and torrents
-		// added by URL won't have metadata immediately. see the
-		// metadata_received_alert.
+		// downloaded the metadata yet. Magnet links won't have metadata
+		// immediately. see the metadata_received_alert.
 		// 
 		// ``piece_priority`` sets or gets the priority for an individual piece,
 		// specified by ``index``.
@@ -1041,6 +1040,10 @@ namespace libtorrent
 		// 
 		// ``piece_priorities`` returns a vector with one element for each piece
 		// in the torrent. Each element is the current priority of that piece.
+		// 
+		// It's possible to cancel the effect of *file* priorities by setting the
+		// priorities for the affected pieces. Care has to be taken when mixing
+		// usage of file- and piece priorities.
 		void piece_priority(int index, int priority) const;
 		int piece_priority(int index) const;
 		void prioritize_pieces(std::vector<int> const& pieces) const;
@@ -1069,6 +1072,16 @@ namespace libtorrent
 		// You cannot set the file priorities on a torrent that does not yet have
 		// metadata or a torrent that is a seed. ``file_priority(int, int)`` and
 		// prioritize_files() are both no-ops for such torrents.
+		// 
+		// Since changing file priorities may involve disk operations (of moving
+		// files in- and out of the part file), the internal accounting of file
+		// priorities happen asynchronously. i.e. setting file priorities and then
+		// immediately querying them may not yield the same priorities just set.
+		// However, the *piece* priorities are updated immediately.
+		// 
+		// when combining file- and piece priorities, the resume file will record
+		// both. When loading the resume data, the file priorities will be applied
+		// first, then the piece priorities.
 		void file_priority(int index, int priority) const;
 		int file_priority(int index) const;
 		void prioritize_files(std::vector<int> const& files) const;

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -67,7 +67,6 @@ void test_interval(int interval)
 	sim::default_config network_cfg;
 	sim::simulation sim{network_cfg};
 
-	lt::time_point start = lt::clock_type::now();
 	bool ran_to_completion = false;
 
 	sim::asio::io_service web_server(sim, address_v4::from_string("2.2.2.2"));
@@ -78,7 +77,7 @@ void test_interval(int interval)
 	std::vector<lt::time_point> announces;
 
 	http.register_handler("/announce"
-		, [&announces,interval,start,&ran_to_completion](std::string method, std::string req
+		, [&announces,interval,&ran_to_completion](std::string method, std::string req
 		, std::map<std::string, std::string>&)
 	{
 		// don't collect events once we're done. We're not interested in the

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -74,6 +74,31 @@ namespace lt = libtorrent;
 #include <conio.h>
 #endif
 
+boost::shared_ptr<lt::torrent_info> generate_torrent()
+{
+	file_storage fs;
+	fs.add_file("test/tmp1", 128 * 1024 * 8);
+	fs.add_file("test/tmp2", 128 * 1024);
+	fs.add_file("test/tmp3", 128 * 1024);
+	lt::create_torrent t(fs, 128 * 1024, 6);
+
+	t.add_tracker("http://torrent_file_tracker.com/announce");
+	t.add_url_seed("http://torrent_file_url_seed.com/");
+
+	int num = t.num_pieces();
+	TEST_CHECK(num > 0);
+	for (int i = 0; i < num; ++i)
+	{
+		sha1_hash ph;
+		for (int k = 0; k < 20; ++k) ph[k] = lt::random();
+		t.set_hash(i, ph);
+	}
+
+	std::vector<char> buf;
+	bencode(std::back_inserter(buf), t.generate());
+	return boost::make_shared<torrent_info>(&buf[0], buf.size());
+}
+
 boost::uint32_t g_addr = 0x92343023;
 
 void init_rand_address()

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -44,6 +44,8 @@ namespace libtorrent
 	class file_storage;
 }
 
+EXPORT boost::shared_ptr<lt::torrent_info> generate_torrent();
+
 EXPORT int print_failures();
 EXPORT unsigned char random_byte();
 

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -220,13 +220,15 @@ TORRENT_TEST(total_wanted)
 	torrent_handle h = ses.add_torrent(p);
 
 	torrent_status st = h.status();
-	std::cout << "total_wanted: " << st.total_wanted << " : " << 1024 << std::endl;
 	TEST_EQUAL(st.total_wanted, 1024);
-	std::cout << "total_wanted_done: " << st.total_wanted_done << " : 0" << std::endl;
 	TEST_EQUAL(st.total_wanted_done, 0);
 
+	// make sure that selecting and unseleting a file quickly still end up with
+	// the last set priority
 	h.file_priority(1, 4);
 	h.file_priority(1, 0);
+
+	TEST_EQUAL(h.status(0).total_wanted, 0);
 	TEST_CHECK(wait_priority(h, std::vector<int>(fs.num_files())));
 	TEST_EQUAL(h.status(0).total_wanted, 0);
 }


### PR DESCRIPTION
even though file priority updares are async. save both file- and piece priorities in fast resume. when loading, apply file prios first, then piece prios