### PR TITLE
request contiguous pieces from fast peers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* pick contiguous pieces from peers with high download rate
 	* fix error handling of moving storage to a drive letter that isn't mounted
 	* fix HTTP Host header when using proxy
 

--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -116,12 +116,24 @@ namespace libtorrent {
 			&& !time_critical_mode
 			&& t.settings().get_int(settings_pack::whole_pieces_threshold) > 0)
 		{
+			// if our download rate lets us download a whole piece in
+			// "whole_pieces_threshold" seconds, we prefer to pick an entire piece.
+			// If we can download multiple whole pieces, we prefer to download that
+			// many contiguous pieces.
+
+			// download_rate times the whole piece threshold (seconds) gives the
+			// number of bytes downloaded in one window of that threshold, divided
+			// by the piece size give us the number of (whole) pieces downloaded
+			// in the window.
+			int const contiguous_pieces =
+				std::min(c.statistics().download_payload_rate()
+				* t.settings().get_int(settings_pack::whole_pieces_threshold)
+				, 8 * 1024 * 1024)
+				/ t.torrent_file().piece_length();
+
 			int const blocks_per_piece = t.torrent_file().piece_length() / t.block_size();
-			prefer_contiguous_blocks
-				= (c.statistics().download_payload_rate()
-				> t.torrent_file().piece_length()
-				/ t.settings().get_int(settings_pack::whole_pieces_threshold))
-				? blocks_per_piece : 0;
+
+			prefer_contiguous_blocks = contiguous_pieces * blocks_per_piece;
 		}
 
 		// if we prefer whole pieces, the piece picker will pick at least


### PR DESCRIPTION
extend the whole_pieces_threshold setting to also request contiguous pieces from fast peers