### PR TITLE
fixed warning about explicitly calling std::move to avoid copying on older compilers

### DIFF
--- a/src/kademlia/find_data.cpp
+++ b/src/kademlia/find_data.cpp
@@ -131,7 +131,7 @@ observer_ptr find_data::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 	if (o) o->m_in_constructor = false;
 #endif
-	return o;
+	return std::move(o);
 }
 
 char const* find_data::name() const { return "find_data"; }

--- a/src/kademlia/get_item.cpp
+++ b/src/kademlia/get_item.cpp
@@ -132,7 +132,7 @@ observer_ptr get_item::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 	if (o) o->m_in_constructor = false;
 #endif
-	return o;
+	return std::move(o);
 }
 
 bool get_item::invoke(observer_ptr o)

--- a/src/kademlia/get_peers.cpp
+++ b/src/kademlia/get_peers.cpp
@@ -162,7 +162,7 @@ observer_ptr get_peers::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 	if (o) o->m_in_constructor = false;
 #endif
-	return o;
+	return std::move(o);
 }
 
 obfuscated_get_peers::obfuscated_get_peers(
@@ -189,7 +189,7 @@ observer_ptr obfuscated_get_peers::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 		if (o) o->m_in_constructor = false;
 #endif
-		return o;
+		return std::move(o);
 	}
 	else
 	{
@@ -198,7 +198,7 @@ observer_ptr obfuscated_get_peers::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 		if (o) o->m_in_constructor = false;
 #endif
-		return o;
+		return std::move(o);
 	}
 }
 

--- a/src/kademlia/refresh.cpp
+++ b/src/kademlia/refresh.cpp
@@ -47,7 +47,7 @@ observer_ptr bootstrap::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 	if (o) o->m_in_constructor = false;
 #endif
-	return o;
+	return std::move(o);
 }
 
 bool bootstrap::invoke(observer_ptr o)

--- a/src/kademlia/traversal_algorithm.cpp
+++ b/src/kademlia/traversal_algorithm.cpp
@@ -82,7 +82,7 @@ observer_ptr traversal_algorithm::new_observer(udp::endpoint const& ep
 #if TORRENT_USE_ASSERTS
 	if (o) o->m_in_constructor = false;
 #endif
-	return o;
+	return std::move(o);
 }
 
 traversal_algorithm::traversal_algorithm(node& dht_node, node_id const& target)

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -648,7 +648,7 @@ namespace libtorrent { namespace {
 		bt_peer_connection* c = static_cast<bt_peer_connection*>(pc.native_handle().get());
 		auto p = std::make_shared<ut_pex_peer_plugin>(m_torrent, *c, *this);
 		c->set_ut_pex(p);
-		return p;
+		return std::move(p);
 	}
 } }
 


### PR DESCRIPTION
With the latest version of Apple Clang, I'm getting this warning:
```
warning: prior to the resolution of a defect report against ISO C++11, local variable '<name>' would have been copied despite being returned by name, due to its not matching the function return type ('shared_ptr<base>' vs 'shared_ptr<child>') [-Wreturn-std-move-in-c++11]

note: call 'std::move' explicitly to avoid copying on older compilers
```
I know it's not relevant, but it's just one thing less to ignore.