### PR TITLE
Fire checked_alert before finished_alert

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8858,6 +8858,14 @@ namespace {
 			m_ses.trigger_auto_manage();
 		}
 
+		INVARIANT_CHECK;
+
+		if (m_ses.alerts().should_post<torrent_checked_alert>())
+		{
+			m_ses.alerts().emplace_alert<torrent_checked_alert>(
+				get_handle());
+		}
+		
 		if (!is_seed())
 		{
 			// turn off super seeding if we're not a seed
@@ -8890,14 +8898,6 @@ namespace {
 			&& !m_seed_mode)
 		{
 			set_state(torrent_status::downloading);
-		}
-
-		INVARIANT_CHECK;
-
-		if (m_ses.alerts().should_post<torrent_checked_alert>())
-		{
-			m_ses.alerts().emplace_alert<torrent_checked_alert>(
-				get_handle());
 		}
 
 #ifndef TORRENT_DISABLE_EXTENSIONS


### PR DESCRIPTION
QBittorrent makes use of both those alerts to schedule a recheck on download completion.
But in case you want to seed a new file QBittorrent ends in a loop because a finished_alert
gets fired before checked_alert which schedules another recheck.