### PR TITLE
Fix Boost handling with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,28 @@ include(GNUInstallDirs)
 include(GeneratePkgConfig)
 include(CMakeDependentOption)
 
-# Boost
+# Options
+
+# these options control target creation and thus have to be declared before the add_library() call
+feature_option(BUILD_SHARED_LIBS "build libtorrent as a shared library" ON)
+feature_option(static_runtime "build libtorrent with static runtime" OFF)
+
+# Configuration
+
+if(static_runtime)
+	include(ucm_flags)
+	ucm_set_runtime(STATIC)
+	set(Boost_USE_MULTITHREADED ON)
+	set(Boost_USE_STATIC_RUNTIME ON)
+	set(OPENSSL_USE_STATIC_LIBS TRUE)
+	set(OPENSSL_MSVC_STATIC_RT TRUE)
+endif()
+
+if (NOT BUILD_SHARED_LIBS)
+	set(Boost_USE_STATIC_LIBS ON)
+endif()
+
+# Packages
 find_public_dependency(Boost REQUIRED COMPONENTS system)
 find_public_dependency(Boost COMPONENTS date_time)
 
@@ -441,10 +462,6 @@ list(TRANSFORM libtorrent_extensions_include_files PREPEND "include/libtorrent/e
 list(TRANSFORM libtorrent_aux_include_files PREPEND "include/libtorrent/aux_/")
 list(TRANSFORM libtorrent_kademlia_include_files PREPEND "include/libtorrent/kademlia/")
 
-# these options control target creation and thus have to be declared before the add_library() call
-feature_option(BUILD_SHARED_LIBS "build libtorrent as a shared library" ON)
-feature_option(static_runtime "build libtorrent with static runtime" OFF)
-
 find_public_dependency(Threads REQUIRED)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
@@ -483,19 +500,6 @@ elseif(MSVC)
 		/wd4268
 		# C4503: 'identifier': decorated name length exceeded, name was truncated
 		/wd4503)
-endif()
-
-if(static_runtime)
-	include(ucm_flags)
-	ucm_set_runtime(STATIC)
-	set(Boost_USE_MULTITHREADED ON)
-	set(Boost_USE_STATIC_RUNTIME ON)
-	set(OPENSSL_USE_STATIC_LIBS TRUE)
-	set(OPENSSL_MSVC_STATIC_RT TRUE)
-endif()
-
-if (NOT BUILD_SHARED_LIBS)
-	set(Boost_USE_STATIC_LIBS ON)
 endif()
 
 add_library(torrent-rasterbar
@@ -541,6 +545,8 @@ target_compile_definitions(torrent-rasterbar
 target_link_libraries(torrent-rasterbar
 	PUBLIC
 		Threads::Threads
+	PRIVATE
+		Boost::system
 )
 
 # Unconditional platform-specific settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ set (SOVERSION "10")
 
 include(GNUInstallDirs)
 include(GeneratePkgConfig)
+include(CMakeDependentOption)
+
+# Boost
+find_public_dependency(Boost REQUIRED COMPONENTS system)
+find_public_dependency(Boost REQUIRED COMPONENTS date_time)
 
 set(libtorrent_include_files
 	add_torrent_params
@@ -577,17 +582,20 @@ if (APPLE)
 	target_link_libraries(torrent-rasterbar PRIVATE "-framework CoreFoundation" "-framework SystemConfiguration")
 endif()
 
-feature_option(build_tests "build tests" OFF)
 feature_option(build_examples "build examples" OFF)
 feature_option(build_tools "build tools" OFF)
 feature_option(python-bindings "build python bindings" OFF)
 
 # these options require existing target
 feature_option(dht "enable support for Mainline DHT" ON)
-if(NOT build_tests) # tests require deprecated symbols
-	target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME deprecated-functions DEFAULT ON
-		DESCRIPTION "enable deprecated functions for backwards compatibility" DISABLED TORRENT_NO_DEPRECATE)
-endif()
+cmake_dependent_option(deprecated-functions "enable deprecated functions for backwards compatibility" ON "Boost_DATE_TIME_FOUND" OFF)
+add_feature_info(deprecated-functions deprecated-functions "enables deprecated functions for backwards compatibility")
+target_compile_definitions(torrent-rasterbar PUBLIC $<$<NOT:$<BOOL:${deprecated-functions}>>:TORRENT_NO_DEPRECATE>)
+target_link_libraries(torrent-rasterbar PUBLIC $<$<BOOL:${deprecated-functions}>:Boost::date_time>)
+
+cmake_dependent_option(build_tests "build tests" OFF "deprecated-functions" OFF)
+add_feature_info(build_tests build_tests "build tests")
+
 feature_option(encryption "Enables encryption in libtorrent" ON)
 feature_option(exceptions "build with exception support" ON)
 target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME extensions DEFAULT ON
@@ -675,14 +683,6 @@ if (dht)
 	endif()
 else()
 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_DISABLE_DHT)
-endif()
-
-# Boost
-find_public_dependency(Boost REQUIRED COMPONENTS system)
-target_link_libraries(torrent-rasterbar PUBLIC Boost::system)
-if (TORRENT_NO_DEPRECATE)
-	find_public_dependency(Boost REQUIRED COMPONENTS date_time)
-	target_link_libraries(torrent-rasterbar PUBLIC Boost::date_time)
 endif()
 
 if (exceptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,9 +678,8 @@ else()
 endif()
 
 # Boost
-find_public_dependency(Boost REQUIRED COMPONENTS system)
-target_include_directories(torrent-rasterbar PUBLIC ${Boost_INCLUDE_DIRS})
-target_link_libraries(torrent-rasterbar PUBLIC ${Boost_SYSTEM_LIBRARY})
+find_public_dependency(Boost REQUIRED COMPONENTS system date_time)
+target_link_libraries(torrent-rasterbar PUBLIC Boost::system Boost::date_time)
 
 if (exceptions)
 	if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,6 @@ target_compile_definitions(torrent-rasterbar
 target_link_libraries(torrent-rasterbar
 	PUBLIC
 		Threads::Threads
-	PRIVATE
 		Boost::system
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(CMakeDependentOption)
 
 # Boost
 find_public_dependency(Boost REQUIRED COMPONENTS system)
-find_public_dependency(Boost REQUIRED COMPONENTS date_time)
+find_public_dependency(Boost COMPONENTS date_time)
 
 set(libtorrent_include_files
 	add_torrent_params

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,8 +678,12 @@ else()
 endif()
 
 # Boost
-find_public_dependency(Boost REQUIRED COMPONENTS system date_time)
-target_link_libraries(torrent-rasterbar PUBLIC Boost::system Boost::date_time)
+find_public_dependency(Boost REQUIRED COMPONENTS system)
+target_link_libraries(torrent-rasterbar PUBLIC Boost::system)
+if (TORRENT_NO_DEPRECATE)
+	find_public_dependency(Boost REQUIRED COMPONENTS date_time)
+	target_link_libraries(torrent-rasterbar PUBLIC Boost::date_time)
+endif()
 
 if (exceptions)
 	if (MSVC)


### PR DESCRIPTION
* Add Boost dependencies as imported libraries. This properly adds Boost
includes, libraries and also definitions to target
* Add forgotten Boost::date_time library