### PR TITLE
Fix setting ipv6 interface

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2055,7 +2055,7 @@ retry:
 			// used to send to the tracker
 			std::vector<ip_interface> ifs = enum_net_interfaces(m_io_service, ec);
 			for (std::vector<ip_interface>::const_iterator i = ifs.begin()
-					, end(ifs.end()); i != end && (want_v4 && want_v6); ++i)
+					, end(ifs.end()); i != end && (want_v4 || want_v6); ++i)
 			{
 				address const& addr = i->interface_address;
 				if (want_v4 && addr.is_v4() && !is_local(addr) && !is_loopback(addr))


### PR DESCRIPTION
The loop stops once we set an ipv4 interface or an ipv6 interface (depends on the sequence of interfaces), leaving the other interface unset. If it results in empty ipv6 interface, then in `http_tracker_connection.cpp` we will fail to include `&ipv6=` segment to private trackers. That's why people reported failure to announce ipv6 address.

I would also advise to revert some previous changes about ipv6 announcement. Since with this fix, if a tracker is accessible via ipv4 and ipv6 at the same time, currently we will announce twice to it via ipv4 and ipv6 respectively. Then in the ipv6 one, the tracker will fail to obtain the ipv4 address. This is especially unexpected by private trackers.