### PR TITLE
update appveyor image and boost version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,26 +60,26 @@ build_script:
   # examples
   - cd %ROOT_DIRECTORY%\examples
   - if defined bjam (
-    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on
     )
 
   # tools
   - cd %ROOT_DIRECTORY%\tools
   - if defined bjam (
-    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on
     )
 
   # test
   - cd %ROOT_DIRECTORY%\test
   - if defined bjam (
-    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on testing.execute=off
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on testing.execute=off
     )
 
   # python binding
   - cd %ROOT_DIRECTORY%\bindings\python
   # we use 64 bit python builds
   - if defined python (
-    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on libtorrent-link=shared stage_module stage_dependencies
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on libtorrent-link=shared stage_module stage_dependencies
     )
 
   # simulations
@@ -99,7 +99,7 @@ build_script:
 test_script:
   - cd %ROOT_DIRECTORY%\test
   - if defined bjam (
-    appveyor-retry b2.exe -l500 --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on win-tests
+    appveyor-retry b2.exe -l500 --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on win-tests
     )
 
   - cd %ROOT_DIRECTORY%\bindings\python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,7 @@ install:
   - set PATH=c:\msys64\mingw32\bin;%PATH%
   - g++ --version
   - set PATH=c:\Python27-x64;%PATH%
+  - set PYTHON_INTERPRETER=c:\Python27-x64\python.exe
   - python --version
   - echo %ROOT_DIRECTORY%
   - cd %BOOST_BUILD_PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
     - master
     - RC_1_2
     - RC_1_1
-image: Previous Visual Studio 2015
+image: Visual Studio 2017
 clone_depth: 1
 environment:
   matrix:
@@ -38,67 +38,67 @@ install:
   - if not defined linkflags ( set linkflags="" )
   - if not defined include ( set include="" )
   - cd %ROOT_DIRECTORY%
-  - set BOOST_ROOT=c:\Libraries\boost_1_63_0
+  - set BOOST_ROOT=c:\Libraries\boost_1_69_0
   - set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
   - echo %BOOST_ROOT%
   - echo %BOOST_BUILD_PATH%
-  - set PATH=%PATH%;%BOOST_BUILD_PATH%\src\engine\bin.ntx86
+  - set PATH=%PATH%;%BOOST_BUILD_PATH%
   - ps: '"using msvc : 14.0 ;`nusing gcc : : : <cxxflags>-std=c++11 ;`nusing python : 3.5 : c:\\Python35-x64 : c:\\Python35-x64\\include : c:\\Python35-x64\\libs ;`n" | Set-Content $env:HOMEDRIVE\$env:HOMEPATH\user-config.jam'
   - type %HOMEDRIVE%%HOMEPATH%\user-config.jam
   - cd %ROOT_DIRECTORY%
   - set PATH=c:\msys64\mingw32\bin;%PATH%
   - g++ --version
+  - set PATH=c:\Python27-x64;%PATH%
   - python --version
   - echo %ROOT_DIRECTORY%
