### PR TITLE
Track the mapped port for each NAT mapping transport

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@
 	* support magnet link parameters with number siffixes
 	* consistently use "lt" namespace in examples and documentation
 	* fix Mingw build to use native cryptoAPI
+	* uPnP/NAT-PMP errors no longer set the client's advertised listen port to zero
 
 1.2 release
 

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -133,15 +133,15 @@ namespace aux {
 		only_outgoing
 	};
 
+	struct listen_port_mapping
+	{
+		port_mapping_t mapping = port_mapping_t{-1};
+		int port = 0;
+	};
+
 	struct listen_socket_t
 	{
-		listen_socket_t()
-		{
-			tcp_port_mapping[0] = port_mapping_t{-1};
-			tcp_port_mapping[1] = port_mapping_t{-1};
-			udp_port_mapping[0] = port_mapping_t{-1};
-			udp_port_mapping[1] = port_mapping_t{-1};
-		}
+		listen_socket_t() = default;
 
 		// listen_socket_t should not be copied or moved because
 		// references to it are held by the DHT and tracker announce
@@ -169,19 +169,35 @@ namespace aux {
 		// had to retry binding with a higher port
 		int original_port = 0;
 
-		// this is typically set to the same as the local
-		// listen port. In case a NAT port forward was
-		// successfully opened, this will be set to the
-		// port that is open on the external (NAT) interface
-		// on the NAT box itself. This is the port that has
-		// to be published to peers, since this is the port
-		// the client is reachable through.
-		int tcp_external_port = 0;
-		int udp_external_port = 0;
+		// tcp_external_port and udp_external_port return the port which
+		// should be published to peers/trackers for this socket
+		// If there are active NAT mappings the return value will be
+		// the external port returned by the NAT router, otherwise the
+		// local listen port is returned
+		int tcp_external_port()
+		{
+			for (auto const& m : tcp_port_mapping)
+			{
+				if (m.port != 0) return m.port;
+			}
+			return local_endpoint.port();
+		}
+
+		int udp_external_port()
+		{
+			for (auto const& m : udp_port_mapping)
+			{
+				if (m.port != 0) return m.port;
+			}
+			if (udp_sock) return udp_sock->sock.local_port();
+			return 0;
+		}
 
 		// 0 is natpmp 1 is upnp
-		port_mapping_t tcp_port_mapping[2];
-		port_mapping_t udp_port_mapping[2];
+		// the order of these arrays determines the priorty in
+		// which their ports will be announced to peers
+		listen_port_mapping tcp_port_mapping[2];
+		listen_port_mapping udp_port_mapping[2];
 
 		// indicates whether this is an SSL listen socket or not
 		transport ssl = transport::plaintext;

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -196,8 +196,8 @@ namespace aux {
 		// 0 is natpmp 1 is upnp
 		// the order of these arrays determines the priorty in
 		// which their ports will be announced to peers
-		listen_port_mapping tcp_port_mapping[2];
-		listen_port_mapping udp_port_mapping[2];
+		aux::array<listen_port_mapping, 2, portmap_transport> tcp_port_mapping;
+		aux::array<listen_port_mapping, 2, portmap_transport> udp_port_mapping;
 
 		// indicates whether this is an SSL listen socket or not
 		transport ssl = transport::plaintext;

--- a/include/libtorrent/units.hpp
+++ b/include/libtorrent/units.hpp
@@ -94,10 +94,14 @@ namespace libtorrent { namespace aux {
 		UnderlyingType m_val;
 	};
 
-	// meta function to return the underlying type of a strong_typedef, or the
-	// type itself if it isn't a strong_typedef
-	template <typename T>
+	// meta function to return the underlying type of a strong_typedef or enumeration
+	// , or the type itself if it isn't a strong_typedef
+	template <typename T, typename = void>
 	struct underlying_index_t { using type = T; };
+
+	template <typename T>
+	struct underlying_index_t<T, typename std::enable_if<std::is_enum<T>::value>::type>
+	{ using type = typename std::underlying_type<T>::type; };
 
 	template <typename U, typename Tag>
 	struct underlying_index_t<aux::strong_typedef<U, Tag>> { using type = U; };

--- a/simulation/test_dht_rate_limit.cpp
+++ b/simulation/test_dht_rate_limit.cpp
@@ -61,7 +61,7 @@ struct obs : dht::dht_observer
 		, address const& /* source */) override
 	{}
 	int get_listen_port(lt::aux::transport, lt::aux::listen_socket_handle const& s) override
-	{ return s.get()->udp_external_port; }
+	{ return s.get()->udp_external_port(); }
 	void get_peers(sha1_hash const&) override {}
 	void outgoing_get_peers(sha1_hash const& /* target */
 		, sha1_hash const& /* sent_target */, udp::endpoint const& /* ep */) override {}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2142,13 +2142,17 @@ namespace aux {
 
 		if ((mask & remap_natpmp) && s.natpmp_mapper)
 		{
-			map_port(*s.natpmp_mapper, portmap_protocol::tcp, tcp_ep, s.tcp_port_mapping[0].mapping);
-			map_port(*s.natpmp_mapper, portmap_protocol::udp, make_tcp(udp_ep), s.udp_port_mapping[0].mapping);
+			map_port(*s.natpmp_mapper, portmap_protocol::tcp, tcp_ep
+				, s.tcp_port_mapping[portmap_transport::natpmp].mapping);
+			map_port(*s.natpmp_mapper, portmap_protocol::udp, make_tcp(udp_ep)
+				, s.udp_port_mapping[portmap_transport::natpmp].mapping);
 		}
 		if ((mask & remap_upnp) && m_upnp)
 		{
-			map_port(*m_upnp, portmap_protocol::tcp, tcp_ep, s.tcp_port_mapping[1].mapping);
-			map_port(*m_upnp, portmap_protocol::udp, make_tcp(udp_ep), s.udp_port_mapping[1].mapping);
+			map_port(*m_upnp, portmap_protocol::tcp, tcp_ep
+				, s.tcp_port_mapping[portmap_transport::upnp].mapping);
+			map_port(*m_upnp, portmap_protocol::udp, make_tcp(udp_ep)
+				, s.udp_port_mapping[portmap_transport::upnp].mapping);
 		}
 	}
 
@@ -5519,13 +5523,13 @@ namespace aux {
 		bool find_tcp_port_mapping(portmap_transport const transport
 			, port_mapping_t mapping, std::shared_ptr<listen_socket_t> const& ls)
 		{
-			return ls->tcp_port_mapping[static_cast<int>(transport)].mapping == mapping;
+			return ls->tcp_port_mapping[transport].mapping == mapping;
 		}
 
 		bool find_udp_port_mapping(portmap_transport const transport
 			, port_mapping_t mapping, std::shared_ptr<listen_socket_t> const& ls)
 		{
-			return ls->udp_port_mapping[static_cast<int>(transport)].mapping == mapping;
+			return ls->udp_port_mapping[transport].mapping == mapping;
 		}
 	}
 
@@ -5570,8 +5574,8 @@ namespace aux {
 				(*ls)->external_address.cast_vote(ip, source_router, address());
 			}
 
-			if (tcp) (*ls)->tcp_port_mapping[static_cast<int>(transport)].port = port;
-			else (*ls)->tcp_port_mapping[static_cast<int>(transport)].port = port;
+			if (tcp) (*ls)->tcp_port_mapping[transport].port = port;
+			else (*ls)->tcp_port_mapping[transport].port = port;
 		}
 
 		if (!ec && m_alerts.should_post<portmap_alert>())
@@ -6729,8 +6733,8 @@ namespace aux {
 	{
 		for (auto& s : m_listen_sockets)
 		{
-			s->tcp_port_mapping[0] = listen_port_mapping();
-			s->udp_port_mapping[0] = listen_port_mapping();
+			s->tcp_port_mapping[portmap_transport::natpmp] = listen_port_mapping();
+			s->udp_port_mapping[portmap_transport::natpmp] = listen_port_mapping();
 			if (!s->natpmp_mapper) continue;
 			s->natpmp_mapper->close();
 			s->natpmp_mapper.reset();
@@ -6744,8 +6748,8 @@ namespace aux {
 		m_upnp->close();
 		for (auto& s : m_listen_sockets)
 		{
-			s->tcp_port_mapping[1] = listen_port_mapping();
-			s->udp_port_mapping[1] = listen_port_mapping();
+			s->tcp_port_mapping[portmap_transport::upnp] = listen_port_mapping();
+			s->udp_port_mapping[portmap_transport::upnp] = listen_port_mapping();
 		}
 		m_upnp.reset();
 	}

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -525,7 +525,7 @@ struct obs : dht::dht_observer
 	}
 
 	int get_listen_port(aux::transport, aux::listen_socket_handle const& s) override
-	{ return s.get()->udp_external_port; }
+	{ return s.get()->udp_external_port(); }
 
 	void get_peers(sha1_hash const&) override {}
 	void outgoing_get_peers(sha1_hash const& /*target*/


### PR DESCRIPTION
Each transport needs to be tracked separately so that a failed mapping request
doesn't cause the listen port for a socket to be cleared to zero.

Fixes #3785