### PR TITLE
fix cmake build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,7 +565,7 @@ target_link_libraries(torrent-rasterbar
 if (WIN32)
 	target_link_libraries(torrent-rasterbar
 		PRIVATE
-			wsock32 ws2_32 Iphlpapi
+			bcrypt wsock32 ws2_32 Iphlpapi
 			debug dbghelp
 	)
 


### PR DESCRIPTION
Commit 3edc305e9d4497bf48e40e4a780fe8e3a26d6c2a introduced a dependency
on bcrypt.lib