### PR TITLE
CMakeLists.txt: `libtorrent_include_files/ed25519` into `libtorrent_aux_include_files/`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ set(libtorrent_include_files
 	disk_job_pool
 	disk_observer
 	download_priority
-	ed25519
 	entry
 	enum_net
 	error
@@ -220,6 +219,7 @@ set(libtorrent_aux_include_files
 	disable_warnings_pop
 	disable_warnings_push
 	disk_job_fence
+	ed25519
 	escape_string
 	export
 	ffs

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,6 @@ HEADERS = \
   disk_job_pool.hpp            \
   disk_observer.hpp            \
   download_priority.hpp        \
-  ed25519.hpp                  \
   entry.hpp                    \
   enum_net.hpp                 \
   error.hpp                    \
@@ -581,6 +580,7 @@ HEADERS = \
   aux_/disable_warnings_pop.hpp     \
   aux_/disable_warnings_push.hpp    \
   aux_/disk_job_fence.hpp           \
+  aux_/ed25519.hpp                  \
   aux_/escape_string.hpp            \
   aux_/export.hpp                   \
   aux_/ffs.hpp                      \

--- a/include/libtorrent/aux_/ed25519.hpp
+++ b/include/libtorrent/aux_/ed25519.hpp
@@ -5,16 +5,7 @@
 #include <stddef.h> // for size_t
 
 namespace libtorrent {
-
-enum
-{
-	ed25519_seed_size = 32,
-	ed25519_private_key_size = 64,
-	ed25519_public_key_size = 32,
-	ed25519_signature_size = 64,
-	ed25519_scalar_size = 32,
-	ed25519_shared_secret_size = 32
-};
+namespace aux {
 
 void TORRENT_EXTRA_EXPORT ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
 void TORRENT_EXTRA_EXPORT ed25519_sign(unsigned char *signature, const unsigned char *message, std::ptrdiff_t message_len, const unsigned char *public_key, const unsigned char *private_key);
@@ -22,6 +13,6 @@ int TORRENT_EXTRA_EXPORT ed25519_verify(const unsigned char *signature, const un
 void TORRENT_EXTRA_EXPORT ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void TORRENT_EXTRA_EXPORT ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 
-}
+} }
 
 #endif // ED25519_HPP

--- a/src/ed25519/add_scalar.cpp
+++ b/src/ed25519/add_scalar.cpp
@@ -1,19 +1,19 @@
 // ignore warnings in this file
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include "libtorrent/ed25519.hpp"
+#include "libtorrent/aux_/ed25519.hpp"
 #include "libtorrent/hasher512.hpp"
 #include "ge.h"
 #include "sc.h"
 
-namespace libtorrent
-{
+namespace libtorrent {
+namespace aux {
 
 /* see http://crypto.stackexchange.com/a/6215/4697 */
 void ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar) {
     const unsigned char SC_1[32] = {1}; /* scalar with value 1 */
-    
-    unsigned char n[32]; 
+
+    unsigned char n[32];
     ge_p3 nB;
     ge_p1p1 A_p1p1;
     ge_p3 A;
@@ -72,4 +72,4 @@ void ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, c
     }
 }
 
-}
+} }

--- a/src/ed25519/key_exchange.cpp
+++ b/src/ed25519/key_exchange.cpp
@@ -1,11 +1,11 @@
 // ignore warnings in this file
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include "libtorrent/ed25519.hpp"
+#include "libtorrent/aux_/ed25519.hpp"
 #include "fe.h"
 
-namespace libtorrent
-{
+namespace libtorrent {
+namespace aux {
 
 void ed25519_key_exchange(unsigned char *shared_secret
 	, const unsigned char *public_key, const unsigned char *private_key) {
@@ -85,4 +85,4 @@ void ed25519_key_exchange(unsigned char *shared_secret
     fe_tobytes(shared_secret, x2);
 }
 
-}
+} }

--- a/src/ed25519/keypair.cpp
+++ b/src/ed25519/keypair.cpp
@@ -1,12 +1,12 @@
 // ignore warnings in this file
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include "libtorrent/ed25519.hpp"
+#include "libtorrent/aux_/ed25519.hpp"
 #include "libtorrent/hasher512.hpp"
 #include "ge.h"
 
-namespace libtorrent
-{
+namespace libtorrent {
+namespace aux {
 
 void ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed) {
     ge_p3 A;
@@ -21,4 +21,4 @@ void ed25519_create_keypair(unsigned char *public_key, unsigned char *private_ke
     ge_p3_tobytes(public_key, &A);
 }
 
-}
+} }

--- a/src/ed25519/sign.cpp
+++ b/src/ed25519/sign.cpp
@@ -1,13 +1,13 @@
 // ignore warnings in this file
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include "libtorrent/ed25519.hpp"
+#include "libtorrent/aux_/ed25519.hpp"
 #include "libtorrent/hasher512.hpp"
 #include "ge.h"
 #include "sc.h"
 
-namespace libtorrent
-{
+namespace libtorrent {
+namespace aux {
 
 void ed25519_sign(unsigned char *signature, const unsigned char *message, std::ptrdiff_t message_len, const unsigned char *public_key, const unsigned char *private_key) {
     ge_p3 R;
@@ -34,4 +34,4 @@ void ed25519_sign(unsigned char *signature, const unsigned char *message, std::p
         , reinterpret_cast<unsigned char*>(r.data()));
 }
 
-}
+} }

--- a/src/ed25519/verify.cpp
+++ b/src/ed25519/verify.cpp
@@ -1,13 +1,13 @@
 // ignore warnings in this file
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include "libtorrent/ed25519.hpp"
+#include "libtorrent/aux_/ed25519.hpp"
 #include "libtorrent/hasher512.hpp"
 #include "ge.h"
 #include "sc.h"
 
-namespace libtorrent
-{
+namespace libtorrent {
+namespace aux {
 
 static int consttime_equal(const unsigned char *x, const unsigned char *y) {
     unsigned char r = 0;
@@ -81,4 +81,4 @@ int ed25519_verify(const unsigned char *signature, const unsigned char *message,
     return 1;
 }
 
-}
+} }

--- a/src/kademlia/ed25519.cpp
+++ b/src/kademlia/ed25519.cpp
@@ -32,7 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <libtorrent/kademlia/ed25519.hpp>
 #include <libtorrent/random.hpp>
-#include <libtorrent/ed25519.hpp>
+#include <libtorrent/aux_/ed25519.hpp>
 
 namespace libtorrent { namespace dht {
 
@@ -53,7 +53,7 @@ namespace libtorrent { namespace dht {
 		auto const sk_ptr = reinterpret_cast<unsigned char*>(sk.bytes.data());
 		auto const seed_ptr = reinterpret_cast<unsigned char const*>(seed.data());
 
-		libtorrent::ed25519_create_keypair(pk_ptr, sk_ptr, seed_ptr);
+		lt::aux::ed25519_create_keypair(pk_ptr, sk_ptr, seed_ptr);
 
 		return std::make_tuple(pk, sk);
 	}
@@ -68,7 +68,7 @@ namespace libtorrent { namespace dht {
 		auto const pk_ptr = reinterpret_cast<unsigned char const*>(pk.bytes.data());
 		auto const sk_ptr = reinterpret_cast<unsigned char const*>(sk.bytes.data());
 
-		libtorrent::ed25519_sign(sig_ptr, msg_ptr, msg.size(), pk_ptr, sk_ptr);
+		lt::aux::ed25519_sign(sig_ptr, msg_ptr, msg.size(), pk_ptr, sk_ptr);
 
 		return sig;
 	}
@@ -80,7 +80,7 @@ namespace libtorrent { namespace dht {
 		auto const msg_ptr = reinterpret_cast<unsigned char const*>(msg.data());
 		auto const pk_ptr = reinterpret_cast<unsigned char const*>(pk.bytes.data());
 
-		return libtorrent::ed25519_verify(sig_ptr, msg_ptr, msg.size(), pk_ptr) == 1;
+		return lt::aux::ed25519_verify(sig_ptr, msg_ptr, msg.size(), pk_ptr) == 1;
 	}
 
 	public_key ed25519_add_scalar(public_key const& pk
@@ -91,7 +91,7 @@ namespace libtorrent { namespace dht {
 		auto const ret_ptr = reinterpret_cast<unsigned char*>(ret.bytes.data());
 		auto const scalar_ptr = reinterpret_cast<unsigned char const*>(scalar.data());
 
-		libtorrent::ed25519_add_scalar(ret_ptr, nullptr, scalar_ptr);
+		lt::aux::ed25519_add_scalar(ret_ptr, nullptr, scalar_ptr);
 
 		return ret;
 	}
@@ -104,7 +104,7 @@ namespace libtorrent { namespace dht {
 		auto const ret_ptr = reinterpret_cast<unsigned char*>(ret.bytes.data());
 		auto const scalar_ptr = reinterpret_cast<unsigned char const*>(scalar.data());
 
-		libtorrent::ed25519_add_scalar(nullptr, ret_ptr, scalar_ptr);
+		lt::aux::ed25519_add_scalar(nullptr, ret_ptr, scalar_ptr);
 
 		return ret;
 	}
@@ -118,7 +118,7 @@ namespace libtorrent { namespace dht {
 		auto const pk_ptr = reinterpret_cast<unsigned char const*>(pk.bytes.data());
 		auto const sk_ptr = reinterpret_cast<unsigned char const*>(sk.bytes.data());
 
-		libtorrent::ed25519_key_exchange(secret_ptr, pk_ptr, sk_ptr);
+		lt::aux::ed25519_key_exchange(secret_ptr, pk_ptr, sk_ptr);
 
 		return secret;
 	}

--- a/test/test_dht_storage.cpp
+++ b/test/test_dht_storage.cpp
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/broadcast_socket.hpp" // for supports_ipv6
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/random.hpp"
-#include "libtorrent/ed25519.hpp"
+#include "libtorrent/kademlia/ed25519.hpp"
 #include "libtorrent/hex.hpp" // from_hex
 
 #include "libtorrent/kademlia/dht_storage.hpp"


### PR DESCRIPTION
note: cmake build is still broken due to
```
CMake Error at CMakeLists.txt:507 (add_library):
Cannot find source file:

    deps/try_signal/try_signal

 Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx
```
I thought it was maybe a path issue, but I cannot find a try_signal.* file, is it auto-generated or was it removed?