### PR TITLE
use less space for timestamps in peer_connection

### DIFF
--- a/include/libtorrent/time.hpp
+++ b/include/libtorrent/time.hpp
@@ -54,6 +54,7 @@ namespace libtorrent {
 	using time_duration = clock_type::duration;
 
 	// 32 bit versions of time_point and duration, with second resolution
+	using milliseconds32 = std::chrono::duration<std::int32_t, std::ratio<1, 1000>>;
 	using seconds32 = std::chrono::duration<std::int32_t>;
 	using minutes32 = std::chrono::duration<std::int32_t, std::ratio<60>>;
 	using time_point32 = std::chrono::time_point<clock_type, seconds32>;


### PR DESCRIPTION
there are 13 timestamp fields in peer_connection. Make 12 of them relative the connect timestamp, and use narrower types