### PR TITLE
always flush disk I/O job queue before shutdown

### DIFF
--- a/include/libtorrent/disk_io_thread.hpp
+++ b/include/libtorrent/disk_io_thread.hpp
@@ -578,9 +578,10 @@ namespace aux {
 		// indices into m_torrents to empty slots
 		std::vector<storage_index_t> m_free_slots;
 
+		std::atomic_flag m_jobs_aborted = ATOMIC_FLAG_INIT;
+
 #if TORRENT_USE_ASSERTS
 		int m_magic = 0x1337;
-		std::atomic<bool> m_jobs_aborted{false};
 #endif
 	};
 }

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -3211,7 +3211,7 @@ constexpr disk_job_flags_t disk_interface::cache_hit;
 	void disk_io_thread::abort_jobs()
 	{
 		TORRENT_ASSERT(m_magic == 0x1337);
-		TORRENT_ASSERT(!m_jobs_aborted.exchange(true));
+		if (m_jobs_aborted.test_and_set()) return;
 
 		jobqueue_t jobs;
 		m_disk_cache.clear(jobs);

--- a/src/disk_io_thread_pool.cpp
+++ b/src/disk_io_thread_pool.cpp
@@ -71,7 +71,6 @@ namespace libtorrent {
 	{
 		std::unique_lock<std::mutex> l(m_mutex);
 		if (m_abort) return;
-		m_max_threads = 0;
 		m_abort = true;
 		m_idle_timer.cancel();
 		stop_threads(int(m_threads.size()));


### PR DESCRIPTION
Leaving jobs on the queue can lead to memory leaks

Fixes #3739