### PR TITLE
deprecated old and slow versions of bdecode()

### DIFF
--- a/bindings/python/src/utility.cpp
+++ b/bindings/python/src/utility.cpp
@@ -5,6 +5,7 @@
 #include "boost_python.hpp"
 #include <libtorrent/identify_client.hpp>
 #include <libtorrent/bencode.hpp>
+#include <libtorrent/bdecode.hpp>
 #include "bytes.hpp"
 
 using namespace boost::python;
@@ -74,7 +75,7 @@ object client_fingerprint_(peer_id const& id)
 
 entry bdecode_(bytes const& data)
 {
-    return bdecode(data.arr.begin(), data.arr.end());
+    return bdecode(data.arr);
 }
 
 bytes bencode_(entry const& e)

--- a/src/kademlia/item.cpp
+++ b/src/kademlia/item.cpp
@@ -162,10 +162,10 @@ void item::assign(entry v)
 void item::assign(entry v, span<char const> salt
 	, sequence_number const seq, public_key const& pk, secret_key const& sk)
 {
-	char buffer[1000];
-	int bsize = bencode(buffer, v);
+	std::array<char, 1000> buffer;
+	int const bsize = bencode(buffer.begin(), v);
 	TORRENT_ASSERT(bsize <= 1000);
-	m_sig = sign_mutable_item({buffer, bsize}
+	m_sig = sign_mutable_item(span<char const>(buffer).first(bsize)
 		, salt, seq, pk, sk);
 	m_salt.assign(salt.data(), static_cast<std::size_t>(salt.size()));
 	m_pk = pk;

--- a/test/dht_server.cpp
+++ b/test/dht_server.cpp
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/socket.hpp"
 #include "libtorrent/aux_/time.hpp"
+#include "libtorrent/bdecode.hpp"
 #include "dht_server.hpp"
 #include "test_utils.hpp"
 
@@ -114,7 +115,7 @@ struct dht_server
 
 	void thread_fun()
 	{
-		char buffer[2000];
+		std::array<char, 2000> buffer;
 
 		for (;;)
 		{
@@ -123,7 +124,7 @@ struct dht_server
 			size_t bytes_transferred;
 			bool done = false;
 			m_socket.async_receive_from(
-				boost::asio::buffer(buffer, sizeof(buffer)), from, 0
+				boost::asio::buffer(buffer.data(), buffer.size()), from, 0
 				, std::bind(&incoming_packet, _1, _2, &bytes_transferred, &ec, &done));
 			while (!done)
 			{
@@ -142,7 +143,7 @@ struct dht_server
 
 			try
 			{
-				entry msg = bdecode(buffer, buffer + bytes_transferred);
+				entry msg = bdecode(span<char const>(buffer).first(int(bytes_transferred)));
 
 #if TORRENT_USE_IOSTREAM
 				std::cout << msg << std::endl;


### PR DESCRIPTION
with the previous improved interoperability with `bdecode_node` the new and fast decoder can be used instead.