### PR TITLE
make node and tracker_node explicitly non-movable

### DIFF
--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -165,7 +165,7 @@ namespace libtorrent { namespace dht {
 				, get_foreign_node_t get_foreign_node
 				, dht_storage_interface& storage);
 			tracker_node(tracker_node const&) = delete;
-			tracker_node(tracker_node&&) = default;
+			tracker_node(tracker_node&&) = delete;
 
 			node dht;
 			deadline_timer connection_timer;

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -101,8 +101,8 @@ public:
 
 	node(node const&) = delete;
 	node& operator=(node const&) = delete;
-	node(node&&) = default;
-	node& operator=(node&&) = default;
+	node(node&&) = delete;
+	node& operator=(node&&) = delete;
 
 	void update_node_id();
 


### PR DESCRIPTION
since the node contains a non-movable std::mutex