### PR TITLE
fix misplaced TORRENT_EXPORT

### DIFF
--- a/include/libtorrent/bdecode.hpp
+++ b/include/libtorrent/bdecode.hpp
@@ -101,7 +101,7 @@ namespace libtorrent {
 TORRENT_EXPORT boost::system::error_category& bdecode_category();
 
 #ifndef TORRENT_NO_DEPRECATED
-TORRENT_DEPRECATED TORRENT_EXPORT
+TORRENT_DEPRECATED_EXPORT
 boost::system::error_category& get_bdecode_category();
 #endif
 

--- a/include/libtorrent/magnet_uri.hpp
+++ b/include/libtorrent/magnet_uri.hpp
@@ -77,8 +77,8 @@ namespace libtorrent
 
 	// This function parses out information from the magnet link and populates the
 	// add_torrent_params object.
-	TORRENT_EXPORT
-	void parse_magnet_uri(std::string const& uri, add_torrent_params& p, error_code& ec);
+	TORRENT_EXPORT void parse_magnet_uri(std::string const& uri
+		, add_torrent_params& p, error_code& ec);
 
 	// internal, delete when merge in master
 	TORRENT_EXTRA_EXPORT

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -97,7 +97,7 @@ namespace libtorrent
 	TORRENT_EXPORT boost::system::error_category& upnp_category();
 
 #ifndef TORRENT_NO_DEPRECATED
-	TORRENT_DEPRECATED TORRENT_EXPORT
+	TORRENT_DEPRECATED_EXPORT
 	boost::system::error_category& get_upnp_category();
 #endif
 


### PR DESCRIPTION
detect cases where TORRENT_EXPORT is placed where gen_reference_doc.py ignores it, and fix the code