### PR TITLE
Fix exporting files

### DIFF
--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -463,7 +463,7 @@ namespace libtorrent
 					return;
 				}
 
-				if (m_part_file)
+				if (m_part_file && use_partfile(i))
 				{
 					m_part_file->export_file(*f, fs.file_offset(i), fs.file_size(i), ec.ec);
 					if (ec)


### PR DESCRIPTION
To avoid overwriting existing files, before exporting anything from a parts file, need to check whether it contains valid data.