### PR TITLE
don't rely on picking io_context back out of socket or timer

### DIFF
--- a/include/libtorrent/http_connection.hpp
+++ b/include/libtorrent/http_connection.hpp
@@ -152,6 +152,7 @@ private:
 	void callback(error_code e, span<char> data = {});
 
 	aux::vector<char> m_recvbuffer;
+	io_context& m_ios;
 
 	std::string m_hostname;
 	std::string m_url;


### PR DESCRIPTION
 in http_connection. Store it as a member