### PR TITLE
include sha1/sha512 in the build unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ set(sources
 	fingerprint
 	gzip
 	hasher
+	sha1
 	hex
 	http_connection
 	http_stream
@@ -647,10 +648,6 @@ else(OPENSSL_FOUND)
 	if (LibGcrypt_FOUND)
 		target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_USE_LIBGCRYPT)
 		target_link_libraries(torrent-rasterbar PRIVATE LibGcrypt::LibGcrypt)
-	else()
-		if (NOT WIN32 AND NOT APPLE)
-			target_sources(torrent-rasterbar PRIVATE src/sha1)
-		endif()
 	endif()
 endif(OPENSSL_FOUND)
 
@@ -666,12 +663,9 @@ if (dht)
 		${ed25519_sources}
 		${libtorrent_kademlia_include_files}
 		src/hasher512
+		src/sha512
 	)
 	target_include_directories(torrent-rasterbar PRIVATE ed25519/src)
-
-	if (NOT OpenSSL_FOUND AND NOT LibGcrypt_FOUND AND NOT WIN32 AND NOT APPLE)
-		target_sources(torrent-rasterbar PRIVATE src/sha512)
-	endif()
 else()
 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_DISABLE_DHT)
 endif()

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix Mingw build to use native cryptoAPI
+
 1.2 release
 
 	* requires boost >= 1.58 to build

--- a/Jamfile
+++ b/Jamfile
@@ -285,23 +285,6 @@ rule building ( properties * )
 		result += <source>src/pe_crypto.cpp ;
 	}
 
