### PR TITLE
pass add_torrent_params by const reference in deprecated add_magnet_uri functions

### DIFF
--- a/include/libtorrent/magnet_uri.hpp
+++ b/include/libtorrent/magnet_uri.hpp
@@ -66,13 +66,13 @@ namespace libtorrent {
 	// deprecated in 0.16. Instead, pass in the magnet link as add_torrent_params::url
 	TORRENT_DEPRECATED_EXPORT
 	torrent_handle add_magnet_uri(session& ses, std::string const& uri
-		, add_torrent_params p);
+		, add_torrent_params const& p);
 #endif
 
 	// deprecated in 0.16. Instead, pass in the magnet link as add_torrent_params::url
 	TORRENT_DEPRECATED_EXPORT
 	torrent_handle add_magnet_uri(session& ses, std::string const& uri
-		, add_torrent_params p, error_code& ec);
+		, add_torrent_params const& p, error_code& ec);
 #endif // TORRENT_ABI_VERSION
 
 

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -109,18 +109,19 @@ namespace libtorrent {
 
 	namespace {
 		torrent_handle add_magnet_uri_deprecated(session& ses, std::string const& uri
-			, add_torrent_params p, error_code& ec)
+			, add_torrent_params const& p, error_code& ec)
 		{
-			parse_magnet_uri(uri, p, ec);
+			add_torrent_params params(p);
+			parse_magnet_uri(uri, params, ec);
 			if (ec) return torrent_handle();
-			return ses.add_torrent(std::move(p), ec);
+			return ses.add_torrent(std::move(params), ec);
 		}
 	}
 
 	torrent_handle add_magnet_uri(session& ses, std::string const& uri
-		, add_torrent_params p, error_code& ec)
+		, add_torrent_params const& p, error_code& ec)
 	{
-		return add_magnet_uri_deprecated(ses, uri, std::move(p), ec);
+		return add_magnet_uri_deprecated(ses, uri, p, ec);
 	}
 
 #ifndef BOOST_NO_EXCEPTIONS
@@ -145,10 +146,10 @@ namespace libtorrent {
 	}
 
 	torrent_handle add_magnet_uri(session& ses, std::string const& uri
-		, add_torrent_params p)
+		, add_torrent_params const& p)
 	{
 		error_code ec;
-		torrent_handle ret = add_magnet_uri_deprecated(ses, uri, std::move(p), ec);
+		torrent_handle ret = add_magnet_uri_deprecated(ses, uri, p, ec);
 		if (ec) aux::throw_ex<system_error>(ec);
 		return ret;
 	}


### PR DESCRIPTION
They are large to copy but since they're deprecated aren't worth the trouble of having an rvalue reference overload