### PR TITLE
only trigger default listen sockets if the listen_interfaces setting …

### DIFF
--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -213,6 +213,9 @@ namespace aux {
 			// socket binding succeeds, the listen_succeeded_alert is posted. There
 			// may be multiple failures before a success.
 			//
+			// The empty string is treated as ``0.0.0.0:0,[::]:0`` (i.e. listen on
+			// all interfaces using an OS selected port).
+			//
 			// For example:
 			// ``[::1]:8888`` - will only accept connections on the IPv6 loopback
 			// address on port 8888.

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -531,14 +531,14 @@ TORRENT_TEST(announce_no_listen)
 {
 	// if we don't listen on any sockets at all (but only make outgoing peer
 	// connections) we still need to make sure we announce to trackers
-	test_ipv6_support("", 2, 2);
+	test_ipv6_support("", 2, num_interfaces * 2);
 }
 
 TORRENT_TEST(announce_udp_no_listen)
 {
 	// since there's no actual udp tracker in this test, we will only try to
 	// announce once, and fail. We won't announce the event=stopped
-	test_udpv6_support("", 1, 1);
+	test_udpv6_support("", 1, num_interfaces);
 }
 
 TORRENT_TEST(ipv6_support_bind_v4_v6_any)

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1822,16 +1822,6 @@ namespace aux {
 			expand_unspecified_address(ifs, eps);
 		}
 
-		// if no listen interfaces are specified, create sockets to use
-		// any interface
-		if (eps.empty())
-		{
-			eps.emplace_back(address_v4(), 0, "", transport::plaintext
-				, duplex::only_outgoing);
-			eps.emplace_back(address_v6(), 0, "", transport::plaintext
-				, duplex::only_outgoing);
-		}
-
 		auto remove_iter = partition_listen_sockets(eps, m_listen_sockets);
 
 		while (remove_iter != m_listen_sockets.end())
@@ -5227,7 +5217,16 @@ namespace aux {
 		INVARIANT_CHECK;
 
 		std::string const net_interfaces = m_settings.get_str(settings_pack::listen_interfaces);
-		m_listen_interfaces = parse_listen_interfaces(net_interfaces);
+		if (!net_interfaces.empty())
+		{
+			m_listen_interfaces = parse_listen_interfaces(net_interfaces);
+		}
+		else
+		{
+			// if no listen interfaces are specified, create sockets to use
+			// any interface
+			m_listen_interfaces = parse_listen_interfaces("0.0.0.0:0,[::]:0");
+		}
 
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log())


### PR DESCRIPTION
…is empty

The old code would add default listen sockets when listen_interfces was
non-empty but only contained invalid interface specifications.

In the future it may be possible to support operation with no listen sockets
at all, but this will require additional work since the announce code currently
requires a listen socket to function.