### PR TITLE
CMake: make BOOST_ASIO_ENABLE_CANCELIO a public definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,11 +207,11 @@ set_target_properties(torrent-rasterbar
 target_compile_definitions(torrent-rasterbar
 	PUBLIC
 		$<$<CONFIG:Debug>:TORRENT_DEBUG>
+		BOOST_ASIO_ENABLE_CANCELIO
 	PRIVATE
 		TORRENT_BUILDING_LIBRARY
 		_FILE_OFFSET_BITS=64
 		BOOST_EXCEPTION_DISABLE
-		BOOST_ASIO_ENABLE_CANCELIO
 )
 
 target_include_directories(torrent-rasterbar


### PR DESCRIPTION
This symbol changes the size of socket objects on Windows so it must be
defined in dependents.

This also applies to RC_1_2 and master.