### PR TITLE
clean up formatting of namespaces and indentation

### DIFF
--- a/docs/gen_reference_doc.py
+++ b/docs/gen_reference_doc.py
@@ -113,7 +113,6 @@ category_mapping = {
 category_fun_mapping = {
     'min_memory_usage()': 'Settings',
     'high_performance_seed()': 'Settings',
-    'cache_status': 'Core',
 }
 
 

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -80,7 +80,6 @@ using lt::piece_index_t;
 using lt::file_index_t;
 using lt::torrent_handle;
 using lt::add_torrent_params;
-using lt::cache_status;
 using lt::total_seconds;
 using lt::torrent_flags_t;
 using lt::seconds;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2879,6 +2879,6 @@ TORRENT_VERSION_NAMESPACE_2_END
 #undef TORRENT_DEFINE_ALERT_PRIO
 #undef PROGRESS_NOTIFICATION
 
-}
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -599,8 +599,6 @@ namespace aux {
 			peer_id deprecated_get_peer_id() const;
 #endif
 
-			void get_cache_info(torrent_handle h, cache_status* ret, int flags) const;
-
 			std::uint16_t listen_port() const override;
 			std::uint16_t listen_port(listen_socket_t* sock) const;
 			std::uint16_t ssl_listen_port() const override;

--- a/include/libtorrent/bdecode.hpp
+++ b/include/libtorrent/bdecode.hpp
@@ -109,8 +109,7 @@ inline boost::system::error_category& get_bdecode_category()
 { return bdecode_category(); }
 #endif
 
-namespace bdecode_errors
-{
+namespace bdecode_errors {
 	// libtorrent uses boost.system's ``error_code`` class to represent
 	// errors. libtorrent has its own error category bdecode_category()
 	// with the error codes defined by error_code_enum.
@@ -142,12 +141,14 @@ namespace bdecode_errors
 }
 } // namespace libtorrent
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 
 	template<> struct is_error_code_enum<libtorrent::bdecode_errors::error_code_enum>
 	{ static const bool value = true; };
 
-} }
+}
+}
 
 namespace libtorrent {
 

--- a/include/libtorrent/bencode.hpp
+++ b/include/libtorrent/bencode.hpp
@@ -69,273 +69,189 @@ namespace libtorrent {
 
 namespace detail {
 
-		template <class OutIt, class In, typename Cond
-			= typename std::enable_if<std::is_integral<In>::value>::type>
-		int write_integer(OutIt& out, In data)
-		{
-			entry::integer_type const val = entry::integer_type(data);
-			TORRENT_ASSERT(data == In(val));
-			// the stack allocated buffer for keeping the
-			// decimal representation of the number can
-			// not hold number bigger than this:
-			static_assert(sizeof(entry::integer_type) <= 8, "64 bit integers required");
-			static_assert(sizeof(data) <= sizeof(entry::integer_type), "input data too big, see entry::integer_type");
-			char buf[21];
-			auto const str = integer_to_str(buf, val);
-			for (char const c : str)
-			{
-				*out = c;
-				++out;
-			}
-			return static_cast<int>(str.size());
-		}
-
-		template <class OutIt>
-		void write_char(OutIt& out, char c)
+	template <class OutIt, class In, typename Cond
+		= typename std::enable_if<std::is_integral<In>::value>::type>
+	int write_integer(OutIt& out, In data)
+	{
+		entry::integer_type const val = entry::integer_type(data);
+		TORRENT_ASSERT(data == In(val));
+		// the stack allocated buffer for keeping the
+		// decimal representation of the number can
+		// not hold number bigger than this:
+		static_assert(sizeof(entry::integer_type) <= 8, "64 bit integers required");
+		static_assert(sizeof(data) <= sizeof(entry::integer_type), "input data too big, see entry::integer_type");
+		char buf[21];
+		auto const str = integer_to_str(buf, val);
+		for (char const c : str)
 		{
 			*out = c;
 			++out;
 		}
+		return static_cast<int>(str.size());
+	}
 
-		template <class InIt>
-		std::string read_until(InIt& in, InIt end, char end_token, bool& err)
+	template <class OutIt>
+	void write_char(OutIt& out, char c)
+	{
+		*out = c;
+		++out;
+	}
+
+	template <class InIt>
+	std::string read_until(InIt& in, InIt end, char end_token, bool& err)
+	{
+		std::string ret;
+		if (in == end)
 		{
-			std::string ret;
+			err = true;
+			return ret;
+		}
+		while (*in != end_token)
+		{
+			ret += *in;
+			++in;
 			if (in == end)
 			{
 				err = true;
 				return ret;
 			}
-			while (*in != end_token)
-			{
-				ret += *in;
-				++in;
-				if (in == end)
-				{
-					err = true;
-					return ret;
-				}
-			}
-			return ret;
 		}
+		return ret;
+	}
 
-		template<class InIt>
-		void read_string(InIt& in, InIt end, int len, std::string& str, bool& err)
+	template<class InIt>
+	void read_string(InIt& in, InIt end, int len, std::string& str, bool& err)
+	{
+		TORRENT_ASSERT(len >= 0);
+		for (int i = 0; i < len; ++i)
 		{
-			TORRENT_ASSERT(len >= 0);
-			for (int i = 0; i < len; ++i)
-			{
-				if (in == end)
-				{
-					err = true;
-					return;
-				}
-				str += *in;
-				++in;
-			}
-		}
-
-		template<class OutIt>
-		int bencode_recursive(OutIt& out, const entry& e)
-		{
-			int ret = 0;
-			switch(e.type())
-			{
-			case entry::int_t:
-				write_char(out, 'i');
-				ret += write_integer(out, e.integer());
-				write_char(out, 'e');
-				ret += 2;
-				break;
-			case entry::string_t:
-				ret += write_integer(out, e.string().length());
-				write_char(out, ':');
-				ret += write_string(e.string(), out);
-				ret += 1;
-				break;
-			case entry::list_t:
-				write_char(out, 'l');
-				for (auto const& i : e.list())
-					ret += bencode_recursive(out, i);
-				write_char(out, 'e');
-				ret += 2;
-				break;
-			case entry::dictionary_t:
-				write_char(out, 'd');
-				for (auto const& i : e.dict())
-				{
-					// write key
-					ret += write_integer(out, i.first.length());
-					write_char(out, ':');
-					ret += write_string(i.first, out);
-					// write value
-					ret += bencode_recursive(out, i.second);
-					ret += 1;
-				}
-				write_char(out, 'e');
-				ret += 2;
-				break;
-			case entry::preformatted_t:
-				std::copy(e.preformatted().begin(), e.preformatted().end(), out);
-				ret += static_cast<int>(e.preformatted().size());
-				break;
-			case entry::undefined_t:
-
-				// empty string
-				write_char(out, '0');
-				write_char(out, ':');
-
-				ret += 2;
-				break;
-			}
-			return ret;
-		}
-#if TORRENT_ABI_VERSION == 1
-		template<class InIt>
-		void bdecode_recursive(InIt& in, InIt end, entry& ret, bool& err, int depth)
-		{
-			if (depth >= 100)
-			{
-				err = true;
-				return;
-			}
-
 			if (in == end)
 			{
 				err = true;
-#if TORRENT_USE_ASSERTS
-				ret.m_type_queried = false;
-#endif
 				return;
 			}
-			switch (*in)
-			{
+			str += *in;
+			++in;
+		}
+	}
 
-			// ----------------------------------------------
-			// integer
-			case 'i':
-				{
-				++in; // 'i'
-				std::string const val = read_until(in, end, 'e', err);
-				if (err) return;
-				TORRENT_ASSERT(*in == 'e');
-				++in; // 'e'
-				ret = entry(entry::int_t);
-				char* end_pointer;
-				ret.integer() = std::strtoll(val.c_str(), &end_pointer, 10);
+	template<class OutIt>
+	int bencode_recursive(OutIt& out, const entry& e)
+	{
+		int ret = 0;
+		switch(e.type())
+		{
+		case entry::int_t:
+			write_char(out, 'i');
+			ret += write_integer(out, e.integer());
+			write_char(out, 'e');
+			ret += 2;
+			break;
+		case entry::string_t:
+			ret += write_integer(out, e.string().length());
+			write_char(out, ':');
+			ret += write_string(e.string(), out);
+			ret += 1;
+			break;
+		case entry::list_t:
+			write_char(out, 'l');
+			for (auto const& i : e.list())
+				ret += bencode_recursive(out, i);
+			write_char(out, 'e');
+			ret += 2;
+			break;
+		case entry::dictionary_t:
+			write_char(out, 'd');
+			for (auto const& i : e.dict())
+			{
+				// write key
+				ret += write_integer(out, i.first.length());
+				write_char(out, ':');
+				ret += write_string(i.first, out);
+				// write value
+				ret += bencode_recursive(out, i.second);
+				ret += 1;
+			}
+			write_char(out, 'e');
+			ret += 2;
+			break;
+		case entry::preformatted_t:
+			std::copy(e.preformatted().begin(), e.preformatted().end(), out);
+			ret += static_cast<int>(e.preformatted().size());
+			break;
+		case entry::undefined_t:
+
+			// empty string
+			write_char(out, '0');
+			write_char(out, ':');
+
+			ret += 2;
+			break;
+		}
+		return ret;
+	}
+#if TORRENT_ABI_VERSION == 1
+	template<class InIt>
+	void bdecode_recursive(InIt& in, InIt end, entry& ret, bool& err, int depth)
+	{
+		if (depth >= 100)
+		{
+			err = true;
+			return;
+		}
+
+		if (in == end)
+		{
+			err = true;
 #if TORRENT_USE_ASSERTS
-				ret.m_type_queried = false;
+			ret.m_type_queried = false;
 #endif
-				if (end_pointer == val.c_str())
+			return;
+		}
+		switch (*in)
+		{
+
+		// ----------------------------------------------
+		// integer
+		case 'i':
+			{
+			++in; // 'i'
+			std::string const val = read_until(in, end, 'e', err);
+			if (err) return;
+			TORRENT_ASSERT(*in == 'e');
+			++in; // 'e'
+			ret = entry(entry::int_t);
+			char* end_pointer;
+			ret.integer() = std::strtoll(val.c_str(), &end_pointer, 10);
+#if TORRENT_USE_ASSERTS
+			ret.m_type_queried = false;
+#endif
+			if (end_pointer == val.c_str())
+			{
+				err = true;
+				return;
+			}
+			}
+			break;
+
+		// ----------------------------------------------
+		// list
+		case 'l':
+			ret = entry(entry::list_t);
+			++in; // 'l'
+			while (*in != 'e')
+			{
+				ret.list().emplace_back();
+				entry& e = ret.list().back();
+				bdecode_recursive(in, end, e, err, depth + 1);
+				if (err)
 				{
-					err = true;
+#if TORRENT_USE_ASSERTS
+					ret.m_type_queried = false;
+#endif
 					return;
 				}
-				}
-				break;
-
-			// ----------------------------------------------
-			// list
-			case 'l':
-				ret = entry(entry::list_t);
-				++in; // 'l'
-				while (*in != 'e')
-				{
-					ret.list().emplace_back();
-					entry& e = ret.list().back();
-					bdecode_recursive(in, end, e, err, depth + 1);
-					if (err)
-					{
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-					if (in == end)
-					{
-						err = true;
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-				}
-#if TORRENT_USE_ASSERTS
-				ret.m_type_queried = false;
-#endif
-				TORRENT_ASSERT(*in == 'e');
-				++in; // 'e'
-				break;
-
-			// ----------------------------------------------
-			// dictionary
-			case 'd':
-				ret = entry(entry::dictionary_t);
-				++in; // 'd'
-				while (*in != 'e')
-				{
-					entry key;
-					bdecode_recursive(in, end, key, err, depth + 1);
-					if (err || key.type() != entry::string_t)
-					{
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-					entry& e = ret[key.string()];
-					bdecode_recursive(in, end, e, err, depth + 1);
-					if (err)
-					{
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-					if (in == end)
-					{
-						err = true;
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-				}
-#if TORRENT_USE_ASSERTS
-				ret.m_type_queried = false;
-#endif
-				TORRENT_ASSERT(*in == 'e');
-				++in; // 'e'
-				break;
-
-			// ----------------------------------------------
-			// string
-			default:
-				static_assert(sizeof(*in) == 1, "Input iterator to 8 bit data required");
-				if (is_digit(char(*in)))
-				{
-					std::string len_s = read_until(in, end, ':', err);
-					if (err)
-					{
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-					TORRENT_ASSERT(*in == ':');
-					++in; // ':'
-					int len = atoi(len_s.c_str());
-					ret = entry(entry::string_t);
-					read_string(in, end, len, ret.string(), err);
-					if (err)
-					{
-#if TORRENT_USE_ASSERTS
-						ret.m_type_queried = false;
-#endif
-						return;
-					}
-				}
-				else
+				if (in == end)
 				{
 					err = true;
 #if TORRENT_USE_ASSERTS
@@ -343,13 +259,97 @@ namespace detail {
 #endif
 					return;
 				}
+			}
+#if TORRENT_USE_ASSERTS
+			ret.m_type_queried = false;
+#endif
+			TORRENT_ASSERT(*in == 'e');
+			++in; // 'e'
+			break;
+
+		// ----------------------------------------------
+		// dictionary
+		case 'd':
+			ret = entry(entry::dictionary_t);
+			++in; // 'd'
+			while (*in != 'e')
+			{
+				entry key;
+				bdecode_recursive(in, end, key, err, depth + 1);
+				if (err || key.type() != entry::string_t)
+				{
+#if TORRENT_USE_ASSERTS
+					ret.m_type_queried = false;
+#endif
+					return;
+				}
+				entry& e = ret[key.string()];
+				bdecode_recursive(in, end, e, err, depth + 1);
+				if (err)
+				{
+#if TORRENT_USE_ASSERTS
+					ret.m_type_queried = false;
+#endif
+					return;
+				}
+				if (in == end)
+				{
+					err = true;
+#if TORRENT_USE_ASSERTS
+					ret.m_type_queried = false;
+#endif
+					return;
+				}
+			}
+#if TORRENT_USE_ASSERTS
+			ret.m_type_queried = false;
+#endif
+			TORRENT_ASSERT(*in == 'e');
+			++in; // 'e'
+			break;
+
+		// ----------------------------------------------
+		// string
+		default:
+			static_assert(sizeof(*in) == 1, "Input iterator to 8 bit data required");
+			if (is_digit(char(*in)))
+			{
+				std::string len_s = read_until(in, end, ':', err);
+				if (err)
+				{
+#if TORRENT_USE_ASSERTS
+					ret.m_type_queried = false;
+#endif
+					return;
+				}
+				TORRENT_ASSERT(*in == ':');
+				++in; // ':'
+				int len = atoi(len_s.c_str());
+				ret = entry(entry::string_t);
+				read_string(in, end, len, ret.string(), err);
+				if (err)
+				{
+#if TORRENT_USE_ASSERTS
+					ret.m_type_queried = false;
+#endif
+					return;
+				}
+			}
+			else
+			{
+				err = true;
 #if TORRENT_USE_ASSERTS
 				ret.m_type_queried = false;
 #endif
+				return;
 			}
+#if TORRENT_USE_ASSERTS
+			ret.m_type_queried = false;
+#endif
 		}
-#endif // TORRENT_ABI_VERSION
 	}
+#endif // TORRENT_ABI_VERSION
+}
 
 	// This function will encode data to bencoded form.
 	//

--- a/include/libtorrent/choker.hpp
+++ b/include/libtorrent/choker.hpp
@@ -39,7 +39,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace aux { struct session_settings; }
+namespace aux {
+	struct session_settings;
+}
 	class peer_connection;
 
 	// sorts the vector of peers in-place. When returning, the top unchoke slots

--- a/include/libtorrent/disk_buffer_pool.hpp
+++ b/include/libtorrent/disk_buffer_pool.hpp
@@ -49,7 +49,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace aux { struct session_settings; }
+namespace aux {
+	struct session_settings;
+}
 	struct disk_observer;
 
 	struct TORRENT_EXTRA_EXPORT disk_buffer_pool

--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -61,39 +61,38 @@ namespace libtorrent {
 	// this is a bittorrent constant
 	constexpr int default_block_size = 0x4000;
 
-	namespace file_open_mode
-	{
-		// open the file for reading only
-		constexpr file_open_mode_t read_only{};
+namespace file_open_mode {
+	// open the file for reading only
+	constexpr file_open_mode_t read_only{};
 
-		// open the file for writing only
-		constexpr file_open_mode_t write_only = 0_bit;
+	// open the file for writing only
+	constexpr file_open_mode_t write_only = 0_bit;
 
-		// open the file for reading and writing
-		constexpr file_open_mode_t read_write = 1_bit;
+	// open the file for reading and writing
+	constexpr file_open_mode_t read_write = 1_bit;
 
-		// the mask for the bits determining read or write mode
-		constexpr file_open_mode_t rw_mask = read_only | write_only | read_write;
+	// the mask for the bits determining read or write mode
+	constexpr file_open_mode_t rw_mask = read_only | write_only | read_write;
 
-		// open the file in sparse mode (if supported by the
-		// filesystem).
-		constexpr file_open_mode_t sparse = 2_bit;
+	// open the file in sparse mode (if supported by the
+	// filesystem).
+	constexpr file_open_mode_t sparse = 2_bit;
 
-		// don't update the access timestamps on the file (if
-		// supported by the operating system and filesystem).
-		// this generally improves disk performance.
-		constexpr file_open_mode_t no_atime = 3_bit;
+	// don't update the access timestamps on the file (if
+	// supported by the operating system and filesystem).
+	// this generally improves disk performance.
+	constexpr file_open_mode_t no_atime = 3_bit;
 
-		// open the file for random access. This disables read-ahead
-		// logic
-		constexpr file_open_mode_t random_access = 5_bit;
+	// open the file for random access. This disables read-ahead
+	// logic
+	constexpr file_open_mode_t random_access = 5_bit;
 
 #if TORRENT_ABI_VERSION == 1
-		// prevent the file from being opened by another process
-		// while it's still being held open by this handle
-		constexpr file_open_mode_t TORRENT_DEPRECATED locked = 6_bit;
+	// prevent the file from being opened by another process
+	// while it's still being held open by this handle
+	constexpr file_open_mode_t TORRENT_DEPRECATED locked = 6_bit;
 #endif
-	}
+}
 
 	// this contains information about a file that's currently open by the
 	// libtorrent disk I/O subsystem. It's associated with a single torrent.
@@ -232,6 +231,6 @@ namespace libtorrent {
 		storage_index_t m_idx{0};
 	};
 
-}
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/entry.hpp
+++ b/include/libtorrent/entry.hpp
@@ -117,7 +117,7 @@ namespace aux {
 			}
 		};
 #endif
-	}
+}
 
 	// The ``entry`` class represents one node in a bencoded hierarchy. It works as a
 	// variant type, it can be either a list, a dictionary (``std::map``), an integer

--- a/include/libtorrent/error_code.hpp
+++ b/include/libtorrent/error_code.hpp
@@ -44,442 +44,441 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace errors
+namespace errors {
+	// libtorrent uses boost.system's ``error_code`` class to represent
+	// errors. libtorrent has its own error category
+	// libtorrent_category() with the error codes defined by
+	// error_code_enum.
+	enum error_code_enum
 	{
-		// libtorrent uses boost.system's ``error_code`` class to represent
-		// errors. libtorrent has its own error category
-		// libtorrent_category() with the error codes defined by
-		// error_code_enum.
-		enum error_code_enum
-		{
-			// Not an error
-			no_error = 0,
-			// Two torrents has files which end up overwriting each other
-			file_collision,
-			// A piece did not match its piece hash
-			failed_hash_check,
-			// The .torrent file does not contain a bencoded dictionary at
-			// its top level
-			torrent_is_no_dict,
-			// The .torrent file does not have an ``info`` dictionary
-			torrent_missing_info,
-			// The .torrent file's ``info`` entry is not a dictionary
-			torrent_info_no_dict,
-			// The .torrent file does not have a ``piece length`` entry
-			torrent_missing_piece_length,
-			// The .torrent file does not have a ``name`` entry
-			torrent_missing_name,
-			// The .torrent file's name entry is invalid
-			torrent_invalid_name,
-			// The length of a file, or of the whole .torrent file is invalid.
-			// Either negative or not an integer
-			torrent_invalid_length,
-			// Failed to parse a file entry in the .torrent
-			torrent_file_parse_failed,
-			// The ``pieces`` field is missing or invalid in the .torrent file
-			torrent_missing_pieces,
-			// The ``pieces`` string has incorrect length
-			torrent_invalid_hashes,
-			// The .torrent file has more pieces than is supported by libtorrent
-			too_many_pieces_in_torrent,
-			// The metadata (.torrent file) that was received from the swarm
-			// matched the info-hash, but failed to be parsed
-			invalid_swarm_metadata,
-			// The file or buffer is not correctly bencoded
-			invalid_bencoding,
-			// The .torrent file does not contain any files
-			no_files_in_torrent,
-			// The string was not properly url-encoded as expected
-			invalid_escaped_string,
-			// Operation is not permitted since the session is shutting down
-			session_is_closing,
-			// There's already a torrent with that info-hash added to the
-			// session
-			duplicate_torrent,
-			// The supplied torrent_handle is not referring to a valid torrent
-			invalid_torrent_handle,
-			// The type requested from the entry did not match its type
-			invalid_entry_type,
-			// The specified URI does not contain a valid info-hash
-			missing_info_hash_in_uri,
-			// One of the files in the torrent was unexpectedly small. This
-			// might be caused by files being changed by an external process
-			file_too_short,
-			// The URL used an unknown protocol. Currently ``http`` and
-			// ``https`` (if built with openssl support) are recognized. For
-			// trackers ``udp`` is recognized as well.
-			unsupported_url_protocol,
-			// The URL did not conform to URL syntax and failed to be parsed
-			url_parse_error,
-			// The peer sent a 'piece' message of length 0
-			peer_sent_empty_piece,
-			// A bencoded structure was corrupt and failed to be parsed
-			parse_failed,
-			// The fast resume file was missing or had an invalid file version
-			// tag
-			invalid_file_tag,
-			// The fast resume file was missing or had an invalid info-hash
-			missing_info_hash,
-			// The info-hash did not match the torrent
-			mismatching_info_hash,
-			// The URL contained an invalid hostname
-			invalid_hostname,
-			// The URL had an invalid port
-			invalid_port,
-			// The port is blocked by the port-filter, and prevented the
-			// connection
-			port_blocked,
-			// The IPv6 address was expected to end with ']'
-			expected_close_bracket_in_address,
-			// The torrent is being destructed, preventing the operation to
-			// succeed
-			destructing_torrent,
-			// The connection timed out
-			timed_out,
-			// The peer is upload only, and we are upload only. There's no point
-			// in keeping the connection
-			upload_upload_connection,
-			// The peer is upload only, and we're not interested in it. There's
-			// no point in keeping the connection
-			uninteresting_upload_peer,
-			// The peer sent an unknown info-hash
-			invalid_info_hash,
-			// The torrent is paused, preventing the operation from succeeding
-			torrent_paused,
-			// The peer sent an invalid have message, either wrong size or
-			// referring to a piece that doesn't exist in the torrent
-			invalid_have,
-			// The bitfield message had the incorrect size
-			invalid_bitfield_size,
-			// The peer kept requesting pieces after it was choked, possible
-			// abuse attempt.
-			too_many_requests_when_choked,
-			// The peer sent a piece message that does not correspond to a
-			// piece request sent by the client
-			invalid_piece,
-			// memory allocation failed
-			no_memory,
-			// The torrent is aborted, preventing the operation to succeed
-			torrent_aborted,
-			// The peer is a connection to ourself, no point in keeping it
-			self_connection,
-			// The peer sent a piece message with invalid size, either negative
-			// or greater than one block
-			invalid_piece_size,
-			// The peer has not been interesting or interested in us for too
-			// long, no point in keeping it around
-			timed_out_no_interest,
-			// The peer has not said anything in a long time, possibly dead
-			timed_out_inactivity,
-			// The peer did not send a handshake within a reasonable amount of
-			// time, it might not be a bittorrent peer
-			timed_out_no_handshake,
-			// The peer has been unchoked for too long without requesting any
-			// data. It might be lying about its interest in us
-			timed_out_no_request,
-			// The peer sent an invalid choke message
-			invalid_choke,
-			// The peer send an invalid unchoke message
-			invalid_unchoke,
-			// The peer sent an invalid interested message
-			invalid_interested,
-			// The peer sent an invalid not-interested message
-			invalid_not_interested,
-			// The peer sent an invalid piece request message
-			invalid_request,
-			// The peer sent an invalid hash-list message (this is part of the
-			// merkle-torrent extension)
-			invalid_hash_list,
-			// The peer sent an invalid hash-piece message (this is part of the
-			// merkle-torrent extension)
-			invalid_hash_piece,
-			// The peer sent an invalid cancel message
-			invalid_cancel,
-			// The peer sent an invalid DHT port-message
-			invalid_dht_port,
-			// The peer sent an invalid suggest piece-message
-			invalid_suggest,
-			// The peer sent an invalid have all-message
-			invalid_have_all,
-			// The peer sent an invalid have none-message
-			invalid_have_none,
-			// The peer sent an invalid reject message
-			invalid_reject,
-			// The peer sent an invalid allow fast-message
-			invalid_allow_fast,
-			// The peer sent an invalid extension message ID
-			invalid_extended,
-			// The peer sent an invalid message ID
-			invalid_message,
-			// The synchronization hash was not found in the encrypted handshake
-			sync_hash_not_found,
-			// The encryption constant in the handshake is invalid
-			invalid_encryption_constant,
-			// The peer does not support plaintext, which is the selected mode
-			no_plaintext_mode,
-			// The peer does not support rc4, which is the selected mode
-			no_rc4_mode,
-			// The peer does not support any of the encryption modes that the
-			// client supports
-			unsupported_encryption_mode,
-			// The peer selected an encryption mode that the client did not
-			// advertise and does not support
-			unsupported_encryption_mode_selected,
-			// The pad size used in the encryption handshake is of invalid size
-			invalid_pad_size,
-			// The encryption handshake is invalid
-			invalid_encrypt_handshake,
-			// The client is set to not support incoming encrypted connections
-			// and this is an encrypted connection
-			no_incoming_encrypted,
-			// The client is set to not support incoming regular bittorrent
-			// connections, and this is a regular connection
-			no_incoming_regular,
-			// The client is already connected to this peer-ID
-			duplicate_peer_id,
-			// Torrent was removed
-			torrent_removed,
-			// The packet size exceeded the upper sanity check-limit
-			packet_too_large,
+		// Not an error
+		no_error = 0,
+		// Two torrents has files which end up overwriting each other
+		file_collision,
+		// A piece did not match its piece hash
+		failed_hash_check,
+		// The .torrent file does not contain a bencoded dictionary at
+		// its top level
+		torrent_is_no_dict,
+		// The .torrent file does not have an ``info`` dictionary
+		torrent_missing_info,
+		// The .torrent file's ``info`` entry is not a dictionary
+		torrent_info_no_dict,
+		// The .torrent file does not have a ``piece length`` entry
+		torrent_missing_piece_length,
+		// The .torrent file does not have a ``name`` entry
+		torrent_missing_name,
+		// The .torrent file's name entry is invalid
+		torrent_invalid_name,
+		// The length of a file, or of the whole .torrent file is invalid.
+		// Either negative or not an integer
+		torrent_invalid_length,
+		// Failed to parse a file entry in the .torrent
+		torrent_file_parse_failed,
+		// The ``pieces`` field is missing or invalid in the .torrent file
+		torrent_missing_pieces,
+		// The ``pieces`` string has incorrect length
+		torrent_invalid_hashes,
+		// The .torrent file has more pieces than is supported by libtorrent
+		too_many_pieces_in_torrent,
+		// The metadata (.torrent file) that was received from the swarm
+		// matched the info-hash, but failed to be parsed
+		invalid_swarm_metadata,
+		// The file or buffer is not correctly bencoded
+		invalid_bencoding,
+		// The .torrent file does not contain any files
+		no_files_in_torrent,
+		// The string was not properly url-encoded as expected
+		invalid_escaped_string,
+		// Operation is not permitted since the session is shutting down
+		session_is_closing,
+		// There's already a torrent with that info-hash added to the
+		// session
+		duplicate_torrent,
+		// The supplied torrent_handle is not referring to a valid torrent
+		invalid_torrent_handle,
+		// The type requested from the entry did not match its type
+		invalid_entry_type,
+		// The specified URI does not contain a valid info-hash
+		missing_info_hash_in_uri,
+		// One of the files in the torrent was unexpectedly small. This
+		// might be caused by files being changed by an external process
+		file_too_short,
+		// The URL used an unknown protocol. Currently ``http`` and
+		// ``https`` (if built with openssl support) are recognized. For
+		// trackers ``udp`` is recognized as well.
+		unsupported_url_protocol,
+		// The URL did not conform to URL syntax and failed to be parsed
+		url_parse_error,
+		// The peer sent a 'piece' message of length 0
+		peer_sent_empty_piece,
+		// A bencoded structure was corrupt and failed to be parsed
+		parse_failed,
+		// The fast resume file was missing or had an invalid file version
+		// tag
+		invalid_file_tag,
+		// The fast resume file was missing or had an invalid info-hash
+		missing_info_hash,
+		// The info-hash did not match the torrent
+		mismatching_info_hash,
+		// The URL contained an invalid hostname
+		invalid_hostname,
+		// The URL had an invalid port
+		invalid_port,
+		// The port is blocked by the port-filter, and prevented the
+		// connection
+		port_blocked,
+		// The IPv6 address was expected to end with ']'
+		expected_close_bracket_in_address,
+		// The torrent is being destructed, preventing the operation to
+		// succeed
+		destructing_torrent,
+		// The connection timed out
+		timed_out,
+		// The peer is upload only, and we are upload only. There's no point
+		// in keeping the connection
+		upload_upload_connection,
+		// The peer is upload only, and we're not interested in it. There's
+		// no point in keeping the connection
+		uninteresting_upload_peer,
+		// The peer sent an unknown info-hash
+		invalid_info_hash,
+		// The torrent is paused, preventing the operation from succeeding
+		torrent_paused,
+		// The peer sent an invalid have message, either wrong size or
+		// referring to a piece that doesn't exist in the torrent
+		invalid_have,
+		// The bitfield message had the incorrect size
+		invalid_bitfield_size,
+		// The peer kept requesting pieces after it was choked, possible
+		// abuse attempt.
+		too_many_requests_when_choked,
+		// The peer sent a piece message that does not correspond to a
+		// piece request sent by the client
+		invalid_piece,
+		// memory allocation failed
+		no_memory,
+		// The torrent is aborted, preventing the operation to succeed
+		torrent_aborted,
+		// The peer is a connection to ourself, no point in keeping it
+		self_connection,
+		// The peer sent a piece message with invalid size, either negative
+		// or greater than one block
+		invalid_piece_size,
+		// The peer has not been interesting or interested in us for too
+		// long, no point in keeping it around
+		timed_out_no_interest,
+		// The peer has not said anything in a long time, possibly dead
+		timed_out_inactivity,
+		// The peer did not send a handshake within a reasonable amount of
+		// time, it might not be a bittorrent peer
+		timed_out_no_handshake,
+		// The peer has been unchoked for too long without requesting any
+		// data. It might be lying about its interest in us
+		timed_out_no_request,
+		// The peer sent an invalid choke message
+		invalid_choke,
+		// The peer send an invalid unchoke message
+		invalid_unchoke,
+		// The peer sent an invalid interested message
+		invalid_interested,
+		// The peer sent an invalid not-interested message
+		invalid_not_interested,
+		// The peer sent an invalid piece request message
+		invalid_request,
+		// The peer sent an invalid hash-list message (this is part of the
+		// merkle-torrent extension)
+		invalid_hash_list,
+		// The peer sent an invalid hash-piece message (this is part of the
+		// merkle-torrent extension)
+		invalid_hash_piece,
+		// The peer sent an invalid cancel message
+		invalid_cancel,
+		// The peer sent an invalid DHT port-message
+		invalid_dht_port,
+		// The peer sent an invalid suggest piece-message
+		invalid_suggest,
+		// The peer sent an invalid have all-message
+		invalid_have_all,
+		// The peer sent an invalid have none-message
+		invalid_have_none,
+		// The peer sent an invalid reject message
+		invalid_reject,
+		// The peer sent an invalid allow fast-message
+		invalid_allow_fast,
+		// The peer sent an invalid extension message ID
+		invalid_extended,
+		// The peer sent an invalid message ID
+		invalid_message,
+		// The synchronization hash was not found in the encrypted handshake
+		sync_hash_not_found,
+		// The encryption constant in the handshake is invalid
+		invalid_encryption_constant,
+		// The peer does not support plaintext, which is the selected mode
+		no_plaintext_mode,
+		// The peer does not support rc4, which is the selected mode
+		no_rc4_mode,
+		// The peer does not support any of the encryption modes that the
+		// client supports
+		unsupported_encryption_mode,
+		// The peer selected an encryption mode that the client did not
+		// advertise and does not support
+		unsupported_encryption_mode_selected,
+		// The pad size used in the encryption handshake is of invalid size
+		invalid_pad_size,
+		// The encryption handshake is invalid
+		invalid_encrypt_handshake,
+		// The client is set to not support incoming encrypted connections
+		// and this is an encrypted connection
+		no_incoming_encrypted,
+		// The client is set to not support incoming regular bittorrent
+		// connections, and this is a regular connection
+		no_incoming_regular,
+		// The client is already connected to this peer-ID
+		duplicate_peer_id,
+		// Torrent was removed
+		torrent_removed,
+		// The packet size exceeded the upper sanity check-limit
+		packet_too_large,
 
-			reserved,
+		reserved,
 
-			// The web server responded with an error
-			http_error,
-			// The web server response is missing a location header
-			missing_location,
-			// The web seed redirected to a path that no longer matches the
-			// .torrent directory structure
-			invalid_redirection,
-			// The connection was closed because it redirected to a different
-			// URL
-			redirecting,
-			// The HTTP range header is invalid
-			invalid_range,
-			// The HTTP response did not have a content length
-			no_content_length,
-			// The IP is blocked by the IP filter
-			banned_by_ip_filter,
-			// At the connection limit
-			too_many_connections,
-			// The peer is marked as banned
-			peer_banned,
-			// The torrent is stopping, causing the operation to fail
-			stopping_torrent,
-			// The peer has sent too many corrupt pieces and is banned
-			too_many_corrupt_pieces,
-			// The torrent is not ready to receive peers
-			torrent_not_ready,
-			// The peer is not completely constructed yet
-			peer_not_constructed,
-			// The session is closing, causing the operation to fail
-			session_closing,
-			// The peer was disconnected in order to leave room for a
-			// potentially better peer
-			optimistic_disconnect,
-			// The torrent is finished
-			torrent_finished,
-			// No UPnP router found
-			no_router,
-			// The metadata message says the metadata exceeds the limit
-			metadata_too_large,
-			// The peer sent an invalid metadata request message
-			invalid_metadata_request,
-			// The peer advertised an invalid metadata size
-			invalid_metadata_size,
-			// The peer sent a message with an invalid metadata offset
-			invalid_metadata_offset,
-			// The peer sent an invalid metadata message
-			invalid_metadata_message,
-			// The peer sent a peer exchange message that was too large
-			pex_message_too_large,
-			// The peer sent an invalid peer exchange message
-			invalid_pex_message,
-			// The peer sent an invalid tracker exchange message
-			invalid_lt_tracker_message,
-			// The peer sent an pex messages too often. This is a possible
-			// attempt of and attack
-			too_frequent_pex,
-			// The operation failed because it requires the torrent to have
-			// the metadata (.torrent file) and it doesn't have it yet.
-			// This happens for magnet links before they have downloaded the
-			// metadata, and also torrents added by URL.
-			no_metadata,
-			// The peer sent an invalid ``dont_have`` message. The don't have
-			// message is an extension to allow peers to advertise that the
-			// no longer has a piece they previously had.
-			invalid_dont_have,
-			// The peer tried to connect to an SSL torrent without connecting
-			// over SSL.
-			requires_ssl_connection,
-			// The peer tried to connect to a torrent with a certificate
-			// for a different torrent.
-			invalid_ssl_cert,
-			// the torrent is not an SSL torrent, and the operation requires
-			// an SSL torrent
-			not_an_ssl_torrent,
-			// peer was banned because its listen port is within a banned port
-			// range, as specified by the port_filter.
-			banned_by_port_filter,
-			// The session_handle is not referring to a valid session_impl
-			invalid_session_handle,
-			// the listen socket associated with this request was closed
-			invalid_listen_socket,
+		// The web server responded with an error
+		http_error,
+		// The web server response is missing a location header
+		missing_location,
+		// The web seed redirected to a path that no longer matches the
+		// .torrent directory structure
+		invalid_redirection,
+		// The connection was closed because it redirected to a different
+		// URL
+		redirecting,
+		// The HTTP range header is invalid
+		invalid_range,
+		// The HTTP response did not have a content length
+		no_content_length,
+		// The IP is blocked by the IP filter
+		banned_by_ip_filter,
+		// At the connection limit
+		too_many_connections,
+		// The peer is marked as banned
+		peer_banned,
+		// The torrent is stopping, causing the operation to fail
+		stopping_torrent,
+		// The peer has sent too many corrupt pieces and is banned
+		too_many_corrupt_pieces,
+		// The torrent is not ready to receive peers
+		torrent_not_ready,
+		// The peer is not completely constructed yet
+		peer_not_constructed,
+		// The session is closing, causing the operation to fail
+		session_closing,
+		// The peer was disconnected in order to leave room for a
+		// potentially better peer
+		optimistic_disconnect,
+		// The torrent is finished
+		torrent_finished,
+		// No UPnP router found
+		no_router,
+		// The metadata message says the metadata exceeds the limit
+		metadata_too_large,
+		// The peer sent an invalid metadata request message
+		invalid_metadata_request,
+		// The peer advertised an invalid metadata size
+		invalid_metadata_size,
+		// The peer sent a message with an invalid metadata offset
+		invalid_metadata_offset,
+		// The peer sent an invalid metadata message
+		invalid_metadata_message,
+		// The peer sent a peer exchange message that was too large
+		pex_message_too_large,
+		// The peer sent an invalid peer exchange message
+		invalid_pex_message,
+		// The peer sent an invalid tracker exchange message
+		invalid_lt_tracker_message,
+		// The peer sent an pex messages too often. This is a possible
+		// attempt of and attack
+		too_frequent_pex,
+		// The operation failed because it requires the torrent to have
+		// the metadata (.torrent file) and it doesn't have it yet.
+		// This happens for magnet links before they have downloaded the
+		// metadata, and also torrents added by URL.
+		no_metadata,
+		// The peer sent an invalid ``dont_have`` message. The don't have
+		// message is an extension to allow peers to advertise that the
+		// no longer has a piece they previously had.
+		invalid_dont_have,
+		// The peer tried to connect to an SSL torrent without connecting
+		// over SSL.
+		requires_ssl_connection,
+		// The peer tried to connect to a torrent with a certificate
+		// for a different torrent.
+		invalid_ssl_cert,
+		// the torrent is not an SSL torrent, and the operation requires
+		// an SSL torrent
+		not_an_ssl_torrent,
+		// peer was banned because its listen port is within a banned port
+		// range, as specified by the port_filter.
+		banned_by_port_filter,
+		// The session_handle is not referring to a valid session_impl
+		invalid_session_handle,
+		// the listen socket associated with this request was closed
+		invalid_listen_socket,
 
 #if TORRENT_ABI_VERSION == 1
-			// these error codes are deprecated, NAT-PMP/PCP error codes have
-			// been moved to their own category
+		// these error codes are deprecated, NAT-PMP/PCP error codes have
+		// been moved to their own category
 
-			// The NAT-PMP router responded with an unsupported protocol version
-			unsupported_protocol_version TORRENT_DEPRECATED_ENUM = 120,
-			// You are not authorized to map ports on this NAT-PMP router
-			natpmp_not_authorized TORRENT_DEPRECATED_ENUM,
-			// The NAT-PMP router failed because of a network failure
-			network_failure TORRENT_DEPRECATED_ENUM,
-			// The NAT-PMP router failed because of lack of resources
-			no_resources TORRENT_DEPRECATED_ENUM,
-			// The NAT-PMP router failed because an unsupported opcode was sent
-			unsupported_opcode TORRENT_DEPRECATED_ENUM,
+		// The NAT-PMP router responded with an unsupported protocol version
+		unsupported_protocol_version TORRENT_DEPRECATED_ENUM = 120,
+		// You are not authorized to map ports on this NAT-PMP router
+		natpmp_not_authorized TORRENT_DEPRECATED_ENUM,
+		// The NAT-PMP router failed because of a network failure
+		network_failure TORRENT_DEPRECATED_ENUM,
+		// The NAT-PMP router failed because of lack of resources
+		no_resources TORRENT_DEPRECATED_ENUM,
+		// The NAT-PMP router failed because an unsupported opcode was sent
+		unsupported_opcode TORRENT_DEPRECATED_ENUM,
 #else
-			deprecated_120 = 120,
-			deprecated_121,
-			deprecated_122,
-			deprecated_123,
-			deprecated_124,
+		deprecated_120 = 120,
+		deprecated_121,
+		deprecated_122,
+		deprecated_123,
+		deprecated_124,
 #endif
 
 
-			// The resume data file is missing the 'file sizes' entry
-			missing_file_sizes = 130,
-			// The resume data file 'file sizes' entry is empty
-			no_files_in_resume_data,
-			// The resume data file is missing the 'pieces' and 'slots' entry
-			missing_pieces,
-			// The number of files in the resume data does not match the number
-			// of files in the torrent
-			mismatching_number_of_files,
-			// One of the files on disk has a different size than in the fast
-			// resume file
-			mismatching_file_size,
-			// One of the files on disk has a different timestamp than in the
-			// fast resume file
-			mismatching_file_timestamp,
-			// The resume data file is not a dictionary
-			not_a_dictionary,
-			// The 'blocks per piece' entry is invalid in the resume data file
-			invalid_blocks_per_piece,
-			// The resume file is missing the 'slots' entry, which is required
-			// for torrents with compact allocation. *DEPRECATED*
-			missing_slots,
-			// The resume file contains more slots than the torrent
-			too_many_slots,
-			// The 'slot' entry is invalid in the resume data
-			invalid_slot_list,
-			// One index in the 'slot' list is invalid
-			invalid_piece_index,
-			// The pieces on disk needs to be re-ordered for the specified
-			// allocation mode. This happens if you specify sparse allocation
-			// and the files on disk are using compact storage. The pieces needs
-			// to be moved to their right position. *DEPRECATED*
-			pieces_need_reorder,
-			// this error is returned when asking to save resume data and
-			// specifying the flag to only save when there's anything new to save
-			// (torrent_handle::only_if_modified) and there wasn't anything changed.
-			resume_data_not_modified,
+		// The resume data file is missing the 'file sizes' entry
+		missing_file_sizes = 130,
+		// The resume data file 'file sizes' entry is empty
+		no_files_in_resume_data,
+		// The resume data file is missing the 'pieces' and 'slots' entry
+		missing_pieces,
+		// The number of files in the resume data does not match the number
+		// of files in the torrent
+		mismatching_number_of_files,
+		// One of the files on disk has a different size than in the fast
+		// resume file
+		mismatching_file_size,
+		// One of the files on disk has a different timestamp than in the
+		// fast resume file
+		mismatching_file_timestamp,
+		// The resume data file is not a dictionary
+		not_a_dictionary,
+		// The 'blocks per piece' entry is invalid in the resume data file
+		invalid_blocks_per_piece,
+		// The resume file is missing the 'slots' entry, which is required
+		// for torrents with compact allocation. *DEPRECATED*
+		missing_slots,
+		// The resume file contains more slots than the torrent
+		too_many_slots,
+		// The 'slot' entry is invalid in the resume data
+		invalid_slot_list,
+		// One index in the 'slot' list is invalid
+		invalid_piece_index,
+		// The pieces on disk needs to be re-ordered for the specified
+		// allocation mode. This happens if you specify sparse allocation
+		// and the files on disk are using compact storage. The pieces needs
+		// to be moved to their right position. *DEPRECATED*
+		pieces_need_reorder,
+		// this error is returned when asking to save resume data and
+		// specifying the flag to only save when there's anything new to save
+		// (torrent_handle::only_if_modified) and there wasn't anything changed.
+		resume_data_not_modified,
 
 
 
-			// The HTTP header was not correctly formatted
-			http_parse_error = 150,
-			// The HTTP response was in the 300-399 range but lacked a location
-			// header
-			http_missing_location,
-			// The HTTP response was encoded with gzip or deflate but
-			// decompressing it failed
-			http_failed_decompress,
+		// The HTTP header was not correctly formatted
+		http_parse_error = 150,
+		// The HTTP response was in the 300-399 range but lacked a location
+		// header
+		http_missing_location,
+		// The HTTP response was encoded with gzip or deflate but
+		// decompressing it failed
+		http_failed_decompress,
 
 
 
-			// The URL specified an i2p address, but no i2p router is configured
-			no_i2p_router = 160,
-			// i2p acceptor is not available yet, can't announce without endpoint
-			no_i2p_endpoint = 161,
+		// The URL specified an i2p address, but no i2p router is configured
+		no_i2p_router = 160,
+		// i2p acceptor is not available yet, can't announce without endpoint
+		no_i2p_endpoint = 161,
 
 
 
-			// The tracker URL doesn't support transforming it into a scrape
-			// URL. i.e. it doesn't contain "announce.
-			scrape_not_available = 170,
-			// invalid tracker response
-			invalid_tracker_response,
-			// invalid peer dictionary entry. Not a dictionary
-			invalid_peer_dict,
-			// tracker sent a failure message
-			tracker_failure,
-			// missing or invalid 'files' entry
-			invalid_files_entry,
-			// missing or invalid 'hash' entry
-			invalid_hash_entry,
-			// missing or invalid 'peers' and 'peers6' entry
-			invalid_peers_entry,
-			// udp tracker response packet has invalid size
-			invalid_tracker_response_length,
-			// invalid transaction id in udp tracker response
-			invalid_tracker_transaction_id,
-			// invalid action field in udp tracker response
-			invalid_tracker_action,
+		// The tracker URL doesn't support transforming it into a scrape
+		// URL. i.e. it doesn't contain "announce.
+		scrape_not_available = 170,
+		// invalid tracker response
+		invalid_tracker_response,
+		// invalid peer dictionary entry. Not a dictionary
+		invalid_peer_dict,
+		// tracker sent a failure message
+		tracker_failure,
+		// missing or invalid 'files' entry
+		invalid_files_entry,
+		// missing or invalid 'hash' entry
+		invalid_hash_entry,
+		// missing or invalid 'peers' and 'peers6' entry
+		invalid_peers_entry,
+		// udp tracker response packet has invalid size
+		invalid_tracker_response_length,
+		// invalid transaction id in udp tracker response
+		invalid_tracker_transaction_id,
+		// invalid action field in udp tracker response
+		invalid_tracker_action,
 
 #if TORRENT_ABI_VERSION == 1
-			// expected string in bencoded string
-			expected_string = 190,
-			// expected colon in bencoded string
-			expected_colon,
-			// unexpected end of file in bencoded string
-			unexpected_eof,
-			// expected value (list, dict, int or string) in bencoded string
-			expected_value,
-			// bencoded recursion depth limit exceeded
-			depth_exceeded,
-			// bencoded item count limit exceeded
-			limit_exceeded,
-			// integer overflow
-			overflow,
+		// expected string in bencoded string
+		expected_string = 190,
+		// expected colon in bencoded string
+		expected_colon,
+		// unexpected end of file in bencoded string
+		unexpected_eof,
+		// expected value (list, dict, int or string) in bencoded string
+		expected_value,
+		// bencoded recursion depth limit exceeded
+		depth_exceeded,
+		// bencoded item count limit exceeded
+		limit_exceeded,
+		// integer overflow
+		overflow,
 #endif
 
-			// random number generation failed
-			no_entropy = 200,
+		// random number generation failed
+		no_entropy = 200,
 
-			// the number of error codes
-			error_code_max
-		};
+		// the number of error codes
+		error_code_max
+	};
 
-		// HTTP errors are reported in the libtorrent::http_category, with error code enums in
-		// the ``libtorrent::errors`` namespace.
-		enum http_errors
-		{
-			cont = 100,
-			ok = 200,
-			created = 201,
-			accepted = 202,
-			no_content = 204,
-			multiple_choices = 300,
-			moved_permanently = 301,
-			moved_temporarily = 302,
-			not_modified = 304,
-			bad_request = 400,
-			unauthorized = 401,
-			forbidden = 403,
-			not_found = 404,
-			internal_server_error = 500,
-			not_implemented = 501,
-			bad_gateway = 502,
-			service_unavailable = 503
-		};
+	// HTTP errors are reported in the libtorrent::http_category, with error code enums in
+	// the ``libtorrent::errors`` namespace.
+	enum http_errors
+	{
+		cont = 100,
+		ok = 200,
+		created = 201,
+		accepted = 202,
+		no_content = 204,
+		multiple_choices = 300,
+		moved_permanently = 301,
+		moved_temporarily = 302,
+		not_modified = 304,
+		bad_request = 400,
+		unauthorized = 401,
+		forbidden = 403,
+		not_found = 404,
+		internal_server_error = 500,
+		not_implemented = 501,
+		bad_gateway = 502,
+		service_unavailable = 503
+	};
 
-		// hidden
-		TORRENT_EXPORT boost::system::error_code make_error_code(error_code_enum e);
+	// hidden
+	TORRENT_EXPORT boost::system::error_code make_error_code(error_code_enum e);
 
-	} // namespace errors
+} // namespace errors
 
 	// return the instance of the libtorrent_error_category which
 	// maps libtorrent error codes to human readable error messages.
@@ -543,15 +542,17 @@ namespace libtorrent {
 
 	// internal
 	std::string print_error(error_code const&);
-}
+} // namespace libtorrent
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 
 	template<> struct is_error_code_enum<libtorrent::errors::error_code_enum>
 	{ static const bool value = true; };
 
 	template<> struct is_error_code_enum<libtorrent::errors::http_errors>
 	{ static const bool value = true; };
-} }
+}
+}
 
 #endif

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -589,7 +589,7 @@ namespace libtorrent {
 		std::int64_t m_total_size;
 	};
 
-	namespace aux {
+namespace aux {
 
 	// returns the piece range that entirely falls within the specified file. the
 	// end piece is one-past the last piece that entirely falls within the file.

--- a/include/libtorrent/fingerprint.hpp
+++ b/include/libtorrent/fingerprint.hpp
@@ -78,7 +78,7 @@ namespace libtorrent {
 
 	// The fingerprint class represents information about a client and its version. It is used
 	// to encode this information into the client's peer id.
-	struct TORRENT_DEPRECATED TORRENT_DEPRECATED_EXPORT fingerprint
+	struct TORRENT_DEPRECATED_EXPORT fingerprint
 	{
 		fingerprint(const char* id_string, int major, int minor, int revision, int tag);
 

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -158,9 +158,8 @@ struct create_torrent;
 
 // include/libtorrent/disk_interface.hpp
 struct open_file_state;
-
-// include/libtorrent/disk_io_thread.hpp
-struct cache_status;
+struct disk_interface;
+struct storage_holder;
 
 // include/libtorrent/entry.hpp
 class entry;
@@ -173,9 +172,6 @@ struct plugin;
 struct torrent_plugin;
 struct peer_plugin;
 struct crypto_plugin;
-
-// include/libtorrent/file_pool.hpp
-struct file_pool;
 
 // include/libtorrent/file_storage.hpp
 struct file_slice;
@@ -227,6 +223,9 @@ TORRENT_VERSION_NAMESPACE_2_END
 // include/libtorrent/peer_request.hpp
 struct peer_request;
 
+// include/libtorrent/performance_counters.hpp
+struct counters;
+
 // include/libtorrent/session.hpp
 class session_proxy;
 struct session_params;
@@ -244,10 +243,6 @@ struct session_status;
 
 // include/libtorrent/settings_pack.hpp
 struct settings_pack;
-
-// include/libtorrent/storage.hpp
-struct storage_interface;
-struct default_storage;
 
 // include/libtorrent/storage_defs.hpp
 struct storage_interface;
@@ -279,6 +274,9 @@ TORRENT_VERSION_NAMESPACE_2_END
 
 // include/libtorrent/file_storage.hpp
 struct file_entry;
+
+// include/libtorrent/fingerprint.hpp
+struct fingerprint;
 
 // include/libtorrent/lazy_entry.hpp
 struct pascal_string;

--- a/include/libtorrent/gzip.hpp
+++ b/include/libtorrent/gzip.hpp
@@ -56,72 +56,72 @@ namespace libtorrent {
 	{ return gzip_category(); }
 #endif
 
-	namespace gzip_errors
+namespace gzip_errors {
+	// libtorrent uses boost.system's ``error_code`` class to represent errors. libtorrent has
+	// its own error category get_gzip_category() with the error codes defined by error_code_enum.
+	enum error_code_enum
 	{
-		// libtorrent uses boost.system's ``error_code`` class to represent errors. libtorrent has
-		// its own error category get_gzip_category() with the error codes defined by error_code_enum.
-		enum error_code_enum
-		{
-			// Not an error
-			no_error = 0,
+		// Not an error
+		no_error = 0,
 
-			// the supplied gzip buffer has invalid header
-			invalid_gzip_header,
+		// the supplied gzip buffer has invalid header
+		invalid_gzip_header,
 
-			// the gzip buffer would inflate to more bytes than the specified
-			// maximum size, and was rejected.
-			inflated_data_too_large,
+		// the gzip buffer would inflate to more bytes than the specified
+		// maximum size, and was rejected.
+		inflated_data_too_large,
 
-			// available inflate data did not terminate
-			data_did_not_terminate,
+		// available inflate data did not terminate
+		data_did_not_terminate,
 
-			// output space exhausted before completing inflate
-			space_exhausted,
+		// output space exhausted before completing inflate
+		space_exhausted,
 
-			// invalid block type (type == 3)
-			invalid_block_type,
+		// invalid block type (type == 3)
+		invalid_block_type,
 
-			// stored block length did not match one's complement
-			invalid_stored_block_length,
+		// stored block length did not match one's complement
+		invalid_stored_block_length,
 
-			// dynamic block code description: too many length or distance codes
-			too_many_length_or_distance_codes,
+		// dynamic block code description: too many length or distance codes
+		too_many_length_or_distance_codes,
 
-			// dynamic block code description: code lengths codes incomplete
-			code_lengths_codes_incomplete,
+		// dynamic block code description: code lengths codes incomplete
+		code_lengths_codes_incomplete,
 
-			// dynamic block code description: repeat lengths with no first length
-			repeat_lengths_with_no_first_length,
+		// dynamic block code description: repeat lengths with no first length
+		repeat_lengths_with_no_first_length,
 
-			// dynamic block code description: repeat more than specified lengths
-			repeat_more_than_specified_lengths,
+		// dynamic block code description: repeat more than specified lengths
+		repeat_more_than_specified_lengths,
 
-			// dynamic block code description: invalid literal/length code lengths
-			invalid_literal_length_code_lengths,
+		// dynamic block code description: invalid literal/length code lengths
+		invalid_literal_length_code_lengths,
 
-			// dynamic block code description: invalid distance code lengths
-			invalid_distance_code_lengths,
+		// dynamic block code description: invalid distance code lengths
+		invalid_distance_code_lengths,
 
-			// invalid literal/length or distance code in fixed or dynamic block
-			invalid_literal_code_in_block,
+		// invalid literal/length or distance code in fixed or dynamic block
+		invalid_literal_code_in_block,
 
-			// distance is too far back in fixed or dynamic block
-			distance_too_far_back_in_block,
+		// distance is too far back in fixed or dynamic block
+		distance_too_far_back_in_block,
 
-			// an unknown error occurred during gzip inflation
-			unknown_gzip_error,
+		// an unknown error occurred during gzip inflation
+		unknown_gzip_error,
 
-			// the number of error codes
-			error_code_max
-		};
+		// the number of error codes
+		error_code_max
+	};
 
-		// hidden
-		TORRENT_EXPORT boost::system::error_code make_error_code(error_code_enum e);
-	}
+	// hidden
+	TORRENT_EXPORT boost::system::error_code make_error_code(error_code_enum e);
+} // namespace gzip_errors
 
-}
+} // namespace libtorrent
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 
 template<>
 struct is_error_code_enum<libtorrent::gzip_errors::error_code_enum>
@@ -131,6 +131,7 @@ template<>
 struct is_error_condition_enum<libtorrent::gzip_errors::error_code_enum>
 { static const bool value = true; };
 
-} }
+}
+}
 
 #endif

