### PR TITLE
Minor fixes - remove abort, atoi, and atol

### DIFF
--- a/include/libtorrent/error_code.hpp
+++ b/include/libtorrent/error_code.hpp
@@ -256,6 +256,8 @@ namespace libtorrent {
 			redirecting,
 			// The HTTP range header is invalid
 			invalid_range,
+			// The HTTP response did have a invalid content length
+			invalid_content_length,
 			// The HTTP response did not have a content length
 			no_content_length,
 			// The IP is blocked by the IP filter

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -147,7 +147,7 @@ namespace libtorrent {
 		auto const i = m_header.find(key.to_string());
 		if (i == m_header.end()) return boost::none;
         char *str;
-		auto const val = std::strtod(i->second.c_str(), &str);
+		auto const val = std::strtol(i->second.c_str(), &str, 10);
 		if (val <= 0 || *str) return boost::none;
 		return seconds32(val);
 	}
@@ -211,7 +211,7 @@ restart_response:
 			if (m_protocol.substr(0, 5) == "HTTP/")
 			{
                 char *str;
-				m_status_code = strtol(read_until(line, ' ', line_end).c_str(), &str);
+				m_status_code = strtol(read_until(line, ' ', line_end).c_str(), &str, 10);
 			    if (*str)
 			    {
 				    m_state = error_state;

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -146,8 +146,9 @@ namespace libtorrent {
 		// TODO: remove to_string() if we're in C++14
 		auto const i = m_header.find(key.to_string());
 		if (i == m_header.end()) return boost::none;
-		auto const val = std::atol(i->second.c_str());
-		if (val <= 0) return boost::none;
+        char *str;
+		auto const val = std::strtod(i->second.c_str(), &str);
+		if (val <= 0 || *str) return boost::none;
 		return seconds32(val);
 	}
 
@@ -209,7 +210,14 @@ restart_response:
 			m_protocol = read_until(line, ' ', line_end);
 			if (m_protocol.substr(0, 5) == "HTTP/")
 			{
-				m_status_code = atoi(read_until(line, ' ', line_end).c_str());
+                char *str;
+				m_status_code = strtol(read_until(line, ' ', line_end).c_str(), &str);
+			    if (*str)
+			    {
+				    m_state = error_state;
+				    error = true;
+				    return ret;
+			    }
 				m_server_message = read_until(line, '\r', line_end);
 
 				// HTTP 1.0 always closes the connection after

--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -332,7 +332,7 @@ namespace libtorrent {
 				}
 
                 char *str;
-				m_response_left = strtod(m_parser.header("content-length").c_str(), &str);
+				m_response_left = strtol(m_parser.header("content-length").c_str(), &str, 10);
                 if (*str)
                 {
                     received_bytes(0, int(bytes_transferred));
@@ -421,7 +421,7 @@ namespace libtorrent {
 				if (!m_parser.finished()) return;
 
                 char *str;
-				int retry_time = std::strtod(std::string(recv_buffer.begin(), recv_buffer.end()).c_str(), &str);
+				int retry_time = std::strtol(std::string(recv_buffer.begin(), recv_buffer.end()).c_str(), &str, 10);
                 // Need some log about an invalid retry time, for now patch the data
                 if (*str) retry_time = 60;
 				if (retry_time <= 0) retry_time = 60;

--- a/src/http_stream.cpp
+++ b/src/http_stream.cpp
@@ -123,11 +123,10 @@ namespace libtorrent {
 
 			status++;
             char *str;
-			int const code = std::strtod(status, &str);
+			int const code = std::strtol(status, &str, 10);
             if (*str)
             {
-                // Change to invalid data
-				h(boost::asio::error::operation_not_supported);
+				h(boost::asio::error::invalid_argument);
 				error_code ec;
 				close(ec);
 				return;

--- a/src/http_stream.cpp
+++ b/src/http_stream.cpp
@@ -122,7 +122,16 @@ namespace libtorrent {
 			}
 
 			status++;
-			int const code = std::atoi(status);
+            char *str;
+			int const code = std::strtod(status, &str);
+            if (*str)
+            {
+                // Change to invalid data
+				h(boost::asio::error::operation_not_supported);
+				error_code ec;
+				close(ec);
+				return;
+            }
 			if (code != 200)
 			{
 				h(boost::asio::error::operation_not_supported);

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -269,11 +269,12 @@ namespace libtorrent {
 						if (divider == token.size() - 1) // no end index
 							continue;
 
-						idx1 = std::atoi(token.substr(0, divider).to_string().c_str());
-						if (idx1 < 0 || idx1 > max_index) // invalid index
+                        char *str;
+						idx1 = std::strtod(token.substr(0, divider).to_string().c_str(), &str);
+						if (idx1 < 0 || idx1 > max_index || *str) // invalid index
 							continue;
-						idx2 = std::atoi(token.substr(divider + 1).to_string().c_str());
-						if (idx2 < 0 || idx2 > max_index) // invalid index
+						idx2 = std::strtod(token.substr(divider + 1).to_string().c_str(), &str);
+						if (idx2 < 0 || idx2 > max_index || *str) // invalid index
 							continue;
 
 						if (idx1 > idx2) // wrong range limits
@@ -281,8 +282,9 @@ namespace libtorrent {
 					}
 					else // it's an index
 					{
-						idx1 = std::atoi(token.to_string().c_str());
-						if (idx1 < 0 || idx1 > max_index) // invalid index
+                        char *str;
+						idx1 = std::strtod(token.to_string().c_str(), &str);
+						if (idx1 < 0 || idx1 > max_index || *str) // invalid index
 							continue;
 						idx2 = idx1;
 					}
@@ -307,8 +309,9 @@ namespace libtorrent {
 				auto const divider = value.find_last_of(':');
 				if (divider != std::string::npos)
 				{
-					int const port = std::atoi(value.substr(divider + 1).to_string().c_str());
-					if (port > 0 && port < int(std::numeric_limits<std::uint16_t>::max()))
+                    char str*
+					int const port = std::strtod(value.substr(divider + 1).to_string().c_str(), &str);
+					if (port > 0 && port < int(std::numeric_limits<std::uint16_t>::max()) && !*str)
 						p.dht_nodes.emplace_back(value.substr(0, divider).to_string(), port);
 				}
 			}

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -270,10 +270,10 @@ namespace libtorrent {
 							continue;
 
                         char *str;
-						idx1 = std::strtod(token.substr(0, divider).to_string().c_str(), &str);
+						idx1 = std::strtol(token.substr(0, divider).to_string().c_str(), &str, 10);
 						if (idx1 < 0 || idx1 > max_index || *str) // invalid index
 							continue;
-						idx2 = std::strtod(token.substr(divider + 1).to_string().c_str(), &str);
+						idx2 = std::strtol(token.substr(divider + 1).to_string().c_str(), &str, 10);
 						if (idx2 < 0 || idx2 > max_index || *str) // invalid index
 							continue;
 
@@ -283,7 +283,7 @@ namespace libtorrent {
 					else // it's an index
 					{
                         char *str;
-						idx1 = std::strtod(token.to_string().c_str(), &str);
+						idx1 = std::strtol(token.to_string().c_str(), &str, 10);
 						if (idx1 < 0 || idx1 > max_index || *str) // invalid index
 							continue;
 						idx2 = idx1;
@@ -309,8 +309,8 @@ namespace libtorrent {
 				auto const divider = value.find_last_of(':');
 				if (divider != std::string::npos)
 				{
-                    char str*
-					int const port = std::strtod(value.substr(divider + 1).to_string().c_str(), &str);
+                    char *str;
+					int const port = std::strtol(value.substr(divider + 1).to_string().c_str(), &str, 10);
 					if (port > 0 && port < int(std::numeric_limits<std::uint16_t>::max()) && !*str)
 						p.dht_nodes.emplace_back(value.substr(0, divider).to_string(), port);
 				}

--- a/src/parse_url.cpp
+++ b/src/parse_url.cpp
@@ -115,13 +115,13 @@ namespace libtorrent {
 		if (port_pos < end)
 		{
 			++port_pos;
-			for (auto i = port_pos; i < end; ++i)
-			{
-				if (is_digit(*i)) continue;
+            char *str;
+			port = std::strtod(std::string(port_pos, end).c_str(), &str);
+            if (*str)
+            {
 				ec = errors::invalid_port;
 				goto exit;
-			}
-			port = std::atoi(std::string(port_pos, end).c_str());
+            }
 		}
 
 		start = end;

--- a/src/parse_url.cpp
+++ b/src/parse_url.cpp
@@ -116,7 +116,7 @@ namespace libtorrent {
 		{
 			++port_pos;
             char *str;
-			port = std::strtod(std::string(port_pos, end).c_str(), &str);
+			port = std::strtol(std::string(port_pos, end).c_str(), &str, 10);
             if (*str)
             {
 				ec = errors::invalid_port;

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -182,7 +182,7 @@ using namespace std::placeholders;
 #ifdef BOOST_NO_EXCEPTIONS
 namespace boost {
 
-	void throw_exception(std::exception const& e) { std::abort(); }
+	void throw_exception(std::exception const& e) { exit(0); }
 }
 #endif
 

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -141,8 +141,9 @@ namespace libtorrent {
 			return ret;
 		}
 
-		int const port_num = std::atoi(port.to_string().c_str());
-		if (port_num <= 0 || port_num > std::numeric_limits<std::uint16_t>::max())
+        char *str;
+		int const port_num = std::strtod(port.to_string().c_str(), &str);
+		if (port_num <= 0 || port_num > std::numeric_limits<std::uint16_t>::max() || *str)
 		{
 			ec = errors::invalid_port;
 			return ret;

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -141,9 +141,9 @@ namespace libtorrent {
 			return ret;
 		}
 
-        char *str;
-		int const port_num = std::strtod(port.to_string().c_str(), &str);
-		if (port_num <= 0 || port_num > std::numeric_limits<std::uint16_t>::max() || *str)
+        char *stri;
+		int const port_num = std::strtol(port.to_string().c_str(), &stri, 10);
+		if (port_num <= 0 || port_num > std::numeric_limits<std::uint16_t>::max() || *stri)
 		{
 			ec = errors::invalid_port;
 			return ret;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -258,8 +258,9 @@ namespace libtorrent {
 			}
 			else
 			{
-				iface.port = std::atoi(port.c_str());
-				if (iface.port < 0 || iface.port > 65535) iface.port = -1;
+                char *str;
+				iface.port = std::strtod(port.c_str(), &str);
+				if (iface.port < 0 || iface.port > 65535 || *str) iface.port = -1;
 			}
 
 			// skip spaces
@@ -313,7 +314,9 @@ namespace libtorrent {
 
 			if (colon != std::string::npos && colon > start)
 			{
-				int port = std::atoi(in.substr(colon + 1, end - colon - 1).c_str());
+                char *str;
+				int port = std::strtod(in.substr(colon + 1, end - colon - 1).c_str(), &str);
+                if (*str) port = -1;
 
 				// skip trailing spaces
 				std::string::size_type soft_end = colon;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -259,7 +259,7 @@ namespace libtorrent {
 			else
 			{
                 char *str;
-				iface.port = std::strtod(port.c_str(), &str);
+				iface.port = std::strtol(port.c_str(), &str, 10);
 				if (iface.port < 0 || iface.port > 65535 || *str) iface.port = -1;
 			}
 
@@ -315,7 +315,7 @@ namespace libtorrent {
 			if (colon != std::string::npos && colon > start)
 			{
                 char *str;
-				int port = std::strtod(in.substr(colon + 1, end - colon - 1).c_str(), &str);
+				int port = std::strtol(in.substr(colon + 1, end - colon - 1).c_str(), &str, 10);
                 if (*str) port = -1;
 
 				// skip trailing spaces

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1125,7 +1125,7 @@ void find_error_code(int const type, string_view string, error_code_parse_state&
 	else if (type == xml_string && state.in_error_code)
 	{
         char *str;
-		state.error_code = std::strtod(string.to_string().c_str(), &str);
+		state.error_code = std::strtol(string.to_string().c_str(), &str, 10);
         // Do something when we find an error
         // if (*str) ERROR;
 		state.exit = true;

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1124,7 +1124,10 @@ void find_error_code(int const type, string_view string, error_code_parse_state&
 	}
 	else if (type == xml_string && state.in_error_code)
 	{
-		state.error_code = std::atoi(string.to_string().c_str());
+        char *str;
+		state.error_code = std::strtod(string.to_string().c_str(), &str);
+        // Do something when we find an error
+        // if (*str) ERROR;
 		state.exit = true;
 	}
 }


### PR DESCRIPTION
Hi, some minor fixes to remove that functions because have undefined behaviors, and are deprecated (at least atoi and atol).

There is a section in the code where i don't know what to do if fails, for now have comments.

Bye.