### PR TITLE
Fix redundant bytes overflow

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1429,7 +1429,7 @@ namespace libtorrent
 		// the number of bytes that has been
 		// downloaded that failed the hash-test
 		boost::uint32_t m_total_failed_bytes;
-		boost::uint32_t m_total_redundant_bytes;
+		boost::uint64_t m_total_redundant_bytes;
 
 		// the sequence number for this torrent, this is a
 		// monotonically increasing number for each added torrent


### PR DESCRIPTION
`uint32_t` = 4GB is too small for redundant bytes if people disable `strict_end_game_mode` on seedboxes. Every time `m_total_redundant_bytes` overflows 4GB,  it is reset to 0, which results in incorrectly reported download bytes.
<https://github.com/arvidn/libtorrent/blob/6381b35891f7fce1c71a798eaae4eb3172f569f4/src/torrent.cpp#L3219-L3222>