### PR TITLE
add abort hook for plugins

### DIFF
--- a/include/libtorrent/extensions.hpp
+++ b/include/libtorrent/extensions.hpp
@@ -224,6 +224,11 @@ namespace libtorrent {
 		// called when plugin is added to a session
 		virtual void added(session_handle const&) {}
 
+		// called when the session is aborted
+		// the plugin should perform any cleanup necessary to allow the session's
+		// destruction (e.g. cancel outstanding async operations)
+		virtual void abort() {}
+
 		// called when a dht request is received.
 		// If your plugin expects this to be called, make sure to include the flag
 		// ``dht_request_feature`` in the return value from implemented_features().

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -824,6 +824,13 @@ namespace aux {
 		// session will become invalid.
 		m_alerts.set_notify_function({});
 
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		for (auto& ext : m_ses_extensions[plugins_all_idx])
+		{
+			ext->abort();
+		}
+#endif
+
 		// this will cancel requests that are not critical for shutting down
 		// cleanly. i.e. essentially tracker hostname lookups that we're not
 		// about to send event=stopped to


### PR DESCRIPTION
Plugins might have ongoing async operations which need to be canceled
when the session is aborted so that the event loop can terminate.