### PR TITLE
make span's and sha1_hash's index and size types signed

### DIFF
--- a/ed25519/src/sign.cpp
+++ b/ed25519/src/sign.cpp
@@ -9,7 +9,7 @@
 namespace libtorrent
 {
 
-void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key) {
+void ed25519_sign(unsigned char *signature, const unsigned char *message, std::ptrdiff_t message_len, const unsigned char *public_key, const unsigned char *private_key) {
     ge_p3 R;
 
     hasher512 hash;

--- a/ed25519/src/verify.cpp
+++ b/ed25519/src/verify.cpp
@@ -50,7 +50,7 @@ static int consttime_equal(const unsigned char *x, const unsigned char *y) {
     return !r;
 }
 
-int ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key) {
+int ed25519_verify(const unsigned char *signature, const unsigned char *message, std::ptrdiff_t message_len, const unsigned char *public_key) {
     unsigned char checker[32];
     ge_p3 A;
     ge_p2 R;

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -676,7 +676,7 @@ struct peer_conn
 
 	void write_piece(piece_index_t const piece, int start, int length)
 	{
-		generate_block({write_buffer, static_cast<std::size_t>(length / 4)}
+		generate_block({write_buffer, length / 4}
 			, piece, start);
 
 		if (corrupt)
@@ -860,7 +860,7 @@ void generate_data(char const* path, torrent_info const& ti)
 			generate_block(piece, i, j);
 			int const left_in_piece = ti.piece_size(i) - j;
 			iovec_t const b = { reinterpret_cast<char*>(piece)
-				, size_t(std::min(left_in_piece, 0x4000))};
+				, std::min(left_in_piece, 0x4000)};
 			storage_error error;
 			st->writev(b, i, j, open_mode::write_only, error);
 			if (error)

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2599,7 +2599,7 @@ TORRENT_VERSION_NAMESPACE_2
 	private:
 		std::reference_wrapper<aux::stack_allocator> m_alloc;
 		aux::allocation_slot m_msg_idx;
-		std::size_t const m_size;
+		int const m_size;
 #if TORRENT_ABI_VERSION == 1
 	public:
 		direction_t TORRENT_DEPRECATED_MEMBER dir;

--- a/include/libtorrent/aux_/alloca.hpp
+++ b/include/libtorrent/aux_/alloca.hpp
@@ -78,8 +78,8 @@ struct alloca_destructor
 
 #include <malloc.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::aux::typed_span<t> v; { \
-	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::size_t>(n); \
-	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(_alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
+	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::ptrdiff_t>(n); \
+	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(_alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
 	v = ::libtorrent::aux::typed_span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); \
 	::libtorrent::aux::uninitialized_default_construct(v.begin(), v.end()); \
 	} \
@@ -89,8 +89,8 @@ struct alloca_destructor
 
 #include <stdlib.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::aux::typed_span<t> v; { \
-	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::size_t>(n); \
-	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
+	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::ptrdiff_t>(n); \
+	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
 	v = ::libtorrent::aux::typed_span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); \
 	::libtorrent::aux::uninitialized_default_construct(v.begin(), v.end()); \
 	} \
@@ -100,8 +100,8 @@ struct alloca_destructor
 
 #include <alloca.h>
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::aux::typed_span<t> v; { \
-	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::size_t>(n); \
-	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * TORRENT_ALLOCA_size)); \
+	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::ptrdiff_t>(n); \
+	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
 	v = ::libtorrent::aux::typed_span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); \
 	::libtorrent::aux::uninitialized_default_construct(v.begin(), v.end()); \
 	} \

--- a/include/libtorrent/aux_/array.hpp
+++ b/include/libtorrent/aux_/array.hpp
@@ -39,7 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-	template <typename T, std::size_t Size, typename IndexType = int>
+	template <typename T, std::size_t Size, typename IndexType = std::ptrdiff_t>
 	using array = container_wrapper<T, IndexType, std::array<T, Size>>;
 
 }}

--- a/include/libtorrent/aux_/deque.hpp
+++ b/include/libtorrent/aux_/deque.hpp
@@ -39,7 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-	template <typename T, typename IndexType = int>
+	template <typename T, typename IndexType = std::ptrdiff_t>
 	using deque = container_wrapper<T, IndexType, std::deque<T>>;
 
 }}

