### PR TITLE
disable wait_for_alert test

### DIFF
--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -213,6 +213,7 @@ TORRENT_TEST(extensions)
 #endif
 }
 
+/*
 namespace {
 
 void post_torrent_added(alert_manager* mgr)
@@ -222,6 +223,8 @@ void post_torrent_added(alert_manager* mgr)
 }
 
 } // anonymous namespace
+
+// this test is too flaky
 
 TORRENT_TEST(wait_for_alert)
 {
@@ -263,6 +266,7 @@ TORRENT_TEST(wait_for_alert)
 
 	posting_thread.join();
 }
+*/
 
 TORRENT_TEST(alert_mask)
 {


### PR DESCRIPTION
since it relies on accurate wall-clock timings, which aren't necessarily possible on some CIs