-  - cd %BOOST_BUILD_PATH%\src\engine
-  - build.bat >nul
+  - cd %BOOST_BUILD_PATH%
+  - bootstrap.bat >nul
   - cd %ROOT_DIRECTORY%
 
 build_script:
   # examples
   - cd %ROOT_DIRECTORY%\examples
   - if defined bjam (
-    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto%
+    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on
     )
 
   # tools
   - cd %ROOT_DIRECTORY%\tools
   - if defined bjam (
-    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto%
+    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on
     )
 
   # test
   - cd %ROOT_DIRECTORY%\test
   - if defined bjam (
-    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% win-tests test_upnp test_natpmp testing.execute=off
+    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on testing.execute=off
     )
 
   # python binding
   - cd %ROOT_DIRECTORY%\bindings\python
   # we use 64 bit python builds
   - if defined python (
-    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% libtorrent-link=shared stage_module stage_dependencies
+    b2.exe --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on libtorrent-link=shared stage_module stage_dependencies
     )
 
   # simulations
   - cd %ROOT_DIRECTORY%\simulation
   - if defined sim (
-    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP testing.execute=off
+    b2.exe --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP asserts=on testing.execute=off
     )
 
   # minimal support for cmake build
   - cd %ROOT_DIRECTORY%
   - mkdir build && cd build
   - if defined cmake (
-    set "PATH=c:\Python27-x64;%PATH%" &&
-    cmake -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 14 2015 Win64" .. &&
+    cmake -DCMAKE_CXX_STANDARD=11 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 15 2017 Win64" .. &&
     cmake --build . --config Release -- -verbosity:minimal
     )
 
 test_script:
   - cd %ROOT_DIRECTORY%\test
   - if defined bjam (
-    appveyor-retry b2.exe -l400 --hash openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% win-tests
+    appveyor-retry b2.exe -l500 --abbreviate-paths openssl-version=pre1.1 warnings=all warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% %linkflags% %include% link=shared crypto=%crypto% asserts=on export-extra=on win-tests
     )
 
   - cd %ROOT_DIRECTORY%\bindings\python
@@ -121,5 +121,5 @@ test_script:
   # certain unexpected terminations (through exceptions)
   - cd %ROOT_DIRECTORY%\simulation
   - if defined sim (
-    b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP
+    b2.exe --hash openssl-version=pre1.1 warnings-as-errors=on -j %NUMBER_OF_PROCESSORS% %compiler% address-model=%model% debug-iterators=off picker-debugging=on invariant-checks=full test_debug %linkflags% %include% boost-link=default link=static crypto=built-in define=BOOST_ASIO_DISABLE_IOCP asserts=on
     )

--- a/examples/Jamfile
+++ b/examples/Jamfile
@@ -9,7 +9,7 @@ if $(BOOST_ROOT)
 	use-project /boost : $(BOOST_ROOT) ;
 }
 
-variant debug-mode : debug : <asserts>on <debug-iterators>on <invariant-checks>on ;
+variant debug-mode : debug : <asserts>on <debug-iterators>on <invariant-checks>full ;
 
 project client_test
 	: requirements

--- a/include/libtorrent/aux_/disable_warnings_push.hpp
+++ b/include/libtorrent/aux_/disable_warnings_push.hpp
@@ -106,4 +106,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4548)
 // 'conversion' conversion from 'type1' to 'type2', possible loss of data
 #pragma warning(disable : 4244)
+// potentially uninitialized local variable '' used
+#pragma warning(disable : 4701)
 #endif

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -494,7 +494,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #if !defined(TORRENT_READ_HANDLER_MAX_SIZE)
 # if defined _GLIBCXX_DEBUG || !defined NDEBUG
-constexpr std::size_t TORRENT_READ_HANDLER_MAX_SIZE = 400;
+constexpr std::size_t TORRENT_READ_HANDLER_MAX_SIZE = 432;
 # else
 // if this is not divisible by 8, we're wasting space
 constexpr std::size_t TORRENT_READ_HANDLER_MAX_SIZE = 342;
@@ -503,7 +503,7 @@ constexpr std::size_t TORRENT_READ_HANDLER_MAX_SIZE = 342;
 
 #if !defined(TORRENT_WRITE_HANDLER_MAX_SIZE)
 # if defined _GLIBCXX_DEBUG || !defined NDEBUG
