### PR TITLE
set HTTP Host to request-target when using proxy

### DIFF
--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -184,12 +184,12 @@ void http_connection::get(std::string const& url, time_duration timeout, int pri
 			request << "Proxy-Authorization: Basic " << base64encode(
 				ps->username + ":" + ps->password) << "\r\n";
 
-		hostname = ps->hostname;
-		port = ps->port;
-
 		request << "Host: " << hostname;
 		if (port != default_port) request << ":" << port << "\r\n";
 		else request << "\r\n";
+
+		hostname = ps->hostname;
+		port = ps->port;
 	}
 	else
 	{


### PR DESCRIPTION
To make the Host field carry the request-target it is enough to set
the Host information before changing the connection destination.

Many proxies rely on the Host field-value to route requests
in a violation of RFC7230 section 5.4.

https://tools.ietf.org/html/rfc7230#section-5.4

A request with the Host field set to the proxy hostname and port
in place of the request-target produces error responses and otherwise
confuses such misconfigured middleboxes.