### PR TITLE
Misc. fixes 

### DIFF
--- a/include/libtorrent/aux_/allocating_handler.hpp
+++ b/include/libtorrent/aux_/allocating_handler.hpp
@@ -54,8 +54,8 @@ namespace libtorrent { namespace aux {
 #ifdef _MSC_VER
 #ifdef TORRENT_USE_OPENSSL
 #ifdef NDEBUG
-	constexpr std::size_t write_handler_max_size = tracking + 224;
-	constexpr std::size_t read_handler_max_size = tracking + 224;
+	constexpr std::size_t write_handler_max_size = tracking + 240;
+	constexpr std::size_t read_handler_max_size = tracking + 240;
 #else
 	constexpr std::size_t write_handler_max_size = tracking + 352;
 	constexpr std::size_t read_handler_max_size = tracking + 416;

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -607,7 +607,7 @@ namespace libtorrent { namespace aux {
 		int ret = 0;
 		for (auto buf : bufs)
 		{
-			ret += buf.size();
+			ret += static_cast<int>(buf.size());
 			std::fill(buf.begin(), buf.end(), 0);
 		}
 		return ret;


### PR DESCRIPTION
* Fix unsafe type narrowing
  MSVC was emitting warning C4244 before this commit.
* Enlarge read/write handler size
  This is required when building with MSVC 2019 v16.1.1, boost 1.70, OpenSSL 1.0.2r