### PR TITLE
choke dishonest peer in anti-leech seeding algorithm

### DIFF
--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -645,6 +645,9 @@ namespace aux {
 		std::time_t last_seen_complete() const { return m_last_seen_complete; }
 		void set_last_seen_complete(int ago) { m_last_seen_complete = ::time(nullptr) - ago; }
 
+		std::int64_t uploaded_at_last_round() const
+		{ return m_uploaded_at_last_round; }
+
 		std::int64_t uploaded_in_last_round() const
 		{ return m_statistics.total_payload_upload() - m_uploaded_at_last_round; }
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -645,9 +645,6 @@ namespace aux {
 		std::time_t last_seen_complete() const { return m_last_seen_complete; }
 		void set_last_seen_complete(int ago) { m_last_seen_complete = ::time(nullptr) - ago; }
 
-		std::int64_t uploaded_at_last_round() const
-		{ return m_uploaded_at_last_round; }
-
 		std::int64_t uploaded_in_last_round() const
 		{ return m_statistics.total_payload_upload() - m_uploaded_at_last_round; }
 

--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -162,8 +162,8 @@ namespace {
 		TORRENT_ASSERT(t);
 
 		std::int64_t const total_size = t->torrent_file().total_size();
-		std::int64_t have_size = peer->num_have_pieces() * t->torrent_file().piece_length();
-		have_size = std::max(have_size, peer->statistics().total_payload_upload());
+		std::int64_t const have_size = std::max(peer->statistics().total_payload_upload()
+			, std::int64_t(t->torrent_file().piece_length()) * peer->num_have_pieces());
 		return int(std::abs((have_size - total_size / 2) * 2000 / total_size));
 	}
 

--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -163,7 +163,7 @@ namespace {
 
 		std::int64_t const total_size = t->torrent_file().total_size();
 		std::int64_t have_size = peer->num_have_pieces() * t->torrent_file().piece_length();
-		have_size = std::max(have_size, peer->uploaded_at_last_round());
+		have_size = std::max(have_size, peer->statistics().total_payload_upload());
 		return int(std::abs((have_size - total_size / 2) * 2000 / total_size));
 	}
 


### PR DESCRIPTION
As discussed in https://github.com/qbittorrent/qBittorrent/issues/10258, some clients (e.g. XunLei) always claim they have zero pieces, even we have uploaded a lot to them. They take most advantage in the anti-leech seeding algorithm but won't share any pieces. Choke them.