### PR TITLE
add a few more stats counters measuring outgoing connection attempts.

### DIFF
--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -536,8 +536,12 @@ class test_session(unittest.TestCase):
         while len(alerts) == 0:
             s.wait_for_alert(1000)
             alerts = s.pop_alerts()
-        a = alerts.pop(0)
-        print(a)
+
+        while len(alerts) > 0:
+            a = alerts.pop(0)
+            print(a)
+            if isinstance(a, lt.session_stats_header_alert):
+                break
         self.assertTrue(isinstance(a, lt.session_stats_header_alert))
         # then the actual stats values
         while len(alerts) == 0:
@@ -554,12 +558,6 @@ class test_session(unittest.TestCase):
         s.post_dht_stats()
         alerts = []
         # first the stats headers log line. but not if logging is disabled
-        while len(alerts) == 0:
-            s.wait_for_alert(1000)
-            alerts = s.pop_alerts()
-        a = alerts.pop(0)
-        self.assertTrue(isinstance(a, lt.session_stats_header_alert))
-        print(a.message())
         while len(alerts) == 0:
             s.wait_for_alert(1000)
             alerts = s.pop_alerts()

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2755,8 +2755,8 @@ TORRENT_VERSION_NAMESPACE_2
 		aux::allocation_slot m_v6_nodes_idx;
 	};
 
-	// The session_stats_header alert is posted during the init of the
-	// session thread.
+	// The session_stats_header alert is posted the first time
+	// post_session_stats() is called
 	//
 	// the ``message()`` member function returns a string representation of the
 	// header that properly match the stats values string returned in

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -721,7 +721,11 @@ namespace aux {
 			{ return &m_ssl_utp_socket_manager; }
 #endif
 
-			void inc_boost_connections() override { ++m_boost_connections; }
+			void inc_boost_connections() override
+			{
+				++m_boost_connections;
+				m_stats_counters.inc_stats_counter(counters::boost_connection_attempts);
+			}
 
 			// the settings for the client
 			aux::session_settings m_settings;
@@ -1297,6 +1301,10 @@ namespace aux {
 
 			// is true if the session is paused
 			bool m_paused = false;
+
+			// set to true the first time post_session_stats() is
+			// called and we post the headers alert
+			bool m_posted_stats_header = false;
 		};
 
 #ifndef TORRENT_DISABLE_LOGGING

--- a/include/libtorrent/performance_counters.hpp
+++ b/include/libtorrent/performance_counters.hpp
@@ -116,6 +116,18 @@ namespace libtorrent {
 			// the number of iterations over the peer list when finding
 			// a connect candidate
 			connection_attempt_loops,
+
+			// the number of peer connection attempts made as high
+			// priority connections for new torrents
+			boost_connection_attempts,
+
+			// calls to torrent::connect_to_peer() that failed
+			missed_connection_attempts,
+
+			// calls to peer_list::connect_one_peer() resulting in
+			// no peer candidate being found
+			no_peer_connection_attempts,
+
 			// successful incoming connections (not rejected for any reason)
 			incoming_connections,
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -552,8 +552,6 @@ namespace aux {
 #ifndef TORRENT_DISABLE_LOGGING
 		session_log(" *** session thread init");
 #endif
-		if (m_alerts.should_post<session_stats_header_alert>())
-			m_alerts.emplace_alert<session_stats_header_alert>();
 
 		// this is where we should set up all async operations. This
 		// is called from within the network thread as opposed to the
@@ -4622,6 +4620,11 @@ namespace aux {
 
 	void session_impl::post_session_stats()
 	{
+		if (!m_posted_stats_header)
+		{
+			m_posted_stats_header = true;
+			m_alerts.emplace_alert<session_stats_header_alert>();
+		}
 		m_disk_thread.update_stats_counters(m_stats_counters);
 
 #ifndef TORRENT_DISABLE_DHT

--- a/src/session_stats.cpp
+++ b/src/session_stats.cpp
@@ -123,6 +123,9 @@ namespace {
 
 		METRIC(peer, connection_attempts)
 		METRIC(peer, connection_attempt_loops)
+		METRIC(peer, boost_connection_attempts)
+		METRIC(peer, missed_connection_attempts)
+		METRIC(peer, no_peer_connection_attempts)
 		METRIC(peer, incoming_connections)
 
 		// the number of peer connections for each kind of socket.

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10061,12 +10061,14 @@ bool is_downloading_state(int const st)
 
 		if (p == nullptr)
 		{
+			m_stats_counters.inc_stats_counter(counters::no_peer_connection_attempts);
 			update_want_peers();
 			return false;
 		}
 
 		if (!connect_to_peer(p))
 		{
+			m_stats_counters.inc_stats_counter(counters::missed_connection_attempts);
 			m_peer_list->inc_failcount(p);
 			update_want_peers();
 			return false;

--- a/tools/parse_session_stats.py
+++ b/tools/parse_session_stats.py
@@ -45,9 +45,11 @@ output_dir = 'session_stats_report'
 
 stat = open(sys.argv[1])
 line = stat.readline()
+print('looking for stats header')
 while 'session stats header:' not in line:
     line = stat.readline()
 
+print('found')
 keys = line.split('session stats header:')[1].strip().split(', ')
 
 try:
@@ -129,7 +131,7 @@ for i in range(0, 6):
 def plot_fun(script):
     ret = os.system('gnuplot "%s" 2>/dev/null' % script)
     if ret != 0 and ret != 256:
-        print('system: %d\n' % ret)
+        print('gnuplot failed: %d\n' % ret)
         raise Exception("abort")
 
     sys.stdout.write('.')
@@ -333,7 +335,8 @@ reports = [
      'peer.num_peers_connected', 'peer.num_peers_half_open'], {'type': stacked}),
     ('peers_max', 'num', '', 'num connected peers', ['peer.num_peers_connected', 'peer.num_peers_half_open']),
     ('peer_churn', 'num', '', 'connecting and disconnecting peers',
-     ['peer.num_peers_half_open', 'peer.connection_attempts']),
+     ['peer.num_peers_half_open', 'peer.connection_attempts', 'peer.boost_connection_attempts',
+      'peer.missed_connection_attempts', 'peer.no_peer_connection_attempts']),
     ('new_peers', 'num', '', '', ['peer.incoming_connections', 'peer.connection_attempts']),
     ('connection_attempts', 'num', '', '', ['peer.connection_attempt_loops', 'peer.connection_attempts']),
     ('pieces', 'num', '', 'number completed pieces', [
@@ -536,9 +539,6 @@ reports = [
         'disk.arc_mfu_ghost_size' \
     ], {'allow-negative': True}),
 
-    ('torrent churn', 'num torrents', '', '', ['ses.num_loaded_torrents', 'ses.num_pinned_torrents']),
-    ('pinned torrents', 'num torrents', '', '', ['ses.num_pinned_torrents']),
-    ('loaded torrents', 'num torrents', '', '', ['ses.num_loaded_torrents', 'ses.num_pinned_torrents']),
     ('request latency', 'us', '', 'latency from receiving requests to sending response', ['disk.request_latency']),
     ('incoming messages', 'num', '', 'number of received bittorrent messages, by type', [ \
         'ses.num_incoming_choke', \
@@ -639,7 +639,7 @@ g = 0
 generations = []
 scripts = []
 
-print('[%s] %04d\r[' % (' ' * len(reports), g), end=' ')
+print('[%s] %04d\r[' % (' ' * len(reports), g), end='')
 for i in reports:
     try:
         options = i[5]


### PR DESCRIPTION
simplify session_stats_header_alert by posting it on first call to post_session_stats() instead of making it gated by the alert_mask