### PR TITLE
change m_torrents to a vector and add a map for lookups on infohash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ set(libtorrent_aux_include_files
 	throw
 	time
 	torrent_impl
+	torrent_list
 	unique_ptr
 	vector
 	win_crypto_provider

--- a/Makefile
+++ b/Makefile
@@ -623,6 +623,7 @@ HEADERS = \
   aux_/throw.hpp                    \
   aux_/time.hpp                     \
   aux_/torrent_impl.hpp             \
+  aux_/torrent_list.hpp             \
   aux_/unique_ptr.hpp               \
   aux_/vector.hpp                   \
   aux_/win_crypto_provider.hpp      \

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -274,6 +274,7 @@ namespace aux {
 #endif
 			using connection_map = std::set<std::shared_ptr<peer_connection>>;
 			using torrent_map = std::unordered_map<sha1_hash, std::shared_ptr<torrent>>;
+			using torrent_array = std::vector<std::shared_ptr<torrent>>;
 
 			session_impl(io_context& ios, settings_pack const& pack
 				, disk_io_constructor_type disk_io);
@@ -373,7 +374,7 @@ namespace aux {
 			std::weak_ptr<torrent> find_disconnect_candidate_torrent() const override;
 			int num_torrents() const override { return int(m_torrents.size()); }
 
-			void insert_torrent(sha1_hash const& ih, std::shared_ptr<torrent> const& t
+			void insert_torrent(std::shared_ptr<torrent> const& t
 #if TORRENT_ABI_VERSION == 1
 				, std::string uuid
 #endif
@@ -881,7 +882,9 @@ namespace aux {
 			// the torrents must be destructed after the torrent_peer_allocator,
 			// since the torrents hold the peer lists that own the torrent_peers
 			// (which are allocated in the torrent_peer_allocator)
-			torrent_map m_torrents;
+			torrent_map m_torrent_index;
+
+			torrent_array m_torrents;
 
 			// all torrents that are downloading or queued,
 			// ordered by their queue position
@@ -1206,14 +1209,14 @@ namespace aux {
 			// round-robin fashion. All torrents are cycled through
 			// within the LSD announce interval (which defaults to
 			// 5 minutes)
-			torrent_map::iterator m_next_lsd_torrent;
+			std::size_t m_next_lsd_torrent;
 
 #ifndef TORRENT_DISABLE_DHT
 			// torrents are announced on the DHT in a
 			// round-robin fashion. All torrents are cycled through
 			// within the DHT announce interval (which defaults to
 			// 15 minutes)
-			torrent_map::iterator m_next_dht_torrent;
+			std::size_t m_next_dht_torrent;
 
 			// torrents that don't have any peers
 			// when added should be announced to the DHT

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/allocating_handler.hpp"
 #include "libtorrent/aux_/time.hpp"
+#include "libtorrent/aux_/torrent_list.hpp"
 
 #ifdef TORRENT_USE_OPENSSL
 #include "libtorrent/ssl_stream.hpp"
@@ -273,8 +274,6 @@ namespace aux {
 			friend class libtorrent::invariant_access;
 #endif
 			using connection_map = std::set<std::shared_ptr<peer_connection>>;
-			using torrent_map = std::unordered_map<sha1_hash, std::shared_ptr<torrent>>;
-			using torrent_array = std::vector<std::shared_ptr<torrent>>;
 
 			session_impl(io_context& ios, settings_pack const& pack
 				, disk_io_constructor_type disk_io);
@@ -456,8 +455,6 @@ namespace aux {
 #if !defined TORRENT_DISABLE_ENCRYPTION
 			torrent const* find_encrypted_torrent(
 				sha1_hash const& info_hash, sha1_hash const& xor_mask) override;
-
-			void add_obfuscated_hash(sha1_hash const& obfuscated, std::weak_ptr<torrent> const& t) override;
 #endif
 
 			void on_lsd_announce(error_code const& e);
@@ -882,19 +879,11 @@ namespace aux {
 			// the torrents must be destructed after the torrent_peer_allocator,
 			// since the torrents hold the peer lists that own the torrent_peers
 			// (which are allocated in the torrent_peer_allocator)
-			torrent_map m_torrent_index;
-
-			torrent_array m_torrents;
+			aux::torrent_list<torrent> m_torrents;
 
 			// all torrents that are downloading or queued,
 			// ordered by their queue position
 			aux::vector<torrent*, queue_position_t> m_download_queue;
-
-#if !defined TORRENT_DISABLE_ENCRYPTION
-			// this maps obfuscated hashes to torrents. It's only
-			// used when encryption is enabled
-			torrent_map m_obfuscated_torrents;
-#endif
 
 #if TORRENT_ABI_VERSION == 1
 			//deprecated in 1.2

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -186,7 +186,7 @@ namespace aux {
 		virtual std::weak_ptr<torrent> find_disconnect_candidate_torrent() const = 0;
 		virtual std::shared_ptr<torrent> delay_load_torrent(sha1_hash const& info_hash
 			, peer_connection* pc) = 0;
-		virtual void insert_torrent(sha1_hash const& ih, std::shared_ptr<torrent> const& t
+		virtual void insert_torrent(std::shared_ptr<torrent> const& t
 #if TORRENT_ABI_VERSION == 1
 			, std::string uuid
 #endif

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -304,8 +304,6 @@ namespace aux {
 #if !defined TORRENT_DISABLE_ENCRYPTION
 		virtual torrent const* find_encrypted_torrent(
 			sha1_hash const& info_hash, sha1_hash const& xor_mask) = 0;
-		virtual void add_obfuscated_hash(sha1_hash const& obfuscated
-			, std::weak_ptr<torrent> const& t) = 0;
 #endif
 
 #ifndef TORRENT_DISABLE_DHT

--- a/include/libtorrent/aux_/torrent_list.hpp
+++ b/include/libtorrent/aux_/torrent_list.hpp
@@ -1,0 +1,174 @@
+/*
+
+Copyright (c) 2019, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_TORRENT_LIST_HPP_INCLUDED
+#define TORRENT_TORRENT_LIST_HPP_INCLUDED
+
+#include "libtorrent/config.hpp"
+#include "libtorrent/sha1_hash.hpp"
+
+#if !defined TORRENT_DISABLE_ENCRYPTION
+#include "libtorrent/hasher.hpp"
+#endif
+
+#include <memory> // for shared_ptr
+#include <vector>
+#include <unordered_map>
+
+namespace libtorrent {
+namespace aux {
+
+template <typename T>
+struct torrent_list
+{
+	// These are non-owning pointers. Lifetime is managed by the `torrent_array`
+	using torrent_map = std::unordered_map<sha1_hash, T*>;
+	using torrent_array = std::vector<std::shared_ptr<T>>;
+
+	using iterator = typename torrent_array::iterator;
+	using const_iterator = typename torrent_array::const_iterator;
+
+	using value_type = typename torrent_array::value_type;
+
+	bool empty() const { return m_array.empty(); }
+
+	iterator begin() { return m_array.begin(); }
+	iterator end() { return m_array.end(); }
+
+	const_iterator begin() const { return m_array.begin(); }
+	const_iterator end() const { return m_array.end(); }
+
+	std::size_t size() const { return m_array.size(); }
+
+	T* operator[](std::size_t const idx)
+	{
+		TORRENT_ASSERT(idx < m_array.size());
+		return m_array[idx].get();
+	}
+
+	T const* operator[](std::size_t const idx) const
+	{
+		TORRENT_ASSERT(idx < m_array.size());
+		return m_array[idx].get();
+	}
+
+	bool insert(sha1_hash const& ih, std::shared_ptr<T> t)
+	{
+		TORRENT_ASSERT(t);
+		bool const added = m_index.insert({ih, t.get()}).second;
+		// if we already have a torrent with this hash, don't do anything
+		if (!added) return false;
+
+#if !defined TORRENT_DISABLE_ENCRYPTION
+		static char const req2[4] = {'r', 'e', 'q', '2'};
+		hasher h(req2);
+		h.update(ih);
+		// this is SHA1("req2" + info-hash), used for
+		// encrypted hand shakes
+		m_obfuscated_index.emplace(h.final(), t.get());
+#endif
+
+		m_array.emplace_back(std::move(t));
+
+		return true;
+	}
+
+#if !defined TORRENT_DISABLE_ENCRYPTION
+	T* find_obfuscated(sha1_hash const& ih)
+	{
+		auto const i = m_obfuscated_index.find(ih);
+		if (i == m_obfuscated_index.end()) return nullptr;
+		return i->second;
+	}
+#endif
+
+	T* find(sha1_hash const& ih) const
+	{
+		auto const i = m_index.find(ih);
+		if (i == m_index.end()) return nullptr;
+		return i->second;
+	}
+
+	bool erase(sha1_hash const& ih)
+	{
+		auto const i = m_index.find(ih);
+		if (i == m_index.end()) return false;
+		auto const array_iter = std::find_if(m_array.begin(), m_array.end()
+			, [&](std::shared_ptr<T> const& p) { return p.get() == i->second; });
+		TORRENT_ASSERT(array_iter != m_array.end());
+		m_index.erase(i);
+
+#if !defined TORRENT_DISABLE_ENCRYPTION
+		static char const req2[4] = {'r', 'e', 'q', '2'};
+		hasher h(req2);
+		h.update(ih);
+		m_obfuscated_index.erase(h.final());
+#endif
+
+		TORRENT_ASSERT(m_index.find(ih) == m_index.end());
+
+		if (array_iter != m_array.end() - 1)
+			std::swap(*array_iter, m_array.back());
+
+		// This is where we, potentially, remove the last reference
+		m_array.pop_back();
+
+		return true;
+	}
+
+	void clear()
+	{
+		m_array.clear();
+		m_index.clear();
+#if !defined TORRENT_DISABLE_ENCRYPTION
+		m_obfuscated_index.clear();
+#endif
+	}
+
+private:
+
+	torrent_array m_array;
+
+	torrent_map m_index;
+
+#if !defined TORRENT_DISABLE_ENCRYPTION
+	// this maps obfuscated hashes to torrents. It's only
+	// used when encryption is enabled
+	torrent_map m_obfuscated_index;
+#endif
+};
+
+}
+}
+
+#endif
+

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -463,7 +463,7 @@ bool is_downloading_state(int const st)
 			return;
 		}
 
-		m_ses.insert_torrent(m_torrent_file->info_hash(), me, m_uuid);
+		m_ses.insert_torrent(me, m_uuid);
 
 		// if the user added any trackers while downloading the
 		// .torrent file, merge them into the new tracker list

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -487,13 +487,6 @@ bool is_downloading_state(int const st)
 		aux::random_shuffle(ws);
 		for (auto& w : ws) m_web_seeds.push_back(std::move(w));
 
-#if !defined TORRENT_DISABLE_ENCRYPTION
-		static char const req2[4] = {'r', 'e', 'q', '2'};
-		hasher h(req2);
-		h.update(m_torrent_file->info_hash());
-		m_ses.add_obfuscated_hash(h.final(), shared_from_this());
-#endif
-
 		if (m_ses.alerts().should_post<metadata_received_alert>())
 		{
 			m_ses.alerts().emplace_alert<metadata_received_alert>(

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -183,6 +183,7 @@ run test_read_piece.cpp ;
 run test_remove_torrent.cpp ;
 run test_flags.cpp ;
 
+run test_torrent_list.cpp ;
 run test_file.cpp ;
 run test_fast_extension.cpp ;
 run test_privacy.cpp ;

--- a/test/test_primitives.cpp
+++ b/test/test_primitives.cpp
@@ -30,7 +30,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#include "libtorrent/entry.hpp"
 #include "libtorrent/broadcast_socket.hpp"
 #include "libtorrent/socket_io.hpp" // for print_endpoint
 #include "libtorrent/announce_entry.hpp"

--- a/test/test_torrent_list.cpp
+++ b/test/test_torrent_list.cpp
@@ -1,0 +1,169 @@
+/*
+
+Copyright (c) 2008-2012, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "test.hpp"
+#include "libtorrent/aux_/torrent_list.hpp"
+#include "libtorrent/sha1_hash.hpp"
+
+using namespace lt;
+
+TORRENT_TEST(torrent_list_empty)
+{
+	aux::torrent_list<int> l;
+	TEST_CHECK(l.empty());
+	TEST_CHECK(l.begin() == l.end());
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1337));
+	TEST_CHECK(!l.empty());
+	TEST_CHECK(l.begin() != l.end());
+}
+
+TORRENT_TEST(torrent_list_size)
+{
+	aux::torrent_list<int> l;
+	TEST_EQUAL(l.size(), 0);
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1337));
+	TEST_EQUAL(l.size(), 1);
+	l.insert(sha1_hash("bcababababababababab"), std::make_shared<int>(1338));
+	TEST_EQUAL(l.size(), 2);
+	l.insert(sha1_hash("cdababababababababab"), std::make_shared<int>(1339));
+	TEST_EQUAL(l.size(), 3);
+}
+
+TORRENT_TEST(torrent_list_duplicates)
+{
+	aux::torrent_list<int> l;
+	TEST_EQUAL(l.size(), 0);
+	TEST_CHECK(l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1337)));
+	TEST_EQUAL(l.size(), 1);
+	TEST_CHECK(!l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1338)));
+	TEST_EQUAL(l.size(), 1);
+}
+
+TORRENT_TEST(torrent_list_lookup)
+{
+	aux::torrent_list<int> l;
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1337));
+	l.insert(sha1_hash("cdababababababababab"), std::make_shared<int>(1338));
+
+	TEST_EQUAL(*l.find(sha1_hash("abababababababababab")), 1337);
+	TEST_EQUAL(*l.find(sha1_hash("cdababababababababab")), 1338);
+	TEST_CHECK(l.find(sha1_hash("deababababababababab")) == nullptr);
+}
+
+TORRENT_TEST(torrent_list_order)
+{
+	aux::torrent_list<int> l;
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1));
+	l.insert(sha1_hash("cdababababababababab"), std::make_shared<int>(2));
+	l.insert(sha1_hash("deababababababababab"), std::make_shared<int>(3));
+	l.insert(sha1_hash("efababababababababab"), std::make_shared<int>(0));
+
+	// iteration order is the same as insertion order, not sort order of
+	// info-hashes
+	std::vector<int> order;
+	for (auto i : l)
+	{
+		order.push_back(*i);
+	}
+
+	TEST_CHECK((order == std::vector<int>{1, 2, 3, 0}));
+
+	TEST_EQUAL(*l[0], 1);
+	TEST_EQUAL(*l[1], 2);
+	TEST_EQUAL(*l[2], 3);
+	TEST_EQUAL(*l[3], 0);
+}
+
+TORRENT_TEST(torrent_list_erase)
+{
+	aux::torrent_list<int> l;
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1337));
+	TEST_CHECK(!l.empty());
+
+	// this doesn't exist, returns false
+	TEST_CHECK(!l.erase(sha1_hash("bcababababababababab")));
+	TEST_CHECK(!l.empty());
+
+	TEST_EQUAL(*l.find(sha1_hash("abababababababababab")), 1337);
+	TEST_CHECK(l.erase(sha1_hash("abababababababababab")));
+	TEST_CHECK(l.find(sha1_hash("abababababababababab")) == nullptr);
+	TEST_CHECK(l.empty());
+}
+
+TORRENT_TEST(torrent_list_erase2)
+{
+	aux::torrent_list<int> l;
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1337));
+	l.insert(sha1_hash("bcababababababababab"), std::make_shared<int>(1338));
+
+	TEST_EQUAL(*l.find(sha1_hash("abababababababababab")), 1337);
+	TEST_EQUAL(l.size(), 2);
+	TEST_CHECK(!l.empty());
+
+	// delete an entry that isn't the last one
+	TEST_CHECK(l.erase(sha1_hash("abababababababababab")));
+	TEST_CHECK(l.find(sha1_hash("abababababababababab")) == nullptr);
+	TEST_EQUAL(l.size(), 1);
+	TEST_CHECK(!l.empty());
+	TEST_EQUAL(*l.find(sha1_hash("bcababababababababab")), 1338);
+}
+
+TORRENT_TEST(torrent_list_clear)
+{
+	aux::torrent_list<int> l;
+	l.insert(sha1_hash("abababababababababab"), std::make_shared<int>(1));
+	l.insert(sha1_hash("cdababababababababab"), std::make_shared<int>(2));
+	l.insert(sha1_hash("deababababababababab"), std::make_shared<int>(3));
+	l.insert(sha1_hash("efababababababababab"), std::make_shared<int>(0));
+
+	TEST_CHECK(!l.empty());
+	l.clear();
+	TEST_CHECK(l.empty());
+}
+
+#if !defined TORRENT_DISABLE_ENCRYPTION
+TORRENT_TEST(torrent_list_obfuscated_lookup)
+{
+	sha1_hash const ih("abababababababababab");
+	aux::torrent_list<int> l;
+	l.insert(ih, std::make_shared<int>(1337));
+
+	TEST_EQUAL(*l.find(ih), 1337);
+	static char const req2[4] = {'r', 'e', 'q', '2'};
+	hasher h(req2);
+	h.update(ih);
+	TEST_EQUAL(*l.find_obfuscated(h.final()), 1337);
+	// this should not exist as an obfuscated hash
+	TEST_CHECK(l.find_obfuscated(ih) == nullptr);
+}
+#endif
+


### PR DESCRIPTION
    With v2, torrents can now have two infohashes. Simply adding multiple
    entries in m_torrents is undesirable because many code paths use
    m_torrents to iterate over every torrent. To keep m_torrents usable for
    iterating over, make it an unsorted vector storing all torrents exactly
    once.

    A new map is created to support fast lookups based on v1 or v2
    infohash.

@ssiloti does this look reasonable? I'm thinking that maybe I should experiment with `boost.multi_index` before I merge