### PR TITLE
fix the asserts=on and invariant-checks=on default build

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -798,9 +798,6 @@ lib torrent
 	<dht>on:<source>src/hasher512.cpp
 	<dht>on:<source>src/sha512.cpp
 
-	<variant>debug:<invariant-checks>on
-	<variant>debug:<asserts>on
-
 	<conditional>@building
 	<conditional>@warnings
 	<cxxflags>$(CXXFLAGS)
@@ -816,8 +813,6 @@ lib torrent
 	: # usage requirements
 	$(usage-requirements)
 	<link>shared:<define>TORRENT_LINKING_SHARED
-	<variant>debug:<invariant-checks>on
-	<variant>debug:<asserts>on
 
 	;
 

--- a/examples/Jamfile
+++ b/examples/Jamfile
@@ -9,6 +9,8 @@ if $(BOOST_ROOT)
 	use-project /boost : $(BOOST_ROOT) ;
 }
 
+variant debug-mode : debug : <asserts>on <debug-iterators>on <invariant-checks>on ;
+
 project client_test
 	: requirements
 	<threading>multi <library>/torrent//torrent
@@ -21,6 +23,7 @@ project client_test
 	<toolset>msvc:<cflags>/wd4373
 	: default-build
 	<link>static
+	<variant>debug-mode
 	;
 
 exe client_test : client_test.cpp print.cpp torrent_view.cpp session_view.cpp ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -49,6 +49,7 @@ local default-build =
 	<invariant-checks>full
 	<picker-debugging>on
 	<logging>on
+	<debug-iterators>on
 	;
 
 project


### PR DESCRIPTION
Right now you can't change them in debug builds. Just make those defaults when building tests and examples. Also enable debug-iterators by default in tests and examples