### PR TITLE
general cleanups of build files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -267,7 +267,7 @@ script:
   - if [[ "$cmake" == "1" ]]; then
       export CXX=g++-5 &&
       export CC=gcc-5 &&
-      cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" -Dbuild_tests=ON -Dbuild_examples=ON -Dpython-bindings=ON -G Ninja .. &&
+      cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=ON -G Ninja .. &&
       cmake --build . -- -j2;
     fi
   - cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,9 +581,8 @@ if (WIN32)
 	)
 
 	target_compile_definitions(torrent-rasterbar
-		PUBLIC
-			_WIN32_WINNT=0x0600 # target Windows Vista or later
-			WIN32_LEAN_AND_MEAN # prevent winsock1 to be included
+		PRIVATE _WIN32_WINNT=0x0600 # target Windows Vista or later
+		PUBLIC WIN32_LEAN_AND_MEAN # prevent winsock1 to be included
 	)
 
 	if (MSVC)

--- a/Jamfile
+++ b/Jamfile
@@ -439,7 +439,7 @@ feature.compose <asserts>on : <define>TORRENT_USE_ASSERTS=1 ;
 feature.compose <asserts>production : <define>TORRENT_USE_ASSERTS=1 <define>TORRENT_PRODUCTION_ASSERTS=1 ;
 feature.compose <asserts>system : <define>TORRENT_USE_ASSERTS=1 <define>TORRENT_USE_SYSTEM_ASSERTS=1 ;
 
-feature windows-version : vista win7 xp : composite propagated link-incompatible ;
+feature windows-version : vista win7 xp : composite propagated ;
 feature.compose <windows-version>vista : <define>_WIN32_WINNT=0x0600 ;
 feature.compose <windows-version>win7 : <define>_WIN32_WINNT=0x0601 ;
 feature.compose <windows-version>xp : <define>_WIN32_WINNT=0x0501 ;

--- a/Makefile.am
+++ b/Makefile.am
@@ -117,7 +117,13 @@ EXTRA_DIST = \
   Jamfile \
   Jamroot.jam \
   CMakeLists.txt \
-  test/CMakeLists.txt \
+  cmake/Modules/FindLibGcrypt.cmake \
+  cmake/Modules/GeneratePkgConfig.cmake \
+  cmake/Modules/ucm_flags.cmake \
+  cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in \
+  cmake/Modules/GeneratePkgConfig/pkg-config.cmake.in \
+  cmake/Modules/GeneratePkgConfig/target-compile-settings.cmake.in \
+  LibtorrentRasterbarConfig.cmake.in \
   setup.py \
   LICENSE \
   README.rst \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,7 +97,7 @@ build_script:
 - mkdir build && cd build
 - if defined cmake (
   set "PATH=c:\Python27-x64;%PATH%" &&
-  cmake -DCMAKE_CXX_FLAGS="/WX /wd4244 /wd4459" -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
+  cmake -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
   cmake --build . --config Release
   )
 

--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -1,4 +1,4 @@
 
 SUBDIRS = python
 
-EXTRA_DIST = README.txt
+EXTRA_DIST = README.txt CMakeLists.txt

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -1,6 +1,8 @@
 
 EXTRA_DIST = \
   Jamfile                   \
+  CMakeLists.txt            \
+  setup.py.cmake.in         \
   setup.py                  \
   client.py                 \
   simple_client.py          \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -20,8 +20,6 @@ client_test_SOURCES = client_test.cpp print.cpp session_view.cpp torrent_view.cp
 stats_counters_SOURCES = stats_counters.cpp
 bt_get_SOURCES = bt-get.cpp
 bt_get2_SOURCES = bt-get2.cpp
-bt_get_CXXFLAGS = -std=c++11
-bt_get2_CXXFLAGS = -std=c++11
 dump_torrent_SOURCES = dump_torrent.cpp
 make_torrent_SOURCES = make_torrent.cpp
 simple_client_SOURCES = simple_client.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,11 +12,10 @@ file(GLOB tests "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
 list(REMOVE_ITEM tests "${CMAKE_CURRENT_SOURCE_DIR}/test_natpmp.cpp") # doesn't build at time of writing
 list(REMOVE_ITEM tests "${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp") # helper file, not a test
 
-add_library(test_common main.cpp test.cpp setup_transfer.cpp dht_server.cpp udp_tracker.cpp
+add_library(test_common STATIC main.cpp test.cpp setup_transfer.cpp dht_server.cpp udp_tracker.cpp
 	peer_server.cpp web_seed_suite.cpp swarm_suite.cpp test_utils.cpp make_torrent.cpp settings.cpp
 )
 target_link_libraries(test_common PUBLIC torrent-rasterbar)
-target_compile_features(test_common PUBLIC cxx_std_11)
 if (MSVC)
 	# C4127: conditional expression is constant
 	# C4309: 'conversion' : truncation of constant value
@@ -27,7 +26,6 @@ endif()
 foreach(TARGET_SRC ${tests})
 	get_filename_component(TARGET ${TARGET_SRC} NAME_WE)
 	add_executable(${TARGET} ${TARGET_SRC})
-	target_compile_features(${TARGET} PRIVATE cxx_std_11)
 	target_link_libraries(${TARGET} test_common)
 	add_test(${TARGET} ${TARGET})
 endforeach()

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -121,12 +121,23 @@ EXTRA_DIST = Jamfile \
   mutable_test_torrents/test2_pad_files.torrent \
   mutable_test_torrents/test3.torrent \
   mutable_test_torrents/test3_pad_files.torrent \
+  ssl/regenerate_test_certificate.sh \
+  ssl/cert_request.pem \
+  ssl/dhparams.pem \
+  ssl/invalid_peer_certificate.pem \
+  ssl/invalid_peer_private_key.pem \
+  ssl/peer_certificate.pem \
+  ssl/peer_private_key.pem \
+  ssl/root_ca_cert.pem \
+  ssl/root_ca_private.pem \
+  ssl/server.pem \
   zeroes.gz \
   corrupt.gz \
   utf8_test.txt \
   web_server.py \
   socks.py \
-  http.py
+  http.py \
+  CMakeLists.txt
 
 EXTRA_PROGRAMS = $(test_programs)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,4 +2,4 @@ add_executable(dht dht_put.cpp)
 target_link_libraries(dht PRIVATE torrent-rasterbar)
 
 add_executable(session_log_alerts session_log_alerts.cpp)
-target_link_libraries(session_log_alerts torrent-rasterbar)
+target_link_libraries(session_log_alerts PRIVATE torrent-rasterbar)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -14,7 +14,8 @@ EXTRA_DIST = Jamfile     \
   parse_peer_log.py      \
   parse_sample.py        \
   parse_session_stats.py \
-  parse_utp_log.py
+  parse_utp_log.py       \
+  CMakeLists.txt
 
 session_log_alerts_SOURCES = session_log_alerts.cpp
 dht_put_SOURCES = dht_put.cpp


### PR DESCRIPTION
Specifically to fix the propagation properties of _WIN32_WINNT, include missing CMake files in the tarball, and fix some risky ABI altering properties in CMake files