### PR TITLE
 Change Jamfile default openssl path on Windows 

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -359,20 +359,13 @@ rule openssl-lib-path ( properties * )
 		# brew install openssl
 		OPENSSL_LIB = /usr/local/opt/openssl/lib ;
 	}
-	else if <target-os>windows in $(properties)
-		&& <toolset>gcc in $(properties)
-		&& $(OPENSSL_LIB) = ""
-	{
-		# on mingw, assume openssl is installed in c:\OpenSSL-Win32 by default
-		OPENSSL_LIB = c:\\OpenSSL-Win32\\lib ;
-	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_LIB) = ""
 	{
-		# on windows, just assume openssl is installed to c:\openssl
+		# on windows, assume openssl is installed to c:\OpenSSL-Win32
 		if <address-model>64 in $(properties)
-		{ OPENSSL_LIB = c:\\openssl\\lib64 ; }
+		{ OPENSSL_LIB = c:\\OpenSSL-Win64\\lib ; }
 		else
-		{ OPENSSL_LIB = c:\\openssl\\lib ; }
+		{ OPENSSL_LIB = c:\\OpenSSL-Win32\\lib ; }
 	}
 
 	local result ;
@@ -392,21 +385,13 @@ rule openssl-include-path ( properties * )
 		# brew install openssl
 		OPENSSL_INCLUDE = /usr/local/opt/openssl/include ;
 	}
-	else if <target-os>windows in $(properties)
-		&& <toolset>gcc in $(properties)
-		&& $(OPENSSL_INCLUDE) = ""
-	{
-		# on mingw, assume openssl is installed in c:\OpenSSL-Win32 by default
-		OPENSSL_INCLUDE = c:\\OpenSSL-Win32\\include ;
-	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_INCLUDE) = ""
 	{
-		# on windows, just assume openssl is installed to c:\openssl
-		# not sure if there's a better way to find out where it may be
+		# on windows, assume openssl is installed to c:\OpenSSL-Win32
 		if <address-model>64 in $(properties)
-		{ OPENSSL_INCLUDE = c:\\openssl\\include64 ; }
+		{ OPENSSL_INCLUDE = c:\\OpenSSL-Win64\\include ; }
 		else
-		{ OPENSSL_INCLUDE = c:\\openssl\\include ; }
+		{ OPENSSL_INCLUDE = c:\\OpenSSL-Win32\\include ; }
 	}
 
 	local result ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,19 +37,6 @@ install:
   - if not defined crypto ( set crypto=built-in )
   - if not defined linkflags ( set linkflags="" )
   - if not defined include ( set include="" )
-  - if %compiler% == msvc-14.0 if defined crypto if not exist openssl-1.0.1p-vs2015.7z (
-    echo downloading openssl-2015
-    & appveyor DownloadFile "https://www.npcglib.org/~stathis/downloads/openssl-1.0.1p-vs2015.7z"
-    )
-  - if %compiler% == msvc-14.0 if defined crypto (
-    echo extracting openssl-2015
-    & 7z x -oc:\ -aoa openssl-1.0.1p-vs2015.7z > nul
-    & rename c:\openssl-1.0.1p-vs2015 openssl
-    & copy c:\openssl\lib64\ssleay32MT.lib c:\openssl\lib64\ssleay32.lib
-    & copy c:\openssl\lib64\libeay32MT.lib c:\openssl\lib64\libeay32.lib
-    & copy c:\openssl\lib\ssleay32MT.lib c:\openssl\lib\ssleay32.lib
-    & copy c:\openssl\lib\libeay32MT.lib c:\openssl\lib\libeay32.lib
-    )
   - cd %ROOT_DIRECTORY%
   - set BOOST_ROOT=c:\Libraries\boost_1_63_0
   - set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
@@ -66,9 +53,6 @@ install:
   - cd %BOOST_BUILD_PATH%\src\engine
   - build.bat >nul
   - cd %ROOT_DIRECTORY%
-
-cache:
-  - openssl-1.0.1p-vs2015.7z
 
 build_script:
   # examples

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,47 +1,47 @@
 version: "{build}"
 branches:
   only:
-  - master
-  - RC_1_1
-  - RC_1_0
+    - master
+    - RC_1_1
+    - RC_1_0
 os: Visual Studio 2015
 clone_depth: 1
 environment:
   matrix:
-  - cmake: 1
-  - variant: test_debug
-    compiler: msvc-14.0
-    model: 64
-    sim: 1
-  - variant: test_debug
-    compiler: msvc-14.0
-    model: 32
-    bjam: 1
-  - variant: test_release
-    compiler: msvc-14.0
-    model: 64
-    python: 1
-    crypto: openssl
-    bjam: 1
-  - variant: test_debug
-    compiler: gcc
-    model: 32
-    crypto: openssl
-    bjam: 1
+    - cmake: 1
+    - variant: test_debug
+      compiler: msvc-14.0
+      model: 64
+      sim: 1
+    - variant: test_debug
+      compiler: msvc-14.0
+      model: 32
+      bjam: 1
+    - variant: test_release
+      compiler: msvc-14.0
+      model: 64
+      python: 1
+      crypto: openssl
+      bjam: 1
+    - variant: test_debug
+      compiler: gcc
+      model: 32
+      crypto: openssl
+      bjam: 1
 
 install:
