### PR TITLE
fixes to the generated documentation

### DIFF
--- a/docs/gen_reference_doc.py
+++ b/docs/gen_reference_doc.py
@@ -98,6 +98,7 @@ category_mapping = {
     'enum_net.hpp': 'Network',
     'broadcast_socket.hpp': 'Network',
     'socket.hpp': 'Network',
+    'address.hpp': 'Network',
     'socket_io.hpp': 'Network',
     'bitfield.hpp': 'Utility',
     'sha1_hash.hpp': 'Utility',
@@ -765,9 +766,8 @@ for filename in files:
             lno = consume_ifdef(lno - 1, lines)
             continue
 
-        if (line == 'namespace detail' or
-                line == 'namespace impl' or
-                line == 'namespace aux') \
+        if (line == 'namespace detail {' or
+                line == 'namespace aux {') \
                 and not internal:
             lno = consume_block(lno, lines)
             continue

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -84,6 +84,7 @@ async
 uTorrent
 pred
 sha1
+sha512
 pread
 preadv
 pwrite
@@ -296,6 +297,7 @@ DLL
 gettime
 toolsets
 libgcrypt
+LibTomCrypt
 CommonCrypto
 cygwin
 gcc

--- a/include/libtorrent/hasher512.hpp
+++ b/include/libtorrent/hasher512.hpp
@@ -65,6 +65,9 @@ namespace libtorrent {
 
 	using sha512_hash = digest32<512>;
 
+	// internal
+	class TORRENT_EXPORT hasher512
+	{
 	// this is a SHA-512 hash class.
 	//
 	// You use it by first instantiating it, then call ``update()`` to feed it
@@ -80,9 +83,6 @@ namespace libtorrent {
 	// call ``reset()`` to reinitialize it.
 	//
 	// The built-in software version of the sha512-algorithm is from LibTomCrypt
-	// For more info, see ``src/sha512.cpp``.
-	class TORRENT_EXPORT hasher512
-	{
 	public:
 
 		hasher512();


### PR DESCRIPTION
hasher512 is not public. fix identification of `detail` and `aux` namespace in `gen_reference_doc.py`