### PR TITLE
fix recently introduced noexcept_move_only type wrapper

### DIFF
--- a/include/libtorrent/aux_/noexcept_movable.hpp
+++ b/include/libtorrent/aux_/noexcept_movable.hpp
@@ -61,7 +61,6 @@ namespace aux {
 	template <typename T>
 	struct noexcept_move_only : T
 	{
-		noexcept_move_only() = default;
 		noexcept_move_only(noexcept_move_only<T>&& rhs) noexcept
 			: T(std::forward<T>(rhs))
 		{}

--- a/simulation/test_error_handling.cpp
+++ b/simulation/test_error_handling.cpp
@@ -164,7 +164,8 @@ void* operator new(std::size_t sz)
 		// to make the heterogeneous queue support throwing moves, nor to replace all
 		// standard types with variants that can move noexcept.
 		if (std::strstr(stack, " libtorrent::entry::operator= ") != nullptr
-			|| std::strstr(stack, " libtorrent::aux::noexcept_movable<std::map<") != nullptr)
+			|| std::strstr(stack, " libtorrent::aux::noexcept_movable<") != nullptr
+			|| std::strstr(stack, " libtorrent::aux::noexcept_move_only<") != nullptr)
 		{
 			++g_alloc_counter;
 			return std::malloc(sz);


### PR DESCRIPTION
it should not provide a default constructor and it should be exempt by error-handling test