--- a/include/libtorrent/hasher512.hpp
+++ b/include/libtorrent/hasher512.hpp
@@ -51,9 +51,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #elif defined TORRENT_USE_LIBCRYPTO
 
-extern "C" {
-#include <openssl/sha.h>
-}
+	extern "C" {
+	#include <openssl/sha.h>
+	}
 
 #else
 #include "libtorrent/sha512.hpp"

--- a/include/libtorrent/heterogeneous_queue.hpp
+++ b/include/libtorrent/heterogeneous_queue.hpp
@@ -44,18 +44,18 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace aux {
+namespace aux {
 
-		struct free_deleter
-		{ void operator()(char* ptr) { return std::free(ptr); } };
+	struct free_deleter
+	{ void operator()(char* ptr) { return std::free(ptr); } };
 
-		inline std::size_t calculate_pad_bytes(char const* inptr, std::size_t alignment)
-		{
-			std::uintptr_t const ptr = reinterpret_cast<std::uintptr_t>(inptr);
-			std::uintptr_t const offset = ptr & (alignment - 1);
-			return (alignment - offset) & (alignment - 1);
-		}
+	inline std::size_t calculate_pad_bytes(char const* inptr, std::size_t alignment)
+	{
+		std::uintptr_t const ptr = reinterpret_cast<std::uintptr_t>(inptr);
+		std::uintptr_t const offset = ptr & (alignment - 1);
+		return (alignment - offset) & (alignment - 1);
 	}
+} // namespace aux
 
 	template <class T>
 	struct heterogeneous_queue
@@ -255,6 +255,6 @@ namespace libtorrent {
 		// the number of objects allocated in m_storage
 		int m_num_items = 0;
 	};
-}
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/hex.hpp
+++ b/include/libtorrent/hex.hpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace aux {
+namespace aux {
 
 	TORRENT_EXTRA_EXPORT int hex_to_int(char in);
 	TORRENT_EXTRA_EXPORT bool is_hex(span<char const> in);
@@ -63,7 +63,7 @@ namespace libtorrent {
 	// (len + 1) / 2 bytes.
 	TORRENT_DEPRECATED_EXPORT bool from_hex(span<char const> in, char* out);
 
-	}
+} // namespace aux
 
 #if TORRENT_ABI_VERSION == 1
 	// deprecated in 1.2
@@ -77,6 +77,6 @@ namespace libtorrent {
 	inline bool from_hex(char const *in, int len, char* out)
 	{ return aux::from_hex({in, len}, out); }
 #endif
-}
+} // namespace libtorrent
 
 #endif // TORRENT_HEX_HPP_INCLUDED

