### PR TITLE
backport RC_1_2: unban 51.x.x.x from dht darknet list

### DIFF
--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -525,7 +525,7 @@ namespace libtorrent { namespace dht {
 			// these are class A networks not available to the public
 			// if we receive messages from here, that seems suspicious
 			static std::uint8_t const class_a[] = { 3, 6, 7, 9, 11, 19, 21, 22, 25
-				, 26, 28, 29, 30, 33, 34, 48, 51, 56 };
+				, 26, 28, 29, 30, 33, 34, 48, 56 };
 
 			if (std::find(std::begin(class_a), std::end(class_a), b[0]) != std::end(class_a))
 			{


### PR DESCRIPTION
according to geoip isp database 51.x.x.x network is using by normal ISP