### PR TITLE
attempt to fix an assert for a newly connected peer

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1867,7 +1867,7 @@ namespace libtorrent {
 		if (!t->valid_metadata() && index >= m_have_piece.end_index())
 		{
 			// TODO: 3 replace this magic number with something that makes sense
-			if (index < piece_index_t(131072))
+			if (index < piece_index_t(524288))
 			{
 				// if we don't have metadata
 				// and we might not have received a bitfield

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1259,6 +1259,7 @@ bool is_downloading_state(int const st)
 		for (auto const p : m_connections)
 		{
 			TORRENT_INCREMENT(m_iterating_connections);
+			if (p->is_disconnecting()) continue;
 			peer_has(p->get_bitfield(), p);
 		}
 	}


### PR DESCRIPTION
that disconnects just as we receive the metadata. disconnecting peers don't have their bitfield properly initialized, so we can't use it