### PR TITLE
remove dead code udp_tracker_connection::pick_target_endpoint

### DIFF
--- a/include/libtorrent/udp_tracker_connection.hpp
+++ b/include/libtorrent/udp_tracker_connection.hpp
@@ -104,8 +104,6 @@ namespace libtorrent {
 
 		void on_timeout(error_code const& ec) override;
 
-		udp::endpoint pick_target_endpoint() const;
-
 		std::string m_hostname;
 		std::vector<tcp::endpoint> m_endpoints;
 


### PR DESCRIPTION
Endpoints are filtered by address family in name_lookup() so this
function will always return the first endpoint.