### PR TITLE
cleanup Jamfiles a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -264,7 +264,7 @@ script:
 # simulation
   - cd simulation
   - 'if [[ "$sim" == "1" ]]; then
-      ${B2} -j2 crypto=built-in warnings-as-errors=on warnings=all debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset deprecated-functions=off;
+      ${B2} -j2 crypto=built-in warnings=all debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset deprecated-functions=off;
     fi'
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
           - python3-pip
           - libboost1.58-all-dev
           - libboost1.58-tools-dev
-    - env: variant=test_debug tests=1 toolset=gcc-sanitizer fuzzers=1
-    - env: variant=test_debug sim=1 crypto=openssl toolset=gcc-sanitizer
+    - env: variant=test_debug tests=1 sanitizer=on fuzzers=1
+    - env: variant=test_debug sim=1 crypto=openssl sanitizer=on
     - env: variant=test_release coverage=1 tests=1 toolset=gcc-coverage python=1
     - env: autotools=1 toolset=gcc
     - env: cmake=1 toolset=gcc
@@ -59,6 +59,7 @@ before_install:
 
   - git submodule update --init --recursive
   - 'if [[ $crypto == "" ]]; then export crypto=built-in; fi'
+  - 'if [[ $sanitizer == "" ]]; then export sanitizer=off; fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" && ( "$tests" == "1" || "$sim" == 1 || "$examples" == "1" || "$tools" == "1" || "$python" == "1" || "$check_headers" == "1" ) ]]; then
     travis_retry brew update > /dev/null && brew install ccache boost-build;
     fi'
@@ -95,17 +96,6 @@ install:
   - 'if [[ $toolset == "gcc" ]]; then
       g++-5 --version;
       echo "using gcc : : ccache g++-5 : <cxxflags>-std=c++11 ;" >> ~/user-config.jam;
-    fi'
-  - 'if [[ $toolset == "gcc-sanitizer" ]]; then
-      echo "using gcc : sanitizer : ccache g++-5 :
-        <cxxflags>-std=c++11
-        <compileflags>-fstack-protector-all
-        <compileflags>-fstack-check
-        <compileflags>-fsanitize=address,undefined
-        <compileflags>-fno-sanitize-recover=address,undefined
-        <linkflags>-fsanitize=address,undefined
-        <linkflags>-fno-sanitize-recover=address,undefined
-        <linkflags>-fuse-ld=gold ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $toolset == "gcc-coverage" ]]; then
       echo "using gcc : coverage : ccache g++-5 --coverage : <cxxflags>-std=c++11 <linkflags>--coverage ;" >> ~/user-config.jam;
@@ -213,18 +203,18 @@ script:
     fi'
 
   - 'if [ "$check_headers" == "1" ]; then
-      ${B2} -j3 check-headers crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant;
+      ${B2} -j3 check-headers sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant;
     fi'
 
 # if we are building with code coverage, report it as soon as possible
 # libtorrent is the name of the test suite target
   - cd test
   - 'if [ "$tests" == "1" ]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant testing.execute=off &&
-      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant -l300 &&
-      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant test_natpmp enum_if -l300 &&
+      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant testing.execute=off &&
+      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant -l300 &&
+      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant test_natpmp enum_if -l300 &&
       if [[ $TRAVIS_OS_NAME != "osx" ]]; then
-        travis_retry ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant test_lsd -l300;
+        travis_retry ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant test_lsd -l300;
       fi &&
       if [ "$coverage" == "1" ]; then
         codecov --root .. --gcov-exec gcov-5;
@@ -240,13 +230,13 @@ script:
 
   - cd ../examples
   - 'if [ "$examples" == "1" ]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant link=shared;
+      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant link=shared;
     fi'
   - cd ..
 
   - cd tools
   - 'if [ "$tools" == "1" ]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant link=shared;
+      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant link=shared;
     fi'
   - cd ..
 
@@ -258,7 +248,7 @@ script:
 # on OSX we need to use the brew version of python, for reasons explained above
   - cd bindings/python
   - 'if [[ "$python" == "1" ]]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant stage_module stage_dependencies libtorrent-link=shared boost-link=shared &&
+      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant stage_module stage_dependencies libtorrent-link=shared boost-link=shared &&
       if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         DYLD_LIBRARY_PATH=./dependencies python2 test.py -b;
       else
@@ -299,6 +289,6 @@ script:
   - cd test
   - 'if [[ "$arch" == "arm" ]];
     then
