### PR TITLE
cmake: add option to build the C bindings library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,7 @@ endif()
 feature_option(build_tests "build tests" OFF)
 feature_option(build_examples "build examples" OFF)
 feature_option(build_tools "build tools" OFF)
+feature_option(c-bindings "build C bindings" OFF)
 feature_option(python-bindings "build python bindings" OFF)
 
 # these options require existing target

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,3 +1,7 @@
 if (python-bindings)
 	add_subdirectory(python)
 endif()
+
+if (c-bindings)
+	add_subdirectory(c)
+endif()

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(torrentc library.cpp)
+target_include_directories(torrentc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(torrentc PRIVATE torrent-rasterbar)
+
+install(TARGETS torrentc
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(FILES libtorrent.h DESTINATION include/libtorrent)
+
+if (build_examples)
+	add_executable(simple_client_c simple_client.c)
+	target_link_libraries(simple_client_c torrentc)
+endif()
+


### PR DESCRIPTION
I somehow overlooked this library when did the work with the CMake build scripts, so here it is.