### PR TITLE
simplify and clean up the handling of name in internal_file_entry

### DIFF
--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -123,7 +123,7 @@ namespace libtorrent {
 		internal_file_entry& operator=(internal_file_entry&& fe) & noexcept;
 		~internal_file_entry();
 
-		void set_name(char const* n, bool borrow_string = false, int string_len = 0);
+		void set_name(string_view n, bool borrow_string = false);
 		string_view filename() const;
 
 		enum {

--- a/include/libtorrent/string_util.hpp
+++ b/include/libtorrent/string_util.hpp
@@ -106,7 +106,7 @@ namespace libtorrent {
 	// strdup is not part of the C standard. Some systems
 	// don't have it and it won't be available when building
 	// in strict ansi mode
-	char* allocate_string_copy(char const* str);
+	char* allocate_string_copy(string_view str);
 
 	// searches for separator ('sep') in the string 'last'.
 	// if found, returns the string_view representing the range from the start of

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -33,7 +33,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/storage.hpp"
 #include "libtorrent/disk_io_thread.hpp"
-#include "libtorrent/string_util.hpp" // for allocate_string_copy
 #include "libtorrent/disk_buffer_holder.hpp"
 #include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/throw.hpp"

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -140,13 +140,12 @@ namespace libtorrent {
 		return static_cast<int>(it - target.begin());
 	}
 
-	char* allocate_string_copy(char const* str)
+	char* allocate_string_copy(string_view str)
 	{
-		if (str == nullptr) return nullptr;
-		std::size_t const len = std::strlen(str);
-		auto* tmp = new char[len + 1];
-		std::copy(str, str + len, tmp);
-		tmp[len] = '\0';
+		if (str.empty()) return nullptr;
+		auto* tmp = new char[str.size() + 1];
+		std::copy(str.data(), str.data() + str.size(), tmp);
+		tmp[str.size()] = '\0';
 		return tmp;
 	}
 


### PR DESCRIPTION
move should be more efficient now, by not always copying the name