### PR TITLE
make random_shuffle() take a range instead of two iterators

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,7 +92,7 @@ build_script:
   - if defined cmake (
     set "PATH=c:\Python27-x64;%PATH%" &&
     cmake -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
-    cmake --build . --config Release -- -verbosity:quiet
+    cmake --build . --config Release -- -verbosity:minimal
     )
 
 test_script:

--- a/examples/make_torrent.cpp
+++ b/examples/make_torrent.cpp
@@ -34,7 +34,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/storage.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/create_torrent.hpp"
 
 #include <functional>

--- a/include/libtorrent/random.hpp
+++ b/include/libtorrent/random.hpp
@@ -40,25 +40,26 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <random>
 #include <algorithm>
 
-namespace libtorrent { namespace aux {
+namespace libtorrent {
+namespace aux {
 
-		TORRENT_EXTRA_EXPORT std::mt19937& random_engine();
+	TORRENT_EXTRA_EXPORT std::mt19937& random_engine();
 
-		template<class RandomIt>
-		void random_shuffle(RandomIt first, RandomIt last)
-		{
-			std::shuffle(first, last, random_engine());
-		}
-
-		// Fills the buffer with random bytes.
-		//
-		// This functions perform differently under different setups
-		// For Windows and all platforms when compiled with libcrypto, it
-		// generates cryptographically random bytes.
-		// If the above conditions are not true, then a standard
-		// fill of bytes is used.
-		TORRENT_EXTRA_EXPORT void random_bytes(span<char> buffer);
+	template <typename Range>
+	void random_shuffle(Range& range)
+	{
+		std::shuffle(range.data(), range.data() + range.size(), random_engine());
 	}
+
+	// Fills the buffer with random bytes.
+	//
+	// This functions perform differently under different setups
+	// For Windows and all platforms when compiled with libcrypto, it
+	// generates cryptographically random bytes.
+	// If the above conditions are not true, then a standard
+	// fill of bytes is used.
+	TORRENT_EXTRA_EXPORT void random_bytes(span<char> buffer);
+}
 
 	TORRENT_EXTRA_EXPORT std::uint32_t random(std::uint32_t m);
 }

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -57,7 +57,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/bandwidth_limit.hpp"
 #include "libtorrent/bandwidth_queue_entry.hpp"
 #include "libtorrent/storage_defs.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
 #include "libtorrent/aux_/time.hpp"

--- a/simulation/setup_dht.cpp
+++ b/simulation/setup_dht.cpp
@@ -270,7 +270,7 @@ dht_network::dht_network(sim::simulation& sim, int num_nodes, std::uint32_t flag
 		{
 			// every now and then, shuffle all_nodes to make the
 			// routing tables more randomly distributed
-			lt::aux::random_shuffle(all_nodes.begin(), all_nodes.end());
+			lt::aux::random_shuffle(all_nodes);
 			cnt = 0;
 		}
 	}

--- a/simulation/setup_swarm.cpp
+++ b/simulation/setup_swarm.cpp
@@ -40,6 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/aux_/path.hpp"
+#include "libtorrent/random.hpp"
 #include <fstream>
 
 #include "settings.hpp"
@@ -294,7 +295,7 @@ void setup_swarm(int num_nodes
 
 		// make sure the sessions have different peer ids
 		lt::peer_id pid;
-		std::generate(&pid[0], &pid[0] + 20, &random_byte);
+		lt::aux::random_bytes(pid);
 		pack.set_str(lt::settings_pack::peer_fingerprint, pid.to_string());
 		if (i == 0) new_session(pack);
 

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -520,7 +520,7 @@ void http_connection::on_resolve(error_code const& e
 		return;
 	}
 
-	aux::random_shuffle(m_endpoints.begin(), m_endpoints.end());
+	aux::random_shuffle(m_endpoints);
 
 	// if we have been told to bind to a particular address
 	// only connect to addresses of the same family

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -45,6 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/session_interface.hpp"
 #include "libtorrent/peer_list.hpp"
 #include "libtorrent/aux_/socket_type.hpp"
+#include "libtorrent/hasher.hpp"
 #include "libtorrent/assert.hpp"
 #include "libtorrent/broadcast_socket.hpp"
 #include "libtorrent/torrent.hpp"

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1509,8 +1509,8 @@ namespace libtorrent {
 		for (auto b : m_priority_boundaries)
 		{
 			if (start == b) continue;
-			auto r = range(m_pieces, start, b);
-			aux::random_shuffle(r.begin(), r.end());
+			span<piece_index_t> r(&m_pieces[start], static_cast<int>(b - start));
+			aux::random_shuffle(r);
 			start = b;
 		}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -279,7 +279,7 @@ bool is_downloading_state(int const st)
 		for (auto const& e : p.http_seeds)
 			ws.emplace_back(e, web_seed_entry::http_seed);
 
-		aux::random_shuffle(ws.begin(), ws.end());
+		aux::random_shuffle(ws);
 		for (auto& w : ws) m_web_seeds.emplace_back(std::move(w));
 
 		// --- TRACKERS ---
@@ -486,7 +486,7 @@ bool is_downloading_state(int const st)
 		// add the web seeds from the .torrent file
 		std::vector<web_seed_entry> const& web_seeds = m_torrent_file->web_seeds();
 		std::vector<web_seed_t> ws(web_seeds.begin(), web_seeds.end());
-		aux::random_shuffle(ws.begin(), ws.end());
+		aux::random_shuffle(ws);
 		for (auto& w : ws) m_web_seeds.push_back(std::move(w));
 
 #if !defined TORRENT_DISABLE_ENCRYPTION
@@ -6265,7 +6265,7 @@ bool is_downloading_state(int const st)
 		// if we didn't save 100 peers, fill in with second choice peers
 		if (int(ret.peers.size()) < 100)
 		{
-			aux::random_shuffle(deferred_peers.begin(), deferred_peers.end());
+			aux::random_shuffle(deferred_peers);
 			for (auto const p : deferred_peers)
 			{
 				ret.peers.push_back(p->ip());
@@ -9210,7 +9210,7 @@ bool is_downloading_state(int const st)
 			std::copy_if(m_connections.begin(), m_connections.end(), std::back_inserter(seeds)
 				, [](peer_connection const* p) { return p->is_seed(); });
 
-			aux::random_shuffle(seeds.begin(), seeds.end());
+			aux::random_shuffle(seeds);
 			TORRENT_ASSERT(to_disconnect <= seeds.end_index());
 			for (auto const& p : span<peer_connection*>(seeds).first(to_disconnect))
 				p->disconnect(errors::upload_upload_connection, operation_t::bittorrent);

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1320,19 +1320,10 @@ namespace {
 			if (!m_urls.empty())
 			{
 				// shuffle each tier
-				auto start = m_urls.begin();
-				std::vector<announce_entry>::iterator stop;
-				int current_tier = m_urls.front().tier;
-				for (stop = m_urls.begin(); stop != m_urls.end(); ++stop)
-				{
-					if (stop->tier != current_tier)
-					{
-						aux::random_shuffle(start, stop);
-						start = stop;
-						current_tier = stop->tier;
-					}
-				}
-				aux::random_shuffle(start, stop);
+				aux::random_shuffle(m_urls);
+				std::stable_sort(m_urls.begin(), m_urls.end()
+					, [](announce_entry const& lhs, announce_entry const& rhs)
+					{ return lhs.tier < rhs.tier; });
 			}
 		}
 

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -41,7 +41,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/peer_connection.hpp"
 #include "libtorrent/bt_peer_connection.hpp"
 #include "libtorrent/peer_connection_handle.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/torrent.hpp"
 #include "libtorrent/torrent_handle.hpp"
@@ -52,6 +51,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/io.hpp"
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/time.hpp"
+
+#if TORRENT_USE_ASSERTS
+#include "libtorrent/hasher.hpp"
+#endif
 
 namespace libtorrent {namespace {
 

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -36,7 +36,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/write_resume_data.hpp"
 #include "libtorrent/add_torrent_params.hpp"
 #include "libtorrent/socket_io.hpp" // for write_*_endpoint()
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/torrent.hpp" // for default_piece_priority

--- a/test/bittorrent_peer.cpp
+++ b/test/bittorrent_peer.cpp
@@ -394,7 +394,7 @@ void peer_conn::on_message(error_code const& ec, size_t bytes_transferred)
 			pieces.clear();
 			for (int i = 0; i < int(pieces.size()); ++i)
 				pieces.push_back(i);
-			aux::random_shuffle(pieces.begin(), pieces.end());
+			aux::random_shuffle(pieces);
 		}
 		else if (msg == 4) // have
 		{
@@ -418,7 +418,7 @@ void peer_conn::on_message(error_code const& ec, size_t bytes_transferred)
 				}
 				++ptr;
 			}
-			aux::random_shuffle(pieces.begin(), pieces.end());
+			aux::random_shuffle(pieces);
 		}
 		else if (msg == 7) // piece
 		{

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -34,7 +34,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <tuple>
 #include <functional>
-#include <random>
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/hasher.hpp"
@@ -51,7 +50,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/hex.hpp" // to_hex
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/path.hpp"
-#include "libtorrent/random.hpp"
 
 #include "test.hpp"
 #include "test_utils.hpp"
@@ -600,9 +598,6 @@ std::shared_ptr<T> clone_ptr(std::shared_ptr<T> const& ptr)
 {
 	return std::make_shared<T>(*ptr);
 }
-
-std::uint8_t random_byte()
-{ return static_cast<std::uint8_t>(lt::random(0xff)); }
 
 std::vector<char> generate_piece(piece_index_t const idx, int const piece_size)
 {

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -43,7 +43,6 @@ POSSIBILITY OF SUCH DAMAGE.
 EXPORT std::shared_ptr<lt::torrent_info> generate_torrent();
 
 EXPORT int print_failures();
-EXPORT unsigned char random_byte();
 
 EXPORT int load_file(std::string const& filename, std::vector<char>& v
 	, lt::error_code& ec, int limit = 8000000);

--- a/test/swarm_suite.cpp
+++ b/test/swarm_suite.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/time.hpp"
 #include "libtorrent/random.hpp"

--- a/test/test_auto_unchoke.cpp
+++ b/test/test_auto_unchoke.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/aux_/path.hpp"

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -1710,7 +1710,7 @@ void test_routing_table(address(&rand_addr)())
 
 	std::vector<node_entry> temp;
 
-	std::generate(tmp.begin(), tmp.end(), random_byte);
+	aux::random_bytes(tmp);
 	table.find_node(tmp, temp, 0, int(nodes.size()) * 2);
 	std::printf("returned-all: %d\n", int(temp.size()));
 	TEST_EQUAL(temp.size(), nodes.size());
@@ -1723,7 +1723,7 @@ void test_routing_table(address(&rand_addr)())
 
 	for (int r = 0; r < reps; ++r)
 	{
-		std::generate(tmp.begin(), tmp.end(), random_byte);
+		aux::random_bytes(tmp);
 		table.find_node(tmp, temp, 0, bucket_size * 2);
 		std::printf("returned: %d\n", int(temp.size()));
 		TEST_EQUAL(int(temp.size()), std::min(bucket_size * 2, int(nodes.size())));
@@ -3065,7 +3065,7 @@ TORRENT_TEST(routing_table_extended)
 	std::vector<std::uint8_t> node_id_prefix;
 	node_id_prefix.reserve(256);
 	for (int i = 0; i < 256; ++i) node_id_prefix.push_back(i & 0xff);
-	aux::random_shuffle(node_id_prefix.begin(), node_id_prefix.end());
+	aux::random_shuffle(node_id_prefix);
 
 	routing_table tbl(id, udp::v4(), 8, sett, &observer);
 	for (std::size_t i = 0; i < 256; ++i)
@@ -3099,7 +3099,7 @@ TORRENT_TEST(routing_table_set_id)
 	std::vector<std::uint8_t> node_id_prefix;
 	node_id_prefix.reserve(256);
 	for (int i = 0; i < 256; ++i) node_id_prefix.push_back(i & 0xff);
-	aux::random_shuffle(node_id_prefix.begin(), node_id_prefix.end());
+	aux::random_shuffle(node_id_prefix);
 	routing_table tbl(id, udp::v4(), 8, sett, &observer);
 	for (std::size_t i = 0; i < 256; ++i)
 	{

--- a/test/test_lsd.cpp
+++ b/test/test_lsd.cpp
@@ -33,7 +33,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
 #include "libtorrent/torrent_status.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include <tuple>
 

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -35,12 +35,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/hasher.hpp"
 #include "libtorrent/pe_crypto.hpp"
-#include "libtorrent/session.hpp"
 #include "libtorrent/random.hpp"
 #include "libtorrent/span.hpp"
-#include "libtorrent/buffer.hpp"
 
-#include "setup_transfer.hpp"
 #include "test.hpp"
 
 #if !defined TORRENT_DISABLE_ENCRYPTION
@@ -52,11 +49,11 @@ void test_enc_handler(lt::crypto_plugin& a, lt::crypto_plugin& b)
 	int const repcount = 128;
 	for (int rep = 0; rep < repcount; ++rep)
 	{
-		std::ptrdiff_t const buf_len = rand() % (512 * 1024);
+		std::ptrdiff_t const buf_len = lt::random(512 * 1024);
 		std::vector<char> buf(static_cast<std::size_t>(buf_len));
 		std::vector<char> cmp_buf(static_cast<std::size_t>(buf_len));
 
-		std::generate(buf.begin(), buf.end(), &std::rand);
+		lt::aux::random_bytes(buf);
 		std::copy(buf.begin(), buf.end(), cmp_buf.begin());
 
 		using namespace lt::aux;

--- a/test/test_pex.cpp
+++ b/test/test_pex.cpp
@@ -36,7 +36,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/extensions/ut_pex.hpp"
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/torrent_status.hpp"

--- a/test/test_recheck.cpp
+++ b/test/test_recheck.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/time.hpp"

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/write_resume_data.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/storage_utils.hpp"
+#include "libtorrent/random.hpp"
 
 #include <memory>
 #include <functional> // for bind
@@ -185,7 +186,7 @@ std::shared_ptr<default_storage> setup_torrent(file_storage& fs
 std::vector<char> new_piece(std::size_t const size)
 {
 	std::vector<char> ret(size);
-	std::generate(ret.begin(), ret.end(), random_byte);
+	aux::random_bytes(ret);
 	return ret;
 }
 

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/time.hpp"

--- a/test/test_utp.cpp
+++ b/test/test_utp.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_settings.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/time.hpp"

--- a/test/test_web_seed_redirect.cpp
+++ b/test/test_web_seed_redirect.cpp
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "setup_transfer.hpp"
 #include "web_seed_suite.hpp"
 #include "settings.hpp"
+#include "libtorrent/random.hpp"
 #include "libtorrent/create_torrent.hpp"
 #include "libtorrent/torrent_info.hpp"
 
@@ -48,8 +49,8 @@ TORRENT_TEST(web_seed_redirect)
 	file_storage fs;
 	int piece_size = 0x4000;
 
-	char random_data[16000];
-	std::generate(random_data, random_data + sizeof(random_data), random_byte);
+	std::array<char, 16000> random_data;
+	aux::random_bytes(random_data);
 	file f("test_file", open_mode::write_only, ec);
 	if (ec)
 	{
@@ -58,7 +59,7 @@ TORRENT_TEST(web_seed_redirect)
 		TEST_ERROR("failed to create file");
 		return;
 	}
-	iovec_t b = { random_data, size_t(16000)};
+	iovec_t b = random_data;
 	f.writev(0, b, ec);
 	fs.add_file("test_file", 16000);
 

--- a/test/web_seed_suite.cpp
+++ b/test/web_seed_suite.cpp
@@ -31,7 +31,6 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/session.hpp"
-#include "libtorrent/hasher.hpp"
 #include "libtorrent/file_pool.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/storage.hpp"


### PR DESCRIPTION
use random_bytes() instead of std::generate() and random_byte(). Remove unused hasher.hpp includes