### PR TITLE
fix subtle race condition in disk I/O thread (for short-lived sessions)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix subtle race condition in disk I/O thread (for short-lived sessions)
 	* update symlinks to conform to BEP 47
 	* fix python bindings for peer_info
 	* support creating symlinks, for torrents with symlinks in them

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -270,7 +270,8 @@ constexpr disk_job_flags_t disk_interface::cache_hit;
 		// see also the comment in thread_fun
 		std::unique_lock<std::mutex> l(m_job_mutex);
 		if (m_abort.exchange(true)) return;
-		bool const no_threads = m_num_running_threads == 0;
+
+		bool const no_threads = num_threads() == 0;
 		// abort outstanding jobs belonging to this torrent
 
 		for (auto i = m_hash_io_jobs.m_queued_jobs.iterate(); i.get(); i.next())
@@ -3100,7 +3101,6 @@ constexpr disk_job_flags_t disk_interface::cache_hit;
 		DLOG("started disk thread %s\n", thread_id_str.str().c_str());
 
 		std::unique_lock<std::mutex> l(m_job_mutex);
-		if (m_abort) return;
 
 		++m_num_running_threads;
 		m_stats_counters.inc_stats_counter(counters::num_running_threads, 1);


### PR DESCRIPTION
@ssiloti does this look reasonable? related to https://github.com/arvidn/libtorrent/issues/3739