-      ${B2} arm-tests warnings-as-errors=on warnings=all crypto=$crypto variant=test_arm $toolset target-os=linux link=static testing.launcher="sudo cp -R bin rootfs/; sudo chroot rootfs";
+      ${B2} arm-tests warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto variant=test_arm $toolset target-os=linux link=static testing.launcher="sudo cp -R bin rootfs/; sudo chroot rootfs";
     fi'
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,19 +202,23 @@ script:
        ${B2} -a -j3 clang_tidy;
     fi'
 
+  # the common boost-build command line arguments. It's important they are all
+  # the same, in order for builds to be reused between invocations
+  - export B2_ARGS="sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant"
+
   - 'if [ "$check_headers" == "1" ]; then
-      ${B2} -j3 check-headers sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant;
+      ${B2} -j3 check-headers ${B2_ARGS};
     fi'
 
 # if we are building with code coverage, report it as soon as possible
 # libtorrent is the name of the test suite target
   - cd test
   - 'if [ "$tests" == "1" ]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant testing.execute=off &&
-      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant -l300 &&
-      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant test_natpmp enum_if -l300 &&
+      ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} testing.execute=off &&
+      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} -l300 &&
+      travis_retry ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} test_natpmp enum_if -l300 &&
       if [[ $TRAVIS_OS_NAME != "osx" ]]; then
-        travis_retry ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant test_lsd -l300;
+        travis_retry ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} test_lsd -l300;
       fi &&
       if [ "$coverage" == "1" ]; then
         codecov --root .. --gcov-exec gcov-5;
@@ -230,13 +234,13 @@ script:
 
   - cd ../examples
   - 'if [ "$examples" == "1" ]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant link=shared;
+      ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} link=shared;
     fi'
   - cd ..
 
   - cd tools
   - 'if [ "$tools" == "1" ]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant link=shared;
+      ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} link=shared;
     fi'
   - cd ..
 
@@ -248,7 +252,7 @@ script:
 # on OSX we need to use the brew version of python, for reasons explained above
   - cd bindings/python
   - 'if [[ "$python" == "1" ]]; then
-      ${B2} -j3 warnings-as-errors=on warnings=all sanitize=$sanitizer crypto=$crypto debug-iterators=on picker-debugging=on asserts=on invariant-checks=full $toolset variant=$variant stage_module stage_dependencies libtorrent-link=shared boost-link=shared &&
+      ${B2} -j3 warnings-as-errors=on warnings=all ${B2_ARGS} stage_module stage_dependencies libtorrent-link=shared boost-link=shared &&
       if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         DYLD_LIBRARY_PATH=./dependencies python2 test.py -b;
       else

