### PR TITLE
don't pick from the end in sequential mode

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -880,15 +880,16 @@ namespace libtorrent
 		else
 		{
 			ret |= piece_picker::rarest_first;
-		}
 
-		if (m_snubbed)
-		{
-			// snubbed peers should request
-			// the common pieces first, just to make
-			// it more likely for all snubbed peers to
-			// request blocks from the same piece
-			ret |= piece_picker::reverse;
+			if (m_snubbed)
+			{
+				// snubbed peers should request
+				// the common pieces first, just to make
+				// it more likely for all snubbed peers to
+				// request blocks from the same piece
+				ret |= piece_picker::reverse;
+			}
+
 		}
 
 		if (m_settings.get_bool(settings_pack::prioritize_partial_pieces))


### PR DESCRIPTION
only make snubbed peers invert the piece picking strategy when we're doing rarest first (i.e. snubbed peers do common-first). Specifically, this prevents snubbed peers from picking from the end of the torrent when in sequential mode.

This specifically would address https://github.com/arvidn/libtorrent/issues/3382. I can't think of any other reasonable use cases for sequential mode, so perhaps this is a reasonable change in behaviour (i.e. without introducing it as a new option).

@ssiloti do you have any thoughts?