--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -49,26 +49,26 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace i2p_error {
+namespace i2p_error {
 
-		// error values for the i2p_category error_category.
-		enum i2p_error_code
-		{
-			no_error = 0,
-			parse_failed,
-			cant_reach_peer,
-			i2p_error,
-			invalid_key,
-			invalid_id,
-			timeout,
-			key_not_found,
-			duplicated_id,
-			num_errors
-		};
+	// error values for the i2p_category error_category.
+	enum i2p_error_code
+	{
+		no_error = 0,
+		parse_failed,
+		cant_reach_peer,
+		i2p_error,
+		invalid_key,
+		invalid_id,
+		timeout,
+		key_not_found,
+		duplicated_id,
+		num_errors
+	};
 
-		// hidden
-		TORRENT_EXPORT boost::system::error_code make_error_code(i2p_error_code e);
-	}
+	// hidden
+	TORRENT_EXPORT boost::system::error_code make_error_code(i2p_error_code e);
+}
 
 	// returns the error category for I2P errors
 	TORRENT_EXPORT boost::system::error_category& i2p_category();
@@ -225,13 +225,15 @@ private:
 
 }
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 
 template<>
 struct is_error_code_enum<libtorrent::i2p_error::i2p_error_code>
 { static const bool value = true; };
 
