### PR TITLE
don't run the SHA-1 and SHA-512 test vector tests by default

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -133,7 +133,6 @@ run
 	test_http_parser.cpp
 	test_xml.cpp
 	test_ip_filter.cpp
-	test_hasher.cpp
 	test_block_cache.cpp
 	test_peer_classes.cpp
 	test_settings_pack.cpp
@@ -156,12 +155,13 @@ run test_piece_picker.cpp ;
 run test_dht.cpp
 	test_dht_storage.cpp
 	test_direct_dht.cpp
-	test_hasher512.cpp
 	: : : <crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto ;
 
 run test_string.cpp test_utf8.cpp ;
 
+run test_hasher.cpp ;
+run test_hasher512.cpp ;
 run test_sha1_hash.cpp ;
 run test_span.cpp ;
 run test_bitfield.cpp ;
@@ -222,6 +222,8 @@ run test_upnp.cpp ;
 
 run test_lsd.cpp ;
 explicit test_lsd ;
+explicit test_hasher ;
+explicit test_hasher512 ;
 
 # these are the tests run on appveyor, while the flapping ones are being
 # transitioned into simulations


### PR DESCRIPTION
as they are slow