### PR TITLE
Log verbiage for put_item

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -356,7 +356,7 @@ namespace {
 		m_type = preformatted_t;
 	}
 
-	// convert a bdecode_node into an old skool entry
+	// convert a bdecode_node into an old school entry
 	entry& entry::operator=(bdecode_node const& e) &
 	{
 		switch (e.type())
@@ -395,7 +395,7 @@ namespace {
 	}
 
 #if TORRENT_ABI_VERSION == 1
-	// convert a lazy_entry into an old skool entry
+	// convert a lazy_entry into an old school entry
 	entry& entry::operator=(lazy_entry const& e) &
 	{
 		switch (e.type())

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -536,7 +536,7 @@ void node::put_item(sha1_hash const& target, entry const& data, std::function<vo
 #ifndef TORRENT_DISABLE_LOGGING
 	if (m_observer != nullptr && m_observer->should_log(dht_logger::node))
 	{
-		m_observer->log(dht_logger::node, "starting get for [ hash: %s ]"
+		m_observer->log(dht_logger::node, "starting put for [ hash: %s ]"
 			, aux::to_hex(target).c_str());
 	}
 #endif
@@ -560,7 +560,7 @@ void node::put_item(public_key const& pk, std::string const& salt
 	{
 		char hex_key[65];
 		aux::to_hex(pk.bytes, hex_key);
-		m_observer->log(dht_logger::node, "starting get for [ key: %s ]", hex_key);
+		m_observer->log(dht_logger::node, "starting put for [ key: %s ]", hex_key);
 	}
 #endif
 


### PR DESCRIPTION
It seems like it should log "starting put" instead of "starting get" in `node::put_item`.
Also corrects the spelling for two entry operator comments.