### PR TITLE
the fuzzers use libfuzzer, so they have to be built by clang

### DIFF
--- a/fuzzers/Jamfile
+++ b/fuzzers/Jamfile
@@ -27,6 +27,7 @@ project fuzzers
 	<linkflags>-fno-omit-frame-pointer
 	<library>/torrent//torrent/
 	: default-build
+	<toolset>clang
 	<fuzz>on
 	<sanitize>on
 	<link>static


### PR DESCRIPTION
Make that the default