### PR TITLE
Add dht_live_nodes and dht_sample_infohashes to Python bindings

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -135,6 +135,34 @@ dict session_stats_values(session_stats_alert const& alert)
     return d;
 }
 
+list dht_live_nodes_nodes(dht_live_nodes_alert const& alert)
+{
+    list result;
+    std::vector<std::pair<sha1_hash, udp::endpoint>> const nodes = alert.nodes();
+    for (std::pair<sha1_hash, udp::endpoint> const& node : nodes)
+    {
+        dict d;
+        d["nid"] = node.first;
+        d["endpoint"] = node.second;
+        result.append(d);
+    }
+    return result;
+}
+
+list dht_sample_infohashes_nodes(dht_sample_infohashes_alert const& alert)
+{
+    list result;
+    std::vector<std::pair<sha1_hash, udp::endpoint>> const nodes = alert.nodes();
+    for (std::pair<sha1_hash, udp::endpoint> const& node : nodes)
+    {
+        dict d;
+        d["nid"] = node.first;
+        d["endpoint"] = node.second;
+        result.append(d);
+    }
+    return result;
+}
+
 #if TORRENT_ABI_VERSION == 1
 entry const& get_resume_data_entry(save_resume_data_alert const& self)
 {
@@ -1068,6 +1096,30 @@ void bind_alert()
         .def_readonly("error", &socks5_alert::error)
         .def_readonly("op", &socks5_alert::op)
         .add_property("ip", make_getter(&socks5_alert::ip, by_value()))
+        ;
+
+    class_<dht_live_nodes_alert, bases<alert>, noncopyable>(
+       "dht_live_nodes_alert", no_init)
+        .add_property("node_id", &dht_live_nodes_alert::node_id)
+        .add_property("num_nodes", &dht_live_nodes_alert::num_nodes)
+        .add_property("nodes", &dht_live_nodes_nodes)
+        ;
+
+    std::vector<sha1_hash> (dht_sample_infohashes_alert::*samples)() const = &dht_sample_infohashes_alert::samples;
+
+    class_<dht_sample_infohashes_alert, bases<alert>, noncopyable>(
+       "dht_sample_infohashes_alert", no_init)
+        .add_property("endpoint", make_getter(&dht_sample_infohashes_alert::endpoint, by_value()))
+        .add_property("interval", make_getter(&dht_sample_infohashes_alert::interval, by_value()))
+        .add_property("num_infohashes", &dht_sample_infohashes_alert::num_infohashes)
+        .add_property("num_samples", &dht_sample_infohashes_alert::num_samples)
+        .add_property("samples", samples)
+        .add_property("num_nodes", &dht_sample_infohashes_alert::num_nodes)
+        .add_property("nodes", &dht_sample_infohashes_nodes)
+        ;
+
+    class_<dht_bootstrap_alert, bases<alert>, noncopyable>(
+        "dht_bootstrap_alert", no_init)
         ;
 
 }

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -1017,6 +1017,8 @@ void bind_session()
         .def("dht_put_mutable_item", &dht_put_mutable_item)
         .def("dht_get_peers", allow_threads(&lt::session::dht_get_peers))
         .def("dht_announce", allow_threads(&lt::session::dht_announce))
+        .def("dht_live_nodes", allow_threads(&lt::session::dht_live_nodes))
+        .def("dht_sample_infohashes", allow_threads(&lt::session::dht_sample_infohashes))
 #endif // TORRENT_DISABLE_DHT
         .def("add_torrent", &add_torrent)
         .def("async_add_torrent", &async_add_torrent)


### PR DESCRIPTION
Add `dht_live_nodes` and `dht_sample_infohashes` functionality and `dht_bootstrap_alert` to Python bindings:
- add function `dht_live_nodes` to session
- add function `dht_sample_infohashes` to session
- add alert `dht_live_nodes_alert` to alerts
- add alert `dht_sample_infohashes_alert` to alerts
- add alert 'dht_bootstrap_alert' to alerts

**I'm still having some trouble with `dht_sample_infohashes_alert` (help requested):**
- property `endpoint` only contains garbage when inspected in Python; not sure if that's an issue with my code or existing code
- property `interval` throws a missing converter error in Python, however a converter for `time_duration` exists in `datetime.cpp`, so this should work, but doesn't; what am I missing?

And thanks by the way for an absolutely great library!