### PR TITLE
don't copy a vector into the async_write operation for iovec

### DIFF
--- a/include/libtorrent/chained_buffer.hpp
+++ b/include/libtorrent/chained_buffer.hpp
@@ -160,7 +160,7 @@ namespace libtorrent {
 		// enough room, returns 0
 		char* allocate_appendix(int s);
 
-		std::vector<boost::asio::const_buffer> const& build_iovec(int to_send);
+		span<boost::asio::const_buffer const> build_iovec(int to_send);
 
 		void clear();
 

--- a/include/libtorrent/span.hpp
+++ b/include/libtorrent/span.hpp
@@ -121,6 +121,8 @@ namespace aux {
 		bool empty() const noexcept { return m_len == 0; }
 		T* data() const noexcept { return m_ptr; }
 
+		using const_iterator = T const*;
+		using const_reverse_iterator = std::reverse_iterator<T const*>;
 		using iterator = T*;
 		using reverse_iterator = std::reverse_iterator<T*>;
 

--- a/src/chained_buffer.cpp
+++ b/src/chained_buffer.cpp
@@ -112,7 +112,7 @@ namespace libtorrent {
 		return insert;
 	}
 
-	std::vector<boost::asio::const_buffer> const& chained_buffer::build_iovec(int const to_send)
+	span<boost::asio::const_buffer const> chained_buffer::build_iovec(int const to_send)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(!m_destructed);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5616,7 +5616,7 @@ namespace libtorrent {
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::outgoing, "ASYNC_WRITE", "bytes: %d", amount_to_send);
 #endif
-		std::vector<boost::asio::const_buffer> const& vec = m_send_buffer.build_iovec(amount_to_send);
+		auto const vec = m_send_buffer.build_iovec(amount_to_send);
 		ADD_OUTSTANDING_ASYNC("peer_connection::on_send_data");
 
 #if TORRENT_USE_ASSERTS

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -175,7 +175,7 @@ bool compare_chained_buffer(chained_buffer& b, char const* mem, int size)
 {
 	if (size == 0) return true;
 	std::vector<char> flat((std::size_t(size)));
-	std::vector<boost::asio::const_buffer> const& iovec2 = b.build_iovec(size);
+	auto const iovec2 = b.build_iovec(size);
 	int copied = copy_buffers(iovec2, &flat[0]);
 	TEST_CHECK(copied == size);
 	return std::memcmp(&flat[0], mem, std::size_t(size)) == 0;


### PR DESCRIPTION
Since the chained_buffer will own the vector anyway, just make it return a span and copy that