### PR TITLE
python-binding: attempt to use numpy's multi-threaded compiler if available

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -9,6 +9,15 @@ import sys
 import shutil
 import multiprocessing
 
+# try to replace the default distutils compiler with the numpy one (which is multi-threaded)
+try:
+    import numpy.distutils.ccompiler
+    import distutils.ccompiler
+    distutils.ccompiler.CCompiler.compile = numpy.distutils.ccompiler.CCompiler_compile
+    os.environ['NPY_NUM_BUILD_JOBS'] = str(multiprocessing.cpu_count())
+except ImportError:
+    pass
+
 
 class flags_parser:
     def __init__(self):


### PR DESCRIPTION
Gives similar behaviour to building the python bindings with `boost-build` if `numpy` is present on the system.