### PR TITLE
extend clang-tidy checks + fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
         <linkflags>-static-libgcc ;" >> ~/user-config.jam;
     fi;'
   - 'if [ $clang_tidy == "1" ]; then
-      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,readability-inconsistent-declaration-parameter-name" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" ]]; then
        echo "using darwin : : ccache clang++ : ;" >> ~/user-config.jam;

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
         <linkflags>-static-libgcc ;" >> ~/user-config.jam;
     fi;'
   - 'if [ $clang_tidy == "1" ]; then
-      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,modernize-use-auto,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,modernize-pass-by-value,modernize-use-auto,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" ]]; then
        echo "using darwin : : ccache clang++ : ;" >> ~/user-config.jam;

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
         <linkflags>-static-libgcc ;" >> ~/user-config.jam;
     fi;'
   - 'if [ $clang_tidy == "1" ]; then
-      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" ]]; then
        echo "using darwin : : ccache clang++ : ;" >> ~/user-config.jam;

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
         <linkflags>-static-libgcc ;" >> ~/user-config.jam;
     fi;'
   - 'if [ $clang_tidy == "1" ]; then
-      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,modernize-use-auto,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" ]]; then
        echo "using darwin : : ccache clang++ : ;" >> ~/user-config.jam;

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
         <linkflags>-static-libgcc ;" >> ~/user-config.jam;
     fi;'
   - 'if [ $clang_tidy == "1" ]; then
-      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" ]]; then
        echo "using darwin : : ccache clang++ : ;" >> ~/user-config.jam;

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
         <linkflags>-static-libgcc ;" >> ~/user-config.jam;
     fi;'
   - 'if [ $clang_tidy == "1" ]; then
-      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,readability-inconsistent-declaration-parameter-name" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+      echo "using clang_tidy : : clang-tidy "-checks=-clang-analyzer-core.*,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list" : <cxxflags>-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW=1 <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
     fi'
   - 'if [[ $TRAVIS_OS_NAME == "osx" ]]; then
        echo "using darwin : : ccache clang++ : ;" >> ~/user-config.jam;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2009,7 +2009,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		TORRENT_UNEXPORT add_torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, add_torrent_params const& p, error_code const& ec);
+			, add_torrent_params p, error_code const& ec);
 
 		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67, alert_priority::critical)
 
@@ -2172,7 +2172,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		TORRENT_UNEXPORT dht_immutable_item_alert(aux::stack_allocator& alloc, sha1_hash const& t
-			, entry const& i);
+			, entry i);
 
 		TORRENT_DEFINE_ALERT_PRIO(dht_immutable_item_alert, 74, alert_priority::critical)
 
@@ -2195,7 +2195,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		TORRENT_UNEXPORT dht_mutable_item_alert(aux::stack_allocator& alloc
 			, std::array<char, 32> const& k, std::array<char, 64> const& sig
-			, std::int64_t sequence, string_view s, entry const& i, bool a);
+			, std::int64_t sequence, string_view s, entry i, bool a);
 
 		TORRENT_DEFINE_ALERT_PRIO(dht_mutable_item_alert, 75, alert_priority::critical)
 

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2602,7 +2602,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		TORRENT_UNEXPORT dht_get_peers_reply_alert(aux::stack_allocator& alloc
 			, sha1_hash const& ih
-			, std::vector<tcp::endpoint> const& v);
+			, std::vector<tcp::endpoint> const& peers);
 
 		static constexpr alert_category_t static_category = alert::dht_operation_notification;
 		TORRENT_DEFINE_ALERT(dht_get_peers_reply_alert, 87)

