### PR TITLE
Add missing new line to DHT put test tool

### DIFF
--- a/tools/dht_put.cpp
+++ b/tools/dht_put.cpp
@@ -194,7 +194,7 @@ void load_dht_state(lt::session& s)
 	f.read(state.data(), size);
 	if (f.fail())
 	{
-		std::fprintf(stderr, "failed to read .dht");
+		std::fprintf(stderr, "failed to read .dht\n");
 		return;
 	}
 
@@ -290,7 +290,7 @@ int main(int argc, char* argv[])
 		dht_immutable_item_alert* item = alert_cast<dht_immutable_item_alert>(a);
 
 		std::string str = item->item.to_string();
-		std::printf("%s", str.c_str());
+		std::printf("%s\n", str.c_str());
 	}
 	else if (argv[0] == "put"_sv)
 	{
@@ -373,7 +373,7 @@ int main(int argc, char* argv[])
 
 			authoritative = item->authoritative;
 			std::string str = item->item.to_string();
-			std::printf("%s: %s", authoritative ? "auth" : "non-auth", str.c_str());
+			std::printf("%s: %s\n", authoritative ? "auth" : "non-auth", str.c_str());
 		}
 	}
 	else


### PR DESCRIPTION
- dht_put mget before adding new line:

`non-auth` -> `/on-auth`, `|on-auth` or `-on-auth`
![libtorrent-dht_put_mget1](https://user-images.githubusercontent.com/7564876/53681782-1542f400-3cb4-11e9-8921-35409303b109.png)

`non-auth` -> `/on-auth`, `|on-auth` or `-on-auth`. next command on the same line as last dht_put output:
![libtorrent-dht_put_mget2](https://user-images.githubusercontent.com/7564876/53681785-183de480-3cb4-11e9-8436-e13633ec9a61.png)

- dht_put mget after adding new line:

![libtorrent-dht_put_mget1-linereturn](https://user-images.githubusercontent.com/7564876/53681849-cc3f6f80-3cb4-11e9-8e3f-33ebf385de1d.png)

![libtorrent-dht_put_mget2-linereturn](https://user-images.githubusercontent.com/7564876/53681851-cfd2f680-3cb4-11e9-8197-104f8fd1fa0b.png)



