### PR TITLE
Added FrostWire's client ID (RC_1_2 backport as in master)

### DIFF
--- a/src/identify_client.cpp
+++ b/src/identify_client.cpp
@@ -171,6 +171,7 @@ namespace {
 		, {"ES", "electric sheep"}
 		, {"FC", "FileCroc"}
 		, {"FT", "FoxTorrent"}
+		, {"FW", "FrostWire"}
 		, {"FX", "Freebox BitTorrent"}
 		, {"GS", "GSTorrent"}
 		, {"HK", "Hekate"}


### PR DESCRIPTION
As accepted in last amendment of bep_0020.rst on github.com/bittorrent/bittorrent.org
See: https://github.com/bittorrent/bittorrent.org/commit/7cb4ec93ea0c643ecf4c0fde63052d05e76eefc6