### PR TITLE
use ref qualifiers on more assignment operators

### DIFF
--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -94,9 +94,9 @@ TORRENT_VERSION_NAMESPACE_2
 		// data for the torrent. For more information, see the ``storage`` field.
 		add_torrent_params();
 		add_torrent_params(add_torrent_params&&) noexcept;
-		add_torrent_params& operator=(add_torrent_params&&) = default;
+		add_torrent_params& operator=(add_torrent_params&&) & = default;
 		add_torrent_params(add_torrent_params const&);
-		add_torrent_params& operator=(add_torrent_params const&);
+		add_torrent_params& operator=(add_torrent_params const&) &;
 
 		// These are all deprecated. use torrent_flags_t instead (in
 		// libtorrent/torrent_flags.hpp)

--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -205,7 +205,7 @@ TORRENT_VERSION_NAMESPACE_2
 		announce_entry();
 		~announce_entry();
 		announce_entry(announce_entry const&);
-		announce_entry& operator=(announce_entry const&);
+		announce_entry& operator=(announce_entry const&) &;
 
 		// tracker URL as it appeared in the torrent file
 		std::string url;

--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -80,7 +80,7 @@ namespace aux {
 		file_handle& operator=(file_handle const& rhs) = delete;
 
 		file_handle(file_handle&& rhs) : m_fd(rhs.m_fd) { rhs.m_fd = invalid_handle; }
-		file_handle& operator=(file_handle&& rhs);
+		file_handle& operator=(file_handle&& rhs) &;
 
 		~file_handle();
 
@@ -106,7 +106,7 @@ namespace aux {
 		file_mapping_handle& operator=(file_mapping_handle const&) = delete;
 
 		file_mapping_handle(file_mapping_handle&& fm);
-		file_mapping_handle& operator=(file_mapping_handle&& fm);
+		file_mapping_handle& operator=(file_mapping_handle&& fm) &;
 
 		HANDLE handle() const { return m_mapping; }
 	private:
@@ -131,7 +131,7 @@ namespace aux {
 		file_mapping& operator=(file_mapping const&) = delete;
 
 		file_mapping(file_mapping&& rhs);
-		file_mapping& operator=(file_mapping&& rhs);
+		file_mapping& operator=(file_mapping&& rhs) &;
 		~file_mapping();
 
 		// ...

--- a/include/libtorrent/aux_/receive_buffer.hpp
+++ b/include/libtorrent/aux_/receive_buffer.hpp
@@ -47,6 +47,9 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 {
 	friend struct crypto_receive_buffer;
 
+	// explicitly disallow assignment, to silence msvc warning
+	receive_buffer& operator=(receive_buffer const&) = delete;
+
 	int packet_size() const { return m_packet_size; }
 	int packet_bytes_remaining() const
 	{
@@ -117,8 +120,6 @@ struct TORRENT_EXTRA_EXPORT receive_buffer
 #endif
 
 private:
-	// explicitly disallow assignment, to silence msvc warning
-	receive_buffer& operator=(receive_buffer const&);
 
 	// m_recv_buffer.data() (start of actual receive buffer)
 	// |
@@ -173,6 +174,9 @@ struct crypto_receive_buffer
 		: m_connection_buffer(next)
 	{}
 
+	// explicitly disallow assignment, to silence msvc warning
+	crypto_receive_buffer& operator=(crypto_receive_buffer const&) = delete;
+
 	span<char> mutable_buffer() { return m_connection_buffer.mutable_buffer(); }
 
 	bool packet_finished() const;
@@ -211,8 +215,6 @@ struct crypto_receive_buffer
 	span<char> mutable_buffer(int bytes);
 
 private:
-	// explicitly disallow assignment, to silence msvc warning
-	crypto_receive_buffer& operator=(crypto_receive_buffer const&);
 
 	int m_recv_pos = (std::numeric_limits<int>::max)();
 	int m_packet_size = 0;

--- a/include/libtorrent/aux_/scope_end.hpp
+++ b/include/libtorrent/aux_/scope_end.hpp
@@ -45,7 +45,7 @@ namespace libtorrent { namespace aux {
 
 		// movable
 		scope_end_impl(scope_end_impl&&) noexcept = default;
-		scope_end_impl& operator=(scope_end_impl&&) noexcept = default;
+		scope_end_impl& operator=(scope_end_impl&&) & noexcept = default;
 
 		// non-copyable
 		scope_end_impl(scope_end_impl const&) = delete;

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -84,7 +84,7 @@ namespace aux {
 	// and writing network packets
 	template <class T> struct big_endian_int
 	{
-		big_endian_int& operator=(T v)
+		big_endian_int& operator=(T v) &
 		{
 			char* p = m_storage;
 			aux::write_impl<T>(v, p);

--- a/include/libtorrent/bdecode.hpp
+++ b/include/libtorrent/bdecode.hpp
@@ -275,9 +275,9 @@ struct TORRENT_EXPORT bdecode_node
 	// For owning nodes, the copy will create a copy of the tree, but the
 	// underlying buffer remains the same.
 	bdecode_node(bdecode_node const&);
-	bdecode_node& operator=(bdecode_node const&);
+	bdecode_node& operator=(bdecode_node const&) &;
 	bdecode_node(bdecode_node&&) noexcept;
-	bdecode_node& operator=(bdecode_node&&) = default;
+	bdecode_node& operator=(bdecode_node&&) & = default;
 
 	// the types of bdecoded nodes
 	enum type_t

--- a/include/libtorrent/bitfield.hpp
+++ b/include/libtorrent/bitfield.hpp
@@ -148,13 +148,13 @@ namespace libtorrent {
 #endif
 
 		// hidden
-		bitfield& operator=(bitfield const& rhs)
+		bitfield& operator=(bitfield const& rhs) &
 		{
 			if (&rhs == this) return *this;
 			assign(rhs.data(), rhs.size());
 			return *this;
 		}
-		bitfield& operator=(bitfield&& rhs) noexcept = default;
+		bitfield& operator=(bitfield&& rhs) & noexcept = default;
 
 		// swaps the bit-fields two variables refer to
 		void swap(bitfield& rhs) noexcept
@@ -288,12 +288,12 @@ namespace libtorrent {
 		{}
 		typed_bitfield(bitfield&& rhs) noexcept : bitfield(std::forward<bitfield>(rhs)) {} // NOLINT
 		typed_bitfield(bitfield const& rhs) : bitfield(rhs) {} // NOLINT
-		typed_bitfield& operator=(typed_bitfield&& rhs) noexcept
+		typed_bitfield& operator=(typed_bitfield&& rhs) & noexcept
 		{
 			this->bitfield::operator=(std::forward<bitfield>(rhs));
 			return *this;
 		}
-		typed_bitfield& operator=(typed_bitfield const& rhs)
+		typed_bitfield& operator=(typed_bitfield const& rhs) &
 		{
 			this->bitfield::operator=(rhs);
 			return *this;

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -229,9 +229,9 @@ namespace aux {
 		// hidden
 		~file_storage();
 		file_storage(file_storage const&);
-		file_storage& operator=(file_storage const&);
+		file_storage& operator=(file_storage const&) &;
 		file_storage(file_storage&&) noexcept;
-		file_storage& operator=(file_storage&&) = default;
+		file_storage& operator=(file_storage&&) & = default;
 
 		// internal limitations restrict file sizes to not be larger than this
 		static constexpr std::int64_t max_file_size = (std::int64_t(1) << 48) - 1;

--- a/include/libtorrent/hasher.hpp
+++ b/include/libtorrent/hasher.hpp
@@ -138,7 +138,7 @@ TORRENT_CRYPTO_NAMESPACE
 		hasher256(char const* data, int len);
 		explicit hasher256(span<char const> data);
 		hasher256(hasher256 const&);
-		hasher256& operator=(hasher256 const&);
+		hasher256& operator=(hasher256 const&) &;
 
 		// append the following bytes to what is being hashed
 		hasher256& update(span<char const> data);

--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -88,6 +88,8 @@ public:
 #if TORRENT_USE_ASSERTS
 	~i2p_stream();
 #endif
+	// explicitly disallow assignment, to silence msvc warning
+	i2p_stream& operator=(i2p_stream const&) = delete;
 
 	enum command_t
 	{
@@ -129,8 +131,6 @@ public:
 	void send_name_lookup(handler_type h);
 
 private:
-	// explicitly disallow assignment, to silence msvc warning
-	i2p_stream& operator=(i2p_stream const&);
 
 	void do_connect(error_code const& e, tcp::resolver::results_type ips
 		, handler_type h);
@@ -168,6 +168,8 @@ class i2p_connection
 public:
 	explicit i2p_connection(io_context& ios);
 	~i2p_connection();
+	// explicitly disallow assignment, to silence msvc warning
+	i2p_connection& operator=(i2p_connection const&) = delete;
 
 	aux::proxy_settings proxy() const;
 
@@ -187,9 +189,6 @@ public:
 	void async_name_lookup(char const* name, name_lookup_handler handler);
 
 private:
-	// explicitly disallow assignment, to silence msvc warning
-	i2p_connection& operator=(i2p_connection const&);
-
 	void on_sam_connect(error_code const& ec, i2p_stream::handler_type& h
 		, std::shared_ptr<i2p_stream>);
 	void do_name_lookup(std::string const& name

--- a/include/libtorrent/invariant_check.hpp
+++ b/include/libtorrent/invariant_check.hpp
@@ -59,15 +59,14 @@ namespace libtorrent {
 		invariant_checker_impl(invariant_checker_impl const& rhs)
 			: self(rhs.self) {}
 
+		invariant_checker_impl& operator=(invariant_checker_impl const&) = delete;
+
 		~invariant_checker_impl()
 		{
 			check_invariant(self);
 		}
 
 		T const& self;
-
-	private:
-		invariant_checker_impl& operator=(invariant_checker_impl const&);
 	};
 
 	template<class T>

--- a/include/libtorrent/kademlia/msg.hpp
+++ b/include/libtorrent/kademlia/msg.hpp
@@ -48,15 +48,15 @@ struct msg
 {
 	msg(bdecode_node const& m, udp::endpoint const& ep): message(m), addr(ep) {}
 
+	// explicitly disallow assignment, to silence msvc warning
+	msg& operator=(msg const&) = delete;
+
 	// the message
 	bdecode_node const& message;
 
 	// the address of the process sending or receiving
 	// the message.
 	udp::endpoint addr;
-private:
-	// explicitly disallow assignment, to silence msvc warning
-	msg& operator=(msg const&);
 };
 
 struct key_desc_t

--- a/include/libtorrent/kademlia/types.hpp
+++ b/include/libtorrent/kademlia/types.hpp
@@ -83,7 +83,7 @@ namespace dht {
 		{ return value < rhs.value; }
 		bool operator>(sequence_number rhs) const
 		{ return value > rhs.value; }
-		sequence_number& operator=(sequence_number rhs)
+		sequence_number& operator=(sequence_number rhs) &
 		{ value = rhs.value; return *this; }
 		bool operator<=(sequence_number rhs) const
 		{ return value <= rhs.value; }

--- a/include/libtorrent/lazy_entry.hpp
+++ b/include/libtorrent/lazy_entry.hpp
@@ -357,7 +357,7 @@ namespace libtorrent {
 		}
 
 		lazy_entry(lazy_entry&&);
-		lazy_entry& operator=(lazy_entry&&);
+		lazy_entry& operator=(lazy_entry&&) &;
 
 	private:
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -264,6 +264,9 @@ namespace aux {
 	friend struct cork;
 	public:
 
+		// explicitly disallow assignment, to silence msvc warning
+		peer_connection& operator=(peer_connection const&) = delete;
+
 		void on_exception(std::exception const& e) override;
 		void on_error(error_code const& ec) override;
 
@@ -754,9 +757,6 @@ namespace aux {
 			, std::size_t bytes_transferred);
 
 		void account_received_bytes(int bytes_transferred);
-
-		// explicitly disallow assignment, to silence msvc warning
-		peer_connection& operator=(peer_connection const&);
 
 		void do_update_interest();
 		void fill_send_buffer();

--- a/include/libtorrent/performance_counters.hpp
+++ b/include/libtorrent/performance_counters.hpp
@@ -472,7 +472,7 @@ namespace libtorrent {
 		counters() TORRENT_COUNTER_NOEXCEPT;
 
 		counters(counters const&) TORRENT_COUNTER_NOEXCEPT;
-		counters& operator=(counters const&) TORRENT_COUNTER_NOEXCEPT;
+		counters& operator=(counters const&) & TORRENT_COUNTER_NOEXCEPT;
 
 		// returns the new value
 		std::int64_t inc_stats_counter(int c, std::int64_t value = 1) TORRENT_COUNTER_NOEXCEPT;

--- a/include/libtorrent/session.hpp
+++ b/include/libtorrent/session.hpp
@@ -117,9 +117,9 @@ namespace aux {
 		session_proxy();
 		~session_proxy();
 		session_proxy(session_proxy const&);
-		session_proxy& operator=(session_proxy const&);
+		session_proxy& operator=(session_proxy const&) &;
 		session_proxy(session_proxy&&) noexcept;
-		session_proxy& operator=(session_proxy&&) noexcept;
+		session_proxy& operator=(session_proxy&&) & noexcept;
 	private:
 		session_proxy(
 			std::shared_ptr<io_context> ios
@@ -156,10 +156,10 @@ TORRENT_VERSION_NAMESPACE_3
 			, std::vector<std::shared_ptr<plugin>> exts);
 
 		// hidden
-		session_params(session_params const&) = default;
-		session_params(session_params&&) = default;
-		session_params& operator=(session_params const&) = default;
-		session_params& operator=(session_params&&) = default;
+		session_params(session_params const&);
+		session_params(session_params&&);
+		session_params& operator=(session_params const&) &;
+		session_params& operator=(session_params&&) &;
 
 		settings_pack settings;
 
@@ -251,8 +251,8 @@ TORRENT_VERSION_NAMESPACE_3_END
 		{ start(flags, settings_pack(pack), nullptr); }
 
 		// movable
-		session(session&&) = default;
-		session& operator=(session&&) = default;
+		session(session&&);
+		session& operator=(session&&) &;
 
 		// non-copyable
 		session(session const&) = delete;

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -83,8 +83,8 @@ namespace libtorrent {
 		session_handle() = default;
 		session_handle(session_handle const& t) = default;
 		session_handle(session_handle&& t) noexcept = default;
-		session_handle& operator=(session_handle const&) = default;
-		session_handle& operator=(session_handle&&) noexcept = default;
+		session_handle& operator=(session_handle const&) & = default;
+		session_handle& operator=(session_handle&&) & noexcept = default;
 
 		// returns true if this handle refers to a valid session object. If the
 		// session has been destroyed, all session_handle objects will expire and

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -52,8 +52,8 @@ namespace aux {
 		allocation_slot() noexcept : m_idx(-1) {}
 		allocation_slot(allocation_slot const&) noexcept = default;
 		allocation_slot(allocation_slot&&) noexcept = default;
-		allocation_slot& operator=(allocation_slot const&) = default;
-		allocation_slot& operator=(allocation_slot&&) noexcept = default;
+		allocation_slot& operator=(allocation_slot const&) & = default;
+		allocation_slot& operator=(allocation_slot&&) & noexcept = default;
 		bool operator==(allocation_slot const& s) const { return m_idx == s.m_idx; }
 		bool operator!=(allocation_slot const& s) const { return m_idx != s.m_idx; }
 		friend struct stack_allocator;
@@ -71,7 +71,7 @@ namespace aux {
 		stack_allocator(stack_allocator const&) = delete;
 		stack_allocator& operator=(stack_allocator const&) = delete;
 		stack_allocator(stack_allocator&&) = default;
-		stack_allocator& operator=(stack_allocator&&) = default;
+		stack_allocator& operator=(stack_allocator&&) & = default;
 
 		allocation_slot copy_string(string_view str);
 		allocation_slot copy_string(char const* str);

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -151,8 +151,8 @@ namespace aux {
 		partial_piece_info() = default;
 		partial_piece_info(partial_piece_info&&) noexcept = default;
 		partial_piece_info(partial_piece_info const&) = default;
-		partial_piece_info& operator=(partial_piece_info const&) = default;
-		partial_piece_info& operator=(partial_piece_info&&) noexcept = default;
+		partial_piece_info& operator=(partial_piece_info const&) & = default;
+		partial_piece_info& operator=(partial_piece_info&&) & noexcept = default;
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 #endif
 		// the index of the piece in question. ``blocks_in_piece`` is the number
@@ -245,8 +245,8 @@ namespace aux {
 		// hidden
 		torrent_handle(torrent_handle const& t) = default;
 		torrent_handle(torrent_handle&& t) noexcept = default;
-		torrent_handle& operator=(torrent_handle const&) = default;
-		torrent_handle& operator=(torrent_handle&&) noexcept = default;
+		torrent_handle& operator=(torrent_handle const&) & = default;
+		torrent_handle& operator=(torrent_handle&&) & noexcept = default;
 
 		// instruct libtorrent to overwrite any data that may already have been
 		// downloaded with the data of the new piece being added.

--- a/include/libtorrent/torrent_peer.hpp
+++ b/include/libtorrent/torrent_peer.hpp
@@ -59,7 +59,7 @@ namespace libtorrent {
 		torrent_peer(std::uint16_t port, bool connectable, peer_source_flags_t src);
 #if TORRENT_USE_ASSERTS
 		torrent_peer(torrent_peer const&) = default;
-		torrent_peer& operator=(torrent_peer const&) = default;
+		torrent_peer& operator=(torrent_peer const&) & = default;
 		~torrent_peer() { TORRENT_ASSERT(in_use); in_use = false; }
 #endif
 
@@ -217,7 +217,7 @@ namespace libtorrent {
 	{
 		ipv4_peer(tcp::endpoint const& ip, bool connectable, peer_source_flags_t src);
 		ipv4_peer(ipv4_peer const& p);
-		ipv4_peer& operator=(ipv4_peer const& p);
+		ipv4_peer& operator=(ipv4_peer const& p) &;
 
 		address_v4 addr;
 	};
@@ -229,7 +229,7 @@ namespace libtorrent {
 		i2p_peer(i2p_peer const&) = delete;
 		i2p_peer& operator=(i2p_peer const&) = delete;
 		i2p_peer(i2p_peer&&) = default;
-		i2p_peer& operator=(i2p_peer&&) = default;
+		i2p_peer& operator=(i2p_peer&&) & = default;
 
 		aux::string_ptr destination;
 	};

--- a/include/libtorrent/udp_socket.hpp
+++ b/include/libtorrent/udp_socket.hpp
@@ -57,6 +57,10 @@ namespace libtorrent {
 	public:
 		explicit udp_socket(io_context& ios);
 
+		// non-copyable
+		udp_socket(udp_socket const&) = delete;
+		udp_socket& operator=(udp_socket const&) = delete;
+
 		static constexpr udp_send_flags_t peer_connection = 0_bit;
 		static constexpr udp_send_flags_t tracker_connection = 1_bit;
 		static constexpr udp_send_flags_t dont_queue = 2_bit;
@@ -133,10 +137,6 @@ namespace libtorrent {
 		}
 
 	private:
-
-		// non-copyable
-		udp_socket(udp_socket const&);
-		udp_socket& operator=(udp_socket const&);
 
 		void wrap(udp::endpoint const& ep, span<char const> p, error_code& ec, udp_send_flags_t flags);
 		void wrap(char const* hostname, int port, span<char const> p, error_code& ec, udp_send_flags_t flags);

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -264,9 +264,9 @@ private:
 		rootdevice();
 		~rootdevice();
 		rootdevice(rootdevice const&);
-		rootdevice& operator=(rootdevice const&);
+		rootdevice& operator=(rootdevice const&) &;
 		rootdevice(rootdevice&&);
-		rootdevice& operator=(rootdevice&&);
+		rootdevice& operator=(rootdevice&&) &;
 
 		// the interface url, through which the list of
 		// supported interfaces are fetched

--- a/src/add_torrent_params.cpp
+++ b/src/add_torrent_params.cpp
@@ -38,7 +38,7 @@ namespace libtorrent {
 	add_torrent_params::add_torrent_params() = default;
 	add_torrent_params::add_torrent_params(add_torrent_params&&) noexcept = default;
 	add_torrent_params::add_torrent_params(add_torrent_params const&) = default;
-	add_torrent_params& add_torrent_params::operator=(add_torrent_params const&) = default;
+	add_torrent_params& add_torrent_params::operator=(add_torrent_params const&) & = default;
 
 #if TORRENT_ABI_VERSION == 1
 #define DECL_FLAG(name) \

--- a/src/announce_entry.cpp
+++ b/src/announce_entry.cpp
@@ -97,7 +97,7 @@ namespace libtorrent {
 
 	announce_entry::~announce_entry() = default;
 	announce_entry::announce_entry(announce_entry const&) = default;
-	announce_entry& announce_entry::operator=(announce_entry const&) = default;
+	announce_entry& announce_entry::operator=(announce_entry const&) & = default;
 
 	void announce_infohash::reset()
 	{

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -240,7 +240,7 @@ namespace aux {
 		(*this) = n;
 	}
 
-	bdecode_node& bdecode_node::operator=(bdecode_node const& n)
+	bdecode_node& bdecode_node::operator=(bdecode_node const& n) &
 	{
 		if (&n == this) return *this;
 		m_tokens = n.m_tokens;

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -84,7 +84,7 @@ namespace libtorrent {
 	// generated, they are put here to explicitly make them part
 	// of libtorrent and properly exported by the .dll.
 	file_storage::file_storage(file_storage const&) = default;
-	file_storage& file_storage::operator=(file_storage const&) = default;
+	file_storage& file_storage::operator=(file_storage const&) & = default;
 	file_storage::file_storage(file_storage&&) noexcept = default;
 
 	void file_storage::reserve(int num_files)

--- a/src/hasher.cpp
+++ b/src/hasher.cpp
@@ -189,7 +189,7 @@ TORRENT_CRYPTO_NAMESPACE
 		gcry_md_copy(&m_context, h.m_context);
 	}
 
-	hasher256& hasher256::operator=(hasher256 const& h)
+	hasher256& hasher256::operator=(hasher256 const& h) &
 	{
 		if (this == &h) return;
 		gcry_md_close(m_context);
@@ -198,7 +198,7 @@ TORRENT_CRYPTO_NAMESPACE
 	}
 #else
 	hasher256::hasher256(hasher256 const&) = default;
-	hasher256& hasher256::operator=(hasher256 const&) = default;
+	hasher256& hasher256::operator=(hasher256 const&) & = default;
 #endif
 
 	hasher256& hasher256::update(char const* data, int len)

--- a/src/ip_notifier.cpp
+++ b/src/ip_notifier.cpp
@@ -131,7 +131,7 @@ struct CFRef
 	~CFRef() { release(); }
 
 	CFRef(CFRef&& rhs) : m_h(rhs.m_h) { rhs.m_h = nullptr; }
-	CFRef& operator=(CFRef&& rhs)
+	CFRef& operator=(CFRef&& rhs) &
 	{
 		if (m_h == rhs.m_h) return *this;
 		release();
@@ -141,7 +141,7 @@ struct CFRef
 	}
 
 	CFRef(CFRef const& rhs) : m_h(rhs.m_h) { retain(); }
-	CFRef& operator=(CFRef const& rhs)
+	CFRef& operator=(CFRef const& rhs) &
 	{
 		if (m_h == rhs.m_h) return *this;
 		release();
@@ -150,8 +150,8 @@ struct CFRef
 		return *this;
 	}
 
-	CFRef& operator=(T h) { m_h = h; return *this;}
-	CFRef& operator=(std::nullptr_t) { release(); return *this;}
+	CFRef& operator=(T h) & { m_h = h; return *this;}
+	CFRef& operator=(std::nullptr_t) & { release(); return *this;}
 
 	T get() const { return m_h; }
 	explicit operator bool() const { return m_h != nullptr; }

--- a/src/lazy_bdecode.cpp
+++ b/src/lazy_bdecode.cpp
@@ -506,7 +506,7 @@ namespace {
 		this->swap(other);
 	}
 
-	lazy_entry& lazy_entry::operator=(lazy_entry&& other)
+	lazy_entry& lazy_entry::operator=(lazy_entry&& other) &
 	{
 		this->swap(other);
 		return *this;

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -278,7 +278,7 @@ void file_handle::close()
 
 file_handle::~file_handle() { close(); }
 
-file_handle& file_handle::operator=(file_handle&& rhs)
+file_handle& file_handle::operator=(file_handle&& rhs) &
 {
 	if (&rhs == this) return *this;
 	close();
@@ -339,7 +339,7 @@ file_mapping_handle::file_mapping_handle(file_handle file, open_mode_t const mod
 		fm.m_mapping = INVALID_HANDLE_VALUE;
 	}
 
-	file_mapping_handle& file_mapping_handle::operator=(file_mapping_handle&& fm)
+	file_mapping_handle& file_mapping_handle::operator=(file_mapping_handle&& fm) &
 	{
 		if (&fm == this) return *this;
 		close();
@@ -441,7 +441,7 @@ file_mapping::file_mapping(file_mapping&& rhs)
 		rhs.m_mapping = nullptr;
 	}
 
-	file_mapping& file_mapping::operator=(file_mapping&& rhs)
+	file_mapping& file_mapping::operator=(file_mapping&& rhs) &
 	{
 		if (&rhs == this) return *this;
 		close();

--- a/src/performance_counters.cpp
+++ b/src/performance_counters.cpp
@@ -63,7 +63,7 @@ namespace libtorrent {
 #endif
 	}
 
-	counters& counters::operator=(counters const& c) TORRENT_COUNTER_NOEXCEPT
+	counters& counters::operator=(counters const& c) & TORRENT_COUNTER_NOEXCEPT
 	{
 		if (&c == this) return *this;
 #ifdef ATOMIC_LLONG_LOCK_FREE

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -417,6 +417,9 @@ namespace {
 			default_plugins(!(flags & add_default_plugins))}, ios);
 	}
 
+	session::session(session&&) = default;
+	session& session::operator=(session&&) & = default;
+
 	session::~session()
 	{
 		aux::dump_call_profile();
@@ -452,9 +455,9 @@ namespace {
 		, m_impl(std::move(impl))
 	{}
 	session_proxy::session_proxy(session_proxy const&) = default;
-	session_proxy& session_proxy::operator=(session_proxy const&) = default;
+	session_proxy& session_proxy::operator=(session_proxy const&) & = default;
 	session_proxy::session_proxy(session_proxy&&) noexcept = default;
-	session_proxy& session_proxy::operator=(session_proxy&&) noexcept = default;
+	session_proxy& session_proxy::operator=(session_proxy&&) & noexcept = default;
 	session_proxy::~session_proxy()
 	{
 		if (m_thread && m_thread.unique())
@@ -500,6 +503,11 @@ TORRENT_VERSION_NAMESPACE_3
 		, dht_storage_constructor(dht::dht_default_storage_constructor)
 #endif
 	{}
+
+	session_params::session_params(session_params const&) = default;
+	session_params::session_params(session_params&&) = default;
+	session_params& session_params::operator=(session_params const&) & = default;
+	session_params& session_params::operator=(session_params&&) & = default;
 
 TORRENT_VERSION_NAMESPACE_3_END
 

--- a/src/torrent_peer.cpp
+++ b/src/torrent_peer.cpp
@@ -233,7 +233,7 @@ namespace libtorrent {
 	}
 
 	ipv4_peer::ipv4_peer(ipv4_peer const&) = default;
-	ipv4_peer& ipv4_peer::operator=(ipv4_peer const& p) = default;
+	ipv4_peer& ipv4_peer::operator=(ipv4_peer const& p) & = default;
 
 #if TORRENT_USE_I2P
 	i2p_peer::i2p_peer(string_view dest, bool connectable_

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -94,9 +94,9 @@ upnp::rootdevice::~rootdevice()
 }
 
 upnp::rootdevice::rootdevice(rootdevice const&) = default;
-upnp::rootdevice& upnp::rootdevice::operator=(rootdevice const&) = default;
+upnp::rootdevice& upnp::rootdevice::operator=(rootdevice const&) & = default;
 upnp::rootdevice::rootdevice(rootdevice&&) = default;
-upnp::rootdevice& upnp::rootdevice::operator=(rootdevice&&) = default;
+upnp::rootdevice& upnp::rootdevice::operator=(rootdevice&&) & = default;
 
 // TODO: 3 bind the broadcast socket. it would probably have to be changed to a vector of interfaces to
 // bind to, since the broadcast socket opens one socket per local

--- a/test/test_heterogeneous_queue.cpp
+++ b/test/test_heterogeneous_queue.cpp
@@ -126,6 +126,9 @@ struct F
 		constructed = false;
 	}
 
+	// non-copyable
+	F& operator=(F const& f) = delete;
+
 	void check_invariant()
 	{
 		TEST_EQUAL(constructed, true);
@@ -139,9 +142,6 @@ struct F
 	bool constructed;
 	bool destructed;
 	bool gutted;
-private:
-	// non-copyable
-	F& operator=(F const& f);
 };
 
 struct G : A


### PR DESCRIPTION
to prevent accidental assignment to temporaries