### PR TITLE
include: GCC 10 support

### DIFF
--- a/include/libtorrent/span.hpp
+++ b/include/libtorrent/span.hpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_SPAN_HPP_INCLUDED
 #define TORRENT_SPAN_HPP_INCLUDED
 
+#include <string>
 #include <array>
 #include <type_traits>
 #include "libtorrent/assert.hpp"


### PR DESCRIPTION
Red Hat is testing GCC 10 and found libtorrent needed to add a direct include on `<string>`.

This is a relatively common failure we're seeing with gcc-10 and occurs
as a result of header file cleanups within libstdc++.  For example
various C++ runtime headers indirectly included <string> which in turn
included <local> and <cerrno>.  Those indirect inclusions have been
eliminated which in turn forces packages to include the C++ headers they
actually need.