### PR TITLE
some cleanup of memcmp()/memcpy()

### DIFF
--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -306,7 +306,6 @@ struct peer_conn
 			// unchoke
 			write_uint32(1, ptr);
 			write_uint8(1, ptr);
-			error_code ec;
 			boost::asio::async_write(s, boost::asio::buffer(write_buf_proto, ptr - write_buf_proto)
 				, std::bind(&peer_conn::on_have_all_sent, this, _1, _2));
 		}
@@ -322,7 +321,6 @@ struct peer_conn
 			// unchoke
 			write_uint32(1, ptr);
 			write_uint8(1, ptr);
-			error_code ec;
 			boost::asio::async_write(s, boost::asio::buffer((char*)buffer, len + 10)
 				, std::bind(&peer_conn::on_have_all_sent, this, _1, _2));
 		}
@@ -390,7 +388,6 @@ struct peer_conn
 		write_uint32(static_cast<int>(current_piece), ptr);
 		write_uint32(block * 16 * 1024, ptr);
 		write_uint32(16 * 1024, ptr);
-		error_code ec;
 		boost::asio::async_write(s, boost::asio::buffer(m, sizeof(msg) - 1)
 			, std::bind(&peer_conn::on_req_sent, this, m, _1, _2));
 

--- a/include/libtorrent/span.hpp
+++ b/include/libtorrent/span.hpp
@@ -162,6 +162,12 @@ namespace aux {
 			&& (lhs.begin() == rhs.begin() || std::equal(lhs.begin(), lhs.end(), rhs.begin()));
 	}
 
+	template <class T, class U>
+	inline bool operator!=(span<T> const& lhs, span<U> const& rhs)
+	{
+		return  lhs.size() != rhs.size()
+			|| (lhs.begin() != rhs.begin() && !std::equal(lhs.begin(), lhs.end(), rhs.begin()));
+	}
 }
 
 #endif // TORRENT_SPAN_HPP_INCLUDED

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -104,7 +104,6 @@ struct dht_node final : lt::dht::socket_manager
 			, *m_dht_storage)
 	{
 		m_dht_storage->update_node_ids({id_from_addr(m_io_service.get_ips().front())});
-		error_code ec;
 		sock().open(m_ipv6 ? asio::ip::udp::v6() : asio::ip::udp::v4());
 		sock().bind(asio::ip::udp::endpoint(
 			m_ipv6 ? lt::address(lt::address_v6::any()) : lt::address(lt::address_v4::any()), 6881));
@@ -161,8 +160,6 @@ struct dht_node final : lt::dht::socket_manager
 
 		send_buf.clear();
 		bencode(std::back_inserter(send_buf), e);
-		error_code ec;
-
 		sock().send_to(boost::asio::const_buffers_1(send_buf.data(), int(send_buf.size())), addr);
 		return true;
 	}

--- a/src/chained_buffer.cpp
+++ b/src/chained_buffer.cpp
@@ -33,7 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/chained_buffer.hpp"
 #include "libtorrent/assert.hpp"
 
-#include <cstring> // for memcpy
+#include <algorithm> // for copy
 
 namespace libtorrent {
 
@@ -90,7 +90,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(!m_destructed);
 		char* const insert = allocate_appendix(static_cast<int>(buf.size()));
 		if (insert == nullptr) return nullptr;
-		std::memcpy(insert, buf.data(), buf.size());
+		std::copy(buf.begin(), buf.end(), insert);
 		return insert;
 	}
 

--- a/src/kademlia/item.cpp
+++ b/src/kademlia/item.cpp
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdio> // for snprintf
 #include <cinttypes> // for PRId64 et.al.
-#include <cstring> // for memcpy
+#include <algorithm> // for copy
 
 #if TORRENT_USE_ASSERTS
 #include "libtorrent/bdecode.hpp"