-} }
+}
+}
 
 #endif // TORRENT_USE_I2P
 

--- a/include/libtorrent/identify_client.hpp
+++ b/include/libtorrent/identify_client.hpp
@@ -82,7 +82,7 @@ namespace aux {
 	// id. This can be used to automate the identification of clients. It will
 	// not be able to identify peers with non- standard encodings. Only Azureus
 	// style, Shadow's style and Mainline style.
-	TORRENT_DEPRECATED_EXPORT TORRENT_DEPRECATED
+	TORRENT_DEPRECATED_EXPORT
 	boost::optional<fingerprint>
 		client_fingerprint(peer_id const& p);
 

--- a/include/libtorrent/io.hpp
+++ b/include/libtorrent/io.hpp
@@ -45,145 +45,145 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 
 namespace detail {
-		template <class T> struct type {};
+	template <class T> struct type {};
 
-		// reads an integer from a byte stream
-		// in big endian byte order and converts
-		// it to native endianess
-		template <class T, class InIt>
-		inline T read_impl(InIt& start, type<T>)
+	// reads an integer from a byte stream
+	// in big endian byte order and converts
+	// it to native endianess
+	template <class T, class InIt>
+	inline T read_impl(InIt& start, type<T>)
+	{
+		T ret = 0;
+		for (int i = 0; i < int(sizeof(T)); ++i)
 		{
-			T ret = 0;
-			for (int i = 0; i < int(sizeof(T)); ++i)
-			{
-				ret <<= 8;
-				ret |= static_cast<std::uint8_t>(*start);
-				++start;
-			}
-			return ret;
+			ret <<= 8;
+			ret |= static_cast<std::uint8_t>(*start);
+			++start;
 		}
+		return ret;
+	}
 
-		template <class InIt>
-		std::uint8_t read_impl(InIt& start, type<std::uint8_t>)
+	template <class InIt>
+	std::uint8_t read_impl(InIt& start, type<std::uint8_t>)
+	{
+		return static_cast<std::uint8_t>(*start++);
+	}
+
+	template <class InIt>
+	std::int8_t read_impl(InIt& start, type<std::int8_t>)
+	{
+		return static_cast<std::int8_t>(*start++);
+	}
+
+	template <class T, class In, class OutIt>
+	typename std::enable_if<(std::is_integral<In>::value
+		&& !std::is_same<In, bool>::value)
+		|| std::is_enum<In>::value, void>::type
+	write_impl(In data, OutIt& start)
+	{
+		// Note: the test for [OutItT==void] below is necessary because
+		// in C++11 std::back_insert_iterator::value_type is void.
+		// This could change in C++17 or above
+		using OutItT = typename std::iterator_traits<OutIt>::value_type;
+		using Byte = typename std::conditional<
+			std::is_same<OutItT, void>::value, char, OutItT>::type;
+		static_assert(sizeof(Byte) == 1, "wrong iterator or pointer type");
+
+		T val = static_cast<T>(data);
+		TORRENT_ASSERT(data == static_cast<In>(val));
+		for (int i = int(sizeof(T)) - 1; i >= 0; --i)
 		{
-			return static_cast<std::uint8_t>(*start++);
-		}
-
-		template <class InIt>
-		std::int8_t read_impl(InIt& start, type<std::int8_t>)
-		{
-			return static_cast<std::int8_t>(*start++);
-		}
-
-		template <class T, class In, class OutIt>
-		typename std::enable_if<(std::is_integral<In>::value
-			&& !std::is_same<In, bool>::value)
-			|| std::is_enum<In>::value, void>::type
-		write_impl(In data, OutIt& start)
-		{
-			// Note: the test for [OutItT==void] below is necessary because
-			// in C++11 std::back_insert_iterator::value_type is void.
-			// This could change in C++17 or above
-			using OutItT = typename std::iterator_traits<OutIt>::value_type;
-			using Byte = typename std::conditional<
-				std::is_same<OutItT, void>::value, char, OutItT>::type;
-			static_assert(sizeof(Byte) == 1, "wrong iterator or pointer type");
-
-			T val = static_cast<T>(data);
-			TORRENT_ASSERT(data == static_cast<In>(val));
-			for (int i = int(sizeof(T)) - 1; i >= 0; --i)
-			{
-				*start = static_cast<Byte>((val >> (i * 8)) & 0xff);
-				++start;
-			}
-		}
-
-		template <class T, class Val, class OutIt>
-		typename std::enable_if<std::is_same<Val, bool>::value, void>::type
-		write_impl(Val val, OutIt& start)
-		{ write_impl<T>(val ? 1 : 0, start); }
-
-		// -- adaptors
-
-		template <class InIt>
-		std::int64_t read_int64(InIt& start)
-		{ return read_impl(start, type<std::int64_t>()); }
-
-		template <class InIt>
-		std::uint64_t read_uint64(InIt& start)
-		{ return read_impl(start, type<std::uint64_t>()); }
-
-		template <class InIt>
-		std::uint32_t read_uint32(InIt& start)
-		{ return read_impl(start, type<std::uint32_t>()); }
-
-		template <class InIt>
-		std::int32_t read_int32(InIt& start)
-		{ return read_impl(start, type<std::int32_t>()); }
-
-		template <class InIt>
-		std::int16_t read_int16(InIt& start)
-		{ return read_impl(start, type<std::int16_t>()); }
-
-		template <class InIt>
-		std::uint16_t read_uint16(InIt& start)
-		{ return read_impl(start, type<std::uint16_t>()); }
-
-		template <class InIt>
-		std::int8_t read_int8(InIt& start)
-		{ return read_impl(start, type<std::int8_t>()); }
-
-		template <class InIt>
-		std::uint8_t read_uint8(InIt& start)
-		{ return read_impl(start, type<std::uint8_t>()); }
-
-
-		template <class T, class OutIt>
-		void write_uint64(T val, OutIt& start)
-		{ write_impl<std::uint64_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_int64(T val, OutIt& start)
-		{ write_impl<std::int64_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_uint32(T val, OutIt& start)
-		{ write_impl<std::uint32_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_int32(T val, OutIt& start)
-		{ write_impl<std::int32_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_uint16(T val, OutIt& start)
-		{ write_impl<std::uint16_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_int16(T val, OutIt& start)
-		{ write_impl<std::int16_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_uint8(T val, OutIt& start)
-		{ write_impl<std::uint8_t>(val, start); }
-
-		template <class T, class OutIt>
-		void write_int8(T val, OutIt& start)
-		{ write_impl<std::int8_t>(val, start); }
-
-		inline int write_string(std::string const& str, char*& start)
-		{
-			std::memcpy(reinterpret_cast<void*>(start), str.c_str(), str.size());
-			start += str.size();
-			return int(str.size());
-		}
-
-		template <class OutIt>
-		int write_string(std::string const& val, OutIt& out)
-		{
-			for (auto const c : val) *out++ = c;
-			return int(val.length());
+			*start = static_cast<Byte>((val >> (i * 8)) & 0xff);
+			++start;
 		}
 	}
+
+	template <class T, class Val, class OutIt>
+	typename std::enable_if<std::is_same<Val, bool>::value, void>::type
+	write_impl(Val val, OutIt& start)
+	{ write_impl<T>(val ? 1 : 0, start); }
+
+	// -- adaptors
+
+	template <class InIt>
+	std::int64_t read_int64(InIt& start)
+	{ return read_impl(start, type<std::int64_t>()); }
+
+	template <class InIt>
+	std::uint64_t read_uint64(InIt& start)
+	{ return read_impl(start, type<std::uint64_t>()); }
+
+	template <class InIt>
+	std::uint32_t read_uint32(InIt& start)
+	{ return read_impl(start, type<std::uint32_t>()); }
+
+	template <class InIt>
+	std::int32_t read_int32(InIt& start)
+	{ return read_impl(start, type<std::int32_t>()); }
+
+	template <class InIt>
+	std::int16_t read_int16(InIt& start)
+	{ return read_impl(start, type<std::int16_t>()); }
+
+	template <class InIt>
+	std::uint16_t read_uint16(InIt& start)
+	{ return read_impl(start, type<std::uint16_t>()); }
+
+	template <class InIt>
+	std::int8_t read_int8(InIt& start)
+	{ return read_impl(start, type<std::int8_t>()); }
+
+	template <class InIt>
+	std::uint8_t read_uint8(InIt& start)
+	{ return read_impl(start, type<std::uint8_t>()); }
+
+
+	template <class T, class OutIt>
+	void write_uint64(T val, OutIt& start)
+	{ write_impl<std::uint64_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_int64(T val, OutIt& start)
+	{ write_impl<std::int64_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_uint32(T val, OutIt& start)
+	{ write_impl<std::uint32_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_int32(T val, OutIt& start)
+	{ write_impl<std::int32_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_uint16(T val, OutIt& start)
+	{ write_impl<std::uint16_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_int16(T val, OutIt& start)
+	{ write_impl<std::int16_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_uint8(T val, OutIt& start)
+	{ write_impl<std::uint8_t>(val, start); }
+
+	template <class T, class OutIt>
+	void write_int8(T val, OutIt& start)
+	{ write_impl<std::int8_t>(val, start); }
+
+	inline int write_string(std::string const& str, char*& start)
+	{
+		std::memcpy(reinterpret_cast<void*>(start), str.c_str(), str.size());
+		start += str.size();
+		return int(str.size());
+	}
+
+	template <class OutIt>
+	int write_string(std::string const& val, OutIt& out)
+	{
+		for (auto const c : val) *out++ = c;
+		return int(val.length());
+	}
+}
 }
 
 #endif // TORRENT_IO_HPP_INCLUDED

--- a/include/libtorrent/kademlia/announce_flags.hpp
+++ b/include/libtorrent/kademlia/announce_flags.hpp
@@ -35,7 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/flags.hpp"
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 using announce_flags_t = flags::bitfield_flag<std::uint8_t, struct dht_announce_flag_tag>;
 
@@ -47,6 +48,7 @@ constexpr announce_flags_t ssl_torrent = 2_bit;
 
 }
 
-}}
+}
+}
 
 #endif

--- a/include/libtorrent/kademlia/dht_observer.hpp
+++ b/include/libtorrent/kademlia/dht_observer.hpp
@@ -43,7 +43,9 @@ namespace libtorrent {
 
 class entry;
 
-namespace aux { struct listen_socket_handle; }
+namespace aux {
+struct listen_socket_handle;
+}
 
 namespace dht {
 
@@ -90,6 +92,7 @@ namespace dht {
 	protected:
 		~dht_observer() = default;
 	};
-}}
+}
+}
 
 #endif

--- a/include/libtorrent/kademlia/dht_state.hpp
+++ b/include/libtorrent/kademlia/dht_state.hpp
@@ -47,7 +47,8 @@ namespace libtorrent {
 	struct bdecode_node;
 }
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 	using node_ids_t = std::vector<std::pair<address, node_id>>;
 	// This structure helps to store and load the state
@@ -71,6 +72,7 @@ namespace libtorrent { namespace dht {
 	TORRENT_EXTRA_EXPORT node_ids_t extract_node_ids(bdecode_node const& e, string_view key);
 	TORRENT_EXTRA_EXPORT dht_state read_dht_state(bdecode_node const& e);
 	TORRENT_EXTRA_EXPORT entry save_dht_state(dht_state const& state);
-}}
+}
+}
 
 #endif // LIBTORRENT_DHT_STATE_HPP

--- a/include/libtorrent/kademlia/dht_storage.hpp
+++ b/include/libtorrent/kademlia/dht_storage.hpp
@@ -48,7 +48,8 @@ namespace libtorrent {
 	class entry;
 }
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 	struct dht_settings;
 
 	// This structure hold the relevant counters for the storage
@@ -239,6 +240,7 @@ namespace libtorrent { namespace dht {
 	TORRENT_EXPORT std::unique_ptr<dht_storage_interface> dht_default_storage_constructor(
 		dht_settings const& settings);
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif //TORRENT_DHT_STORAGE_HPP

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -55,7 +55,8 @@ namespace libtorrent {
 #endif
 }
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 	struct dht_settings;
 
 	struct TORRENT_EXTRA_EXPORT dht_tracker final
@@ -213,6 +214,7 @@ namespace libtorrent { namespace dht {
 		int m_send_quota;
 		time_point m_last_tick;
 	};
-}}
+} // namespace dht
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/kademlia/direct_request.hpp
+++ b/include/libtorrent/kademlia/direct_request.hpp
@@ -36,7 +36,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/kademlia/msg.hpp>
 #include <libtorrent/kademlia/traversal_algorithm.hpp>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 struct direct_traversal : traversal_algorithm
 {
@@ -88,6 +89,7 @@ struct direct_observer : observer
 	}
 };
 
-}} // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif //TORRENT_DIRECT_REQUEST_HPP

