### PR TITLE
move variable scope into its build configuration block

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -521,6 +521,10 @@ constexpr std::size_t TORRENT_WRITE_HANDLER_MAX_SIZE = 342;
 #define TORRENT_USE_INVARIANT_CHECKS 0
 #endif
 
+#if TORRENT_USE_INVARIANT_CHECKS && !TORRENT_USE_ASSERTS
+#error "invariant checks cannot be enabled without asserts"
+#endif
+
 // for non-exception builds
 #ifdef BOOST_NO_EXCEPTIONS
 #define TORRENT_TRY if (true)

--- a/src/ffs.cpp
+++ b/src/ffs.cpp
@@ -88,11 +88,12 @@ namespace libtorrent { namespace aux {
 		for (int i = 0; i < num; i++)
 		{
 			if (ptr[i] == 0) continue;
-			std::uint32_t v = aux::network_to_host(ptr[i]);
 
 #if TORRENT_HAS_BUILTIN_CLZ
+			std::uint32_t const v = aux::network_to_host(ptr[i]);
 			return i * 32 + __builtin_clz(v);
 #elif defined _MSC_VER
+			std::uint32_t const v = aux::network_to_host(ptr[i]);
 			DWORD pos;
 			_BitScanReverse(&pos, v);
 			return i * 32 + 31 - pos;
@@ -148,11 +149,12 @@ namespace libtorrent { namespace aux {
 		for (int i = num - 1; i >= 0; i--)
 		{
 			if (ptr[i] == 0xffffffff) continue;
-			std::uint32_t v = ~aux::network_to_host(ptr[i]);
 
 #if TORRENT_HAS_BUILTIN_CTZ
+			std::uint32_t const v = ~aux::network_to_host(ptr[i]);
 			return (num - i - 1) * 32 + __builtin_ctz(v);
 #elif defined _MSC_VER
+			std::uint32_t const v = ~aux::network_to_host(ptr[i]);
 			DWORD pos;
 			_BitScanForward(&pos, v);
 			return (num - i - 1) * 32 + pos;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7729,7 +7729,6 @@ bool is_downloading_state(int const st)
 			TORRENT_ASSERT(m_info_hash == m_torrent_file->info_hash());
 		}
 
-#if TORRENT_USE_ASSERTS
 		for (torrent_list_index_t i{}; i != m_links.end_index(); ++i)
 		{
 			if (!m_links[i].in_list()) continue;
@@ -7738,7 +7737,6 @@ bool is_downloading_state(int const st)
 			TORRENT_ASSERT(index >= 0);
 			TORRENT_ASSERT(index < int(m_ses.torrent_list(i).size()));
 		}
-#endif
 
 		TORRENT_ASSERT(want_peers_download() == m_links[aux::session_interface::torrent_want_peers_download].in_list());
 		TORRENT_ASSERT(want_peers_finished() == m_links[aux::session_interface::torrent_want_peers_finished].in_list());


### PR DESCRIPTION
prevent invariant-checks enabled and asserts disabled build. remove some redundant preprocessor ifdefs. hasher512 should not hash a new buffer on assignment