### PR TITLE
peer_connection no longer needs to implement the error_handler_interface

### DIFF
--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -257,7 +257,6 @@ namespace aux {
 		, public disk_observer
 		, public peer_connection_interface
 		, public std::enable_shared_from_this<peer_connection>
-		, public aux::error_handler_interface
 	{
 	friend class invariant_access;
 	friend class torrent;
@@ -267,8 +266,8 @@ namespace aux {
 		// explicitly disallow assignment, to silence msvc warning
 		peer_connection& operator=(peer_connection const&) = delete;
 
-		void on_exception(std::exception const& e) override;
-		void on_error(error_code const& ec) override;
+		void on_exception(std::exception const& e);
+		void on_error(error_code const& ec);
 
 		virtual connection_type type() const = 0;
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7617,7 +7617,7 @@ bool is_downloading_state(int const st)
 		to_disconnect.resize(num);
 		auto end = std::partial_sort_copy(m_connections.begin(), m_connections.end()
 			, to_disconnect.begin(), to_disconnect.end(), compare_disconnect_peer);
-		for (auto p : range(to_disconnect.begin(), end))
+		for (auto p : aux::range(to_disconnect.begin(), end))
 		{
 			TORRENT_ASSERT(p->associated_torrent().lock().get() == this);
 			p->disconnect(ec, operation_t::bittorrent);


### PR DESCRIPTION
as it's resolved statically