### PR TITLE
Add magnet uri support for tr.x tracker

### DIFF
--- a/include/libtorrent/string_util.hpp
+++ b/include/libtorrent/string_util.hpp
@@ -117,6 +117,9 @@ namespace libtorrent {
 	// return value is an empty string_view.
 	TORRENT_EXTRA_EXPORT std::pair<string_view, string_view> split_string(string_view last, char sep);
 
+    // checks whether the string_view is a numeric or not
+	TORRENT_EXTRA_EXPORT bool is_numeric(string_view s);
+
 #if TORRENT_USE_I2P
 
 	TORRENT_EXTRA_EXPORT bool is_i2p_url(std::string const& url);

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -190,7 +190,8 @@ namespace libtorrent {
 				error_code e;
 				display_name = unescape_string(value, e);
 			}
-			else if (name == "tr"_sv) // tracker
+			else if (name == "tr"_sv ||
+			    (name.substr(0, 3) == "tr."_sv && is_numeric(name.substr(3)))) // tracker
 			{
 				// since we're about to assign tiers to the trackers, make sure the two
 				// vectors are aligned

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -387,6 +387,13 @@ namespace libtorrent {
 		return {last.substr(0, pos), last.substr(pos + found_sep)};
 	}
 
+	bool is_numeric(string_view s)
+	{
+		if (s.empty()) return false;
+
+        return std::all_of(s.begin(), s.end(), [](char c) { return is_digit(c); } );
+	}
+
 #if TORRENT_USE_I2P
 
 	bool is_i2p_url(std::string const& url)

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -227,6 +227,31 @@ TORRENT_TEST(magnet)
 	p2 = s->abort();
 }
 
+TORRENT_TEST(magnet_tr_x_uri)
+{
+
+    add_torrent_params p = parse_magnet_uri("magnet:"
+        "?tr.0=udp://1"
+        "&tr.1=http://2"
+        "&tr=http://3"
+        "&xt=urn:btih:c352cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");
+    TEST_EQUAL(p.trackers.size(), 3);
+    TEST_EQUAL(p.trackers[0], "udp://1");
+    TEST_EQUAL(p.tracker_tiers[0], 0);
+    TEST_EQUAL(p.trackers[1], "http://2");
+    TEST_EQUAL(p.tracker_tiers[1], 1);
+    TEST_EQUAL(p.trackers[2], "http://3");
+    TEST_EQUAL(p.tracker_tiers[2], 2);
+
+    p = parse_magnet_uri("magnet:"
+        "?tr.a=udp://1"
+        "&tr.1=http://2"
+        "&xt=urn:btih:c352cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");
+    TEST_EQUAL(p.trackers.size(), 1);
+    TEST_EQUAL(p.trackers[0], "http://2");
+    TEST_EQUAL(p.tracker_tiers[0], 0);
+}
+
 TORRENT_TEST(parse_escaped_hash_parameter)
 {
 	add_torrent_params p = parse_magnet_uri("magnet:?xt=urn%3Abtih%3Acdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -421,6 +421,31 @@ TORRENT_TEST(split_string)
 	TEST_CHECK(split_string(""_sv, ' ') == std::make_pair(""_sv, ""_sv));
 }
 
+TORRENT_TEST(is_numeric)
+{
+	TEST_CHECK(is_numeric("0"_sv));
+	TEST_CHECK(is_numeric("1"_sv));
+	TEST_CHECK(is_numeric("2"_sv));
+	TEST_CHECK(is_numeric("3"_sv));
+	TEST_CHECK(is_numeric("4"_sv));
+	TEST_CHECK(is_numeric("5"_sv));
+	TEST_CHECK(is_numeric("6"_sv));
+	TEST_CHECK(is_numeric("7"_sv));
+	TEST_CHECK(is_numeric("8"_sv));
+	TEST_CHECK(is_numeric("9"_sv));
+	TEST_CHECK(is_numeric("1"_sv));
+	TEST_CHECK(is_numeric("23"_sv));
+	TEST_CHECK(is_numeric("456"_sv));
+	TEST_CHECK(is_numeric("7890"_sv));
+
+	TEST_CHECK(!is_numeric(""_sv));
+	TEST_CHECK(!is_numeric(" "_sv));
+	TEST_CHECK(!is_numeric("a"_sv));
+	TEST_CHECK(!is_numeric("Z"_sv));
+	TEST_CHECK(!is_numeric("1A"_sv));
+	TEST_CHECK(!is_numeric("1 111"_sv));
+}
+
 TORRENT_TEST(convert_from_native)
 {
 	TEST_EQUAL(std::string("foobar"), convert_from_native(convert_to_native("foobar")));


### PR DESCRIPTION
This will close #1302.

As for adding tests, I saw in `test_magnet.cpp` the tests that contains the `tr=` part and edited one of them to check my changes.
The qustion is, how do you want to test this? with its own test or add to the current tests or even run the tests for both `tr` and `tr.x`?