### PR TITLE
Fixed peer_request.piece conversion in Python

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -439,7 +439,7 @@ void bind_alert()
         ;
 
     class_<peer_request>("peer_request")
-        .def_readonly("piece", &peer_request::piece)
+        .add_property("piece", make_getter(&peer_request::piece, by_value()))
         .def_readonly("start", &peer_request::start)
         .def_readonly("length", &peer_request::length)
         .def(self == self)

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -94,6 +94,9 @@ class test_torrent_handle(unittest.TestCase):
         self.h.connect_peer(('127.0.0.3', 6881), flags=2)
         self.h.connect_peer(('127.0.0.4', 6881), flags=2, source=4)
 
+        torrent_files = self.h.torrent_file()
+        print(torrent_files.map_file(0, 0, 0).piece)
+
         print(self.h.queue_position())
 
     def test_torrent_handle_in_set(self):


### PR DESCRIPTION
I've also added a test for it in the `test.py` file.

Fixes #3721