### PR TITLE
remove old (incompatible) sequence number build option

### DIFF
--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -44,10 +44,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/cstdint.hpp>
 #include <limits>
 
-// the behavior of the sequence numbers as implemented by uTorrent is not
-// particularly regular. This switch indicates the odd parts.
-#define TORRENT_UT_SEQ 1
-
 #if TORRENT_UTP_LOG
 #include <stdarg.h>
 #include "libtorrent/socket_io.hpp"
@@ -350,7 +346,7 @@ struct utp_socket_impl
 	void parse_close_reason(boost::uint8_t const* ptr, int size);
 	void write_payload(boost::uint8_t* ptr, int size);
 	void maybe_inc_acked_seq_nr();
-	void ack_packet(packet* p, time_point const& receive_time
+	void ack_packet(packet* p, time_point receive_time
 		, boost::uint32_t& min_rtt, boost::uint16_t seq_nr);
 	void write_sack(boost::uint8_t* buf, int size) const;
 	void incoming(boost::uint8_t const* buf, int size, packet* p, time_point now);
@@ -2188,12 +2184,6 @@ bool utp_socket_impl::send_pkt(int const flags)
 		// be a nagle packet waiting for more data
 		TORRENT_ASSERT(m_nagle_packet == NULL);
 
-#if !TORRENT_UT_SEQ
-		// if the other end closed the connection immediately
-		// our FIN packet will end up having the same sequence
-		// number as the SYN, so this assert is invalid
-		TORRENT_ASSERT(!m_outbuf.at(m_seq_nr));
-#endif
 		TORRENT_ASSERT(h->seq_nr == m_seq_nr);
 
 		// 0 is a special sequence number, since it's also used as "uninitialized".
@@ -2447,8 +2437,8 @@ void utp_socket_impl::maybe_inc_acked_seq_nr()
 	m_duplicate_acks = 0;
 }
 
-void utp_socket_impl::ack_packet(packet* p, time_point const& receive_time
-	, boost::uint32_t& min_rtt, boost::uint16_t seq_nr)
+void utp_socket_impl::ack_packet(packet* p, time_point const receive_time
+	, boost::uint32_t& min_rtt, boost::uint16_t const seq_nr)
 {
 #ifdef TORRENT_EXPENSIVE_INVARIANT_CHECKS
 	INVARIANT_CHECK;
@@ -2471,7 +2461,6 @@ void utp_socket_impl::ack_packet(packet* p, time_point const& receive_time
 		TORRENT_ASSERT(p->mtu_probe);
 		// our mtu probe was acked!
 		m_mtu_floor = (std::max)(m_mtu_floor, p->size);
-		if (m_mtu_ceiling < m_mtu_floor) m_mtu_ceiling = m_mtu_floor;
 		update_mtu_limits();
 	}
 
@@ -2857,11 +2846,10 @@ bool utp_socket_impl::incoming_packet(boost::uint8_t const* buf, int size
 	// something is wrong.
 	// If our state is state_none, this packet must be a syn packet
 	// and the ack_nr should be ignored
-	boost::uint16_t cmp_seq_nr = (m_seq_nr - 1) & ACK_MASK;
-#if TORRENT_UT_SEQ
-	if (m_state == UTP_STATE_SYN_SENT && ph->get_type() == ST_STATE)
-		cmp_seq_nr = m_seq_nr;
-#endif
+	boost::uint16_t const cmp_seq_nr =
+		(m_state == UTP_STATE_SYN_SENT && ph->get_type() == ST_STATE)
+		? m_seq_nr : (m_seq_nr - 1) & ACK_MASK;
+
 	if ((m_state != UTP_STATE_NONE || ph->get_type() != ST_SYN)
 		&& (compare_less_wrap(cmp_seq_nr, ph->ack_nr, ACK_MASK)
 			|| compare_less_wrap(ph->ack_nr, m_acked_seq_nr
@@ -2899,7 +2887,9 @@ bool utp_socket_impl::incoming_packet(boost::uint8_t const* buf, int size
 
 	// if the socket is closing, always ignore any packet
 	// with a higher sequence number than the FIN sequence number
-	if (m_eof && compare_less_wrap(m_eof_seq_nr, ph->seq_nr, ACK_MASK))
+	// ST_STATE messages always include the next seqnr.
+	if (m_eof && (compare_less_wrap(m_eof_seq_nr, ph->seq_nr, ACK_MASK)
+		|| (m_eof_seq_nr == ph->seq_nr && ph->get_type() != ST_STATE)))
 	{
 #if TORRENT_UTP_LOG
 		UTP_LOG("%8p: ERROR: incoming packet type: %s seq_nr:%d eof_seq_nr:%d (ignored)\n"
@@ -3678,7 +3668,6 @@ void utp_socket_impl::tick(time_point const now)
 			// we had was the probe. Assume it was dropped
 			// because it was too big
 			m_mtu_ceiling = m_mtu - 1;
-			if (m_mtu_floor > m_mtu_ceiling) m_mtu_floor = m_mtu_ceiling;
 			update_mtu_limits();
 		}
 


### PR DESCRIPTION
Issue MTU probes with less size margin