### PR TITLE
Increase debug_read_iter/debug_write_iter

### DIFF
--- a/include/libtorrent/aux_/allocating_handler.hpp
+++ b/include/libtorrent/aux_/allocating_handler.hpp
@@ -55,8 +55,8 @@ namespace libtorrent { namespace aux {
 
 #ifdef _MSC_VER
 #ifndef NDEBUG
-	constexpr std::size_t debug_read_iter = 16 * sizeof(void*);
-	constexpr std::size_t debug_write_iter = 16 * sizeof(void*);
+	constexpr std::size_t debug_read_iter = 24 * sizeof(void*);
+	constexpr std::size_t debug_write_iter = 24 * sizeof(void*);
 #else
 	constexpr std::size_t debug_read_iter = 0;
 	constexpr std::size_t debug_write_iter = 0;


### PR DESCRIPTION
Here's what I've been using on Windows to fix the error *Handler buffer not large enough* for debug builds. Release builds have been fine.

This builds in both Debug and Release, however I am not knowledgeable enough to make out if we should use something less than 24. An increase by 8 felt good.

Relates to #4058 