### PR TITLE
Add binaries to gitignore and remove duplicate words in comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,22 @@ libtorrent_logs*
 *.pyc
 dist
 *.egg-info
+
+# python binary
+bindings/python/compile_cmd
+
+# binaries in the examples directory
+examples/bt_get
+examples/bt_get2
+examples/client_test
+examples/connection_tester
+examples/custom_storage
+examples/dump_torrent
+examples/make_torrent
+examples/simple_client
+examples/stats_counters
+examples/upnp_test
+
+# binaries in the tests directory
+tools/dht_put
+tools/session_log_alerts

--- a/LICENSE
+++ b/LICENSE
@@ -46,7 +46,7 @@ inflate().
 All dynamically allocated memory comes from the stack.  The stack required
 is less than 2K bytes.  This code is compatible with 16-bit int's and
 assumes that long's are at least 32 bits.  puff.c uses the short data type,
-assumed to be 16 bits, for arrays in order to to conserve memory.  The code
+assumed to be 16 bits, for arrays in order to conserve memory.  The code
 works whether integers are stored big endian or little endian.
 
 In the comments below are "Format notes" that describe the inflate process

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -466,7 +466,7 @@ Other build options are:
 |                       | over TLS, and obfuscated bittorrent connections.  |
 +-----------------------+---------------------------------------------------+
 
-Options are set on the ``cmake`` command line with the ``-D`` option or later on using ``ccmake`` or ``cmake-gui`` applications. ``cmake`` run outputs a summary of all available options and and their current values.
+Options are set on the ``cmake`` command line with the ``-D`` option or later on using ``ccmake`` or ``cmake-gui`` applications. ``cmake`` run outputs a summary of all available options and their current values.
 
 Step 2: Building libtorrent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/extension_protocol.rst
+++ b/docs/extension_protocol.rst
@@ -190,7 +190,7 @@ it possible to map extensions in the handshake to existing extensions with
 fixed message IDs.
 
 The reasoning behind having a single byte as extended message identifier is
-to follow the the bittorrent spec. with its single byte message identifiers.
+to follow the bittorrent spec. with its single byte message identifiers.
 It is also considered to be enough. It won't limit the total number of
 extensions, only the number of extensions used simultaneously.
 

--- a/include/libtorrent/bencode.hpp
+++ b/include/libtorrent/bencode.hpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 // OVERVIEW
 //
-// Bencoding is a common representation in bittorrent used for for dictionary,
+// Bencoding is a common representation in bittorrent used for dictionary,
 // list, int and string hierarchies. It's used to encode .torrent files and
 // some messages in the network protocol. libtorrent also uses it to store
 // settings, resume data and other session state.

--- a/include/libtorrent/peer_info.hpp
+++ b/include/libtorrent/peer_info.hpp
@@ -337,7 +337,7 @@ TORRENT_VERSION_NAMESPACE_2
 		int receive_quota;
 
 		// an estimated round trip time to this peer, in milliseconds. It is
-		// estimated by timing the the TCP ``connect()``. It may be 0 for
+		// estimated by timing the TCP ``connect()``. It may be 0 for
 		// incoming connections.
 		int rtt;
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1362,7 +1362,7 @@ namespace libtorrent {
 			// be met.
 			connections_limit,
 
-			// ``connections_slack`` is the the number of incoming connections
+			// ``connections_slack`` is the number of incoming connections
 			// exceeding the connection limit to accept in order to potentially
 			// replace existing ones.
 			connections_slack,

--- a/include/libtorrent/sliding_average.hpp
+++ b/include/libtorrent/sliding_average.hpp
@@ -65,7 +65,7 @@ struct sliding_average
 		m_mean += (s - m_mean) / m_num_samples;
 
 		if (m_num_samples > 1) {
-			// the the exact same thing for deviation off the mean except -1 on
+			// the exact same thing for deviation off the mean except -1 on
 			// the samples, because the number of deviation samples always lags
 			// behind by 1 (you need to actual samples to have a single deviation
 			// sample).

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -426,7 +426,7 @@ namespace aux {
 			piece_granularity = 1
 		};
 
-		// This function fills in the supplied vector with the the number of
+		// This function fills in the supplied vector with the number of
 		// bytes downloaded of each file in this torrent. The progress values are
 		// ordered the same as the files in the torrent_info. This operation is
 		// not very cheap. Its complexity is *O(n + mj)*. Where *n* is the number

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -424,7 +424,7 @@ namespace libtorrent {
 
 		// Returns the SSL root certificate for the torrent, if it is an SSL
 		// torrent. Otherwise returns an empty string. The certificate is
-		// the the public certificate in x509 format.
+		// the public certificate in x509 format.
 		string_view ssl_cert() const;
 
 		// returns true if this torrent_info object has a torrent loaded.

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1678,7 +1678,7 @@ namespace {
 	}
 
 	// TODO: 2 the salt here is allocated on the heap. It would be nice to
-	// allocate in in the stack_allocator
+	// allocate in the stack_allocator
 	dht_mutable_item_alert::dht_mutable_item_alert(aux::stack_allocator&
 		, std::array<char, 32> const& k
 		, std::array<char, 64> const& sig

--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -299,7 +299,7 @@ namespace {
 		// unchoke few enough peers to not be able to saturate the up-link.
 		// this is done by traversing the peers sorted by our upload rate to
 		// them in decreasing rates. For each peer we increase our threshold
-		// by 1 kB/s. The first peer we get to to whom we upload slower than
+		// by 1 kB/s. The first peer we get to whom we upload slower than
 		// the threshold, we stop and that's the number of unchoke slots we have.
 		if (sett.get_int(settings_pack::choking_algorithm)
 			== settings_pack::rate_based_choker)

--- a/src/puff.cpp
+++ b/src/puff.cpp
@@ -17,7 +17,7 @@
  * All dynamically allocated memory comes from the stack.  The stack required
  * is less than 2K bytes.  This code is compatible with 16-bit int's and
  * assumes that long's are at least 32 bits.  puff.c uses the short data type,
- * assumed to be 16 bits, for arrays in order to to conserve memory.  The code
+ * assumed to be 16 bits, for arrays in order to conserve memory.  The code
  * works whether integers are stored big endian or little endian.
  *
  * In the comments below are "Format notes" that describe the inflate process

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -638,7 +638,7 @@ void upnp::on_reply(udp::endpoint const& from, span<char const> buffer)
 	if (m_ignore_non_routers)
 	{
 		ADD_OUTSTANDING_ASYNC("upnp::map_timer");
-		// check back in in a little bit to see if we have seen any
+		// check back in a little bit to see if we have seen any
 		// devices at one of our default routes. If not, we want to override
 		// ignoring them and use them instead (better than not working).
 		m_map_timer.expires_from_now(seconds(1), ec);


### PR DESCRIPTION
- Remove redundant words in comments like ` to to ` and ` and and `

- Add binaries to git ignore file to prevent untracked files:
![libtorrent-gitignore-files](https://user-images.githubusercontent.com/7564876/53294315-fc18df80-37a9-11e9-94eb-9557c44189f1.png)