--- a/Jamfile
+++ b/Jamfile
@@ -384,7 +384,7 @@ rule sanitizer-options ( properties * )
 		{
 			local version = [ feature.get-values <toolset-clang:version> : $(properties) ] ;
 			# implicit-conversion sanitizer was added in clang-7
-			if $(version) >= 7 {
+			if $(version) >= 7.0 {
 				sanitizers += address,undefined,leak,implicit-conversion ;
 			}
 			else {

--- a/Jamfile
+++ b/Jamfile
@@ -267,14 +267,6 @@ rule building ( properties * )
 		result += <cflags>/bigobj ;
 	}
 
-	if ( <variant>debug in $(properties)
-		&& ( <toolset>clang in $(properties)
-			|| <toolset>gcc in $(properties)
-			|| <toolset>darwin in $(properties) ) )
-	{
-		result += <cflags>-ftrapv ;
-	}
-
 	if ( <asserts>production in $(properties)
 		|| <asserts>on in $(properties) )
 	{
@@ -388,8 +380,6 @@ rule sanitizer-options ( properties * )
 		local flags ;
    
 		# sanitize is a clang and GCC feature
-		# TODO: carve out specific sanitizers based on compiler version
-		# <toolset-gcc:version> <toolset-clang:version>
 		if <toolset>clang in $(properties)
 		{
 			local version = [ feature.get-values <toolset-clang:version> : $(properties) ] ;
@@ -403,19 +393,21 @@ rule sanitizer-options ( properties * )
 			extra = <cflags>-fsanitize-blacklist=$(blacklist-file) ;
 			flags = -fsanitize=$(sanitizers) -fno-sanitize-recover=all ;
 		}
-		else if <toolset>gcc in $(properties)
+		# sanitizers are not available on windows (mingw)
+		else if <toolset>gcc in $(properties) && ! <target-os>windows in $(properties)
 		{
 			local version = [ feature.get-values <toolset-gcc:version> : $(properties) ] ;
-			if $(version) >= 7 {
+			if $(version) >= 7.0 {
 				extra = <cflags>-fsanitize-address-use-after-scope ;
 			}
-			if $(version) >= 5 {
+			if $(version) >= 5.0 {
 				sanitizers = address,undefined,leak ;
 				flags = -fsanitize=$(sanitizers) -fno-sanitize-recover=all ;
 			}
 		}
 		else if <toolset>darwin in $(properties)
 		{
+			# apple's compiler is typically an old version of clang
 			sanitizers = address,undefined ;
 			flags = -fsanitize=$(sanitizers) -fno-sanitize-recover=all ;
 		}
@@ -502,8 +494,7 @@ feature boost-link : default static shared : propagated composite ;
 # constructors on some containers when enabling debug iterators, so it's
 # possible to turn them off
 feature debug-iterators : default off on : composite propagated link-incompatible ;
-feature.compose <debug-iterators>on : <define>_ITERATOR_DEBUG_LEVEL=2 <define>_GLIBCXX_DEBUG
-	<define>_GLIBCXX_DEBUG_PEDANTIC ;
+feature.compose <debug-iterators>on : <define>_GLIBCXX_DEBUG <define>_GLIBCXX_DEBUG_PEDANTIC ;
 feature.compose <debug-iterators>off : <define>_ITERATOR_DEBUG_LEVEL=0 ;
 
 feature fpic : off on : composite propagated link-incompatible ;
@@ -807,9 +798,6 @@ lib torrent
 	<dht>on:<source>src/hasher512.cpp
 	<dht>on:<source>src/sha512.cpp
 
-	<variant>debug:<invariant-checks>on
-	<variant>debug:<asserts>on
-
 	<conditional>@building
 	<conditional>@warnings
 	<cxxflags>$(CXXFLAGS)
@@ -825,8 +813,6 @@ lib torrent
 	: # usage requirements
 	$(usage-requirements)
 	<link>shared:<define>TORRENT_LINKING_SHARED
-	<variant>debug:<invariant-checks>on
-	<variant>debug:<asserts>on
 
 	;
 

--- a/examples/Jamfile
+++ b/examples/Jamfile
@@ -9,6 +9,8 @@ if $(BOOST_ROOT)
 	use-project /boost : $(BOOST_ROOT) ;
 }
 
+variant debug-mode : debug : <asserts>on <debug-iterators>on <sanitize>on <invariant-checks>on ;
+
 project client_test
 	: requirements
 	<threading>multi <library>/torrent//torrent
@@ -21,6 +23,7 @@ project client_test
 	<toolset>msvc:<cflags>/wd4373
 	: default-build
 	<link>static
+	<variant>debug-mode
 	;
 
 exe client_test : client_test.cpp print.cpp torrent_view.cpp session_view.cpp ;

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -62,7 +62,7 @@ namespace libtorrent {
 		file_entry(file_entry const&) = default;
 		file_entry& operator=(file_entry const&) & = default;
 		file_entry(file_entry&&) noexcept = default;
-		file_entry& operator=(file_entry&&) & noexcept = default;
+		file_entry& operator=(file_entry&&) & = default;
 
 		// the full path of this file. The paths are unicode strings
 		// encoded in UTF-8.

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -42,6 +42,17 @@ explicit libtorrent_test ;
 
 lib advapi32 : : <name>Advapi32 ;
 
+local default-build =
+	<threading>multi
+	<link>shared
+	<asserts>on
+	<invariant-checks>full
+	<sanitize>on
+	<debug-iterators>on
+	<picker-debugging>on
+	<logging>on
+	;
+
 project
 	: requirements
 	<export-extra>on
@@ -59,12 +70,7 @@ project
 	<conditional>@warnings
 	<export-extra>on
 	: default-build
-	<threading>multi
-	<asserts>on
-	<invariant-checks>full
-	<link>shared
-	<picker-debugging>on
-	<logging>on
+	$(default-build)
 	;
 
 feature launcher : none valgrind : composite ;
@@ -76,12 +82,7 @@ exe test_natpmp : test_natpmp.cpp
 	<export-extra>on
 	<conditional>@warnings
 	: # default-build
-	<threading>multi
-	<asserts>on
-	<invariant-checks>full
-	<link>shared
-	<picker-debugging>on
-	<logging>on
+	$(default-build)
 	;
 
 exe enum_if : enum_if.cpp
@@ -90,12 +91,7 @@ exe enum_if : enum_if.cpp
 	<export-extra>on
 	<conditional>@warnings
 	: # default-build
-	<threading>multi
-	<asserts>on
-	<invariant-checks>full
-	<link>shared
-	<picker-debugging>on
-	<logging>on
+	$(default-build)
 	;
 
 install stage_enum_if : enum_if : <location>. ;
@@ -104,53 +100,9 @@ explicit test_natpmp ;
 explicit enum_if ;
 explicit stage_enum_if ;
 
-run
-	test_primitives.cpp
-	test_io.cpp
-	test_create_torrent.cpp
-	test_packet_buffer.cpp
-	test_timestamp_history.cpp
-	test_bloom_filter.cpp
-	test_identify_client.cpp
-	test_merkle.cpp
-	test_resolve_links.cpp
-	test_heterogeneous_queue.cpp
-	test_ip_voter.cpp
-	test_sliding_average.cpp
-	test_socket_io.cpp
-	test_part_file.cpp
-	test_peer_list.cpp
-	test_torrent_info.cpp
-	test_time.cpp
-	test_file_storage.cpp
-	test_peer_priority.cpp
-	test_threads.cpp
-	test_tailqueue.cpp
-	test_bandwidth_limiter.cpp
-	test_buffer.cpp
-	test_bencoding.cpp
-	test_bdecode.cpp
-	test_http_parser.cpp
-	test_xml.cpp
-	test_ip_filter.cpp
-	test_block_cache.cpp
-	test_peer_classes.cpp
-	test_settings_pack.cpp
-	test_fence.cpp
-	test_dos_blocker.cpp
-	test_stat_cache.cpp
-	test_enum_net.cpp
-	test_linked_list.cpp
-	test_stack_allocator.cpp
-	test_file_progress.cpp
-	test_generate_peer_id.cpp
-	test_alloca.cpp ;
-
 run test_listen_socket.cpp
 	: : : <crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto ;
-
-run test_piece_picker.cpp ;
 
 run test_dht.cpp
 	test_dht_storage.cpp
@@ -158,8 +110,49 @@ run test_dht.cpp
 	: : : <crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto ;
 
-run test_string.cpp test_utf8.cpp ;
-
+run test_primitives.cpp ;
+run test_io.cpp ;
+run test_create_torrent.cpp ;
+run test_packet_buffer.cpp ;
+run test_timestamp_history.cpp ;
+run test_bloom_filter.cpp ;
+run test_identify_client.cpp ;
+run test_merkle.cpp ;
+run test_resolve_links.cpp ;
+run test_heterogeneous_queue.cpp ;
+run test_ip_voter.cpp ;
+run test_sliding_average.cpp ;
+run test_socket_io.cpp ;
+run test_part_file.cpp ;
+run test_peer_list.cpp ;
+run test_torrent_info.cpp ;
+run test_time.cpp ;
+run test_file_storage.cpp ;
+run test_peer_priority.cpp ;
+run test_threads.cpp ;
+run test_tailqueue.cpp ;
+run test_bandwidth_limiter.cpp ;
+run test_buffer.cpp ;
+run test_bencoding.cpp ;
+run test_bdecode.cpp ;
+run test_http_parser.cpp ;
+run test_xml.cpp ;
+run test_ip_filter.cpp ;
+run test_block_cache.cpp ;
+run test_peer_classes.cpp ;
+run test_settings_pack.cpp ;
+run test_fence.cpp ;
+run test_dos_blocker.cpp ;
+run test_stat_cache.cpp ;
+run test_enum_net.cpp ;
+run test_linked_list.cpp ;
+run test_stack_allocator.cpp ;
+run test_file_progress.cpp ;
+run test_generate_peer_id.cpp ;
+run test_alloca.cpp ;
+run test_piece_picker.cpp ;
+run test_string.cpp ;
+run test_utf8.cpp ;
 run test_hasher.cpp ;
 run test_hasher512.cpp ;
 run test_sha1_hash.cpp ;
@@ -179,7 +172,6 @@ run test_session_params.cpp ;
 run test_read_piece.cpp ;
 run test_remove_torrent.cpp ;
 run test_flags.cpp ;
-
 run test_file.cpp ;
 run test_fast_extension.cpp ;
 run test_privacy.cpp ;


### PR DESCRIPTION
Specifically, give up on the default asserts=on and invariant-checks=on in debug mode. Instead, just make that the default when building the tests and examples. restore all tests to have their own executable.