### PR TITLE
fixed old-style-cast warning when using libgcrypt

### DIFF
--- a/src/hasher.cpp
+++ b/src/hasher.cpp
@@ -114,7 +114,7 @@ namespace libtorrent {
 		sha1_hash digest;
 #ifdef TORRENT_USE_LIBGCRYPT
 		gcry_md_final(m_context);
-		digest.assign((char const*)gcry_md_read(m_context, 0));
+		digest.assign(reinterpret_cast<char const*>(gcry_md_read(m_context, 0)));
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA1_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
 #elif TORRENT_USE_CRYPTOAPI

--- a/src/hasher512.cpp
+++ b/src/hasher512.cpp
@@ -102,7 +102,7 @@ namespace libtorrent {
 		sha512_hash digest;
 #ifdef TORRENT_USE_LIBGCRYPT
 		gcry_md_final(m_context);
-		digest.assign((char const*)gcry_md_read(m_context, 0));
+		digest.assign(reinterpret_cast<char const*>(gcry_md_read(m_context, 0)));
 #elif TORRENT_USE_COMMONCRYPTO
 		CC_SHA512_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
 #elif TORRENT_USE_CRYPTOAPI_SHA_512


### PR DESCRIPTION
But, how realistic is that this library is actually used, is this something that can be removed?