@@ -66,13 +66,13 @@ namespace {
 		{
 			ptr += std::snprintf(ptr, left, "4:salt%d:", int(salt.size()));
 			left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
-			std::memcpy(ptr, salt.data(), std::min(salt.size(), left));
+			std::copy(salt.begin(), salt.begin() + std::min(salt.size(), left), ptr);
 			ptr += std::min(salt.size(), left);
 			left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
 		}
 		ptr += std::snprintf(ptr, left, "3:seqi%" PRId64 "e1:v", seq.value);
 		left = out.size() - aux::numeric_cast<std::size_t>(ptr - out.data());
-		std::memcpy(ptr, v.data(), std::min(v.size(), left));
+		std::copy(v.begin(), v.begin() + std::min(v.size(), left), ptr);
 		ptr += std::min(v.size(), left);
 		TORRENT_ASSERT((ptr - out.data()) <= int(out.size()));
 		return int(ptr - out.data());

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -82,7 +82,7 @@ namespace libtorrent { namespace aux {
 	void clear_bufs(span<iovec_t const> bufs)
 	{
 		for (auto buf : bufs)
-			std::memset(buf.data(), 0, buf.size());
+			std::fill(buf.begin(), buf.end(), 0);
 	}
 
 #if TORRENT_USE_ASSERTS

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -51,6 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/hex.hpp" // to_hex
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/path.hpp"
+#include "libtorrent/random.hpp"
 
 #include "test.hpp"
 #include "test_utils.hpp"
@@ -114,8 +115,7 @@ address rand_v4()
 sha1_hash rand_hash()
 {
 	sha1_hash ret;
-	for (int i = 0; i < 20; ++i)
-		ret[static_cast<std::size_t>(i)] = std::uint8_t(lt::random(0xff));
+	aux::random_bytes(ret);
 	return ret;
 }
 
@@ -668,7 +668,7 @@ void create_random_files(std::string const& path, span<const int> file_sizes
 	aux::vector<char> random_data(300000);
 	for (std::size_t i = 0; i != file_sizes.size(); ++i)
 	{
-		std::generate(random_data.begin(), random_data.end(), random_byte);
+		aux::random_bytes(random_data);
 		char filename[200];
 		std::snprintf(filename, sizeof(filename), "test%d", int(i));
 		char dirname[200];

--- a/test/test_bdecode.cpp
+++ b/test/test_bdecode.cpp
@@ -44,9 +44,7 @@ TORRENT_TEST(integer)
 	bdecode_node e = bdecode(b, ec);
 	TEST_CHECK(!ec);
 	std::printf("%s\n", print_entry(e).c_str());
-	span<const char> section = e.data_section();
-	TEST_CHECK(std::memcmp(b, section.data(), section.size()) == 0);
-	TEST_EQUAL(section.size(), sizeof(b) - 1);
+	TEST_CHECK(span<char>(b, sizeof(b) - 1) == e.data_section());
 	TEST_EQUAL(e.type(), bdecode_node::int_t);
 	TEST_EQUAL(e.int_value(), 12453);
 }
@@ -84,9 +82,7 @@ TORRENT_TEST(string)
 	bdecode_node e = bdecode(b, ec);
 	TEST_CHECK(!ec);
 	std::printf("%s\n", print_entry(e).c_str());
-	span<const char> section = e.data_section();
-	TEST_CHECK(std::memcmp(b, section.data(), section.size()) == 0);
-	TEST_EQUAL(section.size(), sizeof(b) - 1);
+	TEST_CHECK(span<char>(b, sizeof(b) - 1) == e.data_section());
 	TEST_EQUAL(e.type(), bdecode_node::string_t);
 	TEST_EQUAL(e.string_value(), std::string("abcdefghijklmnopqrstuvwxyz"));
 	TEST_EQUAL(e.string_length(), 26);
@@ -104,9 +100,7 @@ TORRENT_TEST(string_prefix1)
 	bdecode_node e = bdecode(test, ec);
 	TEST_CHECK(!ec);
 	std::printf("%d bytes string\n", e.string_length());
-	span<const char> section = e.data_section();
-	TEST_CHECK(std::memcmp(test.c_str(), section.data(), section.size()) == 0);
-	TEST_EQUAL(section.size(), test.size());
+	TEST_CHECK(span<char const>(test) == e.data_section());
 	TEST_EQUAL(e.type(), bdecode_node::string_t);
 	TEST_EQUAL(e.string_length(), 1000000);
 	TEST_EQUAL(e.string_ptr(), test.c_str() + 8);
@@ -120,9 +114,7 @@ TORRENT_TEST(list)
 	bdecode_node e = bdecode(b, ec);
 	TEST_CHECK(!ec);
 	std::printf("%s\n", print_entry(e).c_str());
-	span<const char> section = e.data_section();
-	TEST_CHECK(std::memcmp(b, section.data(), section.size()) == 0);
-	TEST_EQUAL(section.size(), sizeof(b) - 1);
+	TEST_CHECK(span<char>(b, sizeof(b) - 1) == e.data_section());
 	TEST_EQUAL(e.type(), bdecode_node::list_t);
 	TEST_EQUAL(e.list_size(), 2);
 	TEST_EQUAL(e.list_at(0).type(), bdecode_node::int_t);
@@ -130,9 +122,7 @@ TORRENT_TEST(list)
 	TEST_EQUAL(e.list_at(0).int_value(), 12453);
 	TEST_EQUAL(e.list_at(1).string_value(), std::string("aaa"));
 	TEST_EQUAL(e.list_at(1).string_length(), 3);
-	section = e.list_at(1).data_section();
-	TEST_CHECK(std::memcmp("3:aaa", section.data(), section.size()) == 0);
-	TEST_EQUAL(section.size(), 5);
+	TEST_CHECK(span<char const>("3:aaa", 5) == e.list_at(1).data_section());
 }
 
 // test dict
@@ -143,9 +133,7 @@ TORRENT_TEST(dict)
 	bdecode_node e = bdecode(b, ec);
 	TEST_CHECK(!ec);
 	std::printf("%s\n", print_entry(e).c_str());
-	span<const char> section = e.data_section();
-	TEST_CHECK(std::memcmp(b, section.data(), section.size()) == 0);
-	TEST_EQUAL(section.size(), sizeof(b) - 1);
+	TEST_CHECK(span<char>(b, sizeof(b) - 1) == e.data_section());
 	TEST_EQUAL(e.type(), bdecode_node::dict_t);
 	TEST_EQUAL(e.dict_size(), 4);
 	TEST_EQUAL(e.dict_find("a").type(), bdecode_node::int_t);

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -57,7 +57,7 @@ int touch_file(std::string const& filename, int size)
 	error_code ec;
 	if (!f.open(filename, open_mode::write_only, ec)) return -1;
 	if (ec) return -1;
-	iovec_t b = {&v[0], v.size()};
+	iovec_t b = {v};
 	std::int64_t written = f.writev(0, b, ec);
 	if (written != int(v.size())) return -3;
 	if (ec) return -3;

--- a/test/test_hasher.cpp
+++ b/test/test_hasher.cpp
@@ -71,7 +71,7 @@ void test_vector(std::string s, std::string output, int const n = 1)
 	TEST_EQUAL(digest_hex, output);
 
 	std::string output_hex = digest_hex;
-	aux::to_hex(digest.c_str(), digest.size(), &output_hex[0]);
+	aux::to_hex(digest, &output_hex[0]);
 
 	TEST_EQUAL(output_hex, digest_hex);
 }

--- a/test/test_http_connection.cpp
+++ b/test/test_http_connection.cpp
@@ -91,7 +91,7 @@ void http_handler_test(error_code const& ec, http_parser const& parser
 		http_status = parser.status_code();
 		if (http_status == 200)
 		{
-			TEST_CHECK(memcmp(data.data(), data_buffer, data.size()) == 0);
+			TEST_CHECK(span<char>(data_buffer, data.size()) == data);
 		}
 	}
 	print_http_header(parser);

--- a/test/test_http_parser.cpp
+++ b/test/test_http_parser.cpp
@@ -523,7 +523,7 @@ TORRENT_TEST(chunked_encoding)
 
 	char mutable_buffer[100];
 	span<char const> body = parser.get_body();
-	memcpy(mutable_buffer, body.begin(), body.size());
+	std::copy(body.begin(), body.end(), mutable_buffer);
 	body = parser.collapse_chunk_headers({mutable_buffer, body.size()});
 
 	TEST_CHECK(body == span<char const>("test12340123456789abcdef", 24));

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -62,7 +62,7 @@ void test_enc_handler(lt::crypto_plugin& a, lt::crypto_plugin& b)
 		using namespace lt::aux;
 
 		{
-			lt::span<char> iovec(&buf[0], buf_len);
+			lt::span<char> iovec(buf.data(), buf_len);
 			int next_barrier;
 			lt::span<lt::span<char const>> iovec_out;
 			std::tie(next_barrier, iovec_out) = a.encrypt(iovec);
@@ -75,7 +75,7 @@ void test_enc_handler(lt::crypto_plugin& a, lt::crypto_plugin& b)
 			int consume = 0;
 			int produce = 0;
 			int packet_size = 0;
-			lt::span<char> iovec(&buf[0], buf_len);
+			lt::span<char> iovec(buf.data(), buf_len);
 			std::tie(consume, produce, packet_size) = b.decrypt(iovec);
 			TEST_CHECK(buf == cmp_buf);
 			TEST_EQUAL(consume, 0);
@@ -84,7 +84,7 @@ void test_enc_handler(lt::crypto_plugin& a, lt::crypto_plugin& b)
 		}
 
 		{
-			lt::span<char> iovec(&buf[0], buf_len);
+			lt::span<char> iovec(buf.data(), buf_len);
 			int next_barrier;
 			lt::span<lt::span<char const>> iovec_out;
 			std::tie(next_barrier, iovec_out) = b.encrypt(iovec);
@@ -95,7 +95,7 @@ void test_enc_handler(lt::crypto_plugin& a, lt::crypto_plugin& b)
 			int consume = 0;
 			int produce = 0;
 			int packet_size = 0;
-			lt::span<char> iovec2(&buf[0], buf_len);
+			lt::span<char> iovec2(buf.data(), buf_len);
 			std::tie(consume, produce, packet_size) = a.decrypt(iovec2);
 			TEST_CHECK(buf == cmp_buf);
 			TEST_EQUAL(consume, 0);


### PR DESCRIPTION
by turning them into span comparisons and std::copy(). also some more use of random_bytes() instead of loops.