### PR TITLE
add rvalue ref overload of apply_settings()

### DIFF
--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -788,7 +788,8 @@ namespace libtorrent {
 		// Applies the settings specified by the settings_pack ``s``. This is an
 		// asynchronous operation that will return immediately and actually apply
 		// the settings to the main thread of libtorrent some time later.
-		void apply_settings(settings_pack s);
+		void apply_settings(settings_pack const& s);
+		void apply_settings(settings_pack&& s);
 		settings_pack get_settings() const;
 
 #if TORRENT_ABI_VERSION == 1

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -949,7 +949,23 @@ namespace {
 	}
 #endif
 
-	void session_handle::apply_settings(settings_pack s)
+	void session_handle::apply_settings(settings_pack const& s)
+	{
+		TORRENT_ASSERT_PRECOND(!s.has_val(settings_pack::out_enc_policy)
+			|| s.get_int(settings_pack::out_enc_policy)
+				<= settings_pack::pe_disabled);
+		TORRENT_ASSERT_PRECOND(!s.has_val(settings_pack::in_enc_policy)
+			|| s.get_int(settings_pack::in_enc_policy)
+				<= settings_pack::pe_disabled);
+		TORRENT_ASSERT_PRECOND(!s.has_val(settings_pack::allowed_enc_level)
+			|| s.get_int(settings_pack::allowed_enc_level)
+				<= settings_pack::pe_both);
+
+		auto copy = std::make_shared<settings_pack>(s);
+		async_call(&session_impl::apply_settings_pack, copy);
+	}
+
+	void session_handle::apply_settings(settings_pack&& s)
 	{
 		TORRENT_ASSERT_PRECOND(!s.has_val(settings_pack::out_enc_policy)
 			|| s.get_int(settings_pack::out_enc_policy)


### PR DESCRIPTION
to avoid copying the whole settings_pack object