### PR TITLE
removed unused directory::inode()

### DIFF
--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -97,7 +97,6 @@ namespace libtorrent {
 		~directory();
 		void next(error_code& ec);
 		std::string file() const;
-		std::uint64_t inode() const;
 		bool done() const { return m_done; }
 	private:
 #ifdef TORRENT_WINDOWS
@@ -106,15 +105,6 @@ namespace libtorrent {
 		WIN32_FIND_DATAW m_fd;
 #else
 		DIR* m_handle;
-#ifdef TORRENT_ANDROID
-// this is due to a documented bug in android related to a wrong type
-// of ino_t, for general discussion and internal changes see:
-// https://issuetracker.google.com/issues/37011207 - for general discussion
-// https://android-review.googlesource.com/#/c/platform/system/core/+/123482/
-		std::uint64_t m_inode;
-#else
-		ino_t m_inode;
-#endif // TORRENT_ANDROID
 		std::string m_name;
 #endif
 		bool m_done;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -356,8 +356,6 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 		native_path_string f = convert_to_native_path_string(p);
 
 #ifdef TORRENT_WINDOWS
-		m_inode = 0;
-
 		m_handle = FindFirstFileW(f.c_str(), &m_fd);
 		if (m_handle == INVALID_HANDLE_VALUE)
 		{
@@ -366,7 +364,6 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 			return;
 		}
 #else
-
 		m_handle = ::opendir(f.c_str());
 		if (m_handle == nullptr)
 		{
@@ -376,7 +373,7 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 		}
 		// read the first entry
 		next(ec);
-#endif
+#endif // TORRENT_WINDOWS
 	}
 
 	directory::~directory()
@@ -387,11 +384,6 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 #else
 		if (m_handle) ::closedir(m_handle);
 #endif
-	}
-
-	std::uint64_t directory::inode() const
-	{
-		return m_inode;
 	}
 
 	std::string directory::file() const
@@ -420,7 +412,6 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 		errno = 0;
 		if ((de = ::readdir(m_handle)) != nullptr)
 		{
-			m_inode = de->d_ino;
 			m_name = de->d_name;
 		}
 		else


### PR DESCRIPTION
I couldn't find any use of this, git history show that was added at https://github.com/arvidn/libtorrent/commit/11038aeecbf01e5e6fea6e0f0474b50fd4598a06#diff-f4ee62fdb480753221c5ba3084c82e68 and removed a few commits later (back to 2014)