-- git submodule update --init --recursive
-- set ROOT_DIRECTORY=%CD%
-- cd %ROOT_DIRECTORY%
-- if not defined compiler ( set compiler="" )
-- if not defined crypto ( set crypto=built-in )
-- if not defined linkflags ( set linkflags="" )
-- if not defined include ( set include="" )
-- if %compiler% == msvc-14.0 if defined crypto if not exist openssl-1.0.1p-vs2015.7z (
+  - git submodule update --init --recursive
+  - set ROOT_DIRECTORY=%CD%
+  - cd %ROOT_DIRECTORY%
+  - if not defined compiler ( set compiler="" )
+  - if not defined crypto ( set crypto=built-in )
+  - if not defined linkflags ( set linkflags="" )
+  - if not defined include ( set include="" )
+  - if %compiler% == msvc-14.0 if defined crypto if not exist openssl-1.0.1p-vs2015.7z (
     echo downloading openssl-2015
     & appveyor DownloadFile "https://www.npcglib.org/~stathis/downloads/openssl-1.0.1p-vs2015.7z"
-  )
-- if %compiler% == msvc-14.0 if defined crypto (
+    )
+  - if %compiler% == msvc-14.0 if defined crypto (
     echo extracting openssl-2015
     & 7z x -oc:\ -aoa openssl-1.0.1p-vs2015.7z > nul
     & rename c:\openssl-1.0.1p-vs2015 openssl
@@ -49,94 +49,93 @@ install:
     & copy c:\openssl\lib64\libeay32MT.lib c:\openssl\lib64\libeay32.lib
     & copy c:\openssl\lib\ssleay32MT.lib c:\openssl\lib\ssleay32.lib
     & copy c:\openssl\lib\libeay32MT.lib c:\openssl\lib\libeay32.lib
-  )
-- cd %ROOT_DIRECTORY%
-- set BOOST_ROOT=c:\Libraries\boost_1_63_0
-- set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
-- echo %BOOST_ROOT%
-- echo %BOOST_BUILD_PATH%
-- set PATH=%PATH%;%BOOST_BUILD_PATH%\src\engine\bin.ntx86
-- ps: '"using msvc : 14.0 ;`nusing gcc : : : <cxxflags>-std=c++11 ;`nusing python : 3.5 : c:\\Python35-x64 : c:\\Python35-x64\\include : c:\\Python35-x64\\libs ;`n" | Set-Content $env:HOMEDRIVE\$env:HOMEPATH\user-config.jam'
-- type %HOMEDRIVE%%HOMEPATH%\user-config.jam
-- cd %ROOT_DIRECTORY%
-- set PATH=c:\msys64\mingw32\bin;%PATH%
-- g++ --version
-- python --version
-- echo %ROOT_DIRECTORY%
-- cd %BOOST_BUILD_PATH%\src\engine
-- build.bat >nul
-- cd %ROOT_DIRECTORY%
+    )
+  - cd %ROOT_DIRECTORY%
+  - set BOOST_ROOT=c:\Libraries\boost_1_63_0
+  - set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
+  - echo %BOOST_ROOT%
+  - echo %BOOST_BUILD_PATH%
+  - set PATH=%PATH%;%BOOST_BUILD_PATH%\src\engine\bin.ntx86
+  - ps: '"using msvc : 14.0 ;`nusing gcc : : : <cxxflags>-std=c++11 ;`nusing python : 3.5 : c:\\Python35-x64 : c:\\Python35-x64\\include : c:\\Python35-x64\\libs ;`n" | Set-Content $env:HOMEDRIVE\$env:HOMEPATH\user-config.jam'
+  - type %HOMEDRIVE%%HOMEPATH%\user-config.jam
+  - cd %ROOT_DIRECTORY%
+  - set PATH=c:\msys64\mingw32\bin;%PATH%
+  - g++ --version
+  - python --version
+  - echo %ROOT_DIRECTORY%
+  - cd %BOOST_BUILD_PATH%\src\engine
+  - build.bat >nul
+  - cd %ROOT_DIRECTORY%
 
 cache:
-- openssl-1.0.1p-vs2015.7z
+  - openssl-1.0.1p-vs2015.7z
 
 build_script:
+  # examples
+  - cd %ROOT_DIRECTORY%\examples
+  - if defined bjam (
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto%
+    )
 
-# examples
-- cd %ROOT_DIRECTORY%\examples
-- if defined bjam (
-  b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto%
-  )
+  # tools
+  - cd %ROOT_DIRECTORY%\tools
+  - if defined bjam (
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto%
+    )
 