--- a/include/libtorrent/kademlia/dos_blocker.hpp
+++ b/include/libtorrent/kademlia/dos_blocker.hpp
@@ -38,7 +38,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/address.hpp"
 #include "libtorrent/assert.hpp"
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 	struct dht_logger;
 
@@ -88,6 +89,7 @@ namespace libtorrent { namespace dht {
 
 		node_ban_entry m_ban_nodes[num_ban_nodes];
 	};
-}}
+}
+}
 
 #endif

--- a/include/libtorrent/kademlia/ed25519.hpp
+++ b/include/libtorrent/kademlia/ed25519.hpp
@@ -40,7 +40,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <array>
 #include <tuple>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 	// See documentation of internal random_bytes
 	TORRENT_EXPORT std::array<char, 32> ed25519_create_seed();
@@ -97,6 +98,7 @@ namespace libtorrent { namespace dht {
 	TORRENT_EXPORT std::array<char, 32> ed25519_key_exchange(
 		public_key const& pk, secret_key const& sk);
 
-}}
+}
+}
 
 #endif // LIBTORRENT_ED25519_HPP

--- a/include/libtorrent/kademlia/find_data.hpp
+++ b/include/libtorrent/kademlia/find_data.hpp
@@ -41,7 +41,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <map>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 class node;
 
