### PR TITLE
workaround a race condition when (un)mapping files on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,7 +106,7 @@ build_script:
     mkdir build &&
     cd build &&
     set "PATH=c:\Python27-x64;%PATH%" &&
-    cmake -DBOOST_LIBRARYDIR=%BOOST_ROOT%\stage\lib -DCMAKE_CXX_STANDARD=14 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
+    cmake -DBOOST_LIBRARYDIR=%BOOST_ROOT%\stage\lib -DCMAKE_CXX_STANDARD=14 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 15 2017" -A x64 .. &&
     cmake --build . --config Release -- -verbosity:minimal
     )
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -72,7 +72,7 @@ if '--help' not in sys.argv \
         elif sys.version_info[0:2] in ((3, 3), (3, 4)):
             toolset = ' toolset=msvc-10.0'
         elif sys.version_info[0:2] in ((3, 5), (3, 6)):
-            toolset = ' toolset=msvc-14.0'
+            toolset = ' toolset=msvc-14.1'  # libtorrent requires VS 2017 or newer
         else:
             # unknown python version, lets hope the user has the right version of msvc configured
             toolset = ' toolset=msvc'

--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -80,7 +80,11 @@ namespace aux {
 		// file_storage ``fs`` opened at save path ``p``. ``m`` is the
 		// file open mode (see file::open_mode_t).
 		file_view open_file(storage_index_t st, std::string const& p
-			, file_index_t file_index, file_storage const& fs, open_mode_t m);
+			, file_index_t file_index, file_storage const& fs, open_mode_t m
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			, std::shared_ptr<std::mutex> open_unmap_lock
+#endif
+			);
 
 		// release all file views belonging to the specified storage_interface
 		// (``st``) the overload that takes ``file_index`` releases only the file
@@ -111,9 +115,17 @@ namespace aux {
 			file_entry(file_id k
 				, string_view name
 				, open_mode_t const m
-				, std::int64_t const size)
+				, std::int64_t const size
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+				, std::shared_ptr<std::mutex> open_unmap_lock
+#endif
+				)
 				: key(k)
-				, mapping(std::make_shared<file_mapping>(file_handle(name, size, m), m, size))
+				, mapping(std::make_shared<file_mapping>(file_handle(name, size, m), m, size
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+					, open_unmap_lock
+#endif
+					))
 				, mode(m)
 			{}
 

--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -48,6 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define VC_EXTRALEAN
 #endif
 #include <windows.h>
+#include <mutex>
 
 #endif // TORRENT_HAVE_MAP_VIEW_OF_FILE
 
@@ -119,7 +120,11 @@ namespace aux {
 	{
 		friend struct file_view;
 
-		file_mapping(file_handle file, open_mode_t mode, std::int64_t file_size);
+		file_mapping(file_handle file, open_mode_t mode, std::int64_t file_size
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			, std::shared_ptr<std::mutex> open_unmap_lock
+#endif
+			);
 
 		// non-copyable
 		file_mapping(file_mapping const&) = delete;
@@ -145,6 +150,7 @@ namespace aux {
 		std::int64_t m_size;
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 		file_mapping_handle m_file;
+		std::shared_ptr<std::mutex> m_open_unmap_lock;
 #else
 		file_handle m_file;
 #endif

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -194,6 +194,18 @@ namespace aux {
 		mutable std::mutex m_file_created_mutex;
 		mutable typed_bitfield<file_index_t> m_file_created;
 
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+		// Windows has a race condition when unmapping a view while a new
+		// view or mapping object is being created in a different thread.
+		// The race can cause a page of written data to be zeroed out before
+		// it is written out to disk. To avoid the race these calls must be
+		// serialized on a per-file basis. See github issue #3842 for details.
+
+		// This array stores a mutex for each file in the storage object
+		// It must be aquired before calling CreateFileMapping or UnmapViewOfFile
+		mutable std::shared_ptr<std::mutex> m_file_open_unmap_lock;
+#endif
+
 		bool m_allocate_files;
 	};
 

--- a/test/test_mmap.cpp
+++ b/test/test_mmap.cpp
@@ -67,7 +67,11 @@ TORRENT_TEST(mmap_read)
 	}
 
 	auto m = std::make_shared<file_mapping>(aux::file_handle("test_file1", 100, open_mode::read_only)
-		, open_mode::read_only, 100);
+		, open_mode::read_only, 100
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+		, std::make_shared<std::mutex>()
+#endif
+		);
 
 	for (auto const i : boost::combine(m->view().range(), buf))
 	{
@@ -82,7 +86,11 @@ TORRENT_TEST(mmap_write)
 	{
 		auto m = std::make_shared<file_mapping>(aux::file_handle("test_file2", 100
 				, open_mode::write | open_mode::truncate)
-			, open_mode::write | open_mode::truncate, 100);
+			, open_mode::write | open_mode::truncate, 100
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			, std::make_shared<std::mutex>()
+#endif
+			);
 
 		file_view v = m->view();
 		auto range = v.range();


### PR DESCRIPTION
Fixes #3842 

I'm not really happy with the amount of preprocessor noise added for this, but I don't see a clear alternative.