### PR TITLE
add feature to create an affinity to pick adjecent pieces

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2702,6 +2702,7 @@ TORRENT_VERSION_NAMESPACE_2
 		static constexpr picker_flags_t backup1 = 13_bit;
 		static constexpr picker_flags_t backup2 = 14_bit;
 		static constexpr picker_flags_t end_game = 15_bit;
+		static constexpr picker_flags_t extent_affinity = 16_bit;
 
 		// this is a bitmask of which features were enabled for this particular
 		// pick. The bits are defined in the picker_flags_t enum.

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -734,6 +734,12 @@ namespace libtorrent {
 			// preferred in the routing table.
 			dht_prefer_verified_node_ids,
 
+			// when this is true, create an affinity for downloading 4 MiB extents
+			// of adjecent pieces. This is an attempt to achieve better disk I/O
+			// throughput by downloading larger extents of bytes, for torrents with
+			// small piece sizes
+			piece_extent_affinity,
+
 			max_bool_setting_internal
 		};
 

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -370,3 +370,21 @@ TORRENT_TEST(disable_disk_cache)
 	);
 }
 
+TORRENT_TEST(piece_extent_affinity)
+{
+	using namespace lt;
+	run_test(
+		[](lt::session& ses0, lt::session& ses1)
+		{
+			settings_pack p;
+			p.set_bool(settings_pack::piece_extent_affinity, true);
+			ses0.apply_settings(p);
+			ses1.apply_settings(p);
+		},
+		[](lt::session&, lt::alert const*) {},
+		[](std::shared_ptr<lt::session> ses[2]) {
+			TEST_EQUAL(is_seed(*ses[0]), true);
+		}
+	);
+}
+

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2258,6 +2258,7 @@ namespace {
 	constexpr picker_flags_t picker_log_alert::backup1;
 	constexpr picker_flags_t picker_log_alert::backup2;
 	constexpr picker_flags_t picker_log_alert::end_game;
+	constexpr picker_flags_t picker_log_alert::extent_affinity;
 
 	std::string picker_log_alert::message() const
 	{
@@ -2279,6 +2280,7 @@ namespace {
 			"backup1 ",
 			"backup2 ",
 			"end_game "
+			"extent_affinity "
 		};
 
 		std::string ret = peer_alert::message();

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -928,7 +928,12 @@ namespace libtorrent {
 				// request blocks from the same piece
 				ret |= piece_picker::reverse;
 			}
-
+			else
+			{
+				if (m_settings.get_bool(settings_pack::piece_extent_affinity)
+					&& t->num_time_critical_pieces() == 0)
+					ret |= piece_picker::piece_extent_affinity;
+			}
 		}
 
 		if (m_settings.get_bool(settings_pack::prioritize_partial_pieces))

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -208,6 +208,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		SET(proxy_tracker_connections, true, nullptr),
 		SET(enable_ip_notifier, true, &session_impl::update_ip_notifier),
 		SET(dht_prefer_verified_node_ids, true, &session_impl::update_dht_settings),
+		SET(piece_extent_affinity, false, nullptr),
 	}});
 
 	aux::array<int_setting_entry_t, settings_pack::num_int_settings> const int_settings


### PR DESCRIPTION
aligned to 4MiB extents. It's an attempt to improve disk I/O, by writing larger contiguous ranges of bytes. It's off by default.