### PR TITLE
deprecate session_flags_t and some session constructors

### DIFF
--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -423,7 +423,6 @@ void bind_converters()
     to_python_converter<lt::pause_flags_t, from_bitfield_flag<lt::pause_flags_t>>();
     to_python_converter<lt::deadline_flags_t, from_bitfield_flag<lt::deadline_flags_t>>();
     to_python_converter<lt::save_state_flags_t, from_bitfield_flag<lt::save_state_flags_t>>();
-    to_python_converter<lt::session_flags_t, from_bitfield_flag<lt::session_flags_t>>();
     to_python_converter<lt::remove_flags_t, from_bitfield_flag<lt::remove_flags_t>>();
     to_python_converter<lt::reopen_network_flags_t, from_bitfield_flag<lt::reopen_network_flags_t>>();
     to_python_converter<lt::file_flags_t, from_bitfield_flag<lt::file_flags_t>>();
@@ -451,6 +450,10 @@ void bind_converters()
     to_python_converter<lt::aux::noexcept_movable<std::map<lt::piece_index_t, lt::bitfield>>, map_to_dict<lt::aux::noexcept_movable<std::map<lt::piece_index_t, lt::bitfield>>>>();
     to_python_converter<lt::aux::noexcept_movable<std::map<lt::file_index_t, std::string>>, map_to_dict<lt::aux::noexcept_movable<std::map<lt::file_index_t, std::string>>>>();
     to_python_converter<std::map<lt::file_index_t, std::string>, map_to_dict<std::map<lt::file_index_t, std::string>>>();
+
+#if TORRENT_ABI_VERSION <= 2
+    to_python_converter<lt::session_flags_t, from_bitfield_flag<lt::session_flags_t>>();
+#endif
 
 #if TORRENT_ABI_VERSION == 1
     to_python_converter<lt::aux::noexcept_movable<std::vector<char>>, vector_to_list<lt::aux::noexcept_movable<std::vector<char>>>>();
@@ -507,7 +510,6 @@ void bind_converters()
     to_bitfield_flag<lt::pause_flags_t>();
     to_bitfield_flag<lt::deadline_flags_t>();
     to_bitfield_flag<lt::save_state_flags_t>();
-    to_bitfield_flag<lt::session_flags_t>();
     to_bitfield_flag<lt::remove_flags_t>();
     to_bitfield_flag<lt::reopen_network_flags_t>();
     to_bitfield_flag<lt::file_flags_t>();
@@ -515,4 +517,8 @@ void bind_converters()
     to_bitfield_flag<lt::pex_flags_t>();
     to_bitfield_flag<lt::reannounce_flags_t>();
     to_string_view();
+
+#if TORRENT_ABI_VERSION <= 2
+    to_bitfield_flag<lt::session_flags_t>();
+#endif
 }

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -232,7 +232,7 @@ struct counters;
 
 // include/libtorrent/session.hpp
 class session_proxy;
-class session;
+struct session;
 
 // include/libtorrent/session_handle.hpp
 struct session_handle;

--- a/include/libtorrent/magnet_uri.hpp
+++ b/include/libtorrent/magnet_uri.hpp
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 
 	struct torrent_handle;