@@ -82,6 +83,7 @@ struct find_data_observer : traversal_observer
 	void reply(msg const&) override;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // FIND_DATA_050323_HPP

--- a/include/libtorrent/kademlia/get_item.hpp
+++ b/include/libtorrent/kademlia/get_item.hpp
@@ -38,7 +38,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 class get_item : public find_data
 {
@@ -88,6 +89,7 @@ public:
 	void reply(msg const&) override;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // LIBTORRENT_GET_ITEM_HPP

--- a/include/libtorrent/kademlia/get_peers.hpp
+++ b/include/libtorrent/kademlia/get_peers.hpp
@@ -35,7 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <libtorrent/kademlia/find_data.hpp>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 struct get_peers : find_data
 {
@@ -105,6 +106,7 @@ struct obfuscated_get_peers_observer : traversal_observer
 	void reply(msg const&) override;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // LIBTORRENT_GET_PEERS_HPP

--- a/include/libtorrent/kademlia/io.hpp
+++ b/include/libtorrent/kademlia/io.hpp
@@ -36,7 +36,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/kademlia/node_id.hpp"
 #include "libtorrent/socket_io.hpp"
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 	struct node_endpoint
 	{
@@ -57,6 +58,7 @@ namespace libtorrent { namespace dht {
 		return ep;
 	}
 
-}}
+}
+}
 
 #endif