-constexpr std::size_t TORRENT_WRITE_HANDLER_MAX_SIZE = 400;
+constexpr std::size_t TORRENT_WRITE_HANDLER_MAX_SIZE = 432;
 # else
 // if this is not divisible by 8, we're wasting space
 constexpr std::size_t TORRENT_WRITE_HANDLER_MAX_SIZE = 342;

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -82,7 +82,7 @@ namespace libtorrent { namespace aux {
 	void clear_bufs(span<iovec_t const> bufs)
 	{
 		for (auto buf : bufs)
-			std::fill(buf.begin(), buf.end(), 0);
+			std::fill(buf.begin(), buf.end(), char(0));
 	}
 
 #if TORRENT_USE_ASSERTS

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -42,14 +42,14 @@ explicit libtorrent_test ;
 
 lib advapi32 : : <name>Advapi32 ;
 
+variant debug-mode : debug : <asserts>on <debug-iterators>on <invariant-checks>full ;
+
 local default-build =
 	<threading>multi
 	<link>shared
-	<asserts>on
-	<invariant-checks>full
 	<picker-debugging>on
 	<logging>on
-	<debug-iterators>on
+	<variant>debug-mode
 	;
 
 project

--- a/test/http.py
+++ b/test/http.py
@@ -210,7 +210,7 @@ class ConnectionHandler:
                 break
 
 
-def start_server(host='localhost', port=8080, IPv6=False, timeout=100,
+def start_server(host='localhost', port=8080, IPv6=False, timeout=10,
                  handler=ConnectionHandler):
     if IPv6:
         soc_type = socket.AF_INET6
@@ -219,6 +219,7 @@ def start_server(host='localhost', port=8080, IPv6=False, timeout=100,
     soc = socket.socket(soc_type)
     soc.settimeout(120)
     print("PROXY - Serving on %s:%d." % (host, port))  # debug
+    print('python version: %s' % sys.version_info.__str__())
     soc.bind((host, port))
     soc.listen(0)
     while True:

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -214,7 +214,7 @@ alert const* wait_for_alert(lt::session& ses, int type, char const* name
 
 	while (true)
 	{
-		time_point now = clock_type::now();
+		time_point const now = clock_type::now();
 		if (now > end_time) return nullptr;
 
 		alert const* ret = nullptr;

--- a/test/socks.py
+++ b/test/socks.py
@@ -277,6 +277,7 @@ class SocksHandler(StreamRequestHandler):
 if __name__ == '__main__':
 
     debug('starting socks.py %s' % " ".join(sys.argv))
+    debug('python version: %s' % sys.version_info.__str__())
     listen_port = 8002
     i = 1
     while i < len(sys.argv):

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/session.hpp"
 #include "libtorrent/torrent_handle.hpp"
 #include "libtorrent/torrent_info.hpp"
+#include "libtorrent/aux_/path.hpp"
 #include "settings.hpp"
 
 using namespace libtorrent;
@@ -42,13 +43,19 @@ namespace lt = libtorrent;
 
 namespace {
 
+std::string file(std::string name)
+{
+	return combine_path(parent_path(current_working_directory())
+		, combine_path("test_torrents", name));
+}
+
 void test_add_and_get_flags(torrent_flags_t const flags)
 {
 	session ses(settings());
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = std::make_shared<torrent_info>("../test_torrents/base.torrent",
+	p.ti = std::make_shared<torrent_info>(file("base.torrent"),
 		std::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = flags;
@@ -63,7 +70,7 @@ void test_set_after_add(torrent_flags_t const flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = std::make_shared<torrent_info>("../test_torrents/base.torrent",
+	p.ti = std::make_shared<torrent_info>(file("base.torrent"),
 		std::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = torrent_flags::all & ~flags;
@@ -80,7 +87,7 @@ void test_unset_after_add(torrent_flags_t const flags)
 	add_torrent_params p;
 	p.save_path = ".";
 	error_code ec;
-	p.ti = std::make_shared<torrent_info>("../test_torrents/base.torrent",
+	p.ti = std::make_shared<torrent_info>(file("base.torrent"),
 		std::ref(ec));
 	TEST_CHECK(!ec);
 	p.flags = flags;

--- a/test/test_receive_buffer.cpp
+++ b/test/test_receive_buffer.cpp
@@ -215,11 +215,11 @@ TORRENT_TEST(receive_buffer_watermark)
 {
 	receive_buffer b;
 	b.reset(0x4000);
-	b.reserve(35000000);
-	b.received(35000000);
+	b.reserve(33500000);
+	b.received(33500000);
 	b.normalize();
 
-	TEST_EQUAL(b.watermark(), 35000000);
+	TEST_EQUAL(b.watermark(), 33500000);
 }
 
 #if !defined(TORRENT_DISABLE_ENCRYPTION) && !defined(TORRENT_DISABLE_EXTENSIONS)

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -50,6 +50,11 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <fstream>
 
+#ifdef TORRENT_WINDOWS
+#define SEP "\\"
+#else
+#define SEP "/"
+#endif
 using namespace lt;
 
 namespace {
@@ -277,13 +282,13 @@ TORRENT_TEST(piece_slots)
 	std::shared_ptr<torrent_info> ti = generate_torrent();
 
 	error_code ec;
-	create_directories(combine_path("add_torrent_params_test", "test_resume"), ec);
+	create_directories("add_torrent_params_test" SEP "test_resume", ec);
 	{
 		std::vector<char> a(128 * 1024 * 8);
 		std::vector<char> b(128 * 1024);
-		std::ofstream("add_torrent_params_test/test_resume/tmp1").write(a.data(), std::streamsize(a.size()));
-		std::ofstream("add_torrent_params_test/test_resume/tmp2").write(b.data(), std::streamsize(b.size()));
-		std::ofstream("add_torrent_params_test/test_resume/tmp3").write(b.data(), std::streamsize(b.size()));
+		std::ofstream("add_torrent_params_test" SEP "test_resume" SEP "tmp1").write(a.data(), std::streamsize(a.size()));
+		std::ofstream("add_torrent_params_test" SEP "test_resume" SEP "tmp2").write(b.data(), std::streamsize(b.size()));
+		std::ofstream("add_torrent_params_test" SEP "test_resume" SEP "tmp3").write(b.data(), std::streamsize(b.size()));
 	}
 
 	add_torrent_params p;
@@ -340,9 +345,9 @@ void test_piece_slots_seed(settings_pack const& sett)
 	{
 		std::vector<char> a(128 * 1024 * 8);
 		std::vector<char> b(128 * 1024);
-		std::ofstream("add_torrent_params_test/test_resume/tmp1").write(a.data(), std::streamsize(a.size()));
-		std::ofstream("add_torrent_params_test/test_resume/tmp2").write(b.data(), std::streamsize(b.size()));
-		std::ofstream("add_torrent_params_test/test_resume/tmp3").write(b.data(), std::streamsize(b.size()));
+		std::ofstream("add_torrent_params_test" SEP "test_resume" SEP "tmp1").write(a.data(), std::streamsize(a.size()));
+		std::ofstream("add_torrent_params_test" SEP "test_resume" SEP "tmp2").write(b.data(), std::streamsize(b.size()));
+		std::ofstream("add_torrent_params_test" SEP "test_resume" SEP "tmp3").write(b.data(), std::streamsize(b.size()));
 	}
 
 	add_torrent_params p;

--- a/test/test_ssl.cpp
+++ b/test/test_ssl.cpp
@@ -313,7 +313,7 @@ void test_ssl(int const test_idx, bool const use_utp)
 	p2 = ses2.abort();
 }
 
-std::string password_callback(int /*length*/, boost::asio::ssl::context::password_purpose p
+std::string password_callback(std::size_t /*length*/, boost::asio::ssl::context::password_purpose p
 	, std::string pw)
 {
 	if (p != boost::asio::ssl::context::for_reading) return "";

--- a/test/test_utp.cpp
+++ b/test/test_utp.cpp
@@ -53,8 +53,8 @@ void test_transfer()
 {
 	// in case the previous run was terminated
 	error_code ec;
-	remove_all("./tmp1_utp", ec);
-	remove_all("./tmp2_utp", ec);
+	remove_all("tmp1_utp", ec);
+	remove_all("tmp2_utp", ec);
 
 	// these are declared before the session objects
 	// so that they are destructed last. This enables
@@ -85,13 +85,13 @@ void test_transfer()
 	torrent_handle tor2;
 
 	ec.clear();
-	create_directory("./tmp1_utp", ec);
+	create_directory("tmp1_utp", ec);
 	if (ec)
 	{
-		std::printf("ERROR: failed to create test directory \"./tmp1_utp\": (%d) %s\n"
+		std::printf("ERROR: failed to create test directory \"tmp1_utp\": (%d) %s\n"
 			, ec.value(), ec.message().c_str());
 	}
-	std::ofstream file("./tmp1_utp/temporary");
+	std::ofstream file("tmp1_utp/temporary");
 	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 128 * 1024, 6, false);
 	file.close();
 
@@ -141,8 +141,8 @@ TORRENT_TEST(utp)
 	test_transfer();
 
 	error_code ec;
-	remove_all("./tmp1_utp", ec);
-	remove_all("./tmp2_utp", ec);
+	remove_all("tmp1_utp", ec);
+	remove_all("tmp2_utp", ec);
 }
 
 TORRENT_TEST(compare_less_wrap)

--- a/test/test_utp.cpp
+++ b/test/test_utp.cpp
@@ -84,7 +84,13 @@ void test_transfer()
 	torrent_handle tor1;
 	torrent_handle tor2;
 
+	ec.clear();
 	create_directory("./tmp1_utp", ec);
+	if (ec)
+	{
+		std::printf("ERROR: failed to create test directory \"./tmp1_utp\": (%d) %s\n"
+			, ec.value(), ec.message().c_str());
+	}
 	std::ofstream file("./tmp1_utp/temporary");
 	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 128 * 1024, 6, false);
 	file.close();

--- a/test/web_server.py
+++ b/test/web_server.py
@@ -5,6 +5,7 @@ import os
 import ssl
 import gzip
 import base64
+import socket
 
 # Python 3 has moved {Simple,Base}HTTPServer to http module
 try:
@@ -165,11 +166,8 @@ class http_handler(BaseHTTPRequestHandler):
                     s.send_header('Content-Encoding', 'gzip')
                 if not keepalive:
                     s.send_header("Connection", "close")
-                    try:
-                        s.request.shutdown()
-                    except Exception as e:
-                        print('Failed to shutdown read-channel of socket: ', e)
-                        sys.stdout.flush()
+                    if not use_ssl:
+                        s.request.shutdown(socket.SHUT_RD)
 
                 s.end_headers()
 
@@ -204,6 +202,7 @@ if __name__ == '__main__':
     use_ssl = sys.argv[3] != '0'
     keepalive = sys.argv[4] != '0'
     min_interval = sys.argv[5]
+    print('python version: %s' % sys.version_info.__str__())
 
     http_handler.protocol_version = 'HTTP/1.1'
     httpd = http_server_with_timeout(('127.0.0.1', port), http_handler)

--- a/tools/Jamfile
+++ b/tools/Jamfile
@@ -25,6 +25,8 @@ rule link_libtorrent ( properties * )
 	return $(result) ;
 }
 
+variant debug-mode : debug : <asserts>on <debug-iterators>on <invariant-checks>full ;
+
 project tools
    : requirements
 	<threading>multi
@@ -36,6 +38,7 @@ project tools
 	<conditional>@link_libtorrent
 	: default-build
 	<link>static
+	<variant>debug-mode
    ;  
 
 exe dht : dht_put.cpp : <include>../ed25519/src ;


### PR DESCRIPTION
explicitly use python2 for test scripts (as the SSL behavior has changed in python 3 in non-trivial ways).

Also try to speed up the appveyor builds by building examples and tools with the same build configuration as the tests.