### PR TITLE
add rvalue reference overloads for add_torrent_params, settings_pack and session_params

### DIFF
--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -979,8 +979,8 @@ void bind_session()
 #endif // TORRENT_DISABLE_DHT
         .def("add_torrent", &add_torrent)
         .def("async_add_torrent", &async_add_torrent)
-        .def("async_add_torrent", &lt::session::async_add_torrent)
-        .def("add_torrent", allow_threads((lt::torrent_handle (session_handle::*)(add_torrent_params const&))&lt::session::add_torrent))
+        .def("async_add_torrent", static_cast<void (session_handle::*)(lt::add_torrent_params const&)>(&lt::session::async_add_torrent))
+        .def("add_torrent", allow_threads(static_cast<lt::torrent_handle (session_handle::*)(add_torrent_params const&)>(&lt::session::add_torrent)))
 #ifndef BOOST_NO_EXCEPTIONS
 #if TORRENT_ABI_VERSION == 1
         .def(

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -395,7 +395,11 @@ namespace aux {
 			void add_dht_router(std::pair<std::string, int> const& node);
 			void set_dht_settings(dht::dht_settings const& s);
 			dht::dht_settings const& get_dht_settings() const { return m_dht_settings; }
-			void set_dht_state(dht::dht_state state);
+
+			// you must give up ownership of the dht state
+			void set_dht_state(dht::dht_state&& state);
+			void set_dht_state(dht::dht_state const& state) = delete;
+
 			void set_dht_storage(dht::dht_storage_constructor_type sc);
 			void start_dht();
 			void stop_dht();

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -72,7 +72,16 @@ namespace libtorrent { namespace dht {
 			, dht_settings const& settings
 			, counters& cnt
 			, dht_storage_interface& storage
-			, dht_state state);
+			, dht_state&& state);
+
+		// the dht_state must be moved in!
+		dht_tracker(dht_observer* observer
+			, io_service& ios
+			, send_fun_t const& send_fun
+			, dht_settings const& settings
+			, counters& cnt
+			, dht_storage_interface& storage
+			, dht_state const& state) = delete;
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 		// workaround for a bug in msvc 14.0

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -215,7 +215,8 @@ namespace libtorrent {
 		torrent_handle add_torrent(add_torrent_params const& params);
 #endif
 		torrent_handle add_torrent(add_torrent_params const& params, error_code& ec);
-		void async_add_torrent(add_torrent_params params);
+		void async_add_torrent(add_torrent_params&& params);
+		void async_add_torrent(add_torrent_params const& params);
 
 #ifndef BOOST_NO_EXCEPTIONS
 #if TORRENT_ABI_VERSION == 1

--- a/simulation/test_dht_rate_limit.cpp
+++ b/simulation/test_dht_rate_limit.cpp
@@ -124,7 +124,7 @@ TORRENT_TEST(dht_rate_limit)
 	std::unique_ptr<lt::dht::dht_storage_interface> dht_storage(dht::dht_default_storage_constructor(dhtsett));
 	auto dht = std::make_shared<lt::dht::dht_tracker>(
 		&o, dht_ios, std::bind(&send_packet, std::ref(sock), _1, _2, _3, _4, _5)
-		, dhtsett, cnt, *dht_storage, state);
+		, dhtsett, cnt, *dht_storage, std::move(state));
 	dht->new_socket(ls);
 
 	bool stop = false;
@@ -245,7 +245,7 @@ TORRENT_TEST(dht_delete_socket)
 	std::unique_ptr<lt::dht::dht_storage_interface> dht_storage(dht::dht_default_storage_constructor(dhtsett));
 	auto dht = std::make_shared<lt::dht::dht_tracker>(
 		&o, dht_ios, std::bind(&send_packet, std::ref(sock), _1, _2, _3, _4, _5)
-		, dhtsett, cnt, *dht_storage, state);
+		, dhtsett, cnt, *dht_storage, std::move(state));
 
 	dht->start([](std::vector<std::pair<dht::node_entry, std::string>> const&){});
 	dht->new_socket(ls);

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -88,7 +88,7 @@ namespace libtorrent { namespace dht {
 		, dht_settings const& settings
 		, counters& cnt
 		, dht_storage_interface& storage
-		, dht_state state)
+		, dht_state&& state)
 		: m_counters(cnt)
 		, m_storage(storage)
 		, m_state(std::move(state))

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -393,7 +393,12 @@ namespace {
 		return sync_call_ret<torrent_handle>(&session_impl::add_torrent, p, ecr);
 	}
 
-	void session_handle::async_add_torrent(add_torrent_params params)
+	void session_handle::async_add_torrent(add_torrent_params const& params)
+	{
+		async_add_torrent(add_torrent_params(params));
+	}
+
+	void session_handle::async_add_torrent(add_torrent_params&& params)
 	{
 		TORRENT_ASSERT_PRECOND(!params.save_path.empty());
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5860,7 +5860,7 @@ namespace aux {
 		m_dht_settings = settings;
 	}
 
-	void session_impl::set_dht_state(dht::dht_state state)
+	void session_impl::set_dht_state(dht::dht_state&& state)
 	{
 		m_dht_state = std::move(state);
 	}


### PR DESCRIPTION
Those structures are pretty large so being able to take them by rvalue reference may be beneficial