-	class session;
+	struct session;
 
 	// Generates a magnet URI from the specified torrent. If the torrent
 	// handle is invalid, an empty string is returned.

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -80,7 +80,7 @@ namespace libtorrent {
 	// any operation on it will throw an invalid_session_handle.
 	struct TORRENT_EXPORT session_handle
 	{
-		friend class session;
+		friend struct session;
 		friend struct aux::session_impl;
 
 		// hidden
@@ -782,9 +782,11 @@ namespace libtorrent {
 		// delete just the part-file associated with this torrent
 		static constexpr remove_flags_t delete_partfile = 1_bit;
 
+#if TORRENT_ABI_VERSION <= 2
 		// this will add common extensions like ut_pex, ut_metadata, lt_tex
 		// smart_ban and possibly others.
-		static constexpr session_flags_t add_default_plugins = 0_bit;
+		static constexpr session_flags_t TORRENT_DEPRECATED_MEMBER add_default_plugins = 0_bit;
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 		// this will start features like DHT, local service discovery, UPnP

--- a/include/libtorrent/session_types.hpp
+++ b/include/libtorrent/session_types.hpp
@@ -42,8 +42,10 @@ namespace libtorrent {
 	// hidden
 	using save_state_flags_t = flags::bitfield_flag<std::uint32_t, struct save_state_flags_tag>;
 
+#if TORRENT_ABI_VERSION <= 2
 	// hidden
 	using session_flags_t = flags::bitfield_flag<std::uint8_t, struct session_flags_tag>;
+#endif
 
 	// hidden
 	using remove_flags_t = flags::bitfield_flag<std::uint8_t, struct remove_flags_tag>;

--- a/simulation/test_optimistic_unchoke.cpp
+++ b/simulation/test_optimistic_unchoke.cpp
@@ -84,7 +84,7 @@ TORRENT_TEST(optimistic_unchoke)
 
 	session_proxy proxy;
 
-	auto ses = std::make_shared<lt::session>(std::ref(pack), std::ref(ios));
+	auto ses = std::make_shared<lt::session>(pack, ios);
 	ses->async_add_torrent(atp);
 
 	std::vector<std::shared_ptr<sim::asio::io_context>> io_context;
@@ -100,8 +100,8 @@ TORRENT_TEST(optimistic_unchoke)
 			char ep[30];
 			std::snprintf(ep, sizeof(ep), "50.0.%d.%d", (i + 1) >> 8, (i + 1) & 0xff);
 			io_context.push_back(std::make_shared<sim::asio::io_context>(
-				std::ref(sim), addr(ep)));
-			peers.push_back(std::make_shared<peer_conn>(std::ref(*io_context.back())
+				sim, addr(ep)));
+			peers.push_back(std::make_shared<peer_conn>(*io_context.back()
 				, [&,i](int msg, char const* /* buf */, int /* len */)
 				{
 					choke_state& cs = peer_choke_state[i];

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -412,7 +412,7 @@ struct timeout_config : sim::default_config
 		auto it = m_incoming.find(ip);
 		if (it != m_incoming.end()) return sim::route().append(it->second);
 		it = m_incoming.insert(it, std::make_pair(ip, std::make_shared<queue>(
-			std::ref(m_sim->get_io_context())
+			m_sim->get_io_context()
 			, 1000
 			, lt::duration_cast<lt::time_duration>(seconds(10))
 			, 1000, "packet-loss modem in")));
@@ -424,7 +424,7 @@ struct timeout_config : sim::default_config
 		auto it = m_outgoing.find(ip);
 		if (it != m_outgoing.end()) return sim::route().append(it->second);
 		it = m_outgoing.insert(it, std::make_pair(ip, std::make_shared<queue>(
-			std::ref(m_sim->get_io_context()), 1000
+			m_sim->get_io_context(), 1000
 			, lt::duration_cast<lt::time_duration>(seconds(5)), 200 * 1000, "packet-loss out")));
 		return sim::route().append(it->second);
 	}

--- a/simulation/utils.hpp
+++ b/simulation/utils.hpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent
 {
-	class session;
+	struct session;
 	class alert;
 }
 

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -72,7 +72,9 @@ namespace libtorrent {
 	constexpr save_state_flags_t session_handle::save_tracker_proxy TORRENT_DEPRECATED_ENUM;
 #endif
 
+#if TORRENT_ABI_VERSION <= 2
 	constexpr session_flags_t session_handle::add_default_plugins;
+#endif
 #if TORRENT_ABI_VERSION == 1
 	constexpr session_flags_t session_handle::start_default_features;
 #endif

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "setup_transfer.hpp"
 #include "libtorrent/magnet_uri.hpp"
 #include "libtorrent/session.hpp"
+#include "libtorrent/session_params.hpp"
 #include "libtorrent/torrent_handle.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/torrent_info.hpp" // for announce_entry

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -33,7 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/session.hpp"
-#include <functional>
+#include "libtorrent/session_params.hpp"
 
 #include "test.hpp"
 #include "setup_transfer.hpp"
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/session_stats.hpp"
 #include "settings.hpp"
 
+#include <functional>
 #include <fstream>
 
 using namespace std::placeholders;

--- a/test/test_ssl.cpp
+++ b/test/test_ssl.cpp
@@ -164,7 +164,7 @@ void test_ssl(int const test_idx, bool const use_utp)
 	// if a peer fails once, don't try it again
 	sett.set_int(settings_pack::max_failcount, 1);
 
-	lt::session ses1(sett, {});
+	lt::session ses1(session_params{sett, {}});
 
 	// this +20 is here to use a different port as ses1
 	port += 20;
@@ -177,7 +177,7 @@ void test_ssl(int const test_idx, bool const use_utp)
 
 	sett.set_str(settings_pack::listen_interfaces, listen_iface);
 
-	lt::session ses2(sett, {});
+	lt::session ses2(session_params{sett, {}});
 
 	wait_for_listen(ses1, "ses1");
 	wait_for_listen(ses2, "ses2");
@@ -566,7 +566,7 @@ void test_malicious_peer()
 	sett.set_bool(settings_pack::enable_upnp, false);
 	sett.set_bool(settings_pack::enable_natpmp, false);
 
-	lt::session ses1(sett, {});
+	lt::session ses1(session_params{sett, {}});
 	wait_for_listen(ses1, "ses1");
 
 	// create torrent


### PR DESCRIPTION
that take session_flags_t in favor of using session_params. move session constructor definitions into the cpp file. convert session from class to struct