### PR TITLE
Remove define guard around hasher.hpp include

### DIFF
--- a/include/libtorrent/aux_/torrent_list.hpp
+++ b/include/libtorrent/aux_/torrent_list.hpp
@@ -36,10 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/sha1_hash.hpp"
 #include "libtorrent/info_hash.hpp"
-
-#if !defined TORRENT_DISABLE_ENCRYPTION
 #include "libtorrent/hasher.hpp"
-#endif
 
 #include <memory> // for shared_ptr
 #include <vector>


### PR DESCRIPTION
When building libtorrent with the encryption disabled (`cmake -Dencryption=off`) the build would fail with an error `h has incomplete type (class hasher)`.

Removing the define guard around `hasher.hpp` resolves this and the build succeeds.