### PR TITLE
Fire checked_alert before finished_alert

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7377,6 +7377,14 @@ bool is_downloading_state(int const st)
 			// of which torrents to have active
 			m_ses.trigger_auto_manage();
 		}
+		
+		INVARIANT_CHECK;
+
+		if (m_ses.alerts().should_post<torrent_checked_alert>())
+		{
+			m_ses.alerts().emplace_alert<torrent_checked_alert>(
+				get_handle());
+		}
 
 		if (!is_seed())
 		{
@@ -7410,14 +7418,6 @@ bool is_downloading_state(int const st)
 			&& !m_seed_mode)
 		{
 			set_state(torrent_status::downloading);
-		}
-
-		INVARIANT_CHECK;
-
-		if (m_ses.alerts().should_post<torrent_checked_alert>())
-		{
-			m_ses.alerts().emplace_alert<torrent_checked_alert>(
-				get_handle());
 		}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS


### PR DESCRIPTION
QBittorrent makes use of both those alerts to schedule a recheck on download completion.
But in case you want to seed a new file QBittorrent ends in a loop because a finished_alert
gets fired before checked_alert which schedules another recheck.