-# tools
-- cd %ROOT_DIRECTORY%\tools
-- if defined bjam (
-  b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto%
-  )
+  # test
+  - cd %ROOT_DIRECTORY%\test
+  - if defined bjam (
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% win-tests test_upnp test_natpmp testing.execute=off
+    )
 
-# test
-- cd %ROOT_DIRECTORY%\test
-- if defined bjam (
-  b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% win-tests test_upnp test_natpmp testing.execute=off
-  )
+  # python binding
+  - cd %ROOT_DIRECTORY%\bindings\python
+  # we use 64 bit python builds
+  - if defined python (
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% libtorrent-link=shared stage_module stage_dependencies
+    )
 
-# python binding
-- cd %ROOT_DIRECTORY%\bindings\python
-# we use 64 bit python builds
-- if defined python (
-  b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% libtorrent-link=shared stage_module stage_dependencies
-  )
+  # simulations
+  - cd %ROOT_DIRECTORY%\simulation
+  - if defined sim (
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP testing.execute=off
+    )
 
-# simulations
-- cd %ROOT_DIRECTORY%\simulation
-- if defined sim (
-  b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP testing.execute=off
-  )
-
-# minimal support for cmake build
-- cd %ROOT_DIRECTORY%
-- mkdir build && cd build
-- if defined cmake (
-  set "PATH=c:\Python27-x64;%PATH%" &&
-  cmake -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
-  cmake --build . --config Release -- -verbosity:quiet
-  )
+  # minimal support for cmake build
+  - cd %ROOT_DIRECTORY%
+  - mkdir build && cd build
+  - if defined cmake (
+    set "PATH=c:\Python27-x64;%PATH%" &&
+    cmake -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
+    cmake --build . --config Release -- -verbosity:quiet
+    )
 
 test_script:
-- cd %ROOT_DIRECTORY%\test
-- if defined bjam (
-  appveyor-retry b2.exe -l400 --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% win-tests
-  )
+  - cd %ROOT_DIRECTORY%\test
+  - if defined bjam (
+    appveyor-retry b2.exe -l400 --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j2 %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% win-tests
+    )
 
-- cd %ROOT_DIRECTORY%\bindings\python
-# we use 64 bit python build
-- if defined python (
-  copy dependencies\*.* .
-  & c:\Python35-x64\python.exe test.py -b
-  )
+  - cd %ROOT_DIRECTORY%\bindings\python
+  # we use 64 bit python build
+  - if defined python (
+    copy dependencies\*.* .
+    & c:\Python35-x64\python.exe test.py -b
+    )
 
-- if defined cmake (
-  appveyor-retry ctest
-  )
+  - if defined cmake (
+    appveyor-retry ctest
+    )
 
-# simulation tests
-# debug iterators are turned off here because msvc has issues with noexcept
-# specifiers when debug iterators are enabled. Specifically, constructors that
-# allocate memory are still marked as noexcept. That results in program
-# termination
-# the IOCP backend in asio appears to have an issue where it hangs under
-# certain unexpected terminations (through exceptions)
-- cd %ROOT_DIRECTORY%\simulation
-- if defined sim (
-  b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP
-  )
+  # simulation tests
+  # debug iterators are turned off here because msvc has issues with noexcept
+  # specifiers when debug iterators are enabled. Specifically, constructors that
+  # allocate memory are still marked as noexcept. That results in program
+  # termination
+  # the IOCP backend in asio appears to have an issue where it hangs under
+  # certain unexpected terminations (through exceptions)
+  - cd %ROOT_DIRECTORY%\simulation
+  - if defined sim (
+    b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j2 %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP
+    )

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -235,7 +235,8 @@ For more build configuration flags see `Build configurations`_.
 When enabling linking against openssl (by setting the ``crypto`` feature to
 ``openssl``) the Jamfile will look in some default directory for the openssl
 headers and libraries. On macOS, it will look for the homebrew openssl package.
-On windows it will look in ``c:\openssl`` and MinGW in ``c:\OpenSSL-Win32``.
+On Windows, it will look in ``C:\OpenSSL-Win32``, or ``C:\OpenSSL-Win64`` if
+compiling in 64-bit.
 
 To customize the library path and include path for openssl, set the features
 ``openssl-lib`` and ``openssl-include`` respectively.
@@ -482,7 +483,7 @@ If you enabled test in the configuration step, to run them, run::
 
 building with other build systems
 ---------------------------------
-  
+
 If you're building in MS Visual Studio, you may have to set the compiler
 options "force conformance in for loop scope", "treat wchar_t as built-in
 type" and "Enable Run-Time Type Info" to Yes.


### PR DESCRIPTION
The widely used Windows OpenSSL package[1] uses C:\OpenSSL-Win[32|64] as
the install location so set this as default in Jamfile for Windows. It
also means that the appveyor builds can be simplified by using their
installed OpenSSL.

Mingw is set to the same location so remove seperate specification.

[1]: https://slproweb.com/products/Win32OpenSSL.html

Also includes a tidy-up commit of appveyor config