### PR TITLE
Increase UPNP sendbuffer length

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -710,7 +710,7 @@ void upnp::post(upnp::rootdevice const& d, char const* soap
 	TORRENT_ASSERT(d.magic == 1337);
 	TORRENT_ASSERT(d.upnp_connection);
 
-	char header[2048];
+	char header[2560];
 	std::snprintf(header, sizeof(header), "POST %s HTTP/1.1\r\n"
 		"Host: %s:%d\r\n"
 		"Content-Type: text/xml; charset=\"utf-8\"\r\n"


### PR DESCRIPTION
This will increase the UPNP sendbuffer with 512 bytes to a total of 2560. Building with `-Werror` on GCC9 gave the following warning,

```
../src/upnp.cpp: In member function ‘void libtorrent::upnp::get_ip_address(libtorrent::upnp::rootdevice&)’:
../src/upnp.cpp:719:4: warning: ‘%s’ directive output may be truncated writing up to 2047 bytes into a region of size between 1920 and 1923 [-Wformat-truncation=]
  719 |   "%s"
      |    ^~
......
 1096 |  post(d, soap, soap_action);
```

I don't know if we should keep the buffer 2k aligned and in that case perhaps increase it to 4096? Having it at 2560 fixes the warning at least.