--- a/include/libtorrent/aux_/dev_random.hpp
+++ b/include/libtorrent/aux_/dev_random.hpp
@@ -56,7 +56,8 @@ namespace libtorrent { namespace aux {
 
 		void read(span<char> buffer)
 		{
-			std::int64_t const ret = ::read(m_fd, buffer.data(), buffer.size());
+			std::int64_t const ret = ::read(m_fd, buffer.data()
+				, static_cast<std::size_t>(buffer.size()));
 			if (ret != int(buffer.size()))
 			{
 				throw_ex<system_error>(errors::no_entropy);

--- a/include/libtorrent/aux_/io.hpp
+++ b/include/libtorrent/aux_/io.hpp
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <type_traits>
 #include "libtorrent/span.hpp"
+#include "libtorrent/aux_/numeric_cast.hpp"
 
 namespace libtorrent { namespace aux {
 
@@ -55,7 +56,7 @@ namespace libtorrent { namespace aux {
 			ret <<= 8;
 			ret |= static_cast<std::uint8_t>(b);
 		}
-		view = view.subspan(sizeof(T));
+		view = view.subspan(int(sizeof(T)));
 		return ret;
 	}
 
@@ -73,7 +74,7 @@ namespace libtorrent { namespace aux {
 			shift -= 8;
 			b = static_cast<Byte>((val >> shift) & 0xff);
 		}
-		view = view.subspan(sizeof(T));
+		view = view.subspan(int(sizeof(T)));
 	}
 
 	// the single-byte case is separate to avoid a warning on the shift-left by
@@ -167,8 +168,9 @@ namespace libtorrent { namespace aux {
 	template<typename Byte>
 	inline int write_string(std::string const& str, span<Byte>& view)
 	{
+		TORRENT_ASSERT(view.size() >= numeric_cast<int>(str.size()));
 		std::copy(str.begin(), str.end(), view.begin());
-		view = view.subspan(str.size());
+		view = view.subspan(int(str.size()));
 		return int(str.size());
 	}
 

--- a/include/libtorrent/aux_/typed_span.hpp
+++ b/include/libtorrent/aux_/typed_span.hpp
@@ -46,6 +46,8 @@ namespace libtorrent { namespace aux {
 	{
 		using base = span<T>;
 		using underlying_index = typename underlying_index_t<IndexType>::type;
+		using typename span<T>::difference_type;
+		using typename span<T>::index_type;
 
 		// disallow conversions from other index types
 		template <typename OtherIndex>
@@ -60,13 +62,13 @@ namespace libtorrent { namespace aux {
 			: span<T>(v) {}
 
 		typed_span(T& p) noexcept : span<T>(p) {} // NOLINT
-		typed_span(T* p, std::size_t const l) noexcept : span<T>(p, l) {} // NOLINT
+		typed_span(T* p, difference_type const l) noexcept : span<T>(p, l) {} // NOLINT
 
 		template <typename U, std::size_t N>
 		typed_span(std::array<U, N>& arr) noexcept // NOLINT
-			: span<T>(arr.data(), arr.size()) {}
+			: span<T>(arr.data(), static_cast<difference_type>(arr.size())) {}
 
-		template <typename U, std::size_t N>
+		template <typename U, difference_type N>
 		typed_span(U (&arr)[N]) noexcept // NOLINT
 			: span<T>(&arr[0], N) {}
 
@@ -86,12 +88,12 @@ namespace libtorrent { namespace aux {
 #endif
 		{
 			TORRENT_ASSERT(idx >= IndexType(0));
-			return this->base::operator[](std::size_t(static_cast<underlying_index>(idx)));
+			return this->base::operator[](index_type(static_cast<underlying_index>(idx)));
 		}
 
 		IndexType end_index() const
 		{
-			TORRENT_ASSERT(this->size() <= std::size_t((std::numeric_limits<underlying_index>::max)()));
+			TORRENT_ASSERT(this->size() <= difference_type((std::numeric_limits<underlying_index>::max)()));
 			return IndexType(static_cast<underlying_index>(this->size()));
 		}
 
@@ -100,13 +102,13 @@ namespace libtorrent { namespace aux {
 		typed_span first(underlying_index n) const
 		{
 			TORRENT_ASSERT(n >= 0);
-			auto const s = this->base::first(std::size_t(n));
+			auto const s = this->base::first(difference_type(n));
 			return {s.data(), s.size()};
 		}
 
-		typed_span first(std::size_t n) const
+		typed_span first(difference_type n) const
 		{
-			TORRENT_ASSERT(n <= std::size_t((std::numeric_limits<underlying_index>::max)()));
+			TORRENT_ASSERT(n <= difference_type((std::numeric_limits<underlying_index>::max)()));
 			auto const s = this->base::first(n);
 			return {s.data(), s.size()};
 		}
@@ -116,13 +118,13 @@ namespace libtorrent { namespace aux {
 		typed_span last(underlying_index n) const
 		{
 			TORRENT_ASSERT(n >= 0);
-			auto const s = this->base::last(std::size_t(n));
+			auto const s = this->base::last(difference_type(n));
 			return {s.data(), s.size()};
 		}
 
-		typed_span last(std::size_t n) const
+		typed_span last(difference_type n) const
 		{
-			TORRENT_ASSERT(n <= std::size_t((std::numeric_limits<underlying_index>::max)()));
+			TORRENT_ASSERT(n <= difference_type((std::numeric_limits<underlying_index>::max)()));
 			auto const s = this->base::last(n);
 			return {s.data(), s.size()};
 		}
@@ -132,7 +134,7 @@ namespace libtorrent { namespace aux {
 		typed_span subspan(underlying_index offset) const
 		{
 			TORRENT_ASSERT(offset >= 0);
-			auto const s = this->base::subspan(std::size_t(offset));
+			auto const s = this->base::subspan(index_type(offset));
 			return {s.data(), s.size()};
 		}
 
@@ -142,21 +144,21 @@ namespace libtorrent { namespace aux {
 		{
 			TORRENT_ASSERT(offset >= 0);
 			TORRENT_ASSERT(count >= 0);
-			auto const s = this->base::subspan(std::size_t(offset), std::size_t(count));
+			auto const s = this->base::subspan(index_type(offset), difference_type(count));
 			return {s.data(), s.size()};
 		}
 
-		typed_span subspan(std::size_t offset) const
+		typed_span subspan(index_type const offset) const
 		{
-			TORRENT_ASSERT(offset <= std::size_t((std::numeric_limits<underlying_index>::max)()));
+			TORRENT_ASSERT(offset <= index_type((std::numeric_limits<underlying_index>::max)()));
 			auto const s = this->base::subspan(offset);
 			return {s.data(), s.size()};
 		}
 
-		typed_span subspan(std::size_t offset, std::size_t count) const
+		typed_span subspan(index_type const offset, difference_type const count) const
 		{
-			TORRENT_ASSERT(offset <= std::size_t((std::numeric_limits<underlying_index>::max)()));
-			TORRENT_ASSERT(count <= std::size_t((std::numeric_limits<underlying_index>::max)()));
+			TORRENT_ASSERT(offset <= index_type((std::numeric_limits<underlying_index>::max)()));
+			TORRENT_ASSERT(count <= difference_type((std::numeric_limits<underlying_index>::max)()));
 			auto const s = this->base::subspan(offset, count);
 			return {s.data(), s.size()};
 		}

--- a/include/libtorrent/aux_/unique_ptr.hpp
+++ b/include/libtorrent/aux_/unique_ptr.hpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-	template <typename T, typename IndexType = int>
+	template <typename T, typename IndexType = std::ptrdiff_t>
 	struct unique_ptr;
 
 	template <typename T, typename IndexType>

--- a/include/libtorrent/bt_peer_connection.hpp
+++ b/include/libtorrent/bt_peer_connection.hpp
@@ -310,7 +310,7 @@ namespace libtorrent {
 		void write_pe4_sync(int crypto_select);
 
 		void write_pe_vc_cryptofield(span<char> write_buf
-			, int crypto_field, std::size_t pad_size);
+			, int crypto_field, int pad_size);
 
 		// helper to cut down on boilerplate
 		void rc4_decrypt(span<char> buf);
@@ -329,7 +329,7 @@ namespace libtorrent {
 			{
 				// if we're encrypting this buffer, we need to make a copy
 				// since we'll mutate it
-				buffer buf(std::size_t(size), {holder.data(), std::size_t(size)});
+				buffer buf(size, {holder.data(), size});
 				append_send_buffer(std::move(buf), size);
 			}
 			else

--- a/include/libtorrent/ed25519.hpp
+++ b/include/libtorrent/ed25519.hpp
@@ -17,8 +17,8 @@ enum
 };
 
 void TORRENT_EXTRA_EXPORT ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
-void TORRENT_EXTRA_EXPORT ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
-int TORRENT_EXTRA_EXPORT ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key);
+void TORRENT_EXTRA_EXPORT ed25519_sign(unsigned char *signature, const unsigned char *message, std::ptrdiff_t message_len, const unsigned char *public_key, const unsigned char *private_key);
+int TORRENT_EXTRA_EXPORT ed25519_verify(const unsigned char *signature, const unsigned char *message, std::ptrdiff_t message_len, const unsigned char *public_key);
 void TORRENT_EXTRA_EXPORT ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void TORRENT_EXTRA_EXPORT ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 

--- a/include/libtorrent/hex.hpp
+++ b/include/libtorrent/hex.hpp
@@ -54,7 +54,7 @@ namespace libtorrent {
 	// by ``out`` is large enough, i.e. has at least len * 2 bytes of space.
 	TORRENT_DEPRECATED_EXPORT std::string to_hex(span<char const> s);
 	TORRENT_DEPRECATED_EXPORT void to_hex(span<char const> in, char* out);
-	TORRENT_DEPRECATED_EXPORT void to_hex(char const* in, size_t const len, char* out);
+	TORRENT_DEPRECATED_EXPORT void to_hex(char const* in, int const len, char* out);
 
 	// converts the buffer [``in``, ``in`` + len) from hexadecimal to
 	// binary. The binary output is written to the buffer pointed to
@@ -69,13 +69,13 @@ namespace libtorrent {
 	// deprecated in 1.2
 	TORRENT_DEPRECATED
 	inline void to_hex(char const* in, int len, char* out)
-	{ aux::to_hex({in, static_cast<size_t>(len)}, out); }
+	{ aux::to_hex({in, len}, out); }
 	TORRENT_DEPRECATED
 	inline std::string to_hex(std::string const& s)
 	{ return aux::to_hex(s); }
 	TORRENT_DEPRECATED
 	inline bool from_hex(char const *in, int len, char* out)
-	{ return aux::from_hex({in, static_cast<size_t>(len)}, out); }
+	{ return aux::from_hex({in, len}, out); }
 #endif
 }
 

--- a/include/libtorrent/receive_buffer.hpp
+++ b/include/libtorrent/receive_buffer.hpp
@@ -155,7 +155,7 @@ private:
 
 	// keep track of how much of the receive buffer we use, if we're not using
 	// enough of it we shrink it
-	sliding_average<std::int64_t, 20> m_watermark;
+	sliding_average<std::ptrdiff_t, 20> m_watermark;
 
 	buffer m_recv_buffer;
 };
@@ -207,7 +207,7 @@ struct crypto_receive_buffer
 
 	span<char const> get() const;
 
-	span<char> mutable_buffer(std::size_t bytes);
+	span<char> mutable_buffer(int bytes);
 
 private:
 	// explicitly disallow assignment, to silence msvc warning

--- a/include/libtorrent/sha1_hash.hpp
+++ b/include/libtorrent/sha1_hash.hpp
@@ -68,16 +68,19 @@ namespace aux {
 	//
 	// This data structure is 32 bits aligned, like it's the case for
 	// each SHA-N specification.
-	template <std::size_t N>
+	template <std::ptrdiff_t N>
 	class digest32
 	{
 		static_assert(N % 32 == 0, "N must be a multiple of 32");
-		static constexpr std::size_t number_size = N / 32;
+		static constexpr std::ptrdiff_t number_size = N / 32;
 		constexpr static int bits_in_byte = 8;
 	public:
 
+		using difference_type = std::ptrdiff_t;
+		using index_type = std::ptrdiff_t;
+
 		// the size of the hash in bytes
-		static constexpr std::size_t size() noexcept { return N / bits_in_byte; }
+		static constexpr difference_type size() noexcept { return N / bits_in_byte; }
 
 		// constructs an all-zero digest
 		digest32() noexcept { clear(); }
@@ -127,8 +130,8 @@ namespace aux {
 		void assign(span<char const> s) noexcept
 		{
 			TORRENT_ASSERT(s.size() >= N / bits_in_byte);
-			std::size_t const sl = s.size() < size() ? s.size() : size();
-			std::memcpy(m_number.data(), s.data(), sl);
+			auto const sl = s.size() < size() ? s.size() : size();
+			std::memcpy(m_number.data(), s.data(), static_cast<std::size_t>(sl));
 		}
 		void assign(char const* str) noexcept { std::memcpy(m_number.data(), str, size()); }
 
@@ -205,7 +208,6 @@ namespace aux {
 		// in-place bit-wise XOR with the passed in digest.
 		digest32& operator^=(digest32 const& n) noexcept
 		{
-
 			for (auto const v : boost::combine(m_number, n.m_number))
 				boost::get<0>(v) ^= boost::get<1>(v);
 			return *this;
@@ -236,12 +238,12 @@ namespace aux {
 		}
 
 		// accessors for specific bytes
-		std::uint8_t& operator[](std::size_t i) noexcept
+		std::uint8_t& operator[](index_type i) noexcept
 		{
 			TORRENT_ASSERT(i < size());
 			return reinterpret_cast<std::uint8_t*>(m_number.data())[i];
 		}
-		std::uint8_t const& operator[](std::size_t i) const noexcept
+		std::uint8_t const& operator[](index_type i) const noexcept
 		{
 			TORRENT_ASSERT(i < size());
 			return reinterpret_cast<std::uint8_t const*>(m_number.data())[i];

--- a/include/libtorrent/span.hpp
+++ b/include/libtorrent/span.hpp
@@ -64,6 +64,9 @@ namespace aux {
 	template <typename T>
 	struct span
 	{
+		using difference_type = std::ptrdiff_t;
+		using index_type = std::ptrdiff_t;
+
 		span() noexcept : m_ptr(nullptr), m_len(0) {}
 
 		template <typename U, typename
@@ -72,18 +75,19 @@ namespace aux {
 			: m_ptr(v.data()), m_len(v.size()) {}
 
 		span(T& p) noexcept : m_ptr(&p), m_len(1) {} // NOLINT
-		span(T* p, std::size_t const l) noexcept : m_ptr(p), m_len(l) {} // NOLINT
+		span(T* p, difference_type const l) noexcept : m_ptr(p), m_len(l) // NOLINT
+		{ TORRENT_ASSERT(l >= 0); }
 
 		template <typename U, std::size_t N>
 		span(std::array<U, N>& arr) noexcept // NOLINT
-			: m_ptr(arr.data()), m_len(arr.size()) {}
+			: m_ptr(arr.data()), m_len(static_cast<difference_type>(arr.size())) {}
 
 		// this is necessary until C++17, where data() returns a non-const pointer
 		template <typename U>
 		span(std::basic_string<U>& str) noexcept // NOLINT
-			: m_ptr(&str[0]), m_len(str.size()) {}
+			: m_ptr(&str[0]), m_len(static_cast<difference_type>(str.size())) {}
 
-		template <typename U, std::size_t N>
+		template <typename U, difference_type N>
 		span(U (&arr)[N]) noexcept // NOLINT
 			: m_ptr(&arr[0]), m_len(N) {}
 
@@ -93,7 +97,7 @@ namespace aux {
 			, typename U = typename std::remove_reference<decltype(*std::declval<Cont>().data())>::type
 			, typename = typename std::enable_if<aux::compatible_type<U, T>::value>::type>
 		span(Cont& c) // NOLINT
-			: m_ptr(c.data()), m_len(c.size()) {}
+			: m_ptr(c.data()), m_len(static_cast<difference_type>(c.size())) {}
 
 		// allow construction from const containers if T is const
 		// this allows const spans to be constructed from a temporary container
@@ -102,9 +106,9 @@ namespace aux {
 			, typename = typename std::enable_if<aux::compatible_type<U, T>::value
 				&& std::is_const<T>::value>::type>
 		span(Cont const& c) // NOLINT
-			: m_ptr(c.data()), m_len(c.size()) {}
+			: m_ptr(c.data()), m_len(static_cast<difference_type>(c.size())) {}
 
-		std::size_t size() const noexcept { return m_len; }
+		index_type size() const noexcept { return m_len; }
 		bool empty() const noexcept { return m_len == 0; }
 		T* data() const noexcept { return m_ptr; }
 
@@ -119,46 +123,48 @@ namespace aux {
 		T& front() const noexcept { TORRENT_ASSERT(m_len > 0); return m_ptr[0]; }
 		T& back() const noexcept { TORRENT_ASSERT(m_len > 0); return m_ptr[m_len - 1]; }
 
-		span<T> first(std::size_t const n) const
+		span<T> first(difference_type const n) const
 		{
 			TORRENT_ASSERT(size() >= n);
 			return { data(), n };
 		}
 
-		span<T> last(std::size_t const n) const
+		span<T> last(difference_type const n) const
 		{
 			TORRENT_ASSERT(size() >= n);
 			return { data() + size() - n, n };
 		}
 
-		span<T> subspan(std::size_t const offset) const
+		span<T> subspan(index_type const offset) const
 		{
 			TORRENT_ASSERT(size() >= offset);
 			return { data() + offset, size() - offset };
 		}
 
-		span<T> subspan(std::size_t const offset, std::size_t const count) const
+		span<T> subspan(index_type const offset, difference_type const count) const
 		{
+			TORRENT_ASSERT(count >= 0);
 			TORRENT_ASSERT(size() >= offset);
 			TORRENT_ASSERT(size() >= offset + count);
 			return { data() + offset, count };
 		}
 
-		T& operator[](std::size_t const idx) const
+		T& operator[](index_type const idx) const
 		{
 			TORRENT_ASSERT(idx < m_len);
+			TORRENT_ASSERT(idx >= 0);
 			return m_ptr[idx];
 		}
 
 	private:
 		T* m_ptr;
-		std::size_t m_len;
+		difference_type m_len;
 	};
 
 	template <class T, class U>
 	inline bool operator==(span<T> const& lhs, span<U> const& rhs)
 	{
-		return  lhs.size()  == rhs.size()
+		return  lhs.size() == rhs.size()
 			&& (lhs.begin() == rhs.begin() || std::equal(lhs.begin(), lhs.end(), rhs.begin()));
 	}
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -524,7 +524,7 @@ namespace aux {
 #if TORRENT_ABI_VERSION == 1
 		TORRENT_DEPRECATED
 		bool set_metadata(char const* metadata, int size) const
-		{ return set_metadata({metadata, size_t(size)}); }
+		{ return set_metadata({metadata, size}); }
 #endif
 
 		// Returns true if this handle refers to a valid torrent and false if it

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -157,7 +157,7 @@ namespace libtorrent {
 #ifndef BOOST_NO_EXCEPTIONS
 		explicit torrent_info(bdecode_node const& torrent_file);
 		torrent_info(char const* buffer, int size)
-			: torrent_info(span<char const>{buffer, std::size_t(size)}, from_span) {}
+			: torrent_info(span<char const>{buffer, size}, from_span) {}
 		explicit torrent_info(span<char const> buffer, from_span_t);
 		explicit torrent_info(std::string const& filename);
 #endif // BOOST_NO_EXCEPTIONS
@@ -165,7 +165,7 @@ namespace libtorrent {
 		explicit torrent_info(sha1_hash const& info_hash);
 		torrent_info(bdecode_node const& torrent_file, error_code& ec);
 		torrent_info(char const* buffer, int size, error_code& ec)
-			: torrent_info(span<char const>{buffer, std::size_t(size)}, ec, from_span) {}
+			: torrent_info(span<char const>{buffer, size}, ec, from_span) {}
 		torrent_info(span<char const> buffer, error_code& ec, from_span_t);
 		torrent_info(std::string const& filename, error_code& ec);
 
@@ -173,7 +173,7 @@ namespace libtorrent {
 #ifndef BOOST_NO_EXCEPTIONS
 		TORRENT_DEPRECATED
 		torrent_info(char const* buffer, int size, int)
-			: torrent_info(span<char const>{buffer, std::size_t(size)}, from_span) {}
+			: torrent_info(span<char const>{buffer, size}, from_span) {}
 #endif
 		TORRENT_DEPRECATED
 		torrent_info(bdecode_node const& torrent_file, error_code& ec, int)
@@ -183,7 +183,7 @@ namespace libtorrent {
 			: torrent_info(filename, ec) {}
 		TORRENT_DEPRECATED
 		torrent_info(char const* buffer, int size, error_code& ec, int)
-			: torrent_info(span<char const>{buffer, std::size_t(size)}, ec, from_span) {}
+			: torrent_info(span<char const>{buffer, size}, ec, from_span) {}
 		TORRENT_DEPRECATED
 		explicit torrent_info(lazy_entry const& torrent_file);
 		TORRENT_DEPRECATED

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2076,7 +2076,7 @@ namespace {
 		, node(ep)
 		, m_alloc(alloc)
 		, m_msg_idx(alloc.copy_buffer(buf))
-		, m_size(buf.size())
+		, m_size(aux::numeric_cast<int>(buf.size()))
 #if TORRENT_ABI_VERSION == 1
 		, dir(d)
 #endif

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -300,7 +300,7 @@ namespace {
 				if (m_buffer[tokens[token].offset + 1] == '0'
 					&& m_buffer[tokens[token].offset + 2] != 'e')
 				{
-					std::snprintf(error.data(), error.size(), "leading zero in integer");
+					std::snprintf(error.data(), std::size_t(error.size()), "leading zero in integer");
 					return true;
 				}
 				break;
@@ -308,7 +308,7 @@ namespace {
 				if (m_buffer[tokens[token].offset] == '0'
 					&& m_buffer[tokens[token].offset + 1] != ':')
 				{
-					std::snprintf(error.data(), error.size(), "leading zero in string length");
+					std::snprintf(error.data(), std::size_t(error.size()), "leading zero in string length");
 					return true;
 				}
 				break;
@@ -348,12 +348,12 @@ namespace {
 						int cmp = std::memcmp(m_buffer + k1_start, m_buffer + k2_start, std::size_t(min_len));
 						if (cmp > 0 || (cmp == 0 && k1_len > k2_len))
 						{
-							std::snprintf(error.data(), error.size(), "unsorted dictionary key");
+							std::snprintf(error.data(), std::size_t(error.size()), "unsorted dictionary key");
 							return true;
 						}
 						else if (cmp == 0 && k1_len == k2_len)
 						{
-							std::snprintf(error.data(), error.size(), "duplicate dictionary key");
+							std::snprintf(error.data(), std::size_t(error.size()), "duplicate dictionary key");
 							return true;
 						}
 
@@ -384,7 +384,7 @@ namespace {
 		TORRENT_ASSERT(m_token_idx != -1);
 		bdecode_token const& t = m_root_tokens[m_token_idx];
 		bdecode_token const& next = m_root_tokens[m_token_idx + t.next_item];
-		return {m_buffer + t.offset, std::size_t(next.offset - t.offset)};
+		return {m_buffer + t.offset, static_cast<std::ptrdiff_t>(next.offset - t.offset)};
 	}
 
 	bdecode_node bdecode_node::list_at(int i) const
@@ -731,7 +731,7 @@ namespace {
 	int bdecode(char const* start, char const* end, bdecode_node& ret
 		, error_code& ec, int* error_pos, int const depth_limit, int token_limit)
 	{
-		ret = bdecode({start, static_cast<size_t>(end - start)}, ec, error_pos, depth_limit, token_limit);
+		ret = bdecode({start, end - start}, ec, error_pos, depth_limit, token_limit);
 		return ec ? -1 : 0;
 	}
 

--- a/src/bitfield.cpp
+++ b/src/bitfield.cpp
@@ -197,7 +197,7 @@ namespace libtorrent {
 	{
 		int const num = num_words();
 		if (num == 0) return -1;
-		int const count = aux::count_leading_zeros({&m_buf[1], std::size_t(num)});
+		int const count = aux::count_leading_zeros({&m_buf[1], num});
 		return count != num * 32 ? count : -1;
 	}
 
@@ -211,7 +211,7 @@ namespace libtorrent {
 		int const ext = aux::count_trailing_ones(~last) - (31 - (size % 32));
 		return last != 0
 			? (num - 1) * 32 + ext
-			: size - (aux::count_trailing_ones({&m_buf[1], std::size_t(num - 1)}) + ext);
+			: size - (aux::count_trailing_ones({&m_buf[1], num - 1}) + ext);
 	}
 
 	static_assert(std::is_nothrow_move_constructible<bitfield>::value

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -285,7 +285,7 @@ namespace libtorrent {
 			maybe_abort();
 			return;
 		}
-		m_on_receive(s->remote, {s->buffer.data(), bytes_transferred});
+		m_on_receive(s->remote, {s->buffer.data(), int(bytes_transferred)});
 
 		if (maybe_abort()) return;
 		if (!s->socket) return;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -325,7 +325,7 @@ namespace {
 #if TORRENT_USE_ASSERTS
 		m_type_queried = true;
 #endif
-		new(&data) string_type(v.data(), v.size());
+		new(&data) string_type(v.data(), std::size_t(v.size()));
 		m_type = string_t;
 	}
 
@@ -462,7 +462,7 @@ namespace {
 	entry& entry::operator=(span<char const> v) &
 	{
 		destruct();
-		new(&data) string_type(v.data(), v.size());
+		new(&data) string_type(v.data(), std::size_t(v.size()));
 		m_type = string_t;
 #if TORRENT_USE_ASSERTS
 		m_type_queried = true;

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -220,8 +220,8 @@ namespace {
 
 		for (;;)
 		{
-			auto next_msg = buf.subspan(std::size_t(msg_len));
-			int read_len = int(recv(sock, next_msg.data(), next_msg.size(), 0));
+			auto next_msg = buf.subspan(msg_len);
+			int const read_len = int(recv(sock, next_msg.data(), static_cast<std::size_t>(next_msg.size()), 0));
 			if (read_len < 0) return -1;
 
 			nl_hdr = reinterpret_cast<nlmsghdr*>(next_msg.data());

--- a/src/generate_peer_id.cpp
+++ b/src/generate_peer_id.cpp
@@ -43,12 +43,13 @@ peer_id generate_peer_id(session_settings const& sett)
 {
 	peer_id ret;
 	std::string print = sett.get_str(settings_pack::peer_fingerprint);
-	if (print.size() > ret.size()) print.resize(ret.size());
+	if (std::ptrdiff_t(print.size()) > ret.size())
+		print.resize(std::size_t(ret.size()));
 
 	// the client's fingerprint
 	std::copy(print.begin(), print.end(), ret.begin());
-	if (print.length() < ret.size())
-		url_random(span<char>(ret).subspan(print.length()));
+	if (std::ptrdiff_t(print.size()) < ret.size())
+		url_random(span<char>(ret).subspan(std::ptrdiff_t(print.length())));
 	return ret;
 }
 

--- a/src/gzip.cpp
+++ b/src/gzip.cpp
@@ -142,7 +142,7 @@ namespace {
 		{
 			if (buffer.size() < 2) return -1;
 
-			auto const extra_len = static_cast<std::size_t>((buffer[1] << 8) | buffer[0]);
+			auto const extra_len = (buffer[1] << 8) | buffer[0];
 			if (buffer.size() < extra_len + 2) return -1;
 			buffer = buffer.subspan(extra_len + 2);
 		}
@@ -198,7 +198,7 @@ namespace {
 		// if needed
 		unsigned long destlen = 4096;
 		int ret = 0;
-		in = in.subspan(static_cast<std::size_t>(header_len));
+		in = in.subspan(header_len);
 		unsigned long srclen = std::uint32_t(in.size());
 
 		do

--- a/src/hasher.cpp
+++ b/src/hasher.cpp
@@ -66,7 +66,7 @@ namespace libtorrent {
 		: hasher()
 	{
 		TORRENT_ASSERT(len > 0);
-		update({data, size_t(len)});
+		update({data, len});
 	}
 
 #ifdef TORRENT_USE_LIBGCRYPT
@@ -89,7 +89,7 @@ namespace libtorrent {
 
 	hasher& hasher::update(char const* data, int len)
 	{
-		return update({data, size_t(len)});
+		return update({data, len});
 	}
 
 	hasher& hasher::update(span<char const> data)
@@ -102,9 +102,11 @@ namespace libtorrent {
 #elif TORRENT_USE_CRYPTOAPI
 		m_context.update(data);
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA1_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data()), data.size());
+		SHA1_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
+			, static_cast<std::size_t>(data.size()));
 #else
-		SHA1_update(&m_context, reinterpret_cast<unsigned char const*>(data.data()), data.size());
+		SHA1_update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
+			, static_cast<std::size_t>(data.size()));
 #endif
 		return *this;
 	}

--- a/src/hasher512.cpp
+++ b/src/hasher512.cpp
@@ -90,9 +90,11 @@ namespace libtorrent {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.update(data);
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data()), data.size());
+		SHA512_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
+			, static_cast<std::size_t>(data.size()));
 #else
-		SHA512_update(&m_context, reinterpret_cast<unsigned char const*>(data.data()), data.size());
+		SHA512_update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
+			, static_cast<std::size_t>(data.size()));
 #endif
 		return *this;
 	}

--- a/src/hex.cpp
+++ b/src/hex.cpp
@@ -72,10 +72,10 @@ namespace libtorrent {
 	extern char const hex_chars[];
 
 	char const hex_chars[] = "0123456789abcdef";
-	void to_hex(char const* in, size_t const len, char* out)
+	void to_hex(char const* in, int const len, char* out)
 	{
 		int idx = 0;
-		for (size_t i=0; i < len; ++i)
+		for (int i = 0; i < len; ++i)
 		{
 			out[idx++] = hex_chars[std::uint8_t(in[i]) >> 4];
 			out[idx++] = hex_chars[std::uint8_t(in[i]) & 0xf];
@@ -87,15 +87,15 @@ namespace libtorrent {
 		std::string ret;
 		if (!in.empty())
 		{
-			ret.resize(in.size() * 2);
-			to_hex(in.data(), in.size(), &ret[0]);
+			ret.resize(std::size_t(in.size() * 2));
+			to_hex(in.data(), int(in.size()), &ret[0]);
 		}
 		return ret;
 	}
 
 	void to_hex(span<char const> in, char* out)
 	{
-		to_hex(in.data(), in.size(), out);
+		to_hex(in.data(), int(in.size()), out);
 		out[in.size() * 2] = '\0';
 	}
 

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -754,7 +754,7 @@ void http_connection::on_read(error_code const& e
 	{
 		span<char const> rcv_buf(m_recvbuffer);
 		bool error = false;
-		m_parser.incoming(rcv_buf.first(std::size_t(m_read_pos)), error);
+		m_parser.incoming(rcv_buf.first(m_read_pos), error);
 		if (error)
 		{
 			// HTTP parse error
@@ -804,8 +804,8 @@ void http_connection::on_read(error_code const& e
 			if (m_read_pos > m_parser.body_start())
 			{
 				callback(e, span<char>(m_recvbuffer)
-					.first(static_cast<std::size_t>(m_read_pos))
-					.subspan(static_cast<std::size_t>(m_parser.body_start())));
+					.first(m_read_pos)
+					.subspan(m_parser.body_start()));
 			}
 			m_read_pos = 0;
 			m_last_receive = clock_type::now();
@@ -815,14 +815,14 @@ void http_connection::on_read(error_code const& e
 			error_code ec;
 			m_timer.cancel(ec);
 			callback(e, span<char>(m_recvbuffer)
-				.first(static_cast<std::size_t>(m_read_pos))
-				.subspan(static_cast<std::size_t>(m_parser.body_start())));
+				.first(m_read_pos)
+				.subspan(m_parser.body_start()));
 		}
 	}
 	else
 	{
 		TORRENT_ASSERT(!m_bottled);
-		callback(e, span<char>(m_recvbuffer).first(static_cast<std::size_t>(m_read_pos)));
+		callback(e, span<char>(m_recvbuffer).first(m_read_pos));
 		m_read_pos = 0;
 		m_last_receive = clock_type::now();
 	}

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/string_util.hpp" // for ensure_trailing_slash, to_lower
 #include "libtorrent/aux_/escape_string.hpp" // for read_until
 #include "libtorrent/time.hpp" // for seconds32
+#include "libtorrent/aux_/numeric_cast.hpp"
 
 namespace libtorrent {
 
@@ -159,7 +160,7 @@ namespace libtorrent {
 	{
 		TORRENT_ASSERT(recv_buffer.size() >= m_recv_buffer.size());
 		std::tuple<int, int> ret(0, 0);
-		std::size_t start_pos = m_recv_buffer.size();
+		std::ptrdiff_t start_pos = m_recv_buffer.size();
 
 		// early exit if there's nothing new in the receive buffer
 		if (start_pos == recv_buffer.size()) return ret;
@@ -227,7 +228,7 @@ restart_response:
 				m_status_code = 0;
 			}
 			m_state = read_header;
-			start_pos = std::size_t(pos - recv_buffer.data());
+			start_pos = pos - recv_buffer.data();
 		}
 
 		if (m_state == read_header)
@@ -372,7 +373,7 @@ restart_response:
 						incoming -= int(payload);
 					}
 					auto const buf = span<char const>(recv_buffer)
-						.subspan(std::size_t(m_cur_chunk_end));
+						.subspan(aux::numeric_cast<std::ptrdiff_t>(m_cur_chunk_end));
 					std::int64_t chunk_size;
 					int header_size;
 					if (parse_chunk_header(buf, &chunk_size, &header_size))
@@ -571,7 +572,7 @@ restart_response:
 			? std::min(m_chunked_ranges.back().second - m_body_start_pos, received)
 			: m_content_length < 0 ? received : std::min(m_content_length, received);
 
-		return m_recv_buffer.subspan(std::size_t(m_body_start_pos), std::size_t(body_length));
+		return m_recv_buffer.subspan(m_body_start_pos, aux::numeric_cast<std::ptrdiff_t>(body_length));
 	}
 
 	void http_parser::reset()
@@ -605,17 +606,19 @@ restart_response:
 		// the offsets in the array are from the start of the
 		// buffer, not start of the body, so subtract the size
 		// of the HTTP header from them
-		std::size_t const offset = static_cast<std::size_t>(body_start());
+		int const offset = body_start();
 		for (auto const& i : chunks())
 		{
-			size_t const chunk_start = static_cast<std::size_t>(i.first);
-			size_t const chunk_end = static_cast<std::size_t>(i.second);
+			auto const chunk_start = i.first;
+			auto const chunk_end = i.second;
 			TORRENT_ASSERT(i.second - i.first < std::numeric_limits<int>::max());
 			TORRENT_ASSERT(chunk_end - offset <= buffer.size());
-			span<char> chunk = buffer.subspan(chunk_start - offset, chunk_end - chunk_start);
-			std::memmove(write_ptr, chunk.data(), chunk.size());
+			span<char> chunk = buffer.subspan(
+				aux::numeric_cast<std::ptrdiff_t>(chunk_start - offset)
+				, aux::numeric_cast<std::ptrdiff_t>(chunk_end - chunk_start));
+			std::memmove(write_ptr, chunk.data(), std::size_t(chunk.size()));
 			write_ptr += chunk.size();
 		}
-		return buffer.first(static_cast<std::size_t>(write_ptr - buffer.data()));
+		return buffer.first(write_ptr - buffer.data());
 	}
 }

--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -350,27 +350,27 @@ namespace libtorrent {
 				m_body_start = m_parser.body_start();
 			}
 
-			recv_buffer = recv_buffer.subspan(aux::numeric_cast<std::size_t>(m_body_start));
+			recv_buffer = recv_buffer.subspan(m_body_start);
 
 			// =========================
 			// === CHUNKED ENCODING  ===
 			// =========================
 			while (m_parser.chunked_encoding()
 				&& m_chunk_pos >= 0
-				&& m_chunk_pos < int(recv_buffer.size()))
+				&& m_chunk_pos < recv_buffer.size())
 			{
 				int header_size = 0;
 				std::int64_t chunk_size = 0;
-				span<char const> chunk_start(recv_buffer.begin() + m_chunk_pos, aux::numeric_cast<std::size_t>(int(recv_buffer.size()) - m_chunk_pos));
+				span<char const> chunk_start = recv_buffer.subspan(aux::numeric_cast<std::ptrdiff_t>(m_chunk_pos));
 				TORRENT_ASSERT(chunk_start[0] == '\r'
 					|| aux::is_hex(chunk_start[0]));
 				bool ret = m_parser.parse_chunk_header(chunk_start, &chunk_size, &header_size);
 				if (!ret)
 				{
-					TORRENT_ASSERT(bytes_transferred >= aux::numeric_cast<std::size_t>(int(chunk_start.size()) - m_partial_chunk_header));
-					bytes_transferred -= aux::numeric_cast<std::size_t>(int(chunk_start.size()) - m_partial_chunk_header);
-					received_bytes(0, int(chunk_start.size()) - m_partial_chunk_header);
-					m_partial_chunk_header = int(chunk_start.size());
+					TORRENT_ASSERT(bytes_transferred >= aux::numeric_cast<std::size_t>(chunk_start.size() - m_partial_chunk_header));
+					bytes_transferred -= aux::numeric_cast<std::size_t>(chunk_start.size() - m_partial_chunk_header);
+					received_bytes(0, aux::numeric_cast<int>(chunk_start.size() - m_partial_chunk_header));
+					m_partial_chunk_header = aux::numeric_cast<int>(chunk_start.size());
 					if (bytes_transferred == 0) return;
 					break;
 				}
@@ -386,18 +386,19 @@ namespace libtorrent {
 
 					received_bytes(0, header_size - m_partial_chunk_header);
 					m_partial_chunk_header = 0;
-					TORRENT_ASSERT(chunk_size != 0 || int(chunk_start.size()) <= header_size || chunk_start[std::size_t(header_size)] == 'H');
+					TORRENT_ASSERT(chunk_size != 0 || chunk_start.size() <= header_size || chunk_start[header_size] == 'H');
 					// cut out the chunk header from the receive buffer
 					TORRENT_ASSERT(m_chunk_pos + m_body_start < INT_MAX);
-					m_recv_buffer.cut(header_size, t->block_size() + 1024, int(m_chunk_pos + m_body_start));
+					m_recv_buffer.cut(header_size, t->block_size() + 1024, aux::numeric_cast<int>(m_chunk_pos + m_body_start));
 					recv_buffer = m_recv_buffer.get();
-					recv_buffer = recv_buffer.subspan(aux::numeric_cast<std::size_t>(m_body_start));
+					recv_buffer = recv_buffer.subspan(m_body_start);
 					m_chunk_pos += chunk_size;
 					if (chunk_size == 0)
 					{
-						TORRENT_ASSERT(int(m_recv_buffer.get().size()) < m_chunk_pos + m_body_start + 1
-							|| m_recv_buffer.get()[aux::numeric_cast<std::size_t>(m_chunk_pos + m_body_start)] == 'H'
-							|| (m_parser.chunked_encoding() && m_recv_buffer.get()[aux::numeric_cast<std::size_t>(m_chunk_pos + m_body_start)] == '\r'));
+						TORRENT_ASSERT(m_recv_buffer.get().size() < m_chunk_pos + m_body_start + 1
+							|| m_recv_buffer.get()[static_cast<std::ptrdiff_t>(m_chunk_pos + m_body_start)] == 'H'
+							|| (m_parser.chunked_encoding()
+								&& m_recv_buffer.get()[static_cast<std::ptrdiff_t>(m_chunk_pos + m_body_start)] == '\r'));
 						m_chunk_pos = -1;
 					}
 				}
@@ -431,7 +432,7 @@ namespace libtorrent {
 			// we only received the header, no data
 			if (recv_buffer.empty()) break;
 
-			if (int(recv_buffer.size()) < front_request.length) break;
+			if (recv_buffer.size() < front_request.length) break;
 
 			// if the response is chunked, we need to receive the last
 			// terminating chunk and the tail headers before we can proceed
@@ -441,10 +442,10 @@ namespace libtorrent {
 			incoming_piece(front_request, recv_buffer.begin());
 			if (associated_torrent().expired()) return;
 
-			int size_to_cut = m_body_start + front_request.length;
-			TORRENT_ASSERT(int(m_recv_buffer.get().size()) < size_to_cut + 1
-				|| m_recv_buffer.get()[aux::numeric_cast<std::size_t>(size_to_cut)] == 'H'
-				|| (m_parser.chunked_encoding() && m_recv_buffer.get()[aux::numeric_cast<std::size_t>(size_to_cut)] == '\r'));
+			int const size_to_cut = m_body_start + front_request.length;
+			TORRENT_ASSERT(m_recv_buffer.get().size() < size_to_cut + 1
+				|| m_recv_buffer.get()[size_to_cut] == 'H'
+				|| (m_parser.chunked_encoding() && m_recv_buffer.get()[size_to_cut] == '\r'));
 
 			m_recv_buffer.cut(size_to_cut, t->block_size() + 1024);
 			if (m_response_left == 0) m_chunk_pos = 0;

--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -115,7 +115,7 @@ namespace {
 			item.value.reset(new char[std::size_t(size)]);
 			item.size = size;
 		}
-		std::memcpy(item.value.get(), buf.data(), buf.size());
+		std::copy(buf.begin(), buf.end(), item.value.get());
 	}
 
 	void touch_item(dht_immutable_item& f, address const& addr)
@@ -479,7 +479,7 @@ namespace {
 
 			aux::vector<sha1_hash> const& samples = m_infohashes_sample.samples;
 			item["samples"] = span<char const>(
-				reinterpret_cast<char const*>(samples.data()), samples.size() * 20);
+				reinterpret_cast<char const*>(samples.data()), static_cast<std::ptrdiff_t>(samples.size()) * 20);
 
 			return m_infohashes_sample.count();
 		}

--- a/src/kademlia/get_peers.cpp
+++ b/src/kademlia/get_peers.cpp
@@ -102,7 +102,7 @@ void get_peers_observer::log_peers(msg const& m, bdecode_node const& r, int cons
 						, algorithm()->invoke_count()
 						, algorithm()->branch_factor()
 						, print_endpoint(m.addr).c_str()
-						, aux::to_hex({id.string_ptr(), size_t(id.string_length())}).c_str()
+						, aux::to_hex({id.string_ptr(), id.string_length()}).c_str()
 						, distance_exp(algorithm()->target(), node_id(id.string_ptr()))
 						, size);
 				}

--- a/src/kademlia/item.cpp
+++ b/src/kademlia/item.cpp
@@ -61,17 +61,17 @@ namespace {
 #endif
 		char* ptr = out.data();
 
-		std::size_t left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
+		auto left = out.size() - (ptr - out.data());
 		if (!salt.empty())
 		{
-			ptr += std::snprintf(ptr, left, "4:salt%d:", int(salt.size()));
-			left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
+			ptr += std::snprintf(ptr, static_cast<std::size_t>(left), "4:salt%d:", int(salt.size()));
+			left = out.size() - (ptr - out.data());
 			std::copy(salt.begin(), salt.begin() + std::min(salt.size(), left), ptr);
 			ptr += std::min(salt.size(), left);
-			left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
+			left = out.size() - (ptr - out.data());
 		}
-		ptr += std::snprintf(ptr, left, "3:seqi%" PRId64 "e1:v", seq.value);
-		left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
+		ptr += std::snprintf(ptr, static_cast<std::size_t>(left), "3:seqi%" PRId64 "e1:v", seq.value);
+		left = out.size() - (ptr - out.data());
 		std::copy(v.begin(), v.begin() + std::min(v.size(), left), ptr);
 		ptr += std::min(v.size(), left);
 		TORRENT_ASSERT((ptr - out.data()) <= int(out.size()));
@@ -104,7 +104,7 @@ bool verify_mutable_item(
 	char str[1200];
 	int len = canonical_string(v, seq, salt, str);
 
-	return ed25519_verify(sig, {str, size_t(len)}, pk);
+	return ed25519_verify(sig, {str, len}, pk);
 }
 
 // given the bencoded buffer ``v``, the salt (which is optional and may have
@@ -123,11 +123,11 @@ signature sign_mutable_item(
 	char str[1200];
 	int const len = canonical_string(v, seq, salt, str);
 
-	return ed25519_sign({str, size_t(len)}, pk, sk);
+	return ed25519_sign({str, len}, pk, sk);
 }
 
 item::item(public_key const& pk, span<char const> salt)
-	: m_salt(salt.data(), salt.size())
+	: m_salt(salt.data(), static_cast<std::size_t>(salt.size()))
 	, m_pk(pk)
 	, m_seq(0)
 	, m_mutable(true)
@@ -165,9 +165,9 @@ void item::assign(entry v, span<char const> salt
 	char buffer[1000];
 	int bsize = bencode(buffer, v);
 	TORRENT_ASSERT(bsize <= 1000);
-	m_sig = sign_mutable_item({buffer, aux::numeric_cast<std::size_t>(bsize)}
+	m_sig = sign_mutable_item({buffer, bsize}
 		, salt, seq, pk, sk);
-	m_salt.assign(salt.data(), salt.size());
+	m_salt.assign(salt.data(), static_cast<std::size_t>(salt.size()));
 	m_pk = pk;
 	m_seq = seq;
 	m_mutable = true;
@@ -189,7 +189,7 @@ bool item::assign(bdecode_node const& v, span<char const> salt
 	m_pk = pk;
 	m_sig = sig;
 	if (!salt.empty())
-		m_salt.assign(salt.data(), salt.size());
+		m_salt.assign(salt.data(), static_cast<std::size_t>(salt.size()));
 	else
 		m_salt.clear();
 	m_seq = seq;
@@ -206,7 +206,7 @@ void item::assign(entry v, span<char const> salt
 
 	m_pk = pk;
 	m_sig = sig;
-	m_salt.assign(salt.data(), salt.size());
+	m_salt.assign(salt.data(), static_cast<std::size_t>(salt.size()));
 	m_seq = seq;
 	m_mutable = true;
 	m_value = std::move(v);

--- a/src/kademlia/msg.cpp
+++ b/src/kademlia/msg.cpp
@@ -41,14 +41,14 @@ bool verify_message_impl(bdecode_node const& message, span<key_desc_t const> des
 {
 	TORRENT_ASSERT(desc.size() == ret.size());
 
-	std::size_t const size = ret.size();
+	auto const size = ret.size();
 
 	// get a non-root bdecode_node that still
 	// points to the root. message should not be copied
 	bdecode_node msg = message.non_owning();
 
 	// clear the return buffer
-	for (std::size_t i = 0; i < size; ++i)
+	for (int i = 0; i < size; ++i)
 		ret[i].clear();
 
 	// when parsing child nodes, this is the stack
@@ -58,12 +58,12 @@ bool verify_message_impl(bdecode_node const& message, span<key_desc_t const> des
 
 	if (msg.type() != bdecode_node::dict_t)
 	{
-		std::snprintf(error.data(), error.size(), "not a dictionary");
+		std::snprintf(error.data(), static_cast<std::size_t>(error.size()), "not a dictionary");
 		return false;
 	}
 	++stack_ptr;
 	stack[stack_ptr] = msg;
-	for (std::size_t i = 0; i < size; ++i)
+	for (int i = 0; i < size; ++i)
 	{
 		key_desc_t const& k = desc[i];
 
@@ -76,7 +76,7 @@ bool verify_message_impl(bdecode_node const& message, span<key_desc_t const> des
 		if (!ret[i] && (k.flags & key_desc_t::optional) == 0)
 		{
 			// the key was not found, and it's not an optional key
-			std::snprintf(error.data(), error.size(), "missing '%s' key", k.name);
+			std::snprintf(error.data(), static_cast<std::size_t>(error.size()), "missing '%s' key", k.name);
 			return false;
 		}
 
@@ -94,7 +94,8 @@ bool verify_message_impl(bdecode_node const& message, span<key_desc_t const> des
 				ret[i].clear();
 				if ((k.flags & key_desc_t::optional) == 0)
 				{
-					std::snprintf(error.data(), error.size(), "invalid value for '%s'", k.name);
+					std::snprintf(error.data(), static_cast<std::size_t>(error.size())
+						, "invalid value for '%s'", k.name);
 					return false;
 				}
 			}

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -1007,7 +1007,7 @@ void node::incoming_request(msg const& m, entry& e)
 
 		span<char const> salt;
 		if (msg_keys[6])
-			salt = {msg_keys[6].string_ptr(), std::size_t(msg_keys[6].string_length())};
+			salt = {msg_keys[6].string_ptr(), msg_keys[6].string_length()};
 		if (salt.size() > 64)
 		{
 			m_counters.inc_stats_counter(counters::dht_invalid_put);

--- a/src/kademlia/node_id.cpp
+++ b/src/kademlia/node_id.cpp
@@ -84,8 +84,8 @@ node_id generate_id_impl(address const& ip_, std::uint32_t r)
 {
 	std::uint8_t* ip = nullptr;
 
-	static const std::uint8_t v4mask[] = { 0x03, 0x0f, 0x3f, 0xff };
-	static const std::uint8_t v6mask[] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
+	static std::uint8_t const v4mask[] = { 0x03, 0x0f, 0x3f, 0xff };
+	static std::uint8_t const v6mask[] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
 	std::uint8_t const* mask = nullptr;
 	int num_octets = 0;
 
@@ -128,7 +128,7 @@ node_id generate_id_impl(address const& ip_, std::uint32_t r)
 	id[1] = (c >> 16) & 0xff;
 	id[2] = (((c >> 8) & 0xf8) | random(0x7)) & 0xff;
 
-	for (std::size_t i = 3; i < 19; ++i) id[i] = random(0xff) & 0xff;
+	for (int i = 3; i < 19; ++i) id[i] = random(0xff) & 0xff;
 	id[19] = r & 0xff;
 
 	return id;

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -313,13 +313,13 @@ namespace libtorrent {
 				// don't hold the lock during disk I/O
 				l.unlock();
 
-				iovec_t v = {buf.get(), std::size_t(block_to_copy)};
-				auto bytes_read = std::size_t(local_file->readv(slot_offset(slot) + piece_offset, v, ec));
-				v = v.first(bytes_read);
+				iovec_t v = {buf.get(), block_to_copy};
+				auto bytes_read = local_file->readv(slot_offset(slot) + piece_offset, v, ec);
+				v = v.first(static_cast<std::ptrdiff_t>(bytes_read));
 				TORRENT_ASSERT(!ec);
 				if (ec || v.empty()) return;
 
-				f(file_offset, {buf.get(), std::size_t(block_to_copy)});
+				f(file_offset, {buf.get(), block_to_copy});
 
 				// we're done with the disk I/O, grab the lock again to update
 				// the slot map

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -129,7 +129,7 @@ namespace libtorrent {
 
 	int bufs_size(span<iovec_t const> bufs)
 	{
-		std::size_t size = 0;
+		std::ptrdiff_t size = 0;
 		for (auto buf : bufs) size += buf.size();
 		return int(size);
 	}

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -87,8 +87,9 @@ namespace libtorrent {
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
 	{
-		std::array<std::uint8_t, 96> random_key;
-		aux::random_bytes({reinterpret_cast<char*>(random_key.data()), random_key.size()});
+		aux::array<std::uint8_t, 96> random_key;
+		aux::random_bytes({reinterpret_cast<char*>(random_key.data())
+			, static_cast<std::ptrdiff_t>(random_key.size())});
 
 		// create local key (random)
 		mp::import_bits(m_dh_local_secret, random_key.begin(), random_key.end());
@@ -135,15 +136,15 @@ namespace libtorrent {
 			TORRENT_ALLOCA(abufs, span<char>, iovec.size());
 			bufs = abufs;
 			need_destruct = true;
-			size_t num_bufs = 0;
-			for (std::size_t i = 0; to_process > 0 && i < iovec.size(); ++i)
+			int num_bufs = 0;
+			for (int i = 0; to_process > 0 && i < iovec.size(); ++i)
 			{
 				++num_bufs;
 				int const size = int(iovec[i].size());
 				if (to_process < size)
 				{
 					new (&bufs[i]) span<char>(
-						iovec[i].data(), aux::numeric_cast<std::size_t>(to_process));
+						iovec[i].data(), to_process);
 					to_process = 0;
 				}
 				else
@@ -216,7 +217,7 @@ namespace libtorrent {
 		int consume = 0;
 		if (recv_buffer.crypto_packet_finished())
 		{
-			span<char> wr_buf = recv_buffer.mutable_buffer(bytes_transferred);
+			span<char> wr_buf = recv_buffer.mutable_buffer(int(bytes_transferred));
 			int produce = 0;
 			int packet_size = 0;
 			std::tie(consume, produce, packet_size) = m_dec_handler->decrypt(wr_buf);
@@ -285,7 +286,7 @@ namespace libtorrent {
 	{
 		m_decrypt = true;
 		rc4_init(reinterpret_cast<unsigned char const*>(key.data())
-			, key.size(), &m_rc4_incoming);
+			, std::size_t(key.size()), &m_rc4_incoming);
 		// Discard first 1024 bytes
 		char buf[1024];
 		span<char> vec(buf, sizeof(buf));
@@ -296,7 +297,7 @@ namespace libtorrent {
 	{
 		m_encrypt = true;
 		rc4_init(reinterpret_cast<unsigned char const*>(key.data())
-			, key.size(), &m_rc4_outgoing);
+			, std::size_t(key.size()), &m_rc4_outgoing);
 		// Discard first 1024 bytes
 		char buf[1024];
 		span<char> vec(buf, sizeof(buf));

--- a/src/peer_connection_handle.cpp
+++ b/src/peer_connection_handle.cpp
@@ -283,7 +283,7 @@ void peer_connection_handle::send_buffer(char const* begin, int size
 {
 	std::shared_ptr<peer_connection> pc = native_handle();
 	TORRENT_ASSERT(pc);
-	pc->send_buffer({begin, std::size_t(size)}, flags);
+	pc->send_buffer({begin, size}, flags);
 }
 
 std::time_t peer_connection_handle::last_seen_complete() const

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -365,7 +365,7 @@ namespace libtorrent {
 	{
 		int idx = int(dp.info_idx) * m_blocks_per_piece;
 		TORRENT_ASSERT(idx + m_blocks_per_piece <= int(m_block_info.size()));
-		return { &m_block_info[idx], static_cast<std::size_t>(blocks_in_piece(dp.index)) };
+		return { &m_block_info[idx], blocks_in_piece(dp.index) };
 	}
 
 	aux::typed_span<piece_picker::block_info const> piece_picker::blocks_for_piece(
@@ -1258,7 +1258,7 @@ namespace libtorrent {
 			return;
 		}
 
-		int const size = std::min(50, bitmask.size() / 2);
+		int const size = std::min(50, int(bitmask.size() / 2));
 
 		// this is an optimization where if just a few
 		// pieces end up changing, instead of making
@@ -1354,7 +1354,7 @@ namespace libtorrent {
 			return;
 		}
 
-		int const size = std::min(50, bitmask.size() / 2);
+		int const size = std::min(50, int(bitmask.size() / 2));
 
 		// this is an optimization where if just a few
 		// pieces end up changing, instead of making

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -86,7 +86,7 @@ namespace {
 		}
 
 		auto info_hash = rd.dict_find_string_value("info-hash");
-		if (info_hash.size() != sha1_hash::size())
+		if (info_hash.size() != static_cast<std::size_t>(sha1_hash::size()))
 		{
 			ec = errors::missing_info_hash;
 			return ret;

--- a/src/receive_buffer.cpp
+++ b/src/receive_buffer.cpp
@@ -54,8 +54,7 @@ span<char> receive_buffer::reserve(int const size)
 	if (int(m_recv_buffer.size()) < m_recv_end + size)
 	{
 		int const new_size = std::max(m_recv_end + size, m_packet_size);
-		buffer new_buffer(aux::numeric_cast<std::size_t>(new_size)
-			, {m_recv_buffer.data(), aux::numeric_cast<std::size_t>(m_recv_end)});
+		buffer new_buffer(new_size, {m_recv_buffer.data(), m_recv_end});
 		m_recv_buffer = std::move(new_buffer);
 
 		// since we just increased the size of the buffer, reset the watermark to
@@ -77,8 +76,7 @@ void receive_buffer::grow(int const limit)
 		? m_packet_size : std::min(current_size * 3 / 2, limit);
 
 	// re-allocate the buffer and copy over the part of it that's used
-	buffer new_buffer(aux::numeric_cast<std::size_t>(new_size)
-		, {m_recv_buffer.data(), aux::numeric_cast<std::size_t>(m_recv_end)});
+	buffer new_buffer(new_size, {m_recv_buffer.data(), m_recv_end});
 	m_recv_buffer = std::move(new_buffer);
 
 	// since we just increased the size of the buffer, reset the watermark to
@@ -184,25 +182,25 @@ void receive_buffer::normalize(int const force_shrink)
 		&& m_watermark.mean() > (m_recv_end - m_recv_start);
 
 	span<char const> bytes_to_shift(m_recv_buffer.data() + m_recv_start
-		, aux::numeric_cast<std::size_t>(m_recv_end - m_recv_start));
+		, m_recv_end - m_recv_start);
 
 	if (force_shrink)
 	{
 		int const target_size = std::max(std::max(force_shrink
 			, int(bytes_to_shift.size())), m_packet_size);
-		buffer new_buffer(aux::numeric_cast<std::size_t>(target_size), bytes_to_shift);
+		buffer new_buffer(target_size, bytes_to_shift);
 		m_recv_buffer = std::move(new_buffer);
 	}
 	else if (shrink_buffer)
 	{
-		buffer new_buffer(aux::numeric_cast<std::size_t>(m_watermark.mean()), bytes_to_shift);
+		buffer new_buffer(m_watermark.mean(), bytes_to_shift);
 		m_recv_buffer = std::move(new_buffer);
 	}
 	else if (m_recv_end > m_recv_start
 		&& m_recv_start > 0)
 	{
 		std::memmove(m_recv_buffer.data(), bytes_to_shift.data()
-			, bytes_to_shift.size());
+			, std::size_t(bytes_to_shift.size()));
 	}
 
 	m_recv_end -= m_recv_start;
@@ -321,16 +319,16 @@ span<char const> crypto_receive_buffer::get() const
 {
 	span<char const> recv_buffer = m_connection_buffer.get();
 	if (m_recv_pos < m_connection_buffer.pos())
-		recv_buffer = recv_buffer.first(aux::numeric_cast<std::size_t>(m_recv_pos));
+		recv_buffer = recv_buffer.first(m_recv_pos);
 	return recv_buffer;
 }
 
 span<char> crypto_receive_buffer::mutable_buffer(
-	std::size_t const bytes)
+	int const bytes)
 {
 	int const pending_decryption = (m_recv_pos != INT_MAX)
 		? m_connection_buffer.packet_size() - m_recv_pos
-		: int(bytes);
+		: bytes;
 	return m_connection_buffer.mutable_buffer(pending_decryption);
 }
 #endif // TORRENT_DISABLE_ENCRYPTION

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1309,12 +1309,14 @@ namespace aux {
 		if (iface.is_v4())
 		{
 			auto const b = iface.to_v4().to_bytes();
-			h.update({reinterpret_cast<char const*>(b.data()), b.size()});
+			h.update({reinterpret_cast<char const*>(b.data())
+				, std::ptrdiff_t(b.size())});
 		}
 		else
 		{
 			auto const b = iface.to_v6().to_bytes();
-			h.update({reinterpret_cast<char const*>(b.data()), b.size()});
+			h.update({reinterpret_cast<char const*>(b.data())
+				, std::ptrdiff_t(b.size())});
 		}
 		sha1_hash const hash = h.final();
 		unsigned char const* ptr = &hash[0];
@@ -1848,7 +1850,7 @@ namespace aux {
 
 		// all sockets in there stayed the same. Only sockets after this point are
 		// new and should post alerts
-		auto const existing_sockets = m_listen_sockets.size();
+		int const existing_sockets = int(m_listen_sockets.size());
 
 		m_stats_counters.set_value(counters::has_incoming_connections
 			, std::any_of(m_listen_sockets.begin(), m_listen_sockets.end()

--- a/src/sha1_hash.cpp
+++ b/src/sha1_hash.cpp
@@ -69,7 +69,7 @@ namespace aux {
 		int const number_size = number.end_index();
 		if (num_words >= number_size)
 		{
-			std::memset(number.data(), 0, number.size() * 4);
+			std::memset(number.data(), 0, std::size_t(number.size() * 4));
 			return;
 		}
 
@@ -107,7 +107,7 @@ namespace aux {
 		int const number_size = number.end_index();
 		if (num_words >= number_size)
 		{
-			std::memset(number.data(), 0, number.size() * 4);
+			std::memset(number.data(), 0, std::size_t(number.size() * 4));
 			return;
 		}
 		if (num_words > 0)

--- a/src/smart_ban.cpp
+++ b/src/smart_ban.cpp
@@ -182,7 +182,7 @@ namespace {
 			if (error) return;
 
 			hasher h;
-			h.update({buffer.get(), std::size_t(block_size)});
+			h.update({buffer.get(), block_size});
 			h.update(reinterpret_cast<char const*>(&m_salt), sizeof(m_salt));
 
 			auto const range = m_torrent.find_peers(a);
@@ -263,7 +263,7 @@ namespace {
 			if (error) return;
 
 			hasher h;
-			h.update({buffer.get(), std::size_t(block_size)});
+			h.update({buffer.get(), block_size});
 			h.update(reinterpret_cast<char const*>(&m_salt), sizeof(m_salt));
 			sha1_hash const ok_digest = h.final();
 

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -800,7 +800,7 @@ namespace {
 				int ret = 0;
 				for (auto const& b : bufs)
 				{
-					std::memset(b.data(), 0, b.size());
+					std::memset(b.data(), 0, std::size_t(b.size()));
 					ret += int(b.size());
 				}
 				return 0;

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -53,7 +53,7 @@ namespace libtorrent { namespace aux {
 		if (bytes == 0) return ret;
 		for (iovec_t const& src : bufs)
 		{
-			std::size_t const to_copy = std::min(src.size(), std::size_t(bytes));
+			auto const to_copy = std::min(src.size(), std::ptrdiff_t(bytes));
 			*dst = src.first(to_copy);
 			bytes -= int(to_copy);
 			++ret;
@@ -66,13 +66,13 @@ namespace libtorrent { namespace aux {
 	typed_span<iovec_t> advance_bufs(typed_span<iovec_t> bufs, int const bytes)
 	{
 		TORRENT_ASSERT(bytes >= 0);
-		std::size_t size = 0;
+		std::ptrdiff_t size = 0;
 		for (;;)
 		{
 			size += bufs.front().size();
-			if (size >= std::size_t(bytes))
+			if (size >= bytes)
 			{
-				bufs.front() = bufs.front().last(size - std::size_t(bytes));
+				bufs.front() = bufs.front().last(size - bytes);
 				return bufs;
 			}
 			bufs = bufs.subspan(1);
@@ -90,14 +90,14 @@ namespace libtorrent { namespace aux {
 
 	int count_bufs(span<iovec_t const> bufs, int bytes)
 	{
-		std::size_t size = 0;
+		std::ptrdiff_t size = 0;
 		int count = 0;
 		if (bytes == 0) return count;
 		for (auto b : bufs)
 		{
 			++count;
 			size += b.size();
-			if (size >= std::size_t(bytes)) return count;
+			if (size >= bytes) return count;
 		}
 		return count;
 	}

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -151,7 +151,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(!src.empty());
 		TORRENT_ASSERT(!target.empty());
 		TORRENT_ASSERT(target.size() >= src.size());
-		TORRENT_ASSERT(target.size() < std::size_t(std::numeric_limits<int>::max()));
+		TORRENT_ASSERT(target.size() < std::numeric_limits<int>::max());
 
 		auto const it = std::search(target.begin(), target.end(), src.begin(), src.end());
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2138,7 +2138,7 @@ bool is_downloading_state(int const st)
 
 					need_picker();
 
-					const int num_bits = std::min(num_blocks_per_piece, blocks.size());
+					const int num_bits = std::min(num_blocks_per_piece, int(blocks.size()));
 					for (int k = 0; k < num_bits; ++k)
 					{
 						if (blocks.get_bit(k))

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -938,7 +938,7 @@ namespace {
 		// hash the info-field to calculate info-hash
 		auto section = info.data_section();
 		m_info_hash = hasher(section).final();
-		if (info.data_section().size() >= std::numeric_limits<std::uint32_t>::max())
+		if (info.data_section().size() >= std::numeric_limits<int>::max())
 		{
 			ec = errors::metadata_too_large;
 			return false;
@@ -949,7 +949,7 @@ namespace {
 		m_info_section.reset(new char[aux::numeric_cast<std::size_t>(m_info_section_size)]);
 		std::memcpy(m_info_section.get(), section.data(), aux::numeric_cast<std::size_t>(m_info_section_size));
 		TORRENT_ASSERT(section[0] == 'd');
-		TORRENT_ASSERT(section[aux::numeric_cast<std::size_t>(m_info_section_size - 1)] == 'e');
+		TORRENT_ASSERT(section[m_info_section_size - 1] == 'e');
 
 		// when translating a pointer that points into the 'info' tree's
 		// backing buffer, into a pointer to our copy of the info section,

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -385,7 +385,7 @@ namespace libtorrent {
 		if (action == action_t::error)
 		{
 			fail(error_code(errors::tracker_failure)
-				, std::string(buf.data(), buf.size()).c_str());
+				, std::string(buf.data(), static_cast<std::size_t>(buf.size())).c_str());
 			return true;
 		}
 
@@ -582,9 +582,8 @@ namespace libtorrent {
 		resp.incomplete = aux::read_int32(buf);
 		resp.complete = aux::read_int32(buf);
 
-		std::size_t const ip_stride = is_v6(m_target) ? 18 : 6;
-
-		std::size_t const num_peers = buf.size() / ip_stride;
+		int const ip_stride = is_v6(m_target) ? 18 : 6;
+		auto const num_peers = buf.size() / ip_stride;
 		if (buf.size() % ip_stride != 0)
 		{
 			fail(error_code(errors::invalid_tracker_response_length));
@@ -607,8 +606,8 @@ namespace libtorrent {
 
 		if (is_v6(m_target))
 		{
-			resp.peers6.reserve(num_peers);
-			for (std::size_t i = 0; i < num_peers; ++i)
+			resp.peers6.reserve(static_cast<std::size_t>(num_peers));
+			for (int i = 0; i < num_peers; ++i)
 			{
 				ipv6_peer_entry e{};
 				std::memcpy(e.ip.data(), buf.data(), 16);
@@ -619,8 +618,8 @@ namespace libtorrent {
 		}
 		else
 		{
-			resp.peers4.reserve(num_peers);
-			for (std::size_t i = 0; i < num_peers; ++i)
+			resp.peers4.reserve(static_cast<std::size_t>(num_peers));
+			for (int i = 0; i < num_peers; ++i)
 			{
 				ipv4_peer_entry e{};
 				std::memcpy(e.ip.data(), buf.data(), 4);
@@ -658,7 +657,7 @@ namespace libtorrent {
 		if (action == action_t::error)
 		{
 			fail(error_code(errors::tracker_failure)
-				, std::string(buf.data(), buf.size()).c_str());
+				, std::string(buf.data(), static_cast<std::size_t>(buf.size())).c_str());
 			return true;
 		}
 
@@ -761,16 +760,16 @@ namespace libtorrent {
 		if (!m_hostname.empty())
 		{
 			m_man.send_hostname(bind_socket(), m_hostname.c_str()
-				, m_target.port(), {buf, std::size_t(sizeof(buf) - out.size())}, ec
+				, m_target.port(), {buf, int(sizeof(buf)) - out.size()}, ec
 				, udp_socket::tracker_connection);
 		}
 		else
 		{
-			m_man.send(bind_socket(), m_target, {buf, std::size_t(sizeof(buf) - out.size())}, ec
+			m_man.send(bind_socket(), m_target, {buf, int(sizeof(buf)) - out.size()}, ec
 				, udp_socket::tracker_connection);
 		}
 		m_state = action_t::announce;
-		sent_bytes(int(sizeof(buf) - out.size()) + 28); // assuming UDP/IP header
+		sent_bytes(int(sizeof(buf)) - int(out.size()) + 28); // assuming UDP/IP header
 		++m_attempts;
 		if (ec)
 		{

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -984,7 +984,7 @@ void upnp::on_upnp_xml(error_code const& e
 
 	parse_state s;
 	auto body = p.get_body();
-	xml_parse({body.data(), body.size()}, std::bind(&find_control_url, _1, _2, std::ref(s)));
+	xml_parse({body.data(), std::size_t(body.size())}, std::bind(&find_control_url, _1, _2, std::ref(s)));
 	if (s.control_url.empty())
 	{
 #ifndef TORRENT_DISABLE_LOGGING
@@ -1275,12 +1275,12 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 	if (should_log())
 	{
 		log("get external IP address response: %s"
-			, std::string(body.data(), body.size()).c_str());
+			, std::string(body.data(), static_cast<std::size_t>(body.size())).c_str());
 	}
 #endif
 
 	ip_address_parse_state s;
-	xml_parse({body.data(), body.size()}, std::bind(&find_ip_address, _1, _2, std::ref(s)));
+	xml_parse({body.data(), std::size_t(body.size())}, std::bind(&find_ip_address, _1, _2, std::ref(s)));
 #ifndef TORRENT_DISABLE_LOGGING
 	if (s.error_code != -1)
 	{
@@ -1381,7 +1381,7 @@ void upnp::on_upnp_map_response(error_code const& e
 
 	error_code_parse_state s;
 	span<char const> body = p.get_body();
-	xml_parse({body.data(), body.size()}, std::bind(&find_error_code, _1, _2, std::ref(s)));
+	xml_parse({body.data(), std::size_t(body.size())}, std::bind(&find_error_code, _1, _2, std::ref(s)));
 
 	if (s.error_code != -1)
 	{
@@ -1426,7 +1426,7 @@ void upnp::on_upnp_map_response(error_code const& e
 	if (should_log())
 	{
 		log("map response: %s"
-			, std::string(body.data(), body.size()).c_str());
+			, std::string(body.data(), static_cast<std::size_t>(body.size())).c_str());
 	}
 #endif
 
@@ -1528,7 +1528,7 @@ void upnp::on_upnp_unmap_response(error_code const& e
 		{
 			span<char const> body = p.get_body();
 			log("unmap response: %s"
-				, std::string(body.data(), body.size()).c_str());
+				, std::string(body.data(), static_cast<std::size_t>(body.size())).c_str());
 		}
 #endif
 	}
@@ -1537,7 +1537,7 @@ void upnp::on_upnp_unmap_response(error_code const& e
 	if (p.header_finished())
 	{
 		span<char const> body = p.get_body();
-		xml_parse({body.data(), body.size()}, std::bind(&find_error_code, _1, _2, std::ref(s)));
+		xml_parse({body.data(), std::size_t(body.size())}, std::bind(&find_error_code, _1, _2, std::ref(s)));
 	}
 
 	portmap_protocol const proto = m_mappings[mapping].protocol;

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -122,7 +122,7 @@ namespace libtorrent {namespace {
 				TORRENT_ASSERT(hasher(m_metadata.get(), m_metadata_size).final()
 					== m_torrent.torrent_file().info_hash());
 			}
-			return {m_metadata.get(), aux::numeric_cast<std::size_t>(m_metadata_size)};
+			return {m_metadata.get(), m_metadata_size};
 		}
 
 		bool received_metadata(ut_metadata_peer_plugin& source
@@ -278,13 +278,13 @@ namespace libtorrent {namespace {
 			io::write_uint8(bt_peer_connection::msg_extended, header);
 			io::write_uint8(m_message_index, header);
 
-			m_pc.send_buffer({msg, static_cast<std::size_t>(len + 6)});
+			m_pc.send_buffer({msg, len + 6});
 			// TODO: we really need to increment the refcounter on the torrent
 			// while this buffer is still in the peer's send buffer
 			if (metadata_piece_size)
 			{
 				m_pc.append_const_send_buffer(
-					span<char>(const_cast<char*>(metadata), std::size_t(metadata_piece_size)), metadata_piece_size);
+					span<char>(const_cast<char*>(metadata), metadata_piece_size), metadata_piece_size);
 			}
 
 			m_pc.stats_counters().inc_stats_counter(counters::num_outgoing_extended);
@@ -591,7 +591,7 @@ namespace libtorrent {namespace {
 
 		if (!have_all) return false;
 
-		if (!m_torrent.set_metadata({m_metadata.get(), aux::numeric_cast<std::size_t>(m_metadata_size)}))
+		if (!m_torrent.set_metadata({m_metadata.get(), m_metadata_size}))
 		{
 			if (!m_torrent.valid_metadata())
 			{

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -145,7 +145,7 @@ namespace libtorrent {
 		if ((flags & dont_fragment) && len > TORRENT_DEBUG_MTU) return;
 #endif
 
-		m_send_fun(std::move(sock), ep, {p, std::size_t(len)}, ec
+		m_send_fun(std::move(sock), ep, {p, len}, ec
 			, (flags & udp_socket::dont_fragment)
 				| udp_socket::peer_connection);
 	}
@@ -155,7 +155,7 @@ namespace libtorrent {
 	{
 //		UTP_LOGV("incoming packet size:%d\n", size);
 
-		if (p.size() < sizeof(utp_header)) return false;
+		if (p.size() < std::ptrdiff_t(sizeof(utp_header))) return false;
 
 		auto const* ph = reinterpret_cast<utp_header const*>(p.data());
 

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -2604,7 +2604,7 @@ bool utp_socket_impl::incoming_packet(span<std::uint8_t const> buf
 	auto const* ph = reinterpret_cast<utp_header const*>(buf.data());
 	m_sm.inc_stats_counter(counters::utp_packets_in);
 
-	if (buf.size() < sizeof(utp_header))
+	if (buf.size() < int(sizeof(utp_header)))
 	{
 		UTP_LOG("%8p: ERROR: incoming packet size too small:%d (ignored)\n"
 			, static_cast<void*>(this), int(buf.size()));

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -817,7 +817,7 @@ void web_peer_connection::on_receive(error_code const& error
 
 			m_server_string = get_peer_name(m_parser, m_host);
 
-			recv_buffer = recv_buffer.subspan(aux::numeric_cast<std::size_t>(m_body_start));
+			recv_buffer = recv_buffer.subspan(m_body_start);
 
 			m_body_start = m_parser.body_start();
 			m_received_body = 0;
@@ -899,7 +899,7 @@ void web_peer_connection::on_receive(error_code const& error
 					}
 					incoming_payload(recv_buffer.data(), copy_size);
 
-					recv_buffer = recv_buffer.subspan(aux::numeric_cast<std::size_t>(copy_size));
+					recv_buffer = recv_buffer.subspan(copy_size);
 					m_chunk_pos -= copy_size;
 
 					if (recv_buffer.empty()) goto done;
@@ -909,7 +909,7 @@ void web_peer_connection::on_receive(error_code const& error
 
 				int header_size = 0;
 				std::int64_t chunk_size = 0;
-				span<char const> chunk_start = recv_buffer.subspan(aux::numeric_cast<std::size_t>(m_chunk_pos));
+				span<char const> chunk_start = recv_buffer.subspan(m_chunk_pos);
 				TORRENT_ASSERT(chunk_start[0] == '\r'
 					|| aux::is_hex({chunk_start.data(), 1}));
 				bool const ret = m_parser.parse_chunk_header(chunk_start, &chunk_size, &header_size);
@@ -927,10 +927,10 @@ void web_peer_connection::on_receive(error_code const& error
 				received_bytes(0, header_size - m_partial_chunk_header);
 				m_partial_chunk_header = 0;
 				TORRENT_ASSERT(chunk_size != 0
-					|| int(chunk_start.size()) <= header_size || chunk_start[std::size_t(header_size)] == 'H');
+					|| int(chunk_start.size()) <= header_size || chunk_start[header_size] == 'H');
 				TORRENT_ASSERT(m_body_start + m_chunk_pos < INT_MAX);
 				m_chunk_pos += int(chunk_size);
-				recv_buffer = recv_buffer.subspan(aux::numeric_cast<std::size_t>(header_size));
+				recv_buffer = recv_buffer.subspan(header_size);
 
 				// a chunk size of zero means the request is complete. Make sure the
 				// number of payload bytes we've received matches the number we
@@ -940,7 +940,7 @@ void web_peer_connection::on_receive(error_code const& error
 					TORRENT_ASSERT_VAL(m_chunk_pos == 0, m_chunk_pos);
 
 #if TORRENT_USE_ASSERTS
-					span<char const> chunk = recv_buffer.subspan(aux::numeric_cast<std::size_t>(m_chunk_pos));
+					span<char const> chunk = recv_buffer.subspan(m_chunk_pos);
 					TORRENT_ASSERT(chunk.size() == 0 || chunk[0] == 'H');
 #endif
 					m_chunk_pos = -1;
@@ -985,7 +985,7 @@ void web_peer_connection::on_receive(error_code const& error
 			int const copy_size = std::min(file_req.length - m_received_body
 				, int(recv_buffer.size()));
 			incoming_payload(recv_buffer.data(), copy_size);
-			recv_buffer = recv_buffer.subspan(aux::numeric_cast<std::size_t>(copy_size));
+			recv_buffer = recv_buffer.subspan(copy_size);
 
 			TORRENT_ASSERT(m_received_body <= file_req.length);
 			if (m_received_body == file_req.length)

--- a/test/make_torrent.cpp
+++ b/test/make_torrent.cpp
@@ -196,7 +196,7 @@ void generate_files(lt::torrent_info const& ti, std::string const& path
 			buffer[static_cast<std::size_t>(o)] = data;
 		}
 
-		iovec_t b = { &buffer[0], size_t(piece_size) };
+		iovec_t b = { &buffer[0], piece_size };
 		storage_error ec;
 		int ret = st.writev(b, i, 0, open_mode::read_only, ec);
 		if (ret != piece_size || ec)

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -166,7 +166,7 @@ std::map<std::string, std::int64_t> get_counters(lt::session& s)
 
 	static std::vector<stats_metric> metrics = session_stats_metrics();
 	for (auto const& m : metrics)
-		ret[m.name] = sa->counters()[static_cast<std::size_t>(m.value_index)];
+		ret[m.name] = sa->counters()[m.value_index];
 	return ret;
 }
 namespace {
@@ -623,7 +623,7 @@ lt::file_storage make_file_storage(span<const int> const file_sizes
 {
 	using namespace lt;
 	file_storage fs;
-	for (std::size_t i = 0; i != file_sizes.size(); ++i)
+	for (std::ptrdiff_t i = 0; i != file_sizes.size(); ++i)
 	{
 		char filename[200];
 		std::snprintf(filename, sizeof(filename), "test%d", int(i));
@@ -666,7 +666,7 @@ void create_random_files(std::string const& path, span<const int> file_sizes
 {
 	error_code ec;
 	aux::vector<char> random_data(300000);
-	for (std::size_t i = 0; i != file_sizes.size(); ++i)
+	for (std::ptrdiff_t i = 0; i != file_sizes.size(); ++i)
 	{
 		aux::random_bytes(random_data);
 		char filename[200];
@@ -691,7 +691,7 @@ void create_random_files(std::string const& path, span<const int> file_sizes
 		while (to_write > 0)
 		{
 			int const s = std::min(to_write, static_cast<int>(random_data.size()));
-			iovec_t const b = { random_data.data(), size_t(s)};
+			iovec_t const b = { random_data.data(), s};
 			f.writev(offset, b, ec);
 			if (ec) std::printf("failed to write file \"%s\": (%d) %s\n"
 				, full_path.c_str(), ec.value(), ec.message().c_str());

--- a/test/test_bdecode.cpp
+++ b/test/test_bdecode.cpp
@@ -500,7 +500,7 @@ TORRENT_TEST(item_limit)
 {
 	char b[10240];
 	b[0] = 'l';
-	std::size_t i = 1;
+	std::ptrdiff_t i = 1;
 	for (i = 1; i < 10239; i += 2)
 		memcpy(&b[i], "0:", 2);
 	b[i] = 'e';
@@ -782,18 +782,18 @@ TORRENT_TEST(parse_int_overflow)
 
 TORRENT_TEST(parse_length_overflow)
 {
-	char const* b[] = {
-		"d1:a1919191010:11111",
-		"d2143289344:a4:aaaae",
-		"d214328934114:a4:aaaae",
-		"d9205357638345293824:a4:aaaae",
-		"d1:a9205357638345293824:11111",
+	string_view const b[] = {
+		"d1:a1919191010:11111"_sv,
+		"d2143289344:a4:aaaae"_sv,
+		"d214328934114:a4:aaaae"_sv,
+		"d9205357638345293824:a4:aaaae"_sv,
+		"d1:a9205357638345293824:11111"_sv
 	};
 
-	for (int i = 0; i < int(sizeof(b)/sizeof(b[0])); ++i)
+	for (auto const& buf : b)
 	{
 		error_code ec;
-		bdecode_node e = bdecode({b[i], strlen(b[i])}, ec);
+		bdecode_node e = bdecode(buf, ec);
 		TEST_EQUAL(ec, error_code(bdecode_errors::unexpected_eof));
 	}
 }

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -73,7 +73,7 @@ TORRENT_TEST(buffer_swap)
 	buffer b1;
 	TEST_CHECK(b1.size() == 0);
 	buffer b2(10, data);
-	std::size_t const b2_size = b2.size();
+	auto const b2_size = b2.size();
 	TEST_CHECK(b2_size >= 10);
 
 	b1.swap(b2);
@@ -90,7 +90,7 @@ TORRENT_TEST(buffer_subscript)
 	TEST_CHECK(b.size() >= 50);
 
 	for (int i = 0; i < int(sizeof(data)/sizeof(data[0])); ++i)
-		TEST_CHECK(b[std::size_t(i)] == data[i]);
+		TEST_CHECK(b[i] == data[i]);
 }
 
 TORRENT_TEST(buffer_subscript2)
@@ -99,10 +99,10 @@ TORRENT_TEST(buffer_subscript2)
 	TEST_CHECK(b.size() >= 1);
 
 	for (int i = 0; i < int(b.size()); ++i)
-		b[std::size_t(i)] = char(i & 0xff);
+		b[i] = char(i & 0xff);
 
 	for (int i = 0; i < int(b.size()); ++i)
-		TEST_CHECK(b[std::size_t(i)] == (i & 0xff));
+		TEST_CHECK(b[i] == (i & 0xff));
 }
 
 TORRENT_TEST(buffer_move_construct)

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -95,9 +95,8 @@ void add_and_replace(node_id& dst, node_id const& add)
 	bool carry = false;
 	for (int k = 19; k >= 0; --k)
 	{
-		std::size_t idx = std::size_t(k);
-		int sum = dst[idx] + add[idx] + (carry ? 1 : 0);
-		dst[idx] = sum & 255;
+		int sum = dst[k] + add[k] + (carry ? 1 : 0);
+		dst[k] = sum & 255;
 		carry = sum > 255;
 	}
 }
@@ -261,7 +260,7 @@ struct msg_args
 	msg_args& samples(std::vector<sha1_hash> const& samples)
 	{
 		a["samples"] = span<char const>(
-			reinterpret_cast<char const*>(samples.data()), samples.size() * 20);
+			reinterpret_cast<char const*>(samples.data()), int(samples.size()) * 20);
 		return *this;
 	}
 
@@ -1236,35 +1235,35 @@ namespace {
 		{ generate_next(), 8 }
 	};
 
-	std::array<node_entry, 8> build_nodes()
+	lt::aux::array<node_entry, 8> build_nodes()
 	{
-		std::array<node_entry, 8> nodes = {
-			{ node_entry(items[0].target, udp::endpoint(addr4("1.1.1.1"), 1231), 10, true)
-			, node_entry(items[1].target, udp::endpoint(addr4("2.2.2.2"), 1232), 10, true)
-			, node_entry(items[2].target, udp::endpoint(addr4("3.3.3.3"), 1233), 10, true)
-			, node_entry(items[3].target, udp::endpoint(addr4("4.4.4.4"), 1234), 10, true)
-			, node_entry(items[4].target, udp::endpoint(addr4("5.5.5.5"), 1235), 10, true)
-			, node_entry(items[5].target, udp::endpoint(addr4("6.6.6.6"), 1236), 10, true)
-			, node_entry(items[6].target, udp::endpoint(addr4("7.7.7.7"), 1237), 10, true)
-			, node_entry(items[7].target, udp::endpoint(addr4("8.8.8.8"), 1238), 10, true) }
-		};
-		return nodes;
+		return lt::aux::array<node_entry, 8>(
+			std::array<node_entry, 8> {
+			{ { items[0].target, udp::endpoint(addr4("1.1.1.1"), 1231), 10, true}
+			, { items[1].target, udp::endpoint(addr4("2.2.2.2"), 1232), 10, true}
+			, { items[2].target, udp::endpoint(addr4("3.3.3.3"), 1233), 10, true}
+			, { items[3].target, udp::endpoint(addr4("4.4.4.4"), 1234), 10, true}
+			, { items[4].target, udp::endpoint(addr4("5.5.5.5"), 1235), 10, true}
+			, { items[5].target, udp::endpoint(addr4("6.6.6.6"), 1236), 10, true}
+			, { items[6].target, udp::endpoint(addr4("7.7.7.7"), 1237), 10, true}
+			, { items[7].target, udp::endpoint(addr4("8.8.8.8"), 1238), 10, true} }
+		});
 	}
 
-	std::array<node_entry, 9> build_nodes(sha1_hash target)
+	lt::aux::array<node_entry, 9> build_nodes(sha1_hash target)
 	{
-		std::array<node_entry, 9> nodes = {
-			{ node_entry(target, udp::endpoint(addr4("1.1.1.1"), 1231), 10, true)
-			, node_entry(target, udp::endpoint(addr4("2.2.2.2"), 1232), 10, true)
-			, node_entry(target, udp::endpoint(addr4("3.3.3.3"), 1233), 10, true)
-			, node_entry(target, udp::endpoint(addr4("4.4.4.4"), 1234), 10, true)
-			, node_entry(target, udp::endpoint(addr4("5.5.5.5"), 1235), 10, true)
-			, node_entry(target, udp::endpoint(addr4("6.6.6.6"), 1236), 10, true)
-			, node_entry(target, udp::endpoint(addr4("7.7.7.7"), 1237), 10, true)
-			, node_entry(target, udp::endpoint(addr4("8.8.8.8"), 1238), 10, true)
-			, node_entry(target, udp::endpoint(addr4("9.9.9.9"), 1239), 10, true) }
-		};
-		return nodes;
+		return lt::aux::array<node_entry, 9>(
+			std::array<node_entry, 9> {
+			{ { target, udp::endpoint(addr4("1.1.1.1"), 1231), 10, true}
+			, { target, udp::endpoint(addr4("2.2.2.2"), 1232), 10, true}
+			, { target, udp::endpoint(addr4("3.3.3.3"), 1233), 10, true}
+			, { target, udp::endpoint(addr4("4.4.4.4"), 1234), 10, true}
+			, { target, udp::endpoint(addr4("5.5.5.5"), 1235), 10, true}
+			, { target, udp::endpoint(addr4("6.6.6.6"), 1236), 10, true}
+			, { target, udp::endpoint(addr4("7.7.7.7"), 1237), 10, true}
+			, { target, udp::endpoint(addr4("8.8.8.8"), 1238), 10, true}
+			, { target, udp::endpoint(addr4("9.9.9.9"), 1239), 10, true} }
+		});
 	}
 
 span<char const> const empty_salt;
@@ -1367,7 +1366,7 @@ void test_put(address(&rand_addr)())
 			TEST_ERROR(t.error_string);
 		}
 
-		itemv = span<char const>(buffer, std::size_t(bencode(buffer, items[0].ent)));
+		itemv = span<char const>(buffer, bencode(buffer, items[0].ent));
 		sig = sign_mutable_item(itemv, salt, seq, pk, sk);
 		TEST_EQUAL(verify_mutable_item(itemv, salt, seq, pk, sig), true);
 
@@ -1436,7 +1435,7 @@ void test_put(address(&rand_addr)())
 
 		// also test that invalid signatures fail!
 
-		itemv = span<char const>(buffer, std::size_t(bencode(buffer, items[0].ent)));
+		itemv = span<char const>(buffer, bencode(buffer, items[0].ent));
 		sig = sign_mutable_item(itemv, salt, seq, pk, sk);
 		TEST_EQUAL(verify_mutable_item(itemv, salt, seq, pk, sig), 1);
 		// break the signature
@@ -1500,7 +1499,7 @@ void test_put(address(&rand_addr)())
 		// increment sequence number
 		seq = next_seq(seq);
 		// put item 1
-		itemv = span<char const>(buffer, std::size_t(bencode(buffer, items[1].ent)));
+		itemv = span<char const>(buffer, bencode(buffer, items[1].ent));
 		sig = sign_mutable_item(itemv, salt, seq, pk, sk);
 		TEST_EQUAL(verify_mutable_item(itemv, salt, seq, pk, sig), 1);
 
@@ -2261,7 +2260,7 @@ void test_mutable_get(address(&rand_addr)(), bool const with_salt)
 	g_sent_packets.clear();
 
 	signature sig;
-	itemv = span<char const>(buffer, std::size_t(bencode(buffer, items[0].ent)));
+	itemv = span<char const>(buffer, bencode(buffer, items[0].ent));
 	sig = sign_mutable_item(itemv, salt, seq, pk, sk);
 	send_dht_response(t.dht_node, response, initial_node
 		, msg_args()
@@ -2383,7 +2382,7 @@ TORRENT_TEST(immutable_put)
 		// set the branching factor to k to make this a little easier
 		t.sett.search_branching = 8;
 
-		std::array<node_entry, 8> const nodes = build_nodes();
+		lt::aux::array<node_entry, 8> const nodes = build_nodes();
 
 		for (node_entry const& n : nodes)
 			t.dht_node.m_table.add_node(n);
@@ -2399,9 +2398,11 @@ TORRENT_TEST(immutable_put)
 		TEST_EQUAL(g_sent_packets.size(), 8);
 		if (g_sent_packets.size() != 8) break;
 
-		for (std::size_t i = 0; i < 8; ++i)
+		int idx = -1;
+		for (auto& node : nodes)
 		{
-			auto const packet = find_packet(nodes[i].ep());
+			++idx;
+			auto const packet = find_packet(node.ep());
 			TEST_CHECK(packet != g_sent_packets.end());
 			if (packet == g_sent_packets.end()) continue;
 
@@ -2415,22 +2416,24 @@ TORRENT_TEST(immutable_put)
 				continue;
 			}
 			char tok[10];
-			std::snprintf(tok, sizeof(tok), "%02d", int(i));
+			std::snprintf(tok, sizeof(tok), "%02d", idx);
 
 			msg_args args;
-			args.token(tok).port(1234).nid(nodes[i].id).nodes({nodes[i]});
-			send_dht_response(t.dht_node, response, nodes[i].ep(), args);
+			args.token(tok).port(1234).nid(node.id).nodes({node});
+			send_dht_response(t.dht_node, response, node.ep(), args);
 			g_sent_packets.erase(packet);
 		}
 
 		TEST_EQUAL(g_sent_packets.size(), 8);
 		if (g_sent_packets.size() != 8) break;
 
-		itemv = span<char const>(buffer, std::size_t(bencode(buffer, put_data)));
+		itemv = span<char const>(buffer, bencode(buffer, put_data));
 
-		for (int i = 0; i < 8; ++i)
+		idx = -1;
+		for (auto& node : nodes)
 		{
-			auto const packet = find_packet(nodes[std::size_t(i)].ep());
+			++idx;
+			auto const packet = find_packet(node.ep());
 			TEST_CHECK(packet != g_sent_packets.end());
 			if (packet == g_sent_packets.end()) continue;
 
@@ -2444,12 +2447,12 @@ TORRENT_TEST(immutable_put)
 				span<const char> const v = put_immutable_item_keys[6].data_section();
 				TEST_EQUAL(v, span<char const>(flat_data));
 				char tok[10];
-				std::snprintf(tok, sizeof(tok), "%02d", i);
+				std::snprintf(tok, sizeof(tok), "%02d", idx);
 				TEST_EQUAL(put_immutable_item_keys[5].string_value(), tok);
 				if (put_immutable_item_keys[0].string_value() != "q"
 					|| put_immutable_item_keys[2].string_value() != "put") continue;
 
-				if (i < loop) send_dht_response(t.dht_node, response, nodes[std::size_t(i)].ep());
+				if (idx < loop) send_dht_response(t.dht_node, response, node.ep());
 			}
 			else
 			{
@@ -2486,7 +2489,7 @@ TORRENT_TEST(mutable_put)
 		t.sett.search_branching = 8;
 
 		enum { num_test_nodes = 8 };
-		std::array<node_entry, num_test_nodes> const nodes = build_nodes();
+		lt::aux::array<node_entry, num_test_nodes> const nodes = build_nodes();
 
 		for (auto const& n : nodes)
 			t.dht_node.m_table.add_node(n);
@@ -2500,9 +2503,11 @@ TORRENT_TEST(mutable_put)
 		TEST_EQUAL(g_sent_packets.size(), 8);
 		if (g_sent_packets.size() != 8) break;
 
-		for (std::size_t i = 0; i < 8; ++i)
+		int idx = -1;
+		for (auto& node : nodes)
 		{
-			auto const packet = find_packet(nodes[i].ep());
+			++idx;
+			auto const packet = find_packet(node.ep());
 			TEST_CHECK(packet != g_sent_packets.end());
 			if (packet == g_sent_packets.end()) continue;
 
@@ -2516,22 +2521,24 @@ TORRENT_TEST(mutable_put)
 				continue;
 			}
 			char tok[10];
-			std::snprintf(tok, sizeof(tok), "%02d", int(i));
+			std::snprintf(tok, sizeof(tok), "%02d", idx);
 
 			msg_args args;
-			args.token(tok).port(1234).nid(nodes[i].id).nodes({nodes[i]});
-			send_dht_response(t.dht_node, response, nodes[i].ep(), args);
+			args.token(tok).port(1234).nid(node.id).nodes({node});
+			send_dht_response(t.dht_node, response, node.ep(), args);
 			g_sent_packets.erase(packet);
 		}
 
 		TEST_EQUAL(g_sent_packets.size(), 8);
 		if (g_sent_packets.size() != 8) break;
 
-		itemv = span<char const>(buffer, std::size_t(bencode(buffer, items[0].ent)));
+		itemv = span<char const>(buffer, bencode(buffer, items[0].ent));
 
-		for (int i = 0; i < 8; ++i)
+		idx = -1;
+		for (auto& node : nodes)
 		{
-			auto const packet = find_packet(nodes[std::size_t(i)].ep());
+			++idx;
+			auto const packet = find_packet(node.ep());
 			TEST_CHECK(packet != g_sent_packets.end());
 			if (packet == g_sent_packets.end()) continue;
 
@@ -2550,12 +2557,12 @@ TORRENT_TEST(mutable_put)
 				span<const char> const v = put_mutable_item_keys[10].data_section();
 				TEST_CHECK(v == itemv);
 				char tok[10];
-				std::snprintf(tok, sizeof(tok), "%02d", i);
+				std::snprintf(tok, sizeof(tok), "%02d", idx);
 				TEST_EQUAL(put_mutable_item_keys[9].string_value(), tok);
 				if (put_mutable_item_keys[0].string_value() != "q"
 					|| put_mutable_item_keys[2].string_value() != "put") continue;
 
-				if (i < loop) send_dht_response(t.dht_node, response, nodes[std::size_t(i)].ep());
+				if (idx < loop) send_dht_response(t.dht_node, response, node.ep());
 			}
 			else
 			{
@@ -2591,15 +2598,15 @@ TORRENT_TEST(traversal_done)
 	sha1_hash const target = hasher(pk.bytes).final();
 	constexpr int num_test_nodes = 9; // we need K + 1 nodes to create the failing sequence
 
-	std::array<node_entry, num_test_nodes> nodes = build_nodes(target);
+	lt::aux::array<node_entry, num_test_nodes> nodes = build_nodes(target);
 
 	// invert the ith most significant byte so that the test nodes are
 	// progressively closer to the target item
-	for (std::size_t i = 0; i < num_test_nodes; ++i)
+	for (int i = 0; i < num_test_nodes; ++i)
 		nodes[i].id[i] = ~nodes[i].id[i];
 
 	// add the first k nodes to the subject's routing table
-	for (std::size_t i = 0; i < 8; ++i)
+	for (int i = 0; i < 8; ++i)
 		t.dht_node.m_table.add_node(nodes[i]);
 
 	// kick off a mutable put request
@@ -2618,7 +2625,7 @@ TORRENT_TEST(traversal_done)
 		// get_item_cb
 		if (i == num_test_nodes) i = 0;
 
-		auto const packet = find_packet(nodes[std::size_t(i)].ep());
+		auto const packet = find_packet(nodes[i].ep());
 		TEST_CHECK(packet != g_sent_packets.end());
 		if (packet == g_sent_packets.end()) continue;
 
@@ -2635,13 +2642,13 @@ TORRENT_TEST(traversal_done)
 		std::snprintf(tok, sizeof(tok), "%02d", i);
 
 		msg_args args;
-		args.token(tok).port(1234).nid(nodes[std::size_t(i)].id);
+		args.token(tok).port(1234).nid(nodes[i].id);
 
 		// add the address of the closest node to the first response
 		if (i == 1)
 			args.nodes({nodes[8]});
 
-		send_dht_response(t.dht_node, response, nodes[std::size_t(i)].ep(), args);
+		send_dht_response(t.dht_node, response, nodes[i].ep(), args);
 		g_sent_packets.erase(packet);
 
 		// once we've sent the response from the farthest node, we're done

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -244,7 +244,7 @@ void send_bitfield(tcp::socket& s, char const* bits)
 		ptr[i/8] |= (bits[i] == '1' ? 1 : 0) << i % 8;
 	}
 	error_code ec;
-	boost::asio::write(s, boost::asio::buffer(msg.data(), msg.size())
+	boost::asio::write(s, boost::asio::buffer(msg.data(), std::size_t(msg.size()))
 		, boost::asio::transfer_all(), ec);
 	if (ec) TEST_ERROR(ec.message());
 }

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -318,7 +318,7 @@ TORRENT_TEST(file)
 	TEST_EQUAL(ec, error_code());
 	if (ec) std::printf("%s\n", ec.message().c_str());
 	char test[] = "test";
-	size_t const test_word_size = sizeof(test) - 1;
+	int const test_word_size = int(sizeof(test)) - 1;
 	iovec_t b = {test, test_word_size};
 	TEST_EQUAL(f.writev(0, b, ec), test_word_size);
 	if (ec)

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -52,9 +52,9 @@ void test_enc_handler(lt::crypto_plugin& a, lt::crypto_plugin& b)
 	int const repcount = 128;
 	for (int rep = 0; rep < repcount; ++rep)
 	{
-		std::size_t const buf_len = rand() % (512 * 1024);
-		std::vector<char> buf(buf_len);
-		std::vector<char> cmp_buf(buf_len);
+		std::ptrdiff_t const buf_len = rand() % (512 * 1024);
+		std::vector<char> buf(static_cast<std::size_t>(buf_len));
+		std::vector<char> cmp_buf(static_cast<std::size_t>(buf_len));
 
 		std::generate(buf.begin(), buf.end(), &std::rand);
 		std::copy(buf.begin(), buf.end(), cmp_buf.begin());

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -60,8 +60,8 @@ using namespace lt;
 
 namespace {
 
-constexpr std::size_t piece_size = 16 * 1024 * 16;
-constexpr std::size_t half = piece_size / 2;
+constexpr int piece_size = 16 * 1024 * 16;
+constexpr int half = piece_size / 2;
 
 void on_check_resume_data(status_t const status, storage_error const& error, bool* done)
 {
@@ -983,7 +983,7 @@ void alloc_iov(iovec_t* iov, int num_bufs)
 	for (int i = 0; i < num_bufs; ++i)
 	{
 		iov[i] = { new char[static_cast<std::size_t>(num_bufs * (i + 1))]
-			, static_cast<std::size_t>(num_bufs * (i + 1)) };
+			, num_bufs * (i + 1) };
 	}
 }
 
@@ -1081,7 +1081,7 @@ TORRENT_TEST(iovec_bufs_size)
 
 		int expected_size = 0;
 		for (int k = 0; k < i; ++k) expected_size += i * (k + 1);
-		TEST_EQUAL(bufs_size({iov, size_t(i)}), expected_size);
+		TEST_EQUAL(bufs_size({iov, i}), expected_size);
 
 		free_iov(iov, i);
 	}
@@ -1184,7 +1184,7 @@ struct test_read_fileop
 		while (local_size > 0)
 		{
 			int const len = std::min(int(bufs.front().size()), local_size);
-			auto local_buf = bufs.front().first(std::size_t(len));
+			auto local_buf = bufs.front().first(len);
 			for (char& v : local_buf)
 			{
 				v = char(m_counter & 0xff);
@@ -1250,14 +1250,14 @@ TORRENT_TEST(readwritev_stripe_1)
 	test_fileop fop(1);
 	storage_error ec;
 
-	TEST_CHECK(bufs_size({iov, size_t(num_bufs)}) >= fs.total_size());
+	TEST_CHECK(bufs_size({iov, num_bufs}) >= fs.total_size());
 
 	iovec_t iov2[num_bufs];
 	aux::copy_bufs(iov, int(fs.total_size()), iov2);
 	int num_bufs2 = count_bufs(iov2, int(fs.total_size()));
 	TEST_CHECK(num_bufs2 <= num_bufs);
 
-	int ret = readwritev(fs, {iov2, size_t(num_bufs2)}, piece_index_t(0), 0, ec
+	int ret = readwritev(fs, {iov2, num_bufs2}, piece_index_t(0), 0, ec
 		, std::ref(fop));
 
 	TEST_EQUAL(ret, fs.total_size());
@@ -1282,7 +1282,7 @@ TORRENT_TEST(readwritev_single_buffer)
 	storage_error ec;
 
 	std::vector<char> buf(size_t(fs.total_size()));
-	iovec_t iov = { &buf[0], buf.size() };
+	iovec_t iov = { &buf[0], int(buf.size()) };
 	fill_pattern(&iov, 1);
 
 	int ret = readwritev(fs, iov, piece_index_t(0), 0, ec, std::ref(fop));
@@ -1307,7 +1307,7 @@ TORRENT_TEST(readwritev_read)
 	storage_error ec;
 
 	std::vector<char> buf(size_t(fs.total_size()));
-	iovec_t iov = { &buf[0], buf.size() };
+	iovec_t iov = { &buf[0], int(buf.size()) };
 
 	// read everything
 	int ret = readwritev(fs, iov, piece_index_t(0), 0, ec, std::ref(fop));
@@ -1323,8 +1323,7 @@ TORRENT_TEST(readwritev_read_short)
 	storage_error ec;
 
 	std::vector<char> buf(size_t(fs.total_size()));
-	iovec_t iov = { &buf[0]
-		, static_cast<size_t>(fs.total_size()) };
+	iovec_t iov = { buf.data(), static_cast<std::ptrdiff_t>(fs.total_size()) };
 
 	// read everything
 	int ret = readwritev(fs, iov, piece_index_t(0), 0, ec, std::ref(fop));
@@ -1343,8 +1342,7 @@ TORRENT_TEST(readwritev_error)
 	storage_error ec;
 
 	std::vector<char> buf(size_t(fs.total_size()));
-	iovec_t iov = { &buf[0]
-		, static_cast<size_t>(fs.total_size()) };
+	iovec_t iov = { buf.data(), static_cast<std::ptrdiff_t>(fs.total_size()) };
 
 	// read everything
 	int ret = readwritev(fs, iov, piece_index_t(0), 0, ec, std::ref(fop));
@@ -1370,8 +1368,7 @@ TORRENT_TEST(readwritev_zero_size_files)
 	storage_error ec;
 
 	std::vector<char> buf(size_t(fs.total_size()));
-	iovec_t iov = { &buf[0]
-		, static_cast<size_t>(fs.total_size()) };
+	iovec_t iov = { buf.data(), static_cast<std::ptrdiff_t>(fs.total_size()) };
 
 	// read everything
 	int ret = readwritev(fs, iov, piece_index_t(0), 0, ec, std::ref(fop));

--- a/tools/dht_put.cpp
+++ b/tools/dht_put.cpp
@@ -345,7 +345,7 @@ int main(int argc, char* argv[])
 		--argc;
 		if (argc < 1) usage();
 
-		size_t len = strlen(argv[0]);
+		auto const len = static_cast<std::ptrdiff_t>(strlen(argv[0]));
 		if (len != 64)
 		{
 			std::fprintf(stderr, "public key is expected to be 64 hex digits\n");


### PR DESCRIPTION
instead of unsigned `std::size_t`. Specifically `std::ptrdiff_t`. In line with the direction of gsl span and reduce signed->unsigned casts.

This was prompted by the (WIP) [patch](https://github.com/qbittorrent/qBittorrent/pull/9704/files#diff-b369e532eff50253387c9d203da4b928R207) to bring qBT to be compatible with libtorrent-1.2 RC. Specifically, where indices into the counters array was changed from `int` to `std::size_t` to avoid a type conversion warning as the counters changed from a raw pointer to a `lt::span`.

There is some movement in the C++ community to try to fix the problem of all containers using unsigned `std::size_t` as size and index. Herb explains it quite thoroughly in this [PR against the core guidelines](https://github.com/isocpp/CppCoreGuidelines/pull/1115).

I subscribe to gabby's view, as he summarises [here](https://github.com/Microsoft/GSL/issues/171#issuecomment-156202752).

The GSL `span` has a `ptrdiff_t` index type (see [here](https://github.com/Microsoft/GSL/blob/master/include/gsl/span#L361)), and it has had it since 2016.

So, why are signed integers better than unsigned? I've covered this in a [lightning talk](https://www.youtube.com/watch?v=y_0KTXuSOJ4) a while ago, as well as [Jon Kalb's lightning talk from CPPCON](https://www.youtube.com/watch?v=wvtFGa6XJDU).

@aldenml since you did the bulk of the work to rid libtorrent of `-Wconversion` warnings, would you mind taking a look? Do you think this makes sense?

@zeule Since this would affect your patch for libtorrent-1.2, do you have an opinion?

The core changes are in `span.hpp` and `sha1_hash.hpp`.