--- a/include/libtorrent/aux_/disk_job_fence.hpp
+++ b/include/libtorrent/aux_/disk_job_fence.hpp
@@ -70,19 +70,19 @@ namespace aux {
 		// storage, fence_post_fence is returned.
 		// fence_post_none if the fence job was queued.
 		enum { fence_post_fence = 0, fence_post_none = 1 };
-		int raise_fence(disk_io_job* fence_job, counters& cnt);
+		int raise_fence(disk_io_job*, counters&);
 		bool has_fence() const;
 
 		// called whenever a job completes and is posted back to the
 		// main network thread. the tailqueue of jobs will have the
 		// backed-up jobs prepended to it in case this resulted in the
 		// fence being lowered.
-		int job_complete(disk_io_job* j, tailqueue<disk_io_job>& job_queue);
+		int job_complete(disk_io_job*, tailqueue<disk_io_job>&);
 		int num_outstanding_jobs() const { return m_outstanding_jobs; }
 
 		// if there is a fence up, returns true and adds the job
 		// to the queue of blocked jobs
-		bool is_blocked(disk_io_job* j);
+		bool is_blocked(disk_io_job*);
 
 		// the number of blocked jobs
 		int num_blocked() const;

--- a/include/libtorrent/aux_/instantiate_connection.hpp
+++ b/include/libtorrent/aux_/instantiate_connection.hpp
@@ -45,7 +45,7 @@ namespace libtorrent {
 namespace aux {
 
 	// instantiate a socket_type (s) according to the specified criteria
-	TORRENT_EXTRA_EXPORT bool instantiate_connection(io_context& exec
+	TORRENT_EXTRA_EXPORT bool instantiate_connection(io_context&
 		, aux::proxy_settings const& ps, aux::socket_type& s
 		, void* ssl_context
 		, utp_socket_manager* sm

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -61,14 +61,14 @@ namespace libtorrent {
 
 	// given a tree and the number of leaves, expect all leaf hashes to be set and
 	// compute all other hashes starting with the leaves.
-	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs, int first_leaf);
+	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs, int level_start);
 	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs);
 
 	// given a merkle tree (`tree`), clears all hashes in the range of nodes:
-	// [ first_leaf, first_leaf + num_leafs), as well as all of their parents,
+	// [ level_start, level_start+ num_leafs), as well as all of their parents,
 	// within the sub-tree. It does not clear the root of the sub-tree.
 	// see unit test for examples.
-	TORRENT_EXTRA_EXPORT void merkle_clear_tree(span<sha256_hash> tree, int num_leafs, int first_leaf);
+	TORRENT_EXTRA_EXPORT void merkle_clear_tree(span<sha256_hash> tree, int num_leafs, int level_start);
 
 	// given the leaf hashes, computes the merkle root hash. The pad is the hash
 	// to use for the right-side padding, in case the number of leaves is not a

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -293,8 +293,7 @@ namespace aux {
 #endif
 			using connection_map = std::set<std::shared_ptr<peer_connection>>;
 
-			session_impl(io_context& ios, settings_pack const& pack
-				, disk_io_constructor_type disk_io);
+			session_impl(io_context&, settings_pack const&, disk_io_constructor_type);
 			~session_impl() override;
 
 			void start_session();
@@ -363,13 +362,13 @@ namespace aux {
 			// need the initial push to connect peers
 			void prioritize_connections(std::weak_ptr<torrent> t) override;
 
-			void async_accept(std::shared_ptr<tcp::acceptor> const& listener, transport ssl);
-			void on_accept_connection(std::shared_ptr<socket_type> const& s
-				, std::weak_ptr<tcp::acceptor> listener, error_code const& e, transport ssl);
+			void async_accept(std::shared_ptr<tcp::acceptor> const&, transport);
+			void on_accept_connection(std::shared_ptr<socket_type> const&
+				, std::weak_ptr<tcp::acceptor>, error_code const&, transport);
 
-			void incoming_connection(std::shared_ptr<socket_type> const& s);
+			void incoming_connection(std::shared_ptr<socket_type> const&);
 
-			std::weak_ptr<torrent> find_torrent(info_hash_t const& info_hash) const override;
+			std::weak_ptr<torrent> find_torrent(info_hash_t const&) const override;
 #if TORRENT_ABI_VERSION == 1
 			//deprecated in 1.2
 
@@ -395,7 +394,7 @@ namespace aux {
 
 			std::shared_ptr<torrent> delay_load_torrent(info_hash_t const& info_hash
 				, peer_connection* pc) override;
-			void set_queue_position(torrent* t, queue_position_t p) override;
+			void set_queue_position(torrent*, queue_position_t) override;
 
 			void close_connection(peer_connection* p) noexcept override;
 
@@ -1293,7 +1292,7 @@ namespace aux {
 				, std::string const& str) override;
 			void tracker_response(tracker_request const&
 				, libtorrent::address const& tracker_ip
-				, std::list<address> const& ip_list
+				, std::list<address> const& tracker_ips
 				, struct tracker_response const& resp) override;
 			void tracker_request_error(tracker_request const& r
 				, error_code const& ec, const std::string& str

--- a/include/libtorrent/aux_/storage_utils.hpp
+++ b/include/libtorrent/aux_/storage_utils.hpp
@@ -101,7 +101,7 @@ namespace aux {
 	TORRENT_EXTRA_EXPORT bool has_any_file(
 		file_storage const& fs
 		, std::string const& save_path
-		, stat_cache& stat
+		, stat_cache& cache
 		, storage_error& ec);
 
 	TORRENT_EXTRA_EXPORT int read_zeroes(span<iovec_t const> bufs);

--- a/include/libtorrent/aux_/utp_socket_manager.hpp
+++ b/include/libtorrent/aux_/utp_socket_manager.hpp
@@ -69,8 +69,8 @@ namespace aux {
 
 		using incoming_utp_callback_t =  std::function<void(std::shared_ptr<aux::socket_type> const&)>;
 
-		utp_socket_manager(send_fun_t const& send_fun
-			, incoming_utp_callback_t const& cb
+		utp_socket_manager(send_fun_t send_fun
+			, incoming_utp_callback_t cb
 			, io_context& ios
 			, aux::session_settings const& sett
 			, counters& cnt, void* ssl_context);

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -202,7 +202,7 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 	lowest_layer_type const& lowest_layer() const { return *this; }
 
 	// used for incoming connections
-	void set_impl(utp_socket_impl* s);
+	void set_impl(utp_socket_impl*);
 	utp_socket_impl* get_impl();
 
 #ifndef BOOST_NO_EXCEPTIONS
@@ -256,10 +256,10 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 
 	int read_buffer_size() const;
 	static void on_read(void* self, std::size_t bytes_transferred
-		, error_code const& ec, bool kill);
+		, error_code const& ec, bool shutdown);
 	static void on_write(void* self, std::size_t bytes_transferred
-		, error_code const& ec, bool kill);
-	static void on_connect(void* self, error_code const& ec, bool kill);
+		, error_code const& ec, bool shutdown);
+	static void on_connect(void* self, error_code const& ec, bool shutdown);
 	static void on_close_reason(void* self, close_reason_t reason);
 
 	void add_read_buffer(void* buf, std::size_t len);

--- a/include/libtorrent/bloom_filter.hpp
+++ b/include/libtorrent/bloom_filter.hpp
@@ -41,8 +41,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	TORRENT_EXTRA_EXPORT void set_bits(std::uint8_t const* b, std::uint8_t* bits, int len);
-	TORRENT_EXTRA_EXPORT bool has_bits(std::uint8_t const* b, std::uint8_t const* bits, int len);
+	TORRENT_EXTRA_EXPORT void set_bits(std::uint8_t const* k, std::uint8_t* bits, int len);
+	TORRENT_EXTRA_EXPORT bool has_bits(std::uint8_t const* k, std::uint8_t const* bits, int len);
 	TORRENT_EXTRA_EXPORT int count_zero_bits(std::uint8_t const* bits, int len);
 
 	template <int N>
@@ -64,8 +64,8 @@ namespace libtorrent {
 
 		float size() const
 		{
-			const int c = (std::min)(count_zero_bits(bits, N), (N * 8) - 1);
-			const int m = N * 8;
+			int const c = (std::min)(count_zero_bits(bits, N), (N * 8) - 1);
+			int const m = N * 8;
 			return std::log(c / float(m)) / (2.f * std::log(1.f - 1.f/m));
 		}
 

--- a/include/libtorrent/broadcast_socket.hpp
+++ b/include/libtorrent/broadcast_socket.hpp
@@ -78,7 +78,7 @@ namespace libtorrent {
 	class TORRENT_EXTRA_EXPORT broadcast_socket
 	{
 	public:
-		explicit broadcast_socket(udp::endpoint const& multicast_endpoint);
+		explicit broadcast_socket(udp::endpoint multicast_endpoint);
 		~broadcast_socket() { close(); }
 
 		void open(receive_handler_t handler, io_context& ios

--- a/include/libtorrent/crc32c.hpp
+++ b/include/libtorrent/crc32c.hpp
@@ -39,9 +39,8 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 
 	// this is the crc32c (Castagnoli) polynomial
-	TORRENT_EXTRA_EXPORT std::uint32_t crc32c_32(std::uint32_t v);
-	TORRENT_EXTRA_EXPORT std::uint32_t crc32c(std::uint64_t const* v
-		, int num_words);
+	TORRENT_EXTRA_EXPORT std::uint32_t crc32c_32(std::uint32_t);
+	TORRENT_EXTRA_EXPORT std::uint32_t crc32c(std::uint64_t const*, int);
 }
 
 #endif

--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -283,7 +283,7 @@ namespace libtorrent {
 		//
 		// The string is not the path to the cert, it's the actual content of the
 		// certificate.
-		void set_root_cert(string_view pem);
+		void set_root_cert(string_view cert);
 
 		// Sets and queries the private flag of the torrent.
 		// Torrents with the private flag set ask the client to not use any other

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -331,9 +331,9 @@ namespace aux {
 		// instead, use the wchar -> utf8 conversion functions
 		// and pass in utf8 strings
 		TORRENT_DEPRECATED
-		void add_file(std::wstring const& p, std::int64_t size
+		void add_file(std::wstring const& file, std::int64_t size
 			, file_flags_t flags = {}
-			, std::time_t mtime = 0, string_view s_p = "");
+			, std::time_t mtime = 0, string_view symlink_path = "");
 		TORRENT_DEPRECATED
 		void rename_file(file_index_t index, std::wstring const& new_filename);
 		TORRENT_DEPRECATED

--- a/include/libtorrent/gzip.hpp
+++ b/include/libtorrent/gzip.hpp
@@ -45,7 +45,7 @@ namespace libtorrent {
 		span<char const> in
 		, std::vector<char>& buffer
 		, int maximum_size
-		, error_code& error);
+		, error_code& ec);
 
 	// get the ``error_category`` for zip errors
 	TORRENT_EXPORT boost::system::error_category& gzip_category();

--- a/include/libtorrent/http_connection.hpp
+++ b/include/libtorrent/http_connection.hpp
@@ -83,11 +83,11 @@ struct TORRENT_EXTRA_EXPORT http_connection
 {
 	http_connection(io_context& ios
 		, resolver_interface& resolver
-		, http_handler const& handler
+		, http_handler handler
 		, bool bottled = true
 		, int max_bottled_buffer_size = default_max_bottled_buffer_size
-		, http_connect_handler const& ch = http_connect_handler()
-		, http_filter_handler const& fh = http_filter_handler()
+		, http_connect_handler ch = http_connect_handler()
+		, http_filter_handler fh = http_filter_handler()
 #ifdef TORRENT_USE_OPENSSL
 		, ssl::context* ssl_ctx = nullptr
 #endif

--- a/include/libtorrent/http_tracker_connection.hpp
+++ b/include/libtorrent/http_tracker_connection.hpp
@@ -59,7 +59,7 @@ namespace libtorrent {
 		http_tracker_connection(
 			io_context& ios
 			, tracker_manager& man
-			, tracker_request const& req
+			, tracker_request req
 			, std::weak_ptr<request_callback> c);
 
 		void start() override;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -74,7 +74,7 @@ namespace dht {
 
 		dht_tracker(dht_observer* observer
 			, io_context& ios
-			, send_fun_t const& send_fun
+			, send_fun_t send_fun
 			, aux::session_settings const& settings
 			, counters& cnt
 			, dht_storage_interface& storage

--- a/include/libtorrent/kademlia/find_data.hpp
+++ b/include/libtorrent/kademlia/find_data.hpp
@@ -55,7 +55,7 @@ struct find_data : traversal_algorithm
 	using nodes_callback = std::function<void(std::vector<std::pair<node_entry, std::string>> const&)>;
 
 	find_data(node& dht_node, node_id const& target
-		, nodes_callback const& ncallback);
+		, nodes_callback ncallback);
 
 	void got_write_token(node_id const& n, std::string write_token);
 

--- a/include/libtorrent/kademlia/get_item.hpp
+++ b/include/libtorrent/kademlia/get_item.hpp
@@ -57,15 +57,15 @@ public:
 	// for immutable items
 	get_item(node& dht_node
 		, node_id const& target
-		, data_callback const& dcallback
-		, nodes_callback const& ncallback);
+		, data_callback dcallback
+		, nodes_callback ncallback);
 
 	// for mutable items
 	get_item(node& dht_node
 		, public_key const& pk
 		, span<char const> salt
-		, data_callback const& dcallback
-		, nodes_callback const& ncallback);
+		, data_callback dcallback
+		, nodes_callback ncallback);
 
 	char const* name() const override;
 

--- a/include/libtorrent/kademlia/get_peers.hpp
+++ b/include/libtorrent/kademlia/get_peers.hpp
@@ -48,8 +48,8 @@ struct get_peers : find_data
 	void got_peers(std::vector<tcp::endpoint> const& peers);
 
 	get_peers(node& dht_node, node_id const& target
-		, data_callback const& dcallback
-		, nodes_callback const& ncallback
+		, data_callback dcallback
+		, nodes_callback ncallback
 		, bool noseeds);
 
 	char const* name() const override;
@@ -66,8 +66,8 @@ protected:
 struct obfuscated_get_peers : get_peers
 {
 	obfuscated_get_peers(node& dht_node, node_id const& target
-		, data_callback const& dcallback
-		, nodes_callback const& ncallback
+		, data_callback dcallback
+		, nodes_callback ncallback
 		, bool noseeds);
 
 	char const* name() const override;

--- a/include/libtorrent/kademlia/msg.hpp
+++ b/include/libtorrent/kademlia/msg.hpp
@@ -85,7 +85,7 @@ struct key_desc_t
 };
 
 // TODO: move this to its own .hpp/.cpp pair?
-TORRENT_EXTRA_EXPORT bool verify_message_impl(bdecode_node const& msg, span<key_desc_t const> desc
+TORRENT_EXTRA_EXPORT bool verify_message_impl(bdecode_node const& message, span<key_desc_t const> desc
 	, span<bdecode_node> ret, span<char> error);
 
 // verifies that a message has all the required

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -246,7 +246,7 @@ private:
 	// since it might have references to it
 	std::set<traversal_algorithm*> m_running_requests;
 
-	void incoming_request(msg const& h, entry& e);
+	void incoming_request(msg const&, entry&);
 
 	void write_nodes_entries(sha1_hash const& info_hash
 		, bdecode_node const& want, entry& r);

--- a/include/libtorrent/kademlia/put_data.hpp
+++ b/include/libtorrent/kademlia/put_data.hpp
@@ -52,7 +52,7 @@ struct put_data: traversal_algorithm
 {
 	using put_callback = std::function<void(item const&, int)>;
 
-	put_data(node& node, put_callback const& callback);
+	put_data(node& node, put_callback callback);
 
 	char const* name() const override;
 	void start() override;

--- a/include/libtorrent/kademlia/routing_table.hpp
+++ b/include/libtorrent/kademlia/routing_table.hpp
@@ -211,7 +211,7 @@ public:
 
 	// fills the vector with the count nodes from our buckets that
 	// are nearest to the given id.
-	std::vector<node_entry> find_node(node_id const& id
+	std::vector<node_entry> find_node(node_id const& target
 		, find_nodes_flags_t options, int count = 0);
 	void remove_node(node_entry* n, bucket_t* b);
 

--- a/include/libtorrent/kademlia/sample_infohashes.hpp
+++ b/include/libtorrent/kademlia/sample_infohashes.hpp
@@ -52,7 +52,7 @@ public:
 
 	sample_infohashes(node& dht_node
 		, node_id const& target
-		, data_callback const& dcallback);
+		, data_callback dcallback);
 
 	char const* name() const override;
 

--- a/include/libtorrent/lsd.hpp
+++ b/include/libtorrent/lsd.hpp
@@ -59,7 +59,7 @@ private:
 
 	void announce_impl(sha1_hash const& ih, int listen_port
 		, bool broadcast, int retry_count);
-	void resend_announce(error_code const& e, sha1_hash const& ih
+	void resend_announce(error_code const& e, sha1_hash const& info_hash
 		, int listen_port, int retry_count);
 	void on_announce(udp::endpoint const& from, span<char const> buffer);
 

--- a/include/libtorrent/part_file.hpp
+++ b/include/libtorrent/part_file.hpp
@@ -57,7 +57,7 @@ namespace libtorrent {
 	{
 		// create a part file at 'path', that can hold 'num_pieces' pieces.
 		// each piece being 'piece_size' number of bytes
-		part_file(std::string const& path, std::string const& name, int num_pieces, int piece_size);
+		part_file(std::string path, std::string name, int num_pieces, int piece_size);
 		~part_file();
 
 		int writev(span<iovec_t const> bufs, piece_index_t piece, int offset, error_code& ec);

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -391,10 +391,10 @@ namespace aux {
 		bool is_seed() const;
 		int num_have_pieces() const { return m_num_pieces; }
 
-		void set_share_mode(bool m);
+		void set_share_mode(bool);
 		bool share_mode() const { return m_share_mode; }
 
-		void set_upload_only(bool u);
+		void set_upload_only(bool);
 		bool upload_only() const { return m_upload_only; }
 
 		void set_holepunch_mode() override;
@@ -760,10 +760,10 @@ namespace aux {
 
 		void do_update_interest();
 		void fill_send_buffer();
-		void on_disk_read_complete(disk_buffer_holder disk_block
-			, storage_error const& error, peer_request const& r, time_point issue_time);
+		void on_disk_read_complete(disk_buffer_holder buffer
+			, storage_error const& error, peer_request const&, time_point issue_time);
 		void on_disk_write_complete(storage_error const& error
-			, peer_request const &r, std::shared_ptr<torrent> t);
+			, peer_request const&, std::shared_ptr<torrent>);
 		void on_seed_mode_hashed(piece_index_t piece
 			, sha1_hash const& piece_hash, aux::vector<sha256_hash> const& block_hashes
 			, storage_error const& error);

--- a/include/libtorrent/peer_list.hpp
+++ b/include/libtorrent/peer_list.hpp
@@ -123,8 +123,7 @@ namespace libtorrent {
 		// this is called once for every torrent_peer we get from
 		// the tracker, pex, lsd or dht.
 		torrent_peer* add_peer(tcp::endpoint const& remote
-			, peer_source_flags_t source, pex_flags_t flags
-			, torrent_state* state);
+			, peer_source_flags_t, pex_flags_t, torrent_state*);
 
 		// false means duplicate connection
 		bool update_peer_port(int port, torrent_peer* p
@@ -213,7 +212,7 @@ namespace libtorrent {
 
 		bool compare_peer_erase(torrent_peer const& lhs, torrent_peer const& rhs) const;
 		bool compare_peer(torrent_peer const* lhs, torrent_peer const* rhs
-			, external_ip const& external, int source_port) const;
+			, external_ip const& external, int external_port) const;
 
 		void find_connect_candidates(std::vector<torrent_peer*>& peers
 			, int session_time, torrent_state* state);

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -223,8 +223,8 @@ namespace libtorrent {
 
 		// increases the peer count for the given piece
 		// (is used when a HAVE message is received)
-		void inc_refcount(piece_index_t index, const torrent_peer* peer);
-		void dec_refcount(piece_index_t index, const torrent_peer* peer);
+		void inc_refcount(piece_index_t, torrent_peer const*);
+		void dec_refcount(piece_index_t, torrent_peer const*);
 
 		// increases the peer count for the given piece
 		// (is used when a BITFIELD message is received)
@@ -245,8 +245,8 @@ namespace libtorrent {
 		// it means that the refcounter will indicate that
 		// we are not interested in this piece anymore
 		// (i.e. we don't have to maintain a refcount)
-		void we_have(piece_index_t index);
-		void we_dont_have(piece_index_t index);
+		void we_have(piece_index_t);
+		void we_dont_have(piece_index_t);
 
 		// the lowest piece index we do not have
 		piece_index_t cursor() const { return m_cursor; }
@@ -258,9 +258,9 @@ namespace libtorrent {
 		void resize(int blocks_per_piece, int blocks_in_last_piece, int total_num_pieces);
 		int num_pieces() const { return int(m_piece_map.size()); }
 
-		bool have_piece(piece_index_t index) const;
+		bool have_piece(piece_index_t) const;
 
-		bool is_downloading(piece_index_t index) const
+		bool is_downloading(piece_index_t const index) const
 		{
 			TORRENT_ASSERT(index >= piece_index_t(0));
 			TORRENT_ASSERT(index < m_piece_map.end_index());
@@ -272,13 +272,13 @@ namespace libtorrent {
 		// sets the priority of a piece.
 		// returns true if the priority was changed from 0 to non-0
 		// or vice versa
-		bool set_piece_priority(piece_index_t index, download_priority_t prio);
+		bool set_piece_priority(piece_index_t, download_priority_t);
 
 		// returns the priority for the piece at 'index'
-		download_priority_t piece_priority(piece_index_t index) const;
+		download_priority_t piece_priority(piece_index_t) const;
 
 		// returns the current piece priorities for all pieces
-		void piece_priorities(std::vector<download_priority_t>& pieces) const;
+		void piece_priorities(std::vector<download_priority_t>&) const;
 
 		// pieces should be the vector that represents the pieces a
 		// client has. It returns a list of all pieces that this client
@@ -371,10 +371,10 @@ namespace libtorrent {
 		void write_failed(piece_block block);
 		int num_peers(piece_block block) const;
 
-		void piece_passed(piece_index_t index);
+		void piece_passed(piece_index_t);
 
 		// returns information about the given piece
-		void piece_info(piece_index_t index, piece_picker::downloading_piece& st) const;
+		void piece_info(piece_index_t, piece_picker::downloading_piece& st) const;
 
 		struct piece_stats_t
 		{
@@ -384,11 +384,11 @@ namespace libtorrent {
 			bool downloading;
 		};
 
-		piece_stats_t piece_stats(piece_index_t index) const;
+		piece_stats_t piece_stats(piece_index_t) const;
 
 		// if a piece had a hash-failure, it must be restored and
 		// made available for redownloading
-		void restore_piece(piece_index_t index, span<int const> blocks = {});
+		void restore_piece(piece_index_t, span<int const> blocks = {});
 
 		// clears the given piece's download flag
 		// this means that this piece-block can be picked again
@@ -396,7 +396,7 @@ namespace libtorrent {
 
 		// returns true if all blocks in this piece are finished
 		// or if we have the piece
-		bool is_piece_finished(piece_index_t index) const;
+		bool is_piece_finished(piece_index_t) const;
 
 		// returns true if at least one block in this piece is being hashed
 		// only valid for v2 torrents
@@ -404,14 +404,14 @@ namespace libtorrent {
 
 		// returns true if we have the piece or if the piece
 		// has passed the hash check
-		bool has_piece_passed(piece_index_t index) const;
+		bool has_piece_passed(piece_index_t) const;
 
 		// returns the number of blocks there is in the given piece
-		int blocks_in_piece(piece_index_t index) const;
+		int blocks_in_piece(piece_index_t) const;
 
 		// return the peer pointers to all peers that participated in
 		// this piece
-		std::vector<torrent_peer*> get_downloaders(piece_index_t index) const;
+		std::vector<torrent_peer*> get_downloaders(piece_index_t) const;
 
 		std::vector<piece_picker::downloading_piece> get_download_queue() const;
 		int get_download_queue_size() const;
@@ -531,7 +531,7 @@ namespace libtorrent {
 		bool can_pick(piece_index_t piece, typed_bitfield<piece_index_t> const& bitmask) const;
 		bool is_piece_free(piece_index_t piece, typed_bitfield<piece_index_t> const& bitmask) const;
 		index_range<piece_index_t>
-		expand_piece(piece_index_t piece, int whole_pieces
+		expand_piece(piece_index_t piece, int contiguous_blocks
 			, typed_bitfield<piece_index_t> const& have
 			, picker_options_t options) const;
 
@@ -752,7 +752,7 @@ namespace libtorrent {
 		// shuffles the given piece inside it's priority range
 		void shuffle(int priority, prio_index_t elem_index);
 
-		std::vector<downloading_piece>::iterator add_download_piece(piece_index_t index);
+		std::vector<downloading_piece>::iterator add_download_piece(piece_index_t);
 		void erase_download_piece(std::vector<downloading_piece>::iterator i);
 
 		std::vector<downloading_piece>::const_iterator find_dl_piece(download_queue_t, piece_index_t) const;

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -791,12 +791,12 @@ namespace libtorrent {
 		// large state_update to be posted. When removing all torrents, it is
 		// advised to remove them from the back of the queue, to minimize the
 		// shifting.
-		void remove_torrent(const torrent_handle& h, remove_flags_t options = {});
+		void remove_torrent(const torrent_handle&, remove_flags_t = {});
 
 #if TORRENT_ABI_VERSION == 1
 		// deprecated in libtorrent 1.1. use settings_pack instead
 		TORRENT_DEPRECATED
-		void set_pe_settings(pe_settings const& settings);
+		void set_pe_settings(pe_settings const&);
 		TORRENT_DEPRECATED
 		pe_settings get_pe_settings() const;
 #endif
@@ -804,8 +804,8 @@ namespace libtorrent {
 		// Applies the settings specified by the settings_pack ``s``. This is an
 		// asynchronous operation that will return immediately and actually apply
 		// the settings to the main thread of libtorrent some time later.
-		void apply_settings(settings_pack const& s);
-		void apply_settings(settings_pack&& s);
+		void apply_settings(settings_pack const&);
+		void apply_settings(settings_pack&&);
 		settings_pack get_settings() const;
 
 #if TORRENT_ABI_VERSION == 1
@@ -818,7 +818,7 @@ namespace libtorrent {
 		// .. _i2p: http://www.i2p2.de
 
 		TORRENT_DEPRECATED
-		void set_i2p_proxy(proxy_settings const& s);
+		void set_i2p_proxy(proxy_settings const&);
 		TORRENT_DEPRECATED
 		proxy_settings i2p_proxy() const;
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -71,7 +71,7 @@ namespace aux {
 	struct bdecode_node;
 
 	TORRENT_EXTRA_EXPORT settings_pack load_pack_from_dict(bdecode_node const& settings);
-	TORRENT_EXTRA_EXPORT void save_settings_to_dict(aux::session_settings const& s, entry::dictionary_type& sett);
+	TORRENT_EXTRA_EXPORT void save_settings_to_dict(aux::session_settings const& s, entry::dictionary_type& out);
 	TORRENT_EXTRA_EXPORT void apply_pack(settings_pack const* pack, aux::session_settings& sett
 		, aux::session_impl* ses = nullptr);
 	TORRENT_EXTRA_EXPORT void apply_pack_impl(settings_pack const* pack

--- a/include/libtorrent/storage.hpp
+++ b/include/libtorrent/storage.hpp
@@ -87,31 +87,31 @@ namespace aux {
 		// hidden
 		~default_storage();
 
-		bool has_any_file(storage_error& ec);
+		bool has_any_file(storage_error&);
 		void set_file_priority(settings_interface const&
 			, aux::vector<download_priority_t, file_index_t>& prio
-			, storage_error& ec);
+			, storage_error&);
 		void rename_file(file_index_t index, std::string const& new_filename
-			, storage_error& ec);
-		void release_files(storage_error& ec);
-		void delete_files(remove_flags_t options, storage_error& ec);
-		void initialize(settings_interface const&, storage_error& ec);
+			, storage_error&);
+		void release_files(storage_error&);
+		void delete_files(remove_flags_t options, storage_error&);
+		void initialize(settings_interface const&, storage_error&);
 		std::pair<status_t, std::string> move_storage(std::string save_path
-			, move_flags_t flags, storage_error& ec);
+			, move_flags_t, storage_error&);
 		bool verify_resume_data(add_torrent_params const& rd
 			, aux::vector<std::string, file_index_t> const& links
-			, storage_error& error);
+			, storage_error&);
 		bool tick();
 
 		int readv(settings_interface const&, span<iovec_t const> bufs
-			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error& ec);
+			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error&);
 		int writev(settings_interface const&, span<iovec_t const> bufs
-			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error& ec);
+			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error&);
 		int hashv(settings_interface const&, hasher& ph, std::ptrdiff_t len
 			, piece_index_t piece, int offset, aux::open_mode_t flags
-			, storage_error& ec);
+			, storage_error&);
 		int hashv2(settings_interface const&, hasher256& ph, std::ptrdiff_t len
-			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error& ec);
+			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error&);
 
 		// if the files in this storage are mapped, returns the mapped
 		// file_storage, otherwise returns the original file_storage object.

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -449,9 +449,9 @@ namespace libtorrent {
 			bool fail;
 			error_code error;
 		};
-		void read_piece(piece_index_t piece);
-		void on_disk_read_complete(disk_buffer_holder block, storage_error const& se
-			, peer_request const& r, std::shared_ptr<read_piece_struct> rp);
+		void read_piece(piece_index_t);
+		void on_disk_read_complete(disk_buffer_holder, storage_error const&
+			, peer_request const&, std::shared_ptr<read_piece_struct>);
 
 		storage_mode_t storage_mode() const;
 
@@ -607,8 +607,8 @@ namespace libtorrent {
 		void use_interface(std::string net_interface);
 #endif
 
-		void connect_to_url_seed(std::list<web_seed_t>::iterator url);
-		bool connect_to_peer(torrent_peer* peerinfo, bool ignore_limit = false);
+		void connect_to_url_seed(std::list<web_seed_t>::iterator);
+		bool connect_to_peer(torrent_peer*, bool ignore_limit = false);
 
 		int priority() const;
 #if TORRENT_ABI_VERSION == 1
@@ -732,7 +732,7 @@ namespace libtorrent {
 		void tracker_response(
 			tracker_request const& r
 			, address const& tracker_ip
-			, std::list<address> const& ip_list
+			, std::list<address> const& tracker_ips
 			, struct tracker_response const& resp) override;
 		void tracker_request_error(tracker_request const& r
 			, error_code const& ec, const std::string& msg
@@ -896,17 +896,17 @@ namespace libtorrent {
 
 		// this is the asio callback that is called when a name
 		// lookup for a PEER is completed.
-		void on_peer_name_lookup(error_code const& e
-			, std::vector<address> const& addrs
+		void on_peer_name_lookup(error_code const&
+			, std::vector<address> const&
 			, int port
-			, protocol_version v);
+			, protocol_version);
 
 		// this is the asio callback that is called when a name
 		// lookup for a WEB SEED is completed.
-		void on_name_lookup(error_code const& e
-			, std::vector<address> const& addrs
+		void on_name_lookup(error_code const&
+			, std::vector<address> const&
 			, int port
-			, std::list<web_seed_t>::iterator web);
+			, std::list<web_seed_t>::iterator);
 
 		void connect_web_seed(std::list<web_seed_t>::iterator web, tcp::endpoint a);
 
@@ -1049,7 +1049,7 @@ namespace libtorrent {
 
 		torrent_handle get_handle();
 
-		void write_resume_data(add_torrent_params& atp) const;
+		void write_resume_data(add_torrent_params&) const;
 
 		void seen_complete() { m_last_seen_complete = ::time(nullptr); }
 		int time_since_complete() const { return int(::time(nullptr) - m_last_seen_complete); }

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1041,7 +1041,7 @@ namespace aux {
 		//
 		// ``force_lsd_announce`` will announce the torrent on LSD
 		// immediately.
-		void force_reannounce(int seconds = 0, int tracker_index = -1, reannounce_flags_t = {}) const;
+		void force_reannounce(int seconds = 0, int idx = -1, reannounce_flags_t = {}) const;
 		void force_dht_announce() const;
 		void force_lsd_announce() const;
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -344,8 +344,8 @@ namespace aux {
 		//
 		// See http-seeding_ for more information.
 		void add_url_seed(std::string const& url
-			, std::string const& extern_auth = std::string()
-			, web_seed_entry::headers_t const& extra_headers = web_seed_entry::headers_t());
+			, std::string const& ext_auth = std::string()
+			, web_seed_entry::headers_t const& ext_headers = web_seed_entry::headers_t());
 		void add_http_seed(std::string const& url
 			, std::string const& extern_auth = std::string()
 			, web_seed_entry::headers_t const& extra_headers = web_seed_entry::headers_t());
@@ -559,8 +559,8 @@ namespace aux {
 		// the `piece_limit` parameter allows limiting the amount of memory
 		// dedicated to loading the torrent, and fails for torrents that exceed
 		// the limit
-		bool parse_info_section(bdecode_node const& e, error_code& ec);
-		bool parse_info_section(bdecode_node const& e, error_code& ec, int piece_limit);
+		bool parse_info_section(bdecode_node const& info, error_code& ec);
+		bool parse_info_section(bdecode_node const& info, error_code& ec, int max_pieces);
 
 		// This function looks up keys from the info-dictionary of the loaded
 		// torrent file. It can be used to access extension values put in the
@@ -605,8 +605,8 @@ namespace aux {
 		// populate the piece layers from the metadata
 		bool parse_piece_layers(bdecode_node const& e, error_code& ec);
 
-		bool parse_torrent_file(bdecode_node const& libtorrent, error_code& ec);
-		bool parse_torrent_file(bdecode_node const& libtorrent, error_code& ec, int piece_limit);
+		bool parse_torrent_file(bdecode_node const& torrent_file, error_code& ec);
+		bool parse_torrent_file(bdecode_node const& torrent_file, error_code& ec, int piece_limit);
 
 		void resolve_duplicate_filenames();
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -86,9 +86,9 @@ namespace aux {
 		using headers_t = std::vector<std::pair<std::string, std::string>>;
 
 		// hidden
-		web_seed_entry(std::string const& url_, type_t type_
-			, std::string const& auth_ = std::string()
-			, headers_t const& extra_headers_ = headers_t());
+		web_seed_entry(std::string url_, type_t type_
+			, std::string auth_ = std::string()
+			, headers_t extra_headers_ = headers_t());
 
 		// URL and type comparison
 		bool operator==(web_seed_entry const& e) const

--- a/include/libtorrent/torrent_peer.hpp
+++ b/include/libtorrent/torrent_peer.hpp
@@ -215,7 +215,7 @@ namespace libtorrent {
 
 	struct TORRENT_EXTRA_EXPORT ipv4_peer : torrent_peer
 	{
-		ipv4_peer(tcp::endpoint const& ip, bool connectable, peer_source_flags_t src);
+		ipv4_peer(tcp::endpoint const& ep, bool connectable, peer_source_flags_t src);
 		ipv4_peer(ipv4_peer const& p);
 		ipv4_peer& operator=(ipv4_peer const& p) &;
 
@@ -225,7 +225,7 @@ namespace libtorrent {
 #if TORRENT_USE_I2P
 	struct TORRENT_EXTRA_EXPORT i2p_peer : torrent_peer
 	{
-		i2p_peer(string_view dst, bool connectable, peer_source_flags_t src);
+		i2p_peer(string_view dest, bool connectable, peer_source_flags_t src);
 		i2p_peer(i2p_peer const&) = delete;
 		i2p_peer& operator=(i2p_peer const&) = delete;
 		i2p_peer(i2p_peer&&) = default;
@@ -237,7 +237,7 @@ namespace libtorrent {
 
 	struct TORRENT_EXTRA_EXPORT ipv6_peer : torrent_peer
 	{
-		ipv6_peer(tcp::endpoint const& ip, bool connectable, peer_source_flags_t src);
+		ipv6_peer(tcp::endpoint const& ep, bool connectable, peer_source_flags_t src);
 		ipv6_peer(ipv6_peer const& p);
 
 		const address_v6::bytes_type addr;

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -234,7 +234,7 @@ enum class event_t : std::uint8_t
 	struct TORRENT_EXTRA_EXPORT timeout_handler
 		: std::enable_shared_from_this<timeout_handler>
 	{
-		explicit timeout_handler(io_context& str);
+		explicit timeout_handler(io_context&);
 
 		timeout_handler(timeout_handler const&) = delete;
 		timeout_handler& operator=(timeout_handler const&) = delete;

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -277,7 +277,7 @@ enum class event_t : std::uint8_t
 		: timeout_handler
 	{
 		tracker_connection(tracker_manager& man
-			, tracker_request const& req
+			, tracker_request req
 			, io_context& ios
 			, std::weak_ptr<request_callback> r);
 
@@ -329,8 +329,8 @@ enum class event_t : std::uint8_t
 			, span<char const>
 			, error_code&, udp_send_flags_t)>;
 
-		tracker_manager(send_fun_t const& send_fun
-			, send_fun_hostname_t const& send_fun_hostname
+		tracker_manager(send_fun_t send_fun
+			, send_fun_hostname_t send_fun_hostname
 			, counters& stats_counters
 			, resolver_interface& resolver
 			, aux::session_settings const& sett

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -150,7 +150,7 @@ struct TORRENT_EXTRA_EXPORT upnp final
 	, single_threaded
 {
 	upnp(io_context& ios
-		, std::string const& user_agent
+		, std::string user_agent
 		, aux::portmap_callback& cb
 		, bool ignore_nonrouters);
 	~upnp();

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -231,7 +231,7 @@ private:
 	void return_error(port_mapping_t mapping, int code);
 #ifndef TORRENT_DISABLE_LOGGING
 	bool should_log() const;
-	void log(char const* msg, ...) const TORRENT_FORMAT(2,3);
+	void log(char const* fmt, ...) const TORRENT_FORMAT(2,3);
 #endif
 
 	void get_ip_address(rootdevice& d);

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1483,9 +1483,9 @@ namespace {
 	}
 
 	add_torrent_alert::add_torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, add_torrent_params const& p, error_code const& ec)
+		, add_torrent_params p, error_code const& ec)
 		: torrent_alert(alloc, h)
-		, params(p)
+		, params(std::move(p))
 		, error(ec)
 	{}
 
@@ -1671,8 +1671,8 @@ namespace {
 	}
 
 	dht_immutable_item_alert::dht_immutable_item_alert(aux::stack_allocator&
-		, sha1_hash const& t, entry const& i)
-		: target(t), item(i)
+		, sha1_hash const& t, entry i)
+		: target(t), item(std::move(i))
 	{}
 
 	std::string dht_immutable_item_alert::message() const
@@ -1691,9 +1691,9 @@ namespace {
 		, std::array<char, 64> const& sig
 		, std::int64_t sequence
 		, string_view s
-		, entry const& i
+		, entry i
 		, bool a)
-		: key(k), signature(sig), seq(sequence), salt(s), item(i), authoritative(a)
+		: key(k), signature(sig), seq(sequence), salt(s), item(std::move(i)), authoritative(a)
 	{}
 
 	std::string dht_mutable_item_alert::message() const

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2242,7 +2242,7 @@ namespace {
 	{
 		// we need to copy this array to make sure the structures are properly
 		// aligned, not just to have a nice API
-		std::size_t const num_blocks = aux::numeric_cast<std::size_t>(m_num_blocks);
+		auto const num_blocks = aux::numeric_cast<std::size_t>(m_num_blocks);
 		std::vector<piece_block> ret(num_blocks);
 
 		char const* start = m_alloc.get().ptr(m_array_idx);

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -703,7 +703,7 @@ namespace aux {
 	{
 		TORRENT_ASSERT(type() == string_t);
 		bdecode_token const& t = m_root_tokens[m_token_idx];
-		std::size_t const size = aux::numeric_cast<std::size_t>(token_source_span(t) - t.start_offset());
+		auto const size = aux::numeric_cast<std::size_t>(token_source_span(t) - t.start_offset());
 		TORRENT_ASSERT(t.type == bdecode_token::string);
 
 		return string_view(m_buffer + t.offset + t.start_offset(), size);

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -268,9 +268,6 @@ namespace aux {
 		, m_buffer(buf)
 		, m_buffer_size(len)
 		, m_token_idx(idx)
-		, m_last_index(-1)
-		, m_last_token(-1)
-		, m_size(-1)
 	{
 		TORRENT_ASSERT(tokens != nullptr);
 		TORRENT_ASSERT(idx >= 0);

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -144,8 +144,8 @@ namespace libtorrent {
 	}
 
 	broadcast_socket::broadcast_socket(
-		udp::endpoint const& multicast_endpoint)
-		: m_multicast_endpoint(multicast_endpoint)
+		udp::endpoint multicast_endpoint)
+		: m_multicast_endpoint(std::move(multicast_endpoint))
 		, m_outstanding_operations(0)
 		, m_abort(false)
 	{

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -797,7 +797,7 @@ namespace {
 		if (m_state != state_t::read_packet
 			|| int(recv_buffer.size()) <= 9
 			|| recv_buffer[0] != msg_piece)
-			return piece_block_progress();
+			return {};
 
 		const char* ptr = recv_buffer.data() + 1;
 		peer_request r;
@@ -806,8 +806,7 @@ namespace {
 		r.length = m_recv_buffer.packet_size() - 9;
 
 		// is any of the piece message header data invalid?
-		if (!verify_piece(r))
-			return piece_block_progress();
+		if (!verify_piece(r)) return {};
 
 		piece_block_progress p;
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -215,7 +215,7 @@ namespace {
 
 #if !defined TORRENT_DISABLE_ENCRYPTION
 
-		std::uint8_t out_policy = std::uint8_t(m_settings.get_int(settings_pack::out_enc_policy));
+		auto out_policy = static_cast<std::uint8_t>(m_settings.get_int(settings_pack::out_enc_policy));
 
 #ifdef TORRENT_USE_OPENSSL
 		// never try an encrypted connection when already using SSL
@@ -2345,7 +2345,7 @@ namespace {
 		if (should_log(peer_log_alert::outgoing_message))
 		{
 			std::string bitfield_string;
-			std::size_t const n_pieces = aux::numeric_cast<std::size_t>(num_pieces);
+			auto const n_pieces = aux::numeric_cast<std::size_t>(num_pieces);
 			bitfield_string.resize(n_pieces);
 			for (std::size_t k = 0; k < n_pieces; ++k)
 			{

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -160,7 +160,7 @@ struct TORRENT_EXTRA_EXPORT disk_io_thread final
 
 	void settings_updated() override;
 	storage_holder new_torrent(storage_params params
-		, std::shared_ptr<void> const& torrent) override;
+		, std::shared_ptr<void> const& owner) override;
 	void remove_torrent(storage_index_t) override;
 
 	void abort(bool wait) override;

--- a/src/disk_job_pool.cpp
+++ b/src/disk_job_pool.cpp
@@ -52,16 +52,16 @@ namespace libtorrent {
 	disk_io_job* disk_job_pool::allocate_job(job_action_t const type)
 	{
 		std::unique_lock<std::mutex> l(m_job_mutex);
-		disk_io_job* ptr = static_cast<disk_io_job*>(m_job_pool.malloc());
+		void* storage = m_job_pool.malloc();
 		m_job_pool.set_next_size(100);
-		if (ptr == nullptr) return nullptr;
+		if (storage == nullptr) return nullptr;
 		++m_jobs_in_use;
 		if (type == job_action_t::read) ++m_read_jobs;
 		else if (type == job_action_t::write) ++m_write_jobs;
 		l.unlock();
-		TORRENT_ASSERT(ptr);
+		TORRENT_ASSERT(storage);
 
-		new (ptr) disk_io_job;
+		auto ptr = new (storage) disk_io_job;
 		ptr->action = type;
 #if TORRENT_USE_ASSERTS
 		ptr->in_use = true;

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -206,7 +206,7 @@ namespace {
 		}
 		else
 		{
-			return address();
+			return {};
 		}
 	}
 #endif

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -90,8 +90,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <arpa/inet.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <unistd.h>
 #include <sys/types.h>
 

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -256,7 +256,7 @@ namespace {
 
 	int nl_dump_request(int sock, std::uint16_t type, std::uint32_t seq, char family, span<char> msg, std::size_t msg_len)
 	{
-		nlmsghdr* nl_msg = reinterpret_cast<nlmsghdr*>(msg.data());
+		auto* nl_msg = reinterpret_cast<nlmsghdr*>(msg.data());
 		nl_msg->nlmsg_len = std::uint32_t(NLMSG_LENGTH(msg_len));
 		nl_msg->nlmsg_type = type;
 		nl_msg->nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
@@ -286,7 +286,7 @@ namespace {
 
 	bool parse_route(int s, nlmsghdr* nl_hdr, ip_route* rt_info)
 	{
-		rtmsg* rt_msg = reinterpret_cast<rtmsg*>(NLMSG_DATA(nl_hdr));
+		auto* rt_msg = reinterpret_cast<rtmsg*>(NLMSG_DATA(nl_hdr));
 
 		if (!valid_addr_family(rt_msg->rtm_family) || (rt_msg->rtm_table != RT_TABLE_MAIN
 			&& rt_msg->rtm_table != RT_TABLE_LOCAL))
@@ -306,7 +306,7 @@ namespace {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
 #endif
-		for (rtattr* rt_attr = reinterpret_cast<rtattr*>(RTM_RTA(rt_msg));
+		for (auto* rt_attr = reinterpret_cast<rtattr*>(RTM_RTA(rt_msg));
 			RTA_OK(rt_attr, rt_len); rt_attr = RTA_NEXT(rt_attr, rt_len))
 		{
 			switch(rt_attr->rta_type)
@@ -359,7 +359,7 @@ namespace {
 
 	bool parse_nl_address(nlmsghdr* nl_hdr, ip_interface* ip_info)
 	{
-		ifaddrmsg* addr_msg = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(nl_hdr));
+		auto* addr_msg = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(nl_hdr));
 
 		if (!valid_addr_family(addr_msg->ifa_family))
 			return false;
@@ -402,7 +402,7 @@ namespace {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
 #endif
-		for (rtattr* rt_attr = reinterpret_cast<rtattr*>(IFA_RTA(addr_msg));
+		for (auto* rt_attr = reinterpret_cast<rtattr*>(IFA_RTA(addr_msg));
 			RTA_OK(rt_attr, rt_len); rt_attr = RTA_NEXT(rt_attr, rt_len))
 		{
 			switch(rt_attr->rta_type)
@@ -573,7 +573,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		}
 
 		char msg[NL_BUFSIZE] = {};
-		nlmsghdr* nl_msg = reinterpret_cast<nlmsghdr*>(msg);
+		auto* nl_msg = reinterpret_cast<nlmsghdr*>(msg);
 		int len = nl_dump_request(sock, RTM_GETADDR, 0, AF_PACKET, msg, sizeof(ifaddrmsg));
 		if (len < 0)
 		{
@@ -1207,7 +1207,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		std::uint32_t seq = 0;
 
 		char msg[NL_BUFSIZE] = {};
-		nlmsghdr* nl_msg = reinterpret_cast<nlmsghdr*>(msg);
+		auto* nl_msg = reinterpret_cast<nlmsghdr*>(msg);
 		int len = nl_dump_request(sock, RTM_GETROUTE, seq++, AF_UNSPEC, msg, sizeof(rtmsg));
 		if (len < 0)
 		{

--- a/src/error_code.cpp
+++ b/src/error_code.cpp
@@ -46,7 +46,7 @@ namespace libtorrent {
 		const char* name() const BOOST_SYSTEM_NOEXCEPT override;
 		std::string message(int ev) const override;
 		boost::system::error_condition default_error_condition(int ev) const BOOST_SYSTEM_NOEXCEPT override
-		{ return boost::system::error_condition(ev, *this); }
+		{ return {ev, *this}; }
 	};
 
 	const char* libtorrent_error_category::name() const BOOST_SYSTEM_NOEXCEPT
@@ -340,7 +340,7 @@ namespace libtorrent {
 		}
 		boost::system::error_condition default_error_condition(
 			int ev) const BOOST_SYSTEM_NOEXCEPT override
-		{ return boost::system::error_condition(ev, *this); }
+		{ return {ev, *this}; }
 	};
 
 	boost::system::error_category& http_category()
@@ -354,7 +354,7 @@ namespace libtorrent {
 		// hidden
 		boost::system::error_code make_error_code(error_code_enum e)
 		{
-			return boost::system::error_code(e, libtorrent_category());
+			return {e, libtorrent_category()};
 		}
 	}
 

--- a/src/escape_string.cpp
+++ b/src/escape_string.cpp
@@ -47,7 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #if TORRENT_USE_ICONV
 #include <iconv.h>
-#include <locale.h>
+#include <clocale>
 #endif
 
 #include "libtorrent/assert.hpp"
@@ -579,7 +579,7 @@ namespace {
 		if (size == std::size_t(-1)) return s;
 		std::string ret;
 		ret.resize(size);
-		size = wcstombs(&ret[0], ws.c_str(), size + 1);
+		size = std::wcstombs(&ret[0], ws.c_str(), size + 1);
 		if (size == std::size_t(-1)) return s;
 		ret.resize(size);
 		return ret;
@@ -589,7 +589,7 @@ namespace {
 	{
 		std::wstring ws;
 		ws.resize(s.size());
-		std::size_t size = mbstowcs(&ws[0], s.c_str(), s.size());
+		std::size_t size = std::mbstowcs(&ws[0], s.c_str(), s.size());
 		if (size == std::size_t(-1)) return s;
 		return libtorrent::wchar_utf8(ws);
 	}

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -216,8 +216,8 @@ namespace {
 		else
 		{
 			// yes we do. use it
-			return aux::path_index_t(aux::numeric_cast<std::uint32_t>(
-				p.base() - m_paths.begin() - 1));
+			return aux::path_index_t{aux::numeric_cast<std::uint32_t>(
+				p.base() - m_paths.begin() - 1)};
 		}
 	}
 
@@ -473,7 +473,7 @@ namespace aux {
 
 		TORRENT_ASSERT(file_iter != m_files.begin());
 		--file_iter;
-		return file_index_t(int(file_iter - m_files.begin()));
+		return file_index_t{int(file_iter - m_files.begin())};
 	}
 
 	file_index_t file_storage::file_index_at_piece(piece_index_t const piece) const
@@ -493,7 +493,7 @@ namespace aux {
 
 	piece_index_t file_storage::piece_index_at_file(file_index_t f) const
 	{
-		return piece_index_t(aux::numeric_cast<int>(file_offset(f) / piece_length()));
+		return piece_index_t{aux::numeric_cast<int>(file_offset(f) / piece_length())};
 	}
 
 #if TORRENT_ABI_VERSION <= 2

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -68,11 +68,11 @@ namespace libtorrent {
 
 http_connection::http_connection(io_context& ios
 	, resolver_interface& resolver
-	, http_handler const& handler
+	, http_handler handler
 	, bool bottled
 	, int max_bottled_buffer_size
-	, http_connect_handler const& ch
-	, http_filter_handler const& fh
+	, http_connect_handler ch
+	, http_filter_handler fh
 #ifdef TORRENT_USE_OPENSSL
 	, ssl::context* ssl_ctx
 #endif
@@ -87,9 +87,9 @@ http_connection::http_connection(io_context& ios
 	, m_i2p_conn(nullptr)
 #endif
 	, m_resolver(resolver)
-	, m_handler(handler)
-	, m_connect_handler(ch)
-	, m_filter_handler(fh)
+	, m_handler(std::move(handler))
+	, m_connect_handler(std::move(ch))
+	, m_filter_handler(std::move(fh))
 	, m_timer(ios)
 	, m_read_timeout(seconds(5))
 	, m_completion_timeout(seconds(5))

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -65,9 +65,9 @@ namespace libtorrent {
 	http_tracker_connection::http_tracker_connection(
 		io_context& ios
 		, tracker_manager& man
-		, tracker_request const& req
+		, tracker_request req
 		, std::weak_ptr<request_callback> c)
-		: tracker_connection(man, req, ios, std::move(c))
+		: tracker_connection(man, std::move(req), ios, std::move(c))
 		, m_ioc(ios)
 	{}
 

--- a/src/i2p_stream.cpp
+++ b/src/i2p_stream.cpp
@@ -118,16 +118,16 @@ namespace libtorrent {
 		return ret;
 	}
 
-	void i2p_connection::open(std::string const& s, int port
+	void i2p_connection::open(std::string const& hostname, int port
 		, i2p_stream::handler_type handler)
 	{
 		// we already seem to have a session to this SAM router
-		if (m_hostname == s
+		if (m_hostname == hostname
 			&& m_port == port
 			&& m_sam_socket
 			&& (is_open() || m_state == sam_connecting)) return;
 
-		m_hostname = s;
+		m_hostname = hostname;
 		m_port = port;
 
 		if (m_hostname.empty()) return;

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -89,7 +89,7 @@ namespace libtorrent { namespace dht {
 	// unit and connecting them together.
 	dht_tracker::dht_tracker(dht_observer* observer
 		, io_context& ios
-		, send_fun_t const& send_fun
+		, send_fun_t send_fun
 		, aux::session_settings const& settings
 		, counters& cnt
 		, dht_storage_interface& storage
@@ -97,7 +97,7 @@ namespace libtorrent { namespace dht {
 		: m_counters(cnt)
 		, m_storage(storage)
 		, m_state(std::move(state))
-		, m_send_fun(send_fun)
+		, m_send_fun(std::move(send_fun))
 		, m_log(observer)
 		, m_key_refresh_timer(ios)
 		, m_refresh_timer(ios)

--- a/src/kademlia/find_data.cpp
+++ b/src/kademlia/find_data.cpp
@@ -84,9 +84,9 @@ void find_data_observer::reply(msg const& m)
 find_data::find_data(
 	node& dht_node
 	, node_id const& target
-	, nodes_callback const& ncallback)
+	, nodes_callback ncallback)
 	: traversal_algorithm(dht_node, target)
-	, m_nodes_callback(ncallback)
+	, m_nodes_callback(std::move(ncallback))
 	, m_done(false)
 {
 }

--- a/src/kademlia/get_item.cpp
+++ b/src/kademlia/get_item.cpp
@@ -102,10 +102,10 @@ void get_item::got_data(bdecode_node const& v,
 get_item::get_item(
 	node& dht_node
 	, node_id const& target
-	, data_callback const& dcallback
-	, nodes_callback const& ncallback)
-	: find_data(dht_node, target, ncallback)
-	, m_data_callback(dcallback)
+	, data_callback dcallback
+	, nodes_callback ncallback)
+	: find_data(dht_node, target, std::move(ncallback))
+	, m_data_callback(std::move(dcallback))
 	, m_immutable(true)
 {
 }
@@ -114,10 +114,10 @@ get_item::get_item(
 	node& dht_node
 	, public_key const& pk
 	, span<char const> salt
-	, data_callback const& dcallback
-	, nodes_callback const& ncallback)
-	: find_data(dht_node, item_target_id(salt, pk), ncallback)
-	, m_data_callback(dcallback)
+	, data_callback dcallback
+	, nodes_callback ncallback)
+	: find_data(dht_node, item_target_id(salt, pk), std::move(ncallback))
+	, m_data_callback(std::move(dcallback))
 	, m_data(pk, salt)
 	, m_immutable(false)
 {

--- a/src/kademlia/get_peers.cpp
+++ b/src/kademlia/get_peers.cpp
@@ -167,11 +167,11 @@ observer_ptr get_peers::new_observer(udp::endpoint const& ep
 
 obfuscated_get_peers::obfuscated_get_peers(
 	node& dht_node
-	, node_id const& info_hash
+	, node_id const& target
 	, data_callback const& dcallback
 	, nodes_callback const& ncallback
 	, bool noseeds)
-	: get_peers(dht_node, info_hash, dcallback, ncallback, noseeds)
+	: get_peers(dht_node, target, dcallback, ncallback, noseeds)
 	, m_obfuscated(true)
 {
 }

--- a/src/kademlia/get_peers.cpp
+++ b/src/kademlia/get_peers.cpp
@@ -122,11 +122,11 @@ void get_peers::got_peers(std::vector<tcp::endpoint> const& peers)
 get_peers::get_peers(
 	node& dht_node
 	, node_id const& target
-	, data_callback const& dcallback
-	, nodes_callback const& ncallback
+	, data_callback dcallback
+	, nodes_callback ncallback
 	, bool noseeds)
-	: find_data(dht_node, target, ncallback)
-	, m_data_callback(dcallback)
+	: find_data(dht_node, target, std::move(ncallback))
+	, m_data_callback(std::move(dcallback))
 	, m_noseeds(noseeds)
 {
 }
@@ -168,10 +168,10 @@ observer_ptr get_peers::new_observer(udp::endpoint const& ep
 obfuscated_get_peers::obfuscated_get_peers(
 	node& dht_node
 	, node_id const& target
-	, data_callback const& dcallback
-	, nodes_callback const& ncallback
+	, data_callback dcallback
+	, nodes_callback ncallback
 	, bool noseeds)
-	: get_peers(dht_node, target, dcallback, ncallback, noseeds)
+	: get_peers(dht_node, target, std::move(dcallback), std::move(ncallback), noseeds)
 	, m_obfuscated(true)
 {
 }

--- a/src/kademlia/item.cpp
+++ b/src/kademlia/item.cpp
@@ -131,19 +131,14 @@ signature sign_mutable_item(
 item::item(public_key const& pk, span<char const> salt)
 	: m_salt(salt.data(), static_cast<std::size_t>(salt.size()))
 	, m_pk(pk)
-	, m_seq(0)
 	, m_mutable(true)
 {}
 
 item::item(entry v)
 	: m_value(std::move(v))
-	, m_seq(0)
-	, m_mutable(false)
 {}
 
 item::item(bdecode_node const& v)
-	: m_seq(0)
-	, m_mutable(false)
 {
 	// TODO: implement ctor for entry from bdecode_node?
 	m_value = v;

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -436,8 +436,8 @@ void node::get_peers(sha1_hash const& info_hash
 	bool const noseeds = bool(flags & announce::seed);
 
 	auto ta = m_settings.get_bool(settings_pack::dht_privacy_lookups)
-		? std::make_shared<dht::obfuscated_get_peers>(*this, info_hash, dcallback, ncallback, noseeds)
-		: std::make_shared<dht::get_peers>(*this, info_hash, dcallback, ncallback, noseeds);
+		? std::make_shared<dht::obfuscated_get_peers>(*this, info_hash, std::move(dcallback), std::move(ncallback), noseeds)
+		: std::make_shared<dht::get_peers>(*this, info_hash, std::move(dcallback), std::move(ncallback), noseeds);
 
 	ta->start();
 }
@@ -479,8 +479,7 @@ void node::direct_request(udp::endpoint const& ep, entry& e
 	m_rpc.invoke(e, ep, o);
 }
 
-void node::get_item(sha1_hash const& target
-	, std::function<void(item const&)> f)
+void node::get_item(sha1_hash const& target, std::function<void(item const&)> f)
 {
 #ifndef TORRENT_DISABLE_LOGGING
 	if (m_observer != nullptr && m_observer->should_log(dht_logger::node))
@@ -507,7 +506,7 @@ void node::get_item(public_key const& pk, std::string const& salt
 	}
 #endif
 
-	auto ta = std::make_shared<dht::get_item>(*this, pk, salt, f
+	auto ta = std::make_shared<dht::get_item>(*this, pk, salt, std::move(f)
 		, find_data::nodes_callback());
 	ta->start();
 }

--- a/src/kademlia/put_data.cpp
+++ b/src/kademlia/put_data.cpp
@@ -42,9 +42,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace dht {
 
-put_data::put_data(node& dht_node, put_callback const& callback)
+put_data::put_data(node& dht_node, put_callback callback)
 	: traversal_algorithm(dht_node, {})
-	, m_put_callback(callback)
+	, m_put_callback(std::move(callback))
 {}
 
 char const* put_data::name() const { return "put_data"; }

--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -156,7 +156,7 @@ routing_table::add_node_status_t replace_node_impl(node_entry const& e
 	// should not have been called
 	TORRENT_ASSERT(int(b.size()) >= bucket_size_limit);
 
-	bucket_t::iterator j = std::max_element(b.begin(), b.end()
+	auto j = std::max_element(b.begin(), b.end()
 		, [](node_entry const& lhs, node_entry const& rhs)
 		{ return lhs.fail_count() < rhs.fail_count(); });
 	TORRENT_ASSERT(j != b.end());

--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -505,8 +505,8 @@ routing_table::find_node(udp::endpoint const& ep)
 			return std::make_tuple(&*j, i, &i->live_nodes);
 		}
 	}
-	return std::tuple<node_entry*, routing_table::table_t::iterator, bucket_t*>(
-		nullptr, m_buckets.end(), nullptr);
+	return std::tuple<node_entry*, routing_table::table_t::iterator, bucket_t*>
+	{nullptr, m_buckets.end(), nullptr};
 }
 
 // TODO: this need to take bucket "prefix" into account. It should be unified

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -470,7 +470,7 @@ bool rpc_manager::invoke(entry& e, udp::endpoint const& target_addr
 	std::string transaction_id;
 	transaction_id.resize(2);
 	char* out = &transaction_id[0];
-	std::uint16_t const tid = std::uint16_t(random(0x7fff));
+	auto const tid = static_cast<std::uint16_t>(random(0x7fff));
 	aux::write_uint16(tid, out);
 	e["t"] = transaction_id;
 

--- a/src/kademlia/rpc_manager.cpp
+++ b/src/kademlia/rpc_manager.cpp
@@ -110,7 +110,7 @@ address observer::target_addr() const
 
 udp::endpoint observer::target_ep() const
 {
-	return udp::endpoint(target_addr(), m_port);
+	return {target_addr(), m_port};
 }
 
 void observer::abort()

--- a/src/kademlia/sample_infohashes.cpp
+++ b/src/kademlia/sample_infohashes.cpp
@@ -44,9 +44,9 @@ namespace libtorrent { namespace dht
 
 sample_infohashes::sample_infohashes(node& dht_node
 	, node_id const& target
-	, data_callback const& dcallback)
+	, data_callback dcallback)
 	: traversal_algorithm(dht_node, target)
-	, m_data_callback(dcallback) {}
+	, m_data_callback(std::move(dcallback)) {}
 
 char const* sample_infohashes::name() const { return "sample_infohashes"; }
 

--- a/src/lazy_bdecode.cpp
+++ b/src/lazy_bdecode.cpp
@@ -444,7 +444,7 @@ namespace {
 		else if (int(m_size) == this->capacity())
 		{
 			std::size_t const capacity = std::size_t(this->capacity()) * lazy_entry_grow_factor / 100;
-			lazy_entry* tmp = new (std::nothrow) lazy_entry[capacity + 1];
+			auto* const tmp = new (std::nothrow) lazy_entry[capacity + 1];
 			if (tmp == nullptr) return nullptr;
 			std::move(m_data.list, m_data.list + m_size + 1, tmp);
 

--- a/src/natpmp.cpp
+++ b/src/natpmp.cpp
@@ -94,7 +94,7 @@ struct pcp_error_category final : boost::system::error_category
 	}
 	boost::system::error_condition default_error_condition(
 		int ev) const BOOST_SYSTEM_NOEXCEPT override
-	{ return boost::system::error_condition(ev, *this); }
+	{ return {ev, *this}; }
 };
 
 boost::system::error_category& pcp_category()
@@ -108,7 +108,7 @@ namespace errors
 	// hidden
 	boost::system::error_code make_error_code(pcp_errors e)
 	{
-		return boost::system::error_code(e, pcp_category());
+		return {e, pcp_category()};
 	}
 }
 

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -82,10 +82,10 @@ namespace {
 
 namespace libtorrent {
 
-	part_file::part_file(std::string const& path, std::string const& name
+	part_file::part_file(std::string path, std::string name
 		, int const num_pieces, int const piece_size)
-		: m_path(path)
-		, m_name(name)
+		: m_path(std::move(path))
+		, m_name(std::move(name))
 		, m_max_pieces(num_pieces)
 		, m_piece_size(piece_size)
 		, m_header_size(round_up((2 + num_pieces) * 4))

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -481,7 +481,7 @@ namespace {
 	{
 		for (int i = int(f.size()) - 1; i >= 0; --i)
 		{
-			std::size_t const idx = std::size_t(i);
+			auto const idx = static_cast<std::size_t>(i);
 			if (f[idx] == '/') break;
 #ifdef TORRENT_WINDOWS
 			if (f[idx] == '\\') break;

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -129,7 +129,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(is_single_thread());
 		INVARIANT_CHECK;
 
-		for (iterator i = m_peers.begin(); i != m_peers.end();)
+		for (auto i = m_peers.begin(); i != m_peers.end();)
 		{
 			if ((filter.access((*i)->address()) & ip_filter::blocked) == 0)
 			{
@@ -190,7 +190,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(is_single_thread());
 		INVARIANT_CHECK;
 
-		for (iterator i = m_peers.begin(); i != m_peers.end();)
+		for (auto i = m_peers.begin(); i != m_peers.end();)
 		{
 			if ((filter.access((*i)->port) & port_filter::blocked) == 0)
 			{
@@ -273,7 +273,7 @@ namespace libtorrent {
 
 		// if this peer is in the connect candidate
 		// cache, erase it from there as well
-		std::vector<torrent_peer*>::iterator ci = std::find(m_candidate_cache.begin(), m_candidate_cache.end(), *i);
+		auto const ci = std::find(m_candidate_cache.begin(), m_candidate_cache.end(), *i);
 		if (ci != m_candidate_cache.end()) m_candidate_cache.erase(ci);
 
 		m_peer_allocator.free_peer_entry(*i);
@@ -975,7 +975,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(is_single_thread());
 		INVARIANT_CHECK;
 
-		iterator iter = std::lower_bound(m_peers.begin(), m_peers.end()
+		auto iter = std::lower_bound(m_peers.begin(), m_peers.end()
 			, destination, peer_address_compare());
 
 		if (iter != m_peers.end() && (*iter)->dest() == destination)
@@ -1220,7 +1220,7 @@ namespace libtorrent {
 
 		TORRENT_ASSERT(c);
 
-		iterator iter = std::lower_bound(m_peers.begin(), m_peers.end()
+		auto const iter = std::lower_bound(m_peers.begin(), m_peers.end()
 			, c->remote().address(), peer_address_compare());
 
 		if (iter != m_peers.end() && (*iter)->address() == c->remote().address())

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1851,7 +1851,7 @@ namespace libtorrent {
 
 	download_priority_t piece_picker::piece_priority(piece_index_t const index) const
 	{
-		return download_priority_t(m_piece_map[index].piece_priority);
+		return download_priority_t{static_cast<std::uint8_t>(m_piece_map[index].piece_priority)};
 	}
 
 	void piece_picker::piece_priorities(std::vector<download_priority_t>& pieces) const

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -220,7 +220,7 @@ namespace {
 				, default_priority);
 			for (int i = 0; i < num_files; ++i)
 			{
-				std::size_t const idx = std::size_t(i);
+				auto const idx = static_cast<std::size_t>(i);
 				ret.file_priorities[idx] = aux::clamp(
 					download_priority_t(static_cast<std::uint8_t>(
 						file_priority.list_int_value_at(i

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -495,7 +495,7 @@ TORRENT_VERSION_NAMESPACE_3
 #endif
 	{}
 
-	session_params::session_params(settings_pack const& sp
+	session_params::session_params(settings_pack const& sp // NOLINT
 		, std::vector<std::shared_ptr<plugin>> exts)
 		: settings(sp)
 		, extensions(std::move(exts))

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3993,7 +3993,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		// would be O(1).
 		for (auto& i : m_connections)
 		{
-			peer_connection* p = i.get();
+			peer_connection* const p = i.get();
 			TORRENT_ASSERT(p);
 			torrent_peer* pi = p->peer_info_struct();
 			if (!pi) continue;
@@ -4051,7 +4051,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		for (auto i = opt_unchoke.begin(); i != opt_unchoke_end; ++i)
 		{
 			torrent_peer* pi = (*i->peer)->peer_info_struct();
-			peer_connection* p = static_cast<peer_connection*>(pi->connection);
+			auto* const p = static_cast<peer_connection*>(pi->connection);
 			if (pi->optimistically_unchoked)
 			{
 #ifndef TORRENT_DISABLE_LOGGING
@@ -4091,7 +4091,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		for (torrent_peer* pi : prev_opt_unchoke)
 		{
 			TORRENT_ASSERT(pi->optimistically_unchoked);
-			auto* p = static_cast<peer_connection*>(pi->connection);
+			auto* const p = static_cast<peer_connection*>(pi->connection);
 			std::shared_ptr<torrent> t = p->associated_torrent().lock();
 			pi->optimistically_unchoked = false;
 			m_stats_counters.inc_stats_counter(counters::num_peers_up_unchoked_optimistic, -1);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5655,7 +5655,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		m_dht = std::make_shared<dht::dht_tracker>(
 			static_cast<dht::dht_observer*>(this)
 			, m_io_context
-			, [=](aux::listen_socket_handle const& sock
+			, [this](aux::listen_socket_handle const& sock
 				, udp::endpoint const& ep
 				, span<char const> p
 				, error_code& ec
@@ -6588,7 +6588,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		// the upnp constructor may fail and call the callbacks
 		m_upnp = std::make_shared<upnp>(m_io_context
 			, m_settings.get_bool(settings_pack::anonymous_mode)
-				? "" : m_settings.get_str(settings_pack::user_agent)
+				? std::string{} : m_settings.get_str(settings_pack::user_agent)
 			, *this
 			, m_settings.get_bool(settings_pack::upnp_ignore_nonrouters));
 		m_upnp->start();

--- a/src/session_udp_sockets.cpp
+++ b/src/session_udp_sockets.cpp
@@ -72,7 +72,7 @@ namespace libtorrent { namespace aux {
 		if (sockets.empty())
 		{
 			ec.assign(boost::system::errc::not_supported, generic_category());
-			return tcp::endpoint();
+			return {};
 		}
 
 		utp_socket_impl* impl = nullptr;
@@ -104,10 +104,10 @@ namespace libtorrent { namespace aux {
 
 			utp_init_socket(impl, sockets[idx]);
 			auto udp_ep = sockets[idx]->local_endpoint();
-			return tcp::endpoint(udp_ep.address(), udp_ep.port());
+			return {udp_ep.address(), udp_ep.port()};
 		}
 
-		return tcp::endpoint();
+		return {};
 	}
 
 	void outgoing_sockets::update_proxy(proxy_settings const& settings)

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -502,13 +502,13 @@ namespace libtorrent {
 			, m_file_priority, m_stat_cache, m_save_path, ec);
 	}
 
-	std::pair<status_t, std::string> default_storage::move_storage(std::string sp
+	std::pair<status_t, std::string> default_storage::move_storage(std::string save_path
 		, move_flags_t const flags, storage_error& ec)
 	{
 		m_pool.release(storage_index());
 
 		status_t ret;
-		std::tie(ret, m_save_path) = aux::move_storage(files(), m_save_path, std::move(sp)
+		std::tie(ret, m_save_path) = aux::move_storage(files(), m_save_path, std::move(save_path)
 			, m_part_file.get(), flags, ec);
 
 		// clear the stat cache in case the new location has new files

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4595,7 +4595,7 @@ bool is_downloading_state(int const st)
 			avail_vec.push_back(i);
 		}
 
-		if (avail_vec.empty()) return piece_index_t(-1);
+		if (avail_vec.empty()) return piece_index_t{-1};
 		return avail_vec[random(std::uint32_t(avail_vec.size() - 1))];
 	}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1382,7 +1382,7 @@ bool is_downloading_state(int const st)
 			ASN1_IA5STRING* domain = gen->d.dNSName;
 			if (domain->type != V_ASN1_IA5STRING || !domain->data || !domain->length) continue;
 			auto const* torrent_name = reinterpret_cast<char const*>(domain->data);
-			std::size_t const name_length = aux::numeric_cast<std::size_t>(domain->length);
+			auto const name_length = aux::numeric_cast<std::size_t>(domain->length);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			if (i > 1) names += " | n: ";
@@ -1415,7 +1415,7 @@ bool is_downloading_state(int const st)
 		if (common_name && common_name->data && common_name->length)
 		{
 			auto const* torrent_name = reinterpret_cast<char const*>(common_name->data);
-			std::size_t const name_length = aux::numeric_cast<std::size_t>(common_name->length);
+			auto const name_length = aux::numeric_cast<std::size_t>(common_name->length);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			if (!names.empty()) names += " | n: ";
@@ -4657,8 +4657,8 @@ bool is_downloading_state(int const st)
 
 	std::uint32_t torrent::tracker_key() const
 	{
-		uintptr_t const self = reinterpret_cast<uintptr_t>(this);
-		uintptr_t const ses = reinterpret_cast<uintptr_t>(&m_ses);
+		auto const self = reinterpret_cast<uintptr_t>(this);
+		auto const ses = reinterpret_cast<uintptr_t>(&m_ses);
 		std::uint32_t const storage = m_storage
 			? static_cast<std::uint32_t>(static_cast<storage_index_t>(m_storage))
 			: 0;
@@ -6346,7 +6346,7 @@ bool is_downloading_state(int const st)
 		for (auto peer : m_connections)
 		{
 			if (peer->type() != connection_type::bittorrent) continue;
-			bt_peer_connection* btpeer = static_cast<bt_peer_connection*>(peer);
+			auto* const btpeer = static_cast<bt_peer_connection*>(peer);
 			btpeer->maybe_send_hash_request();
 		}
 	}

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -95,9 +95,9 @@ namespace libtorrent {
 	tcp::endpoint block_info::peer() const
 	{
 		if (is_v6_addr)
-			return tcp::endpoint(address_v6(addr.v6), port);
+			return {address_v6(addr.v6), port};
 		else
-			return tcp::endpoint(address_v4(addr.v4), port);
+			return {address_v4(addr.v4), port};
 	}
 
 #ifndef BOOST_NO_EXCEPTIONS

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -723,12 +723,12 @@ namespace {
 
 } // anonymous namespace
 
-	web_seed_entry::web_seed_entry(std::string const& url_, type_t type_
-		, std::string const& auth_
-		, headers_t const& extra_headers_)
-		: url(url_)
-		, auth(auth_)
-		, extra_headers(extra_headers_)
+	web_seed_entry::web_seed_entry(std::string url_, type_t type_
+		, std::string auth_
+		, headers_t extra_headers_)
+		: url(std::move(url_))
+		, auth(std::move(auth_))
+		, extra_headers(std::move(extra_headers_))
 		, type(std::uint8_t(type_))
 	{
 	}
@@ -1808,7 +1808,7 @@ namespace {
 				, web_seed_entry::url_seed);
 			if ((m_flags & multifile) && num_files() > 1)
 				ensure_trailing_slash(ent.url);
-			m_web_seeds.push_back(ent);
+			m_web_seeds.push_back(std::move(ent));
 		}
 		else if (url_seeds && url_seeds.type() == bdecode_node::list_t)
 		{
@@ -1824,7 +1824,7 @@ namespace {
 				if ((m_flags & multifile) && num_files() > 1)
 					ensure_trailing_slash(ent.url);
 				if (!unique.insert(ent.url).second) continue;
-				m_web_seeds.push_back(ent);
+				m_web_seeds.push_back(std::move(ent));
 			}
 		}
 
@@ -1844,9 +1844,9 @@ namespace {
 			{
 				bdecode_node const url = http_seeds.list_at(i);
 				if (url.type() != bdecode_node::string_t || url.string_length() == 0) continue;
-				std::string const u = maybe_url_encode(url.string_value().to_string());
+				std::string u = maybe_url_encode(url.string_value().to_string());
 				if (!unique.insert(u).second) continue;
-				m_web_seeds.emplace_back(u, web_seed_entry::http_seed);
+				m_web_seeds.emplace_back(std::move(u), web_seed_entry::http_seed);
 			}
 		}
 

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -429,7 +429,7 @@ namespace {
 		{
 			if (bdecode_node const s_p = dict.dict_find_list("symlink path"))
 			{
-				std::size_t const preallocate = std::size_t(path_length(s_p, ec));
+				auto const preallocate = static_cast<std::size_t>(path_length(s_p, ec));
 				if (ec) return false;
 				symlink_path.reserve(preallocate);
 				for (int i = 0, end(s_p.list_size()); i < end; ++i)
@@ -578,7 +578,7 @@ namespace {
 		{
 			if (bdecode_node const s_p = dict.dict_find_list("symlink path"))
 			{
-				std::size_t const preallocate = std::size_t(path_length(s_p, ec));
+				auto const preallocate = static_cast<std::size_t>(path_length(s_p, ec));
 				if (ec) return false;
 				symlink_path.reserve(preallocate);
 				for (int i = 0, end(s_p.list_size()); i < end; ++i)

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1262,9 +1262,9 @@ namespace {
 		return m_info_dict.dict_find_string_value("ssl-cert");
 	}
 
-	bool torrent_info::parse_info_section(bdecode_node const& e, error_code& ec)
+	bool torrent_info::parse_info_section(bdecode_node const& info, error_code& ec)
 	{
-		return parse_info_section(e, ec, default_piece_limit);
+		return parse_info_section(info, ec, default_piece_limit);
 	}
 
 	bool torrent_info::parse_info_section(bdecode_node const& info

--- a/src/torrent_peer.cpp
+++ b/src/torrent_peer.cpp
@@ -275,7 +275,7 @@ namespace libtorrent {
 				static_cast<ipv6_peer const*>(this)->addr);
 		else
 #if TORRENT_USE_I2P
-		if (is_i2p_addr) return libtorrent::address();
+		if (is_i2p_addr) return {};
 		else
 #endif
 		return static_cast<ipv4_peer const*>(this)->addr;

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -148,11 +148,11 @@ constexpr tracker_request_flags_t tracker_request::i2p;
 
 	tracker_connection::tracker_connection(
 		tracker_manager& man
-		, tracker_request const& req
+		, tracker_request req
 		, io_context& ios
 		, std::weak_ptr<request_callback> r)
 		: timeout_handler(ios)
-		, m_req(req)
+		, m_req(std::move(req))
 		, m_requester(std::move(r))
 		, m_man(man)
 	{}
@@ -194,8 +194,8 @@ constexpr tracker_request_flags_t tracker_request::i2p;
 		m_man.received_bytes(bytes);
 	}
 
-	tracker_manager::tracker_manager(send_fun_t const& send_fun
-		, send_fun_hostname_t const& send_fun_hostname
+	tracker_manager::tracker_manager(send_fun_t send_fun
+		, send_fun_hostname_t send_fun_hostname
 		, counters& stats_counters
 		, resolver_interface& resolver
 		, aux::session_settings const& sett
@@ -203,8 +203,8 @@ constexpr tracker_request_flags_t tracker_request::i2p;
 		, aux::session_logger& ses
 #endif
 		)
-		: m_send_fun(send_fun)
-		, m_send_fun_hostname(send_fun_hostname)
+		: m_send_fun(std::move(send_fun))
+		, m_send_fun_hostname(std::move(send_fun_hostname))
 		, m_host_resolver(resolver)
 		, m_settings(sett)
 		, m_stats_counters(stats_counters)

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -252,7 +252,7 @@ port_mapping_t upnp::add_mapping(portmap_protocol const p, int const external_po
 
 	for (auto const& dev : m_devices)
 	{
-		rootdevice& d = const_cast<rootdevice&>(dev);
+		auto& d = const_cast<rootdevice&>(dev);
 		TORRENT_ASSERT(d.magic == 1337);
 
 		if (d.mapping.end_index() <= mapping_index)
@@ -291,7 +291,7 @@ void upnp::delete_mapping(port_mapping_t const mapping)
 
 	for (auto const& dev : m_devices)
 	{
-		rootdevice& d = const_cast<rootdevice&>(dev);
+		auto& d = const_cast<rootdevice&>(dev);
 		TORRENT_ASSERT(d.magic == 1337);
 
 		TORRENT_ASSERT(mapping < d.mapping.end_index());
@@ -1578,7 +1578,7 @@ void upnp::on_expire(error_code const& ec)
 
 	for (auto& dev : m_devices)
 	{
-		rootdevice& d = const_cast<rootdevice&>(dev);
+		auto& d = const_cast<rootdevice&>(dev);
 		TORRENT_ASSERT(d.magic == 1337);
 		for (port_mapping_t m{0}; m < m_mappings.end_index(); ++m)
 		{
@@ -1616,7 +1616,7 @@ void upnp::close()
 
 	for (auto& dev : m_devices)
 	{
-		rootdevice& d = const_cast<rootdevice&>(dev);
+		auto& d = const_cast<rootdevice&>(dev);
 		TORRENT_ASSERT(d.magic == 1337);
 		if (d.control_url.empty()) continue;
 		for (auto& m : d.mapping)

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -102,10 +102,10 @@ upnp::rootdevice& upnp::rootdevice::operator=(rootdevice&&) & = default;
 // bind to, since the broadcast socket opens one socket per local
 // interface by default
 upnp::upnp(io_context& ios
-	, std::string const& user_agent
+	, std::string user_agent
 	, aux::portmap_callback& cb
 	, bool ignore_nonrouters)
-	: m_user_agent(user_agent)
+	: m_user_agent(std::move(user_agent))
 	, m_callback(cb)
 	, m_retry_count(0)
 	, m_io_service(ios)

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -181,9 +181,9 @@ namespace libtorrent {namespace {
 
 		struct metadata_piece
 		{
-			metadata_piece(): num_requests(0), last_request(min_time()) {}
-			int num_requests;
-			time_point last_request;
+			metadata_piece() = default;
+			int num_requests = 0;
+			time_point last_request = min_time();
 			std::weak_ptr<ut_metadata_peer_plugin> source;
 			bool operator<(metadata_piece const& rhs) const
 			{ return num_requests < rhs.num_requests; }

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -149,7 +149,7 @@ namespace libtorrent { namespace {
 					if (peer->type() != connection_type::bittorrent)
 						continue;
 
-					bt_peer_connection* p = static_cast<bt_peer_connection*>(peer);
+					auto const* const p = static_cast<bt_peer_connection const*>(peer);
 
 					// if the peer has told us which port its listening on,
 					// use that port. But only if we didn't connect to the peer.
@@ -553,7 +553,7 @@ namespace libtorrent { namespace {
 				if (peer->type() != connection_type::bittorrent)
 					continue;
 
-				bt_peer_connection* p = static_cast<bt_peer_connection*>(peer);
+				auto const* const p = static_cast<bt_peer_connection const*>(peer);
 
 				// no supported flags to set yet
 				// 0x01 - peer supports encryption

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -234,10 +234,10 @@ namespace {
 		return wide;
 	}
 
-	std::wstring utf8_wchar(string_view wide)
+	std::wstring utf8_wchar(string_view utf8)
 	{
 		error_code ec;
-		std::wstring ret = utf8_wchar(wide, ec);
+		std::wstring ret = utf8_wchar(utf8, ec);
 		if (ec) aux::throw_ex<system_error>(ec);
 		return ret;
 	}

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -51,14 +51,14 @@ namespace libtorrent {
 namespace aux {
 
 	utp_socket_manager::utp_socket_manager(
-		send_fun_t const& send_fun
-		, incoming_utp_callback_t const& cb
+		send_fun_t send_fun
+		, incoming_utp_callback_t cb
 		, io_context& ios
 		, aux::session_settings const& sett
 		, counters& cnt
 		, void* ssl_context)
-		: m_send_fun(send_fun)
-		, m_cb(cb)
+		: m_send_fun(std::move(send_fun))
+		, m_cb(std::move(cb))
 		, m_sett(sett)
 		, m_counters(cnt)
 		, m_ios(ios)

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -250,7 +250,7 @@ struct utp_socket_impl
 			ec = boost::asio::error::not_connected;
 		else
 			TORRENT_ASSERT(m_remote_address != address_v4::any());
-		return tcp::endpoint(m_remote_address, m_port);
+		return {m_remote_address, m_port};
 	}
 	std::size_t available() const;
 	// returns true if there were handlers cancelled
@@ -696,7 +696,7 @@ bool utp_match(utp_socket_impl* s, udp::endpoint const& ep, std::uint16_t const 
 
 udp::endpoint utp_remote_endpoint(utp_socket_impl* s)
 {
-	return udp::endpoint(s->m_remote_address, s->m_port);
+	return {s->m_remote_address, s->m_port};
 }
 
 std::uint16_t utp_receive_id(utp_socket_impl* s)
@@ -808,7 +808,7 @@ utp_stream::endpoint_type utp_stream::remote_endpoint(error_code& ec) const
 	if (!m_impl)
 	{
 		ec = boost::asio::error::not_connected;
-		return endpoint_type();
+		return {};
 	}
 	return m_impl->remote_endpoint(ec);
 }
@@ -818,18 +818,18 @@ utp_stream::endpoint_type utp_stream::local_endpoint(error_code& ec) const
 	if (m_impl == nullptr)
 	{
 		ec = boost::asio::error::not_connected;
-		return endpoint_type();
+		return {};
 	}
 
 	auto s = m_impl->m_sock.lock();
 	if (!s)
 	{
 		ec = boost::asio::error::not_connected;
-		return endpoint_type();
+		return {};
 	}
 
 	udp::endpoint ep = s->local_endpoint();
-	return endpoint_type(ep.address(), ep.port());
+	return {ep.address(), ep.port()};
 }
 
 utp_stream::~utp_stream()

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1438,7 +1438,7 @@ void utp_socket_impl::parse_close_reason(std::uint8_t const* ptr, int const size
 	if (size != 4) return;
 	// skip reserved bytes
 	ptr += 2;
-	close_reason_t incoming_close_reason = static_cast<close_reason_t>(aux::read_uint16(ptr));
+	auto const incoming_close_reason = static_cast<close_reason_t>(aux::read_uint16(ptr));
 
 	UTP_LOGV("%8p: incoming close_reason: %d\n"
 		, static_cast<void*>(this), int(incoming_close_reason));
@@ -1770,7 +1770,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 	// for non MTU-probes, use the conservative packet size
 	int const effective_mtu = mtu_probe ? m_mtu : m_mtu_floor;
 
-	std::uint32_t const close_reason = static_cast<std::uint32_t>(m_close_reason);
+	auto const close_reason = static_cast<std::uint32_t>(m_close_reason);
 
 	int sack = 0;
 	if (m_inbuf.size())

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -200,7 +200,7 @@ namespace libtorrent {
 			entry::list_type& fl = ret["mapped_files"].list();
 			for (auto const& ent : atp.renamed_files)
 			{
-				std::size_t const idx(static_cast<std::size_t>(static_cast<int>(ent.first)));
+				auto const idx = static_cast<std::size_t>(static_cast<int>(ent.first));
 				if (idx >= fl.size()) fl.resize(idx + 1);
 				fl[idx] = ent.second;
 			}

--- a/src/xml_parse.cpp
+++ b/src/xml_parse.cpp
@@ -132,7 +132,7 @@ namespace libtorrent {
 				start = i;
 				// find end of attribute name
 				while (i != tag_end && *i != '=' && !is_space(*i)) ++i;
-				std::size_t const name_len = std::size_t(i - start);
+				auto const name_len = static_cast<std::size_t>(i - start);
 
 				// look for equality sign
 				for (; i != tag_end && *i != '='; ++i);


### PR DESCRIPTION
* modernize-pass-by-value
* modernize-use-auto
* modernize-use-default-member-init
* hicpp-deprecated-headers
* readability-inconsistent-declaration-parameter-name
* modernize-return-braced-init-list