### PR TITLE
put default build configuration for tests in a variable

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -42,6 +42,15 @@ explicit libtorrent_test ;
 
 lib advapi32 : : <name>Advapi32 ;
 
+local default-build =
+	<threading>multi
+	<link>shared
+	<asserts>on
+	<invariant-checks>full
+	<picker-debugging>on
+	<logging>on
+	;
+
 project
 	: requirements
 	<export-extra>on
@@ -59,12 +68,7 @@ project
 	<conditional>@warnings
 	<export-extra>on
 	: default-build
-	<threading>multi
-	<asserts>on
-	<invariant-checks>full
-	<link>shared
-	<picker-debugging>on
-	<logging>on
+	$(default-build)
 	;
 
 feature launcher : none valgrind : composite ;
@@ -76,12 +80,7 @@ exe test_natpmp : test_natpmp.cpp
 	<export-extra>on
 	<conditional>@warnings
 	: # default-build
-	<threading>multi
-	<asserts>on
-	<invariant-checks>full
-	<link>shared
-	<picker-debugging>on
-	<logging>on
+	$(default-build)
 	;
 
 exe enum_if : enum_if.cpp
@@ -90,12 +89,7 @@ exe enum_if : enum_if.cpp
 	<export-extra>on
 	<conditional>@warnings
 	: # default-build
-	<threading>multi
-	<asserts>on
-	<invariant-checks>full
-	<link>shared
-	<picker-debugging>on
-	<logging>on
+	$(default-build)
 	;
 
 install stage_enum_if : enum_if : <location>. ;
@@ -104,53 +98,9 @@ explicit test_natpmp ;
 explicit enum_if ;
 explicit stage_enum_if ;
 
-run
-	test_primitives.cpp
-	test_io.cpp
-	test_create_torrent.cpp
-	test_packet_buffer.cpp
-	test_timestamp_history.cpp
-	test_bloom_filter.cpp
-	test_identify_client.cpp
-	test_merkle.cpp
-	test_resolve_links.cpp
-	test_heterogeneous_queue.cpp
-	test_ip_voter.cpp
-	test_sliding_average.cpp
-	test_socket_io.cpp
-	test_part_file.cpp
-	test_peer_list.cpp
-	test_torrent_info.cpp
-	test_time.cpp
-	test_file_storage.cpp
-	test_peer_priority.cpp
-	test_threads.cpp
-	test_tailqueue.cpp
-	test_bandwidth_limiter.cpp
-	test_buffer.cpp
-	test_bencoding.cpp
-	test_bdecode.cpp
-	test_http_parser.cpp
-	test_xml.cpp
-	test_ip_filter.cpp
-	test_block_cache.cpp
-	test_peer_classes.cpp
-	test_settings_pack.cpp
-	test_fence.cpp
-	test_dos_blocker.cpp
-	test_stat_cache.cpp
-	test_enum_net.cpp
-	test_linked_list.cpp
-	test_stack_allocator.cpp
-	test_file_progress.cpp
-	test_generate_peer_id.cpp
-	test_alloca.cpp ;
-
 run test_listen_socket.cpp
 	: : : <crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto ;
-
-run test_piece_picker.cpp ;
 
 run test_dht.cpp
 	test_dht_storage.cpp
@@ -158,8 +108,49 @@ run test_dht.cpp
 	: : : <crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto ;
 
-run test_string.cpp test_utf8.cpp ;
-
+run test_primitives.cpp ;
+run test_io.cpp ;
+run test_create_torrent.cpp ;
+run test_packet_buffer.cpp ;
+run test_timestamp_history.cpp ;
+run test_bloom_filter.cpp ;
+run test_identify_client.cpp ;
+run test_merkle.cpp ;
+run test_resolve_links.cpp ;
+run test_heterogeneous_queue.cpp ;
+run test_ip_voter.cpp ;
+run test_sliding_average.cpp ;
+run test_socket_io.cpp ;
+run test_part_file.cpp ;
+run test_peer_list.cpp ;
+run test_torrent_info.cpp ;
+run test_time.cpp ;
+run test_file_storage.cpp ;
+run test_peer_priority.cpp ;
+run test_threads.cpp ;
+run test_tailqueue.cpp ;
+run test_bandwidth_limiter.cpp ;
+run test_buffer.cpp ;
+run test_bencoding.cpp ;
+run test_bdecode.cpp ;
+run test_http_parser.cpp ;
+run test_xml.cpp ;
+run test_ip_filter.cpp ;
+run test_block_cache.cpp ;
+run test_peer_classes.cpp ;
+run test_settings_pack.cpp ;
+run test_fence.cpp ;
+run test_dos_blocker.cpp ;
+run test_stat_cache.cpp ;
+run test_enum_net.cpp ;
+run test_linked_list.cpp ;
+run test_stack_allocator.cpp ;
+run test_file_progress.cpp ;
+run test_generate_peer_id.cpp ;
+run test_alloca.cpp ;
+run test_piece_picker.cpp ;
+run test_string.cpp ;
+run test_utf8.cpp ;
 run test_hasher.cpp ;
 run test_hasher512.cpp ;
 run test_sha1_hash.cpp ;
@@ -179,7 +170,6 @@ run test_session_params.cpp ;
 run test_read_piece.cpp ;
 run test_remove_torrent.cpp ;
 run test_flags.cpp ;
-
 run test_file.cpp ;
 run test_fast_extension.cpp ;
 run test_privacy.cpp ;


### PR DESCRIPTION
to avoid repetition. Make all tests built as individual executables again