### PR TITLE
fix assertion when sending a udp packet to a closed socket

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2306,7 +2306,7 @@ namespace aux {
 
 		auto s = std::static_pointer_cast<session_udp_socket>(si);
 
-		TORRENT_ASSERT(s->sock.local_endpoint().protocol() == ep.protocol());
+		TORRENT_ASSERT(s->sock.is_closed() || s->sock.local_endpoint().protocol() == ep.protocol());
 
 		s->sock.send(ep, p, ec, flags);
 


### PR DESCRIPTION
This can happen particularly during shutdown. We should eventually get to a
point where this doesn't happen, but since we close the sockets immediately
upon initiating shutdown it's hard to avoid for now.