### PR TITLE
use hidden friends for iostream operators

### DIFF
--- a/include/libtorrent/flags.hpp
+++ b/include/libtorrent/flags.hpp
@@ -125,15 +125,15 @@ struct bitfield_flag
 
 	bitfield_flag& operator=(bitfield_flag const& rhs) noexcept = default;
 	bitfield_flag& operator=(bitfield_flag&& rhs) noexcept = default;
+
+#if TORRENT_USE_IOSTREAM
+	friend std::ostream& operator<<(std::ostream& os, bitfield_flag val)
+	{ return os << static_cast<UnderlyingType>(val); }
+#endif
+
 private:
 	UnderlyingType m_val;
 };
-
-#if TORRENT_USE_IOSTREAM
-	template <typename T, typename Tag>
-	std::ostream& operator<<(std::ostream& os, bitfield_flag<T, Tag> val)
-	{ return os << static_cast<T>(val); }
-#endif
 
 } // flags
 } // libtorrent

--- a/include/libtorrent/info_hash.hpp
+++ b/include/libtorrent/info_hash.hpp
@@ -123,16 +123,16 @@ namespace {
 			return std::tie(v1, v2) < std::tie(o.v1, o.v2);
 		}
 
+#if TORRENT_USE_IOSTREAM
+		friend std::ostream& operator<<(std::ostream& os, info_hash_t const& ih)
+		{
+			return os << '[' << ih.v1 << ',' << ih.v2 << ']';
+		}
+#endif // TORRENT_USE_IOSTREAM
+
 		sha1_hash v1;
 		sha256_hash v2;
 	};
-
-#if TORRENT_USE_IOSTREAM
-	inline std::ostream& operator<<(std::ostream& os, info_hash_t const& ih)
-	{
-		return os << '[' << ih.v1 << ',' << ih.v2 << ']';
-	}
-#endif // TORRENT_USE_IOSTREAM
 
 }
 

--- a/include/libtorrent/sha1_hash.hpp
+++ b/include/libtorrent/sha1_hash.hpp
@@ -57,13 +57,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	// TODO: find a better place for these functions
-namespace aux {
-
-		TORRENT_EXTRA_EXPORT void bits_shift_left(span<std::uint32_t> number, int n);
-		TORRENT_EXTRA_EXPORT void bits_shift_right(span<std::uint32_t> number, int n);
-} // namespace aux
-
 	// This type holds an N digest or any other kind of N bits
 	// sequence. It implements a number of convenience functions, such
 	// as bit operations, comparison operators etc.
@@ -150,19 +143,9 @@ namespace aux {
 				, [](std::uint32_t v) { return v == 0; });
 		}
 
-		// shift left ``n`` bits.
-		digest32& operator<<=(int const n) noexcept
-		{
-			aux::bits_shift_left(m_number, n);
-			return *this;
-		}
-
-		// shift right ``n`` bits.
-		digest32& operator>>=(int const n) noexcept
-		{
-			aux::bits_shift_right(m_number, n);
-			return *this;
-		}
+		// shift left or right ``n`` bits.
+		digest32& operator<<=(int n) noexcept;
+		digest32& operator>>=(int n) noexcept;
 
 		// standard comparison operators
 		bool operator==(digest32 const& n) const noexcept
@@ -272,10 +255,24 @@ namespace aux {
 			return std::string(reinterpret_cast<char const*>(m_number.data()), size());
 		}
 
+#if TORRENT_USE_IOSTREAM
+		// print a sha1_hash object to an ostream as 40 hexadecimal digits
+		friend std::ostream& operator<<(std::ostream& os, digest32<N> const& val)
+		{ val.stream_out(os); return os; }
+
+		// read 40 hexadecimal digits from an istream into a sha1_hash
+		friend std::istream& operator>>(std::istream& is, digest32<N>& val)
+		{ val.stream_in(is); return is; }
+#endif // TORRENT_USE_IOSTREAM
+
 	private:
 
-		std::array<std::uint32_t, number_size> m_number;
+#if TORRENT_USE_IOSTREAM
+		void stream_in(std::istream& is);
+		void stream_out(std::ostream& os) const;
+#endif // TORRENT_USE_IOSTREAM
 
+		std::array<std::uint32_t, number_size> m_number;
 	};
 
 	// This type holds a SHA-1 digest or any other kind of 20 byte
@@ -288,16 +285,16 @@ namespace aux {
 	using sha256_hash = digest32<256>;
 
 #if TORRENT_USE_IOSTREAM
-
-	// print a sha1_hash object to an ostream as 40 hexadecimal digits
-	TORRENT_EXPORT std::ostream& operator<<(std::ostream& os, sha1_hash const& peer);
-	TORRENT_EXPORT std::ostream& operator<<(std::ostream& os, sha256_hash const& peer);
-
-	// read 40 hexadecimal digits from an istream into a sha1_hash
-	TORRENT_EXPORT std::istream& operator>>(std::istream& is, sha1_hash& peer);
-	TORRENT_EXPORT std::istream& operator>>(std::istream& is, sha256_hash& peer);
-
+	extern template void digest32<160>::stream_out(std::ostream&) const;
+	extern template void digest32<256>::stream_out(std::ostream&) const;
+	extern template void digest32<160>::stream_in(std::istream&);
+	extern template void digest32<256>::stream_in(std::istream&);
 #endif // TORRENT_USE_IOSTREAM
+
+	extern template digest32<160>& digest32<160>::operator<<=(int) noexcept;
+	extern template digest32<256>& digest32<256>::operator<<=(int) noexcept;
+	extern template digest32<160>& digest32<160>::operator>>=(int) noexcept;
+	extern template digest32<256>& digest32<256>::operator>>=(int) noexcept;
 }
 
 namespace std {

--- a/include/libtorrent/units.hpp
+++ b/include/libtorrent/units.hpp
@@ -93,6 +93,12 @@ namespace aux {
 
 		strong_typedef& operator=(strong_typedef const& rhs) & noexcept = default;
 		strong_typedef& operator=(strong_typedef&& rhs) & noexcept = default;
+
+#if TORRENT_USE_IOSTREAM
+		friend std::ostream& operator<<(std::ostream& os, strong_typedef val)
+		{ return os << static_cast<UnderlyingType>(val); }
+#endif
+
 	private:
 		UnderlyingType m_val;
 	};
@@ -123,12 +129,6 @@ namespace aux {
 	template <typename T, typename Tag>
 	strong_typedef<T, Tag> prev(strong_typedef<T, Tag> v)
 	{ return --v;}
-
-#if TORRENT_USE_IOSTREAM
-	template <typename T, typename Tag>
-	std::ostream& operator<<(std::ostream& os, strong_typedef<T, Tag> val)
-	{ return os << static_cast<T>(val); }
-#endif
 
 } // namespace libtorrent::aux
 


### PR DESCRIPTION
to avoid polluting the global overload set