### PR TITLE
require tracker_request objects be moved into queue_manager. also rep…

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -476,7 +476,7 @@ namespace aux {
 			port_filter const& get_port_filter() const override;
 			void ban_ip(address addr) override;
 
-			void queue_tracker_request(tracker_request& req
+			void queue_tracker_request(tracker_request&& req
 				, std::weak_ptr<request_callback> c) override;
 
 			// ==== peer class operations ====

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -233,8 +233,11 @@ namespace aux {
 		virtual void apply_settings_pack(std::shared_ptr<settings_pack> pack) = 0;
 		virtual session_settings const& settings() const = 0;
 
-		virtual void queue_tracker_request(tracker_request& req
+		// the tracker request object must be moved in
+		virtual void queue_tracker_request(tracker_request&& req
 			, std::weak_ptr<request_callback> c) = 0;
+		void queue_tracker_request(tracker_request const& req
+			, std::weak_ptr<request_callback> c) = delete;
 
 		// peer-classes
 		virtual void set_peer_classes(peer_class_set* s, address const& a, int st) = 0;

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -357,9 +357,14 @@ namespace libtorrent {
 
 		void queue_request(
 			io_service& ios
-			, tracker_request r
+			, tracker_request&& r
 			, std::weak_ptr<request_callback> c
 				= std::weak_ptr<request_callback>());
+		void queue_request(
+			io_service& ios
+			, tracker_request const& r
+			, std::weak_ptr<request_callback> c
+				= std::weak_ptr<request_callback>()) = delete;
 		void abort_all_requests(bool all = false);
 
 		void remove_request(http_tracker_connection const* c);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2919,12 +2919,12 @@ bool is_downloading_state(int const st)
 				if (m_abort && m_ses.should_log())
 				{
 					auto tl = std::make_shared<aux::tracker_logger>(m_ses);
-					m_ses.queue_tracker_request(req, tl);
+					m_ses.queue_tracker_request(tracker_request(req), tl);
 				}
 				else
 #endif
 				{
-					m_ses.queue_tracker_request(req, shared_from_this());
+					m_ses.queue_tracker_request(tracker_request(req), shared_from_this());
 				}
 
 				aep.updating = true;
@@ -2979,7 +2979,7 @@ bool is_downloading_state(int const st)
 #endif
 		req.key = tracker_key();
 		req.triggered_manually = user_triggered;
-		m_ses.queue_tracker_request(req, shared_from_this());
+		m_ses.queue_tracker_request(std::move(req), shared_from_this());
 	}
 
 	void torrent::tracker_warning(tracker_request const& req, std::string const& msg)


### PR DESCRIPTION
…lace non-const reference parameter with rvalue reference