--- a/include/libtorrent/kademlia/item.hpp
+++ b/include/libtorrent/kademlia/item.hpp
@@ -39,7 +39,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/span.hpp>
 #include <libtorrent/kademlia/types.hpp>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 // calculate the target hash for an immutable item.
 TORRENT_EXTRA_EXPORT sha1_hash item_target_id(span<char const> v);
@@ -121,6 +122,7 @@ private:
 	bool m_mutable = false;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // LIBTORRENT_ITEM_HPP

--- a/include/libtorrent/kademlia/msg.hpp
+++ b/include/libtorrent/kademlia/msg.hpp
@@ -95,6 +95,7 @@ bool verify_message(bdecode_node const& msg, key_desc_t const (&desc)[Size]
 	return verify_message_impl(msg, desc, ret, error);
 }
 
-} }
+}
+}
 
 #endif

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -57,7 +57,8 @@ namespace libtorrent {
 	struct counters;
 }
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 struct traversal_algorithm;
 struct dht_observer;
@@ -279,6 +280,7 @@ private:
 #endif
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // NODE_HPP

--- a/include/libtorrent/kademlia/node_entry.hpp
+++ b/include/libtorrent/kademlia/node_entry.hpp
@@ -39,7 +39,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/union_endpoint.hpp"
 #include "libtorrent/time.hpp" // for time_point
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 struct TORRENT_EXTRA_EXPORT node_entry
 {
@@ -78,6 +79,7 @@ struct TORRENT_EXTRA_EXPORT node_entry
 	std::uint8_t timeout_count;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/kademlia/node_id.hpp
+++ b/include/libtorrent/kademlia/node_id.hpp
@@ -39,7 +39,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/sha1_hash.hpp>
 #include <libtorrent/address.hpp>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 using node_id = libtorrent::sha1_hash;
 
@@ -69,6 +70,7 @@ TORRENT_EXTRA_EXPORT bool verify_id(node_id const& nid, address const& source_ip
 TORRENT_EXTRA_EXPORT bool matching_prefix(node_id const& nid, int mask, int prefix, int offset);
 TORRENT_EXTRA_EXPORT node_id generate_prefix_mask(int bits);
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // NODE_ID_HPP

--- a/include/libtorrent/kademlia/put_data.hpp
+++ b/include/libtorrent/kademlia/put_data.hpp
@@ -40,7 +40,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 struct msg;
 class node;
@@ -84,6 +85,7 @@ struct put_data_observer : traversal_observer
 	std::string m_token;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // TORRENT_PUT_DATA_HPP

--- a/include/libtorrent/kademlia/refresh.hpp
+++ b/include/libtorrent/kademlia/refresh.hpp
@@ -36,7 +36,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/kademlia/node_id.hpp>
 #include <libtorrent/kademlia/get_peers.hpp>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 class bootstrap : public get_peers
 {
@@ -58,6 +59,7 @@ protected:
 
 };
 
-} } // namespace libtorrent::dht
+} // namesapce dht
+} // namespace libtorrent
 
 #endif // REFRESH_050324_HPP

--- a/include/libtorrent/kademlia/routing_table.hpp
+++ b/include/libtorrent/kademlia/routing_table.hpp
@@ -47,7 +47,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/time.hpp>
 #include <libtorrent/aux_/vector.hpp>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 struct dht_settings;
 struct dht_logger;
@@ -300,6 +301,7 @@ private:
 	int const m_bucket_size;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // ROUTING_TABLE_HPP

--- a/include/libtorrent/kademlia/rpc_manager.hpp
+++ b/include/libtorrent/kademlia/rpc_manager.hpp
@@ -46,7 +46,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/kademlia/observer.hpp>
 #include <libtorrent/aux_/listen_socket_handle.hpp>
 
-namespace libtorrent { class entry; }
+namespace libtorrent {
+class entry;
+}
 
 namespace libtorrent {
 namespace dht {
@@ -135,6 +137,7 @@ private:
 	std::uint32_t m_destructing:1;
 };
 
-} } // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/kademlia/sample_infohashes.hpp
+++ b/include/libtorrent/kademlia/sample_infohashes.hpp
@@ -38,8 +38,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <libtorrent/kademlia/traversal_algorithm.hpp>
 #include <libtorrent/time.hpp>
 
-namespace libtorrent { namespace dht
-{
+namespace libtorrent {
+namespace dht {
 
 class sample_infohashes final : public traversal_algorithm
 {
@@ -74,6 +74,7 @@ public:
 	void reply(msg const&) override;
 };
 
-}} // namespace libtorrent::dht
+} // namespace dht
+} // namespace libtorrent
 
 #endif // TORRENT_SAMPLE_INFOHASHES_HPP

--- a/include/libtorrent/kademlia/types.hpp
+++ b/include/libtorrent/kademlia/types.hpp
@@ -35,7 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdint>
 
-namespace libtorrent { namespace dht {
+namespace libtorrent {
+namespace dht {
 
 	struct public_key
 	{
@@ -90,6 +91,7 @@ namespace libtorrent { namespace dht {
 		std::int64_t value;
 	};
 
-}}
+} // namespace dht
+} // namespace libtorrent
 
 #endif // LIBTORRENT_TYPES_HPP

--- a/include/libtorrent/natpmp.hpp
+++ b/include/libtorrent/natpmp.hpp
@@ -45,37 +45,38 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace errors
+namespace errors {
+	// See RFC 6887 Section 7.4
+	enum pcp_errors
 	{
-		// See RFC 6887 Section 7.4
-		enum pcp_errors
-		{
-			pcp_success = 0,
-			pcp_unsupp_version,
-			pcp_not_authorized,
-			pcp_malformed_request,
-			pcp_unsupp_opcode,
-			pcp_unsupp_option,
-			pcp_malformed_option,
-			pcp_network_failure,
-			pcp_no_resources,
-			pcp_unsupp_protocol,
-			pcp_user_ex_quota,
-			pcp_cannot_provide_external,
-			pcp_address_mismatch,
-			pcp_excessive_remote_peers,
-		};
+		pcp_success = 0,
+		pcp_unsupp_version,
+		pcp_not_authorized,
+		pcp_malformed_request,
+		pcp_unsupp_opcode,
+		pcp_unsupp_option,
+		pcp_malformed_option,
+		pcp_network_failure,
+		pcp_no_resources,
+		pcp_unsupp_protocol,
+		pcp_user_ex_quota,
+		pcp_cannot_provide_external,
+		pcp_address_mismatch,
+		pcp_excessive_remote_peers,
+	};
 
-		boost::system::error_code make_error_code(pcp_errors e);
-	}
+	boost::system::error_code make_error_code(pcp_errors e);
+} // namespace errors
 
 	boost::system::error_category& pcp_category();
-}
+} // namespace libtorrent
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 	template<> struct is_error_code_enum<libtorrent::errors::pcp_errors>
 	{ static const bool value = true; };
