### PR TITLE
remove w3 compiler flag in cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,7 +462,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES GNU)
 		-Wno-format-zero-length
 		-ftemplate-depth=512)
 elseif(MSVC)
-	add_compile_options(
+    # remove default warning level from CMAKE_CXX_FLAGS
+    string (REGEX REPLACE " +/(W|w)[0-4] +" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    add_compile_options(
 		/W4
 		# C4251: 'identifier' : class 'type' needs to have dll-interface to be
 		#        used by clients of class 'type2'


### PR DESCRIPTION
In cmake is added `/W4` compilation option, so `/W3` and `/W4` are defined at once in CMAKE_CXX_FLAGS, `/W3` is defined by default.

Because of that, every compilation command generates warning:
```
[1/158 0.7/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\entry.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[2/158 0.7/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\disk_buffer_holder.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[3/158 1.0/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\chained_buffer.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[4/158 0.7/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\generate_peer_id.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[5/158 0.8/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\block_cache.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[6/158 0.9/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\lazy_bdecode.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[7/158 1.0/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\choker.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[8/158 1.1/sec] Building CXX object CMakeFiles\torrent-rasterbar.dir\src\web_connection_base.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
```

This PR removes this warnings.