### PR TITLE
fix build client_test.cpp (vc++2017)

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -41,10 +41,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <utility>
 #include <deque>
 #include <fstream>
-#include <regex>
 #include <algorithm> // for min()/max()
 
 #include "libtorrent/config.hpp"
+
+#include <regex>
 
 #ifdef TORRENT_WINDOWS
 #include <direct.h> // for _mkdir and _getcwd
@@ -96,6 +97,7 @@ using lt::make_address_v4;
 using lt::make_address;
 
 using std::chrono::duration_cast;
+using std::stoi;
 
 #ifdef _WIN32
 


### PR DESCRIPTION
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1225): error C2039: 'regex': is not a member of 'std'
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\cinttypes(19): note: see declaration of 'std'
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1225): error C2065: 'regex': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1225): error C2146: syntax error: missing ';' before identifier 'regex'
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1225): error C3861: 'regex': identifier not found
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1230): error C2039: 'smatch': is not a member of 'std'
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\cinttypes(19): note: see declaration of 'std'
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1230): error C2065: 'smatch': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1230): error C2146: syntax error: missing ';' before identifier 'm'
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1230): error C2065: 'm': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1231): error C2039: 'regex_match': is not a member of 'std'
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\cinttypes(19): note: see declaration of 'std'
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1231): error C2065: 'm': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1231): error C2065: 'regex': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1231): error C3861: 'regex_match': identifier not found
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1233): error C2065: 'm': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1233): error C3861: 'stoi': identifier not found
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1234): error C2065: 'm': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1234): error C3861: 'stoi': identifier not found
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1236): error C2065: 'm': undeclared identifier
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1236): error C3861: 'stoi': identifier not found
1>q:\vc15\r5xx-libtorrent-git\libtorrent\examples\client_test.cpp(1235): error C2660: 'libtorrent::ip_filter::add_rule': function does not take 2 arguments
1>q:\vc15\r5xx-libtorrent-git\libtorrent\include\libtorrent\ip_filter.hpp(291): note: see declaration of 'libtorrent::ip_filter::add_rule'
1>Done building project "torrent-client-2017.vcxproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 1 up-to-date, 0 skipped ==========