-	if <crypto>built-in in $(properties)
-		&& ! <target-os>windows in $(properties)
-		&& ! <target-os>darwin in $(properties)
-	{
-		result += <source>src/sha1.cpp ;
-		if <dht>on in $(properties)
-		{
-			result += <source>src/sha512.cpp ;
-		}
-	}
-
-	if <target-os>windows in $(properties)
-		&& <windows-version>xp in $(properties)
-	{
-		result += <source>src/sha512.cpp ;
-	}
-
 	if ( <toolset>darwin in $(properties)
 		|| <toolset>gcc in $(properties)
 		|| <toolset>clang in $(properties)
@@ -651,6 +634,7 @@ SOURCES =
 	session_call
 	session_udp_sockets
 	settings_pack
+	sha1
 	sha1_hash
 	socket_io
 	socket_type
@@ -785,6 +769,7 @@ lib torrent
 	<dht>on:<source>src/kademlia/$(KADEMLIA_SOURCES).cpp
 	<dht>on:<source>ed25519/src/$(ED25519_SOURCES).cpp
 	<dht>on:<source>src/hasher512.cpp
+	<dht>on:<source>src/sha512.cpp
 
 	<conditional>@building
 	<conditional>@warnings

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -234,6 +234,22 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_USE_PREADV 1
 #define TORRENT_USE_PWRITEV 1
 
+# if !defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_LIBGCRYPT
+// unless some other crypto library has been specified, default to the native
+// windows CryptoAPI
+#define TORRENT_USE_CRYPTOAPI 1
+
+#ifdef NTDDI_VERSION
+# if (NTDDI_VERSION > NTDDI_WINXPSP2)
+#  define TORRENT_USE_CRYPTOAPI_SHA_512 1
+# endif
+#else // NTDDI_VERSION not defined so use simple _WIN32_WINNT check
+# if _WIN32_WINNT >= 0x0600
+#  define TORRENT_USE_CRYPTOAPI_SHA_512 1
+# endif
+#endif
+
+#endif
 // ==== WINDOWS ===
 #elif defined _WIN32
 #define TORRENT_WINDOWS

--- a/include/libtorrent/sha1.hpp
+++ b/include/libtorrent/sha1.hpp
@@ -14,6 +14,12 @@ changelog at the end of sha1.cpp
 #define TORRENT_SHA1_HPP_INCLUDED
 
 #include "libtorrent/config.hpp"
+
+#if !defined TORRENT_USE_LIBGCRYPT \
+	&& !TORRENT_USE_COMMONCRYPTO \
+	&& !TORRENT_USE_CRYPTOAPI \
+	&& !defined TORRENT_USE_LIBCRYPTO
+
 #include <cstdint>
 
 namespace libtorrent {
@@ -32,4 +38,5 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT void SHA1_final(std::uint8_t* digest, sha1_ctx* context);
 }
 
+#endif
 #endif

--- a/include/libtorrent/sha512.hpp
+++ b/include/libtorrent/sha512.hpp
@@ -2,6 +2,12 @@
 #define TORRENT_SHA512_HPP_INCLUDED
 
 #include "libtorrent/config.hpp"
+
+#if !defined TORRENT_USE_LIBGCRYPT \
+	&& !TORRENT_USE_COMMONCRYPTO \
+	&& !TORRENT_USE_CRYPTOAPI_SHA_512 \
+	&& !defined TORRENT_USE_LIBCRYPTO
+
 #include <cstdint>
 
 namespace libtorrent {
@@ -20,4 +26,5 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT int SHA512_final(std::uint8_t* digest, sha512_ctx* context);
 }
 
+#endif
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,12 +35,6 @@ KADEMLIA_SOURCES = \
   hasher512.cpp
 endif
 
-if ! WITH_OPENSSL
-BUILTIN_CRYPTO_SOURCES = \
-  sha1.cpp                      \
-  sha512.cpp
-endif
-
 libtorrent_rasterbar_la_SOURCES = \
   web_connection_base.cpp         \
   alert.cpp                       \
@@ -166,10 +160,10 @@ libtorrent_rasterbar_la_SOURCES = \
   add_torrent_params.cpp          \
   peer_info.cpp                   \
   stack_allocator.cpp             \
+  sha1.cpp                        \
+  sha512.cpp                      \
   \
-  $(KADEMLIA_SOURCES)             \
-  \
-  $(BUILTIN_CRYPTO_SOURCES)
+  $(KADEMLIA_SOURCES)
 
 AM_CFLAGS = -I$(top_srcdir)/ed25519/src -std=c99
 AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY -I$(top_srcdir)/include -I$(top_srcdir)/ed25519/src @DEBUGFLAGS@ @OPENSSL_INCLUDES@

--- a/src/sha1.cpp
+++ b/src/sha1.cpp
@@ -10,10 +10,15 @@ By Steve Reid <sreid@sea-to-sky.net>
 changelog at the end of the file.
 */
 
+#include "libtorrent/sha1.hpp"
+
+#if !defined TORRENT_USE_LIBGCRYPT \
+	&& !TORRENT_USE_COMMONCRYPTO \
+	&& !TORRENT_USE_CRYPTOAPI \
+	&& !defined TORRENT_USE_LIBCRYPTO
+
 #include <cstdio>
 #include <cstring>
-
-#include "libtorrent/sha1.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/predef/other/endian.h>
@@ -236,6 +241,8 @@ void SHA1_final(u8* digest, sha1_ctx* context)
 }
 
 } // libtorrent namespace
+
+#endif
 
 /************************************************************
 

--- a/src/sha512.cpp
+++ b/src/sha512.cpp
@@ -3,6 +3,11 @@
 
 #include "libtorrent/sha512.hpp"
 
+#if !defined TORRENT_USE_LIBGCRYPT \
+	&& !TORRENT_USE_COMMONCRYPTO \
+	&& !TORRENT_USE_CRYPTOAPI_SHA_512 \
+	&& !defined TORRENT_USE_LIBCRYPTO
+
 // ignore warnings in this file
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
@@ -280,3 +285,5 @@ int SHA512_final(std::uint8_t* out, sha512_ctx* md)
 }
 
 } // libtorrent namespace
+
+#endif


### PR DESCRIPTION
match build configuration options to using built-in sha1/sah512 and defining them