-} }
+}
+}
 
 namespace libtorrent {
 
@@ -204,6 +205,6 @@ private:
 	bool m_abort = false;
 };
 
-}
+} // namespace libtorrent
 
 #endif

--- a/include/libtorrent/random.hpp
+++ b/include/libtorrent/random.hpp
@@ -40,7 +40,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <random>
 #include <algorithm>
 
-namespace libtorrent { namespace aux {
+namespace libtorrent {
+namespace aux {
 
 		TORRENT_EXTRA_EXPORT std::mt19937& random_engine();
 
@@ -58,7 +59,7 @@ namespace libtorrent { namespace aux {
 		// If the above conditions are not true, then a standard
 		// fill of bytes is used.
 		TORRENT_EXTRA_EXPORT void random_bytes(span<char> buffer);
-	}
+}
 
 	TORRENT_EXTRA_EXPORT std::uint32_t random(std::uint32_t m);
 }

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -56,7 +56,10 @@ POSSIBILITY OF SUCH DAMAGE.
 //
 namespace libtorrent {
 
-	namespace aux { struct session_impl; struct session_settings; }
+namespace aux {
+	struct session_impl;
+	struct session_settings;
+}
 
 	struct settings_pack;
 	struct bdecode_node;

--- a/include/libtorrent/sha1_hash.hpp
+++ b/include/libtorrent/sha1_hash.hpp
@@ -60,7 +60,7 @@ namespace aux {
 
 		TORRENT_EXTRA_EXPORT void bits_shift_left(span<std::uint32_t> number, int n);
 		TORRENT_EXTRA_EXPORT void bits_shift_right(span<std::uint32_t> number, int n);
-	}
+} // namespace aux
 
 	// This type holds an N digest or any other kind of N bits
 	// sequence. It implements a number of convenience functions, such
@@ -295,8 +295,7 @@ namespace aux {
 #endif // TORRENT_USE_IOSTREAM
 }
 
-namespace std
-{
+namespace std {
 	template <>
 	struct hash<libtorrent::sha1_hash>
 	{

--- a/include/libtorrent/socket_io.hpp
+++ b/include/libtorrent/socket_io.hpp
@@ -137,7 +137,7 @@ namespace detail {
 			}
 			return ret;
 		}
-	} // namespace detail
+} // namespace detail
 
 }
 

--- a/include/libtorrent/socks5_stream.hpp
+++ b/include/libtorrent/socks5_stream.hpp
@@ -190,11 +190,13 @@ private:
 
 }
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 
 	template<> struct is_error_code_enum<libtorrent::socks_error::socks_error_code>
 	{ static const bool value = true; };
 
-} }
+}
+}
 
 #endif

--- a/include/libtorrent/ssl_stream.hpp
+++ b/include/libtorrent/ssl_stream.hpp
@@ -50,8 +50,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 namespace libtorrent {
-
-	namespace ssl {
+namespace ssl {
 
 #if defined TORRENT_BUILD_SIMULATOR
 	using sim::asio::ssl::context;
@@ -62,7 +61,7 @@ namespace libtorrent {
 	using boost::asio::ssl::stream_base;
 	using boost::asio::ssl::stream;
 #endif
-	}
+}
 
 template <class Stream>
 class ssl_stream

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -43,7 +43,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio> // for vsnprintf
 #include <cstring>
 
-namespace libtorrent { namespace aux {
+namespace libtorrent {
+namespace aux {
 
 	struct allocation_slot
 	{
@@ -88,6 +89,7 @@ namespace libtorrent { namespace aux {
 		vector<char> m_storage;
 	};
 
-} }
+}
+}
 
 #endif

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1264,8 +1264,7 @@ namespace aux {
 	};
 }
 
-namespace std
-{
+namespace std {
 	template <>
 	struct hash<libtorrent::torrent_handle>
 	{

--- a/include/libtorrent/torrent_status.hpp
+++ b/include/libtorrent/torrent_status.hpp
@@ -572,10 +572,9 @@ TORRENT_VERSION_NAMESPACE_2
 	};
 
 TORRENT_VERSION_NAMESPACE_2_END
-}
+} // namespace libtorrent
 
-namespace std
-{
+namespace std {
 	template <>
 	struct hash<libtorrent::torrent_status>
 	{

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -82,7 +82,10 @@ namespace libtorrent {
 #if TORRENT_USE_I2P
 	class i2p_connection;
 #endif
-	namespace aux { struct session_logger; struct session_settings; }
+namespace aux {
+	struct session_logger;
+	struct session_settings;
+}
 
 	struct TORRENT_EXTRA_EXPORT tracker_request
 	{

--- a/include/libtorrent/units.hpp
+++ b/include/libtorrent/units.hpp
@@ -41,7 +41,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 
-namespace libtorrent { namespace aux {
+namespace libtorrent {
+namespace aux {
 	template <typename Tag>
 	struct difference_tag;
 

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -52,45 +52,44 @@ namespace libtorrent {
 	struct http_connection;
 	class http_parser;
 
-	namespace upnp_errors
+namespace upnp_errors {
+	// error codes for the upnp_error_category. They hold error codes
+	// returned by UPnP routers when mapping ports
+	enum error_code_enum
 	{
-		// error codes for the upnp_error_category. They hold error codes
-		// returned by UPnP routers when mapping ports
-		enum error_code_enum
-		{
-			// No error
-			no_error = 0,
-			// One of the arguments in the request is invalid
-			invalid_argument = 402,
-			// The request failed
-			action_failed = 501,
-			// The specified value does not exist in the array
-			value_not_in_array = 714,
-			// The source IP address cannot be wild-carded, but
-			// must be fully specified
-			source_ip_cannot_be_wildcarded = 715,
-			// The external port cannot be wildcarded, but must
-			// be specified
-			external_port_cannot_be_wildcarded = 716,
-			// The port mapping entry specified conflicts with a
-			// mapping assigned previously to another client
-			port_mapping_conflict = 718,
-			// Internal and external port value must be the same
-			internal_port_must_match_external = 724,
-			// The NAT implementation only supports permanent
-			// lease times on port mappings
-			only_permanent_leases_supported = 725,
-			// RemoteHost must be a wildcard and cannot be a
-			// specific IP address or DNS name
-			remote_host_must_be_wildcard = 726,
-			// ExternalPort must be a wildcard and cannot be a
-			// specific port
-			external_port_must_be_wildcard = 727
-		};
+		// No error
+		no_error = 0,
+		// One of the arguments in the request is invalid
+		invalid_argument = 402,
+		// The request failed
+		action_failed = 501,
+		// The specified value does not exist in the array
+		value_not_in_array = 714,
+		// The source IP address cannot be wild-carded, but
+		// must be fully specified
+		source_ip_cannot_be_wildcarded = 715,
+		// The external port cannot be wildcarded, but must
+		// be specified
+		external_port_cannot_be_wildcarded = 716,
+		// The port mapping entry specified conflicts with a
+		// mapping assigned previously to another client
+		port_mapping_conflict = 718,
+		// Internal and external port value must be the same
+		internal_port_must_match_external = 724,
+		// The NAT implementation only supports permanent
+		// lease times on port mappings
+		only_permanent_leases_supported = 725,
+		// RemoteHost must be a wildcard and cannot be a
+		// specific IP address or DNS name
+		remote_host_must_be_wildcard = 726,
+		// ExternalPort must be a wildcard and cannot be a
+		// specific port
+		external_port_must_be_wildcard = 727
+	};
 
-		// hidden
-		TORRENT_EXPORT boost::system::error_code make_error_code(error_code_enum e);
-	}
+	// hidden
+	TORRENT_EXPORT boost::system::error_code make_error_code(error_code_enum e);
+} // namespace upnp_errors
 
 	// the boost.system error category for UPnP errors
 	TORRENT_EXPORT boost::system::error_category& upnp_category();
@@ -365,13 +364,15 @@ private:
 	mutable time_point m_last_if_update;
 };
 
-}
+} // namespace libtorrent
 
-namespace boost { namespace system {
+namespace boost {
+namespace system {
 
 	template<> struct is_error_code_enum<libtorrent::upnp_errors::error_code_enum>
 	{ static const bool value = true; };
 
-} }
+}
+}
 
 #endif

--- a/include/libtorrent/utf8.hpp
+++ b/include/libtorrent/utf8.hpp
@@ -44,26 +44,25 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	namespace utf8_errors
+namespace utf8_errors {
+	enum error_code_enum
 	{
-		enum error_code_enum
-		{
-			// conversion successful
-			conversion_ok,
+		// conversion successful
+		conversion_ok,
 
-			// partial character in source, but hit end
-			source_exhausted,
+		// partial character in source, but hit end
+		source_exhausted,
 
-			// insuff. room in target for conversion
-			target_exhausted,
+		// insuff. room in target for conversion
+		target_exhausted,
 
-			// source sequence is illegal/malformed
-			source_illegal
-		};
+		// source sequence is illegal/malformed
+		source_illegal
+	};
 
-		// hidden
-		TORRENT_EXPORT error_code make_error_code(error_code_enum e);
-	}
+	// hidden
+	TORRENT_EXPORT error_code make_error_code(error_code_enum e);
+} // namespace utf8_errors
 
 	TORRENT_EXPORT boost::system::error_category const& utf8_category();
 
@@ -79,6 +78,6 @@ namespace libtorrent {
 	// TODO: 3 take a string_view here
 	TORRENT_EXTRA_EXPORT std::pair<std::int32_t, int>
 		parse_utf8_codepoint(string_view str);
-}
+} // namespace libtorrent
 
 #endif

--- a/src/session_stats.cpp
+++ b/src/session_stats.cpp
@@ -336,8 +336,7 @@ namespace {
 		METRIC(disk, disk_blocks_in_use)
 
 		// ``queued_disk_jobs`` is the number of disk jobs currently queued,
-		// waiting to be executed by a disk thread. Deprecates
-		// ``cache_status::job_queue_length``.
+		// waiting to be executed by a disk thread.
 		METRIC(disk, queued_disk_jobs)
 		METRIC(disk, num_running_disk_jobs)
 		METRIC(disk, num_read_jobs)
@@ -357,8 +356,7 @@ namespace {
 		METRIC(disk, queued_write_bytes)
 
 		// the number of blocks written and read from disk in total. A block is 16
-		// kiB. ``num_blocks_written`` and ``num_blocks_read`` deprecates
-		// ``cache_status::blocks_written`` and ``cache_status::blocks_read`` respectively.
+		// kiB. ``num_blocks_written`` and ``num_blocks_read``
 		METRIC(disk, num_blocks_written)
 		METRIC(disk, num_blocks_read)
 
@@ -371,8 +369,6 @@ namespace {
 
 		// the number of disk I/O operation for reads and writes. One disk
 		// operation may transfer more then one block.
-		// These counters deprecates ``cache_status::writes`` and
-		// ``cache_status::reads``.
 		METRIC(disk, num_write_ops)
 		METRIC(disk, num_read_ops)
 

--- a/src/sha1.cpp
+++ b/src/sha1.cpp
@@ -235,7 +235,7 @@ void SHA1_final(u8* digest, sha1_ctx* context)
 	}
 }
 
-} // libtorrent namespace
+} // namespace libtorrent
 
 /************************************************************
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -95,8 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/download_priority.hpp"
 #include "libtorrent/hex.hpp" // to_hex
 #include "libtorrent/aux_/range.hpp"
-// TODO: factor out cache_status to its own header
-#include "libtorrent/disk_io_thread.hpp" // for cache_status
+#include "libtorrent/disk_io_thread.hpp" // for hasher_thread_divisor
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/generate_peer_id.hpp"


### PR DESCRIPTION
* only open a single namespace per line
* only close a single namespace per line
* namespaces are always left-most indented
* removed cache_status left-overs
