### PR TITLE
add userdata to torrent_alert

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -112,7 +112,7 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT torrent_alert : alert
 	{
 		// internal
-		torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h, void* userdata);
 		torrent_alert(torrent_alert&&) noexcept = default;
 
 #if TORRENT_ABI_VERSION == 1
@@ -127,6 +127,11 @@ TORRENT_VERSION_NAMESPACE_2
 		torrent_handle handle;
 
 		char const* torrent_name() const;
+
+		// User data field from add_torrent_params. May be used for any
+		// purpose including finding client data associated with this
+		// torrent without performing a search
+		void* userdata;
 
 	protected:
 		std::reference_wrapper<aux::stack_allocator const> m_alloc;
@@ -144,7 +149,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		peer_alert(aux::stack_allocator& alloc, torrent_handle const& h,
-			tcp::endpoint const& i, peer_id const& pi);
+			tcp::endpoint const& i, peer_id const& pi, void* userdata);
 		peer_alert(peer_alert&& rhs) noexcept = default;
 
 #if TORRENT_ABI_VERSION == 1
@@ -172,7 +177,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		tracker_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, tcp::endpoint const& ep, string_view u);
+			, tcp::endpoint const& ep, string_view u, void* userdata);
 
 #if TORRENT_ABI_VERSION == 1
 		static const int TORRENT_DEPRECATED_MEMBER alert_type = 2;
@@ -230,7 +235,7 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_DEPRECATED_EXPORT torrent_added_alert final : torrent_alert
 	{
 		// internal
-		torrent_added_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		torrent_added_alert(aux::stack_allocator& alloc, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT(torrent_added_alert, 3)
 		static constexpr alert_category_t static_category = alert::status_notification;
@@ -262,7 +267,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_removed_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h, sha1_hash const& ih);
+			, torrent_handle const& h, sha1_hash const& ih, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_removed_alert, 4, alert_priority_critical)
 		static constexpr alert_category_t static_category = alert::status_notification;
@@ -282,9 +287,9 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		read_piece_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, piece_index_t p, boost::shared_array<char> d, int s);
+			, piece_index_t p, boost::shared_array<char> d, int s, void* userdata);
 		read_piece_alert(aux::stack_allocator& alloc, torrent_handle h
-			, piece_index_t p, error_code e);
+			, piece_index_t p, error_code e, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(read_piece_alert, 5, alert_priority_critical)
 
@@ -307,7 +312,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		file_completed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, file_index_t idx);
+			, file_index_t idx, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(file_completed_alert, 6, alert_priority_normal)
 
@@ -334,7 +339,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		file_renamed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, string_view n, file_index_t idx);
+			, string_view n, file_index_t idx, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(file_renamed_alert, 7, alert_priority_critical)
 
@@ -370,7 +375,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		file_rename_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, file_index_t idx
-			, error_code ec);
+			, error_code ec, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(file_rename_failed_alert, 8, alert_priority_critical)
 
@@ -471,7 +476,7 @@ TORRENT_VERSION_NAMESPACE_2
 
 		// internal
 		performance_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, performance_warning_t w);
+			, performance_warning_t w, void* userdata);
 
 		TORRENT_DEFINE_ALERT(performance_alert, 9)
 
@@ -488,7 +493,8 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		state_changed_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, torrent_status::state_t st
-			, torrent_status::state_t prev_st);
+			, torrent_status::state_t prev_st
+			, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(state_changed_alert, 10, alert_priority_high)
 
@@ -517,7 +523,7 @@ TORRENT_VERSION_NAMESPACE_2
 		tracker_error_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
 			, int times, string_view u
-			, error_code const& e, string_view m);
+			, error_code const& e, string_view m, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(tracker_error_alert, 11, alert_priority_high)
 
@@ -547,7 +553,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		tracker_warning_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
-			, string_view u, string_view m);
+			, string_view u, string_view m, void* userdata);
 
 		TORRENT_DEFINE_ALERT(tracker_warning_alert, 12)
 
@@ -572,7 +578,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		scrape_reply_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
-			, int incomp, int comp, string_view u);
+			, int incomp, int comp, string_view u, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(scrape_reply_alert, 13, alert_priority_critical)
 
@@ -593,10 +599,10 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		scrape_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
-			, string_view u, error_code const& e);
+			, string_view u, error_code const& e, void* userdata);
 		scrape_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
-			, string_view u, string_view m);
+			, string_view u, string_view m, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(scrape_failed_alert, 14, alert_priority_critical)
 
@@ -629,7 +635,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		tracker_reply_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
-			, int np, string_view u);
+			, int np, string_view u, void* userdata);
 
 		TORRENT_DEFINE_ALERT(tracker_reply_alert, 15)
 
@@ -651,7 +657,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		dht_reply_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h
-			, int np);
+			, int np, void* userdata);
 
 		TORRENT_DEFINE_ALERT(dht_reply_alert, 16)
 
@@ -669,7 +675,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		tracker_announce_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
-			, string_view u, int e);
+			, string_view u, int e, void* userdata);
 
 		TORRENT_DEFINE_ALERT(tracker_announce_alert, 17)
 
@@ -691,7 +697,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		hash_failed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, piece_index_t index);
+			, piece_index_t index, void* userdata);
 
 		TORRENT_DEFINE_ALERT(hash_failed_alert, 18)
 
@@ -707,7 +713,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		peer_ban_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep, peer_id const& peer_id);
+			, tcp::endpoint const& ep, peer_id const& peer_id, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_ban_alert, 19)
 
@@ -721,7 +727,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		peer_unsnubbed_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep, peer_id const& peer_id);
+			, tcp::endpoint const& ep, peer_id const& peer_id, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_unsnubbed_alert, 20)
 
@@ -735,7 +741,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		peer_snubbed_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep, peer_id const& peer_id);
+			, tcp::endpoint const& ep, peer_id const& peer_id, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_snubbed_alert, 21)
 
@@ -750,7 +756,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		peer_error_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, tcp::endpoint const& ep, peer_id const& peer_id, operation_t op
-			, error_code const& e);
+			, error_code const& e, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_error_alert, 22)
 
@@ -775,7 +781,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		peer_connect_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep, peer_id const& peer_id, int type);
+			, tcp::endpoint const& ep, peer_id const& peer_id, int type, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_connect_alert, 23)
 
@@ -793,7 +799,7 @@ TORRENT_VERSION_NAMESPACE_2
 		peer_disconnected_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
 			, peer_id const& peer_id, operation_t op, int type, error_code const& e
-			, close_reason_t r);
+			, close_reason_t r, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_disconnected_alert, 24)
 
@@ -828,7 +834,8 @@ TORRENT_VERSION_NAMESPACE_2
 		invalid_request_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, tcp::endpoint const& ep
 			, peer_id const& peer_id, peer_request const& r
-			, bool we_have, bool peer_interested, bool withheld);
+			, bool we_have, bool peer_interested, bool withheld
+			, void* userdata);
 
 		TORRENT_DEFINE_ALERT(invalid_request_alert, 25)
 
@@ -857,7 +864,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_finished_alert(aux::stack_allocator& alloc,
-			torrent_handle h);
+			torrent_handle h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_finished_alert, 26, alert_priority_high)
 
@@ -875,7 +882,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		piece_finished_alert(aux::stack_allocator& alloc,
-			torrent_handle const& h, piece_index_t piece_num);
+			torrent_handle const& h, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(piece_finished_alert, 27)
 
@@ -902,7 +909,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		request_dropped_alert(aux::stack_allocator& alloc, torrent_handle h
 			, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-			, piece_index_t piece_num);
+			, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(request_dropped_alert, 28)
 
@@ -930,7 +937,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		block_timeout_alert(aux::stack_allocator& alloc, torrent_handle h
 			, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-			, piece_index_t piece_num);
+			, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(block_timeout_alert, 29)
 
@@ -958,7 +965,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		block_finished_alert(aux::stack_allocator& alloc, torrent_handle h
 			, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-			, piece_index_t piece_num);
+			, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(block_finished_alert, 30)
 
@@ -984,8 +991,8 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		block_downloading_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep
-			, peer_id const& peer_id, int block_num, piece_index_t piece_num);
+			, tcp::endpoint const& ep, peer_id const& peer_id
+			, int block_num, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(block_downloading_alert, 31)
 
@@ -1015,8 +1022,8 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		unwanted_block_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep
-			, peer_id const& peer_id, int block_num, piece_index_t piece_num);
+			, tcp::endpoint const& ep, peer_id const& peer_id
+			, int block_num, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(unwanted_block_alert, 32)
 
@@ -1036,7 +1043,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		storage_moved_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h, string_view p);
+			, torrent_handle const& h, string_view p, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(storage_moved_alert, 33, alert_priority_critical)
 
@@ -1061,7 +1068,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		storage_moved_failed_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, error_code const& e, string_view file
-			, operation_t op);
+			, operation_t op, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(storage_moved_failed_alert, 34, alert_priority_critical)
 
@@ -1098,7 +1105,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_deleted_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h, sha1_hash const& ih);
+			, torrent_handle const& h, sha1_hash const& ih, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_deleted_alert, 35, alert_priority_critical)
 
@@ -1113,8 +1120,8 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT torrent_delete_failed_alert final : torrent_alert
 	{
 		// internal
-		torrent_delete_failed_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h, error_code const& e, sha1_hash const& ih);
+		torrent_delete_failed_alert(aux::stack_allocator& alloc, torrent_handle const& h
+			, error_code const& e, sha1_hash const& ih, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_delete_failed_alert, 36, alert_priority_critical)
 
@@ -1140,10 +1147,12 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		save_resume_data_alert(aux::stack_allocator& alloc
 			, add_torrent_params&& params
-			, torrent_handle const& h);
+			, torrent_handle const& h
+			, void* userdata);
 		save_resume_data_alert(aux::stack_allocator& alloc
 			, add_torrent_params const& params
-			, torrent_handle const& h) = delete;
+			, torrent_handle const& h
+			, void* userdata) = delete;
 
 		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_alert, 37, alert_priority_critical)
 
@@ -1167,7 +1176,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		save_resume_data_failed_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h, error_code const& e);
+			, torrent_handle const& h, error_code const& e, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(save_resume_data_failed_alert, 38, alert_priority_critical)
 
@@ -1189,7 +1198,7 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT torrent_paused_alert final : torrent_alert
 	{
 		// internal
-		torrent_paused_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		torrent_paused_alert(aux::stack_allocator& alloc, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_paused_alert, 39, alert_priority_high)
 
@@ -1202,7 +1211,7 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT torrent_resumed_alert final : torrent_alert
 	{
 		// internal
-		torrent_resumed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		torrent_resumed_alert(aux::stack_allocator& alloc, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_resumed_alert, 40, alert_priority_high)
 
@@ -1215,7 +1224,7 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT torrent_checked_alert final : torrent_alert
 	{
 		// internal
-		torrent_checked_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		torrent_checked_alert(aux::stack_allocator& alloc, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_checked_alert, 41, alert_priority_high)
 
@@ -1228,9 +1237,9 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		url_seed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, string_view u, error_code const& e);
+			, string_view u, error_code const& e, void* userdata);
 		url_seed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, string_view u, string_view m);
+			, string_view u, string_view m, void* userdata);
 
 		TORRENT_DEFINE_ALERT(url_seed_alert, 42)
 
@@ -1268,7 +1277,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		file_error_alert(aux::stack_allocator& alloc, error_code const& ec
-			, string_view file, operation_t op, torrent_handle const& h);
+			, string_view file, operation_t op, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(file_error_alert, 43, alert_priority_high)
 
@@ -1305,7 +1314,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		metadata_failed_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h, error_code const& ec);
+			, torrent_handle const& h, error_code const& ec, void* userdata);
 
 		TORRENT_DEFINE_ALERT(metadata_failed_alert, 44)
 
@@ -1345,7 +1354,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		metadata_received_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h);
+			, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT(metadata_received_alert, 45)
 
@@ -1676,7 +1685,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		fastresume_rejected_alert(aux::stack_allocator& alloc
 			, torrent_handle const& h, error_code const& ec, string_view file
-			, operation_t op);
+			, operation_t op, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(fastresume_rejected_alert, 53, alert_priority_critical)
 
@@ -1718,7 +1727,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		peer_blocked_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, tcp::endpoint const& ep, int r);
+			, tcp::endpoint const& ep, int r, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_blocked_alert, 54)
 
@@ -1783,7 +1792,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		stats_alert(aux::stack_allocator& alloc, torrent_handle const& h, int interval
-			, stat const& s);
+			, stat const& s, void* userdata);
 
 		TORRENT_DEFINE_ALERT(stats_alert, 57)
 
@@ -1834,7 +1843,7 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT cache_flushed_alert final : torrent_alert
 	{
 		// internal
-		cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(cache_flushed_alert, 58, alert_priority_high)
 
@@ -1861,7 +1870,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		anonymous_mode_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, int k, string_view s);
+			, int k, string_view s, void* userdata);
 
 		TORRENT_DEFINE_ALERT(anonymous_mode_alert, 59)
 
@@ -1896,7 +1905,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		lsd_peer_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, tcp::endpoint const& i);
+			, tcp::endpoint const& i, void* userdata);
 
 		TORRENT_DEFINE_ALERT(lsd_peer_alert, 60)
 
@@ -1911,7 +1920,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		trackerid_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, tcp::endpoint const& ep , string_view u, const std::string& id);
+			, tcp::endpoint const& ep , string_view u, const std::string& id, void* userdata);
 
 		TORRENT_DEFINE_ALERT(trackerid_alert, 61)
 
@@ -1947,7 +1956,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_error_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, error_code const& e, string_view f);
+			, error_code const& e, string_view f, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_error_alert, 64, alert_priority_high)
 
@@ -1978,7 +1987,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_need_cert_alert(aux::stack_allocator& alloc
-			, torrent_handle const& h);
+			, torrent_handle const& h, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_need_cert_alert, 65, alert_priority_critical)
 
@@ -2039,7 +2048,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		add_torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, add_torrent_params const& p, error_code const& ec);
+			, add_torrent_params const& p, error_code const& ec, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(add_torrent_alert, 67, alert_priority_critical)
 
@@ -2186,7 +2195,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_update_alert(aux::stack_allocator& alloc, torrent_handle h
-			, sha1_hash const& old_hash, sha1_hash const& new_hash);
+			, sha1_hash const& old_hash, sha1_hash const& new_hash, void* userdata);
 
 		TORRENT_DEFINE_ALERT_PRIO(torrent_update_alert, 71, alert_priority_critical)
 
@@ -2413,7 +2422,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		torrent_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
-			, char const* fmt, va_list v);
+			, char const* fmt, va_list v, void* userdata);
 
 		TORRENT_DEFINE_ALERT(torrent_log_alert, 80)
 
@@ -2454,7 +2463,8 @@ TORRENT_VERSION_NAMESPACE_2
 		peer_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, tcp::endpoint const& i, peer_id const& pi
 			, peer_log_alert::direction_t dir
-			, char const* event, char const* fmt, va_list v);
+			, char const* event, char const* fmt, va_list v
+			, void* userdata);
 
 		TORRENT_DEFINE_ALERT(peer_log_alert, 81)
 
@@ -2574,7 +2584,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		incoming_request_alert(aux::stack_allocator& alloc
 			, peer_request r, torrent_handle h
-			, tcp::endpoint const& ep, peer_id const& peer_id);
+			, tcp::endpoint const& ep, peer_id const& peer_id, void* userdata);
 
 		static constexpr alert_category_t static_category = alert::incoming_request_notification;
 		TORRENT_DEFINE_ALERT(incoming_request_alert, 84)
@@ -2733,7 +2743,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		picker_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
 			, tcp::endpoint const& ep, peer_id const& peer_id, picker_flags_t flags
-			, span<piece_block const> blocks);
+			, span<piece_block const> blocks, void* userdata);
 
 		TORRENT_DEFINE_ALERT(picker_log_alert, 89)
 
@@ -2902,7 +2912,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// internal
 		block_uploaded_alert(aux::stack_allocator& alloc, torrent_handle h
 			, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-			, piece_index_t piece_num);
+			, piece_index_t piece_num, void* userdata);
 
 		TORRENT_DEFINE_ALERT(block_uploaded_alert, 94)
 

--- a/include/libtorrent/aux_/torrent_impl.hpp
+++ b/include/libtorrent/aux_/torrent_impl.hpp
@@ -55,21 +55,21 @@ namespace libtorrent {
 			, e.what());
 #endif
 		alerts().emplace_alert<torrent_error_alert>(get_handle()
-			, e.code(), e.what());
+			, e.code(), e.what(), m_userdata);
 		pause();
 	} catch (std::exception const& e) {
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("EXCEPTION: %s", e.what());
 #endif
 		alerts().emplace_alert<torrent_error_alert>(get_handle()
-			, error_code(), e.what());
+			, error_code(), e.what(), m_userdata);
 		pause();
 	} catch (...) {
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("EXCEPTION: unknown");
 #endif
 		alerts().emplace_alert<torrent_error_alert>(get_handle()
-			, error_code(), "unknown error");
+			, error_code(), "unknown error", m_userdata);
 		pause();
 	}
 #endif

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1161,6 +1161,8 @@ namespace libtorrent {
 
 		static constexpr int no_gauge_state = 0xf;
 
+		void* get_userdata() const { return m_userdata; }
+
 	private:
 
 		void on_exception(std::exception const& e) override;
@@ -1726,6 +1728,9 @@ namespace libtorrent {
 		// mutate the list while doing this
 		mutable int m_iterating_connections = 0;
 #endif
+
+		// userdata from add_torrent_params
+		void* m_userdata;	
 	};
 }
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -92,8 +92,10 @@ namespace libtorrent {
 	time_point alert::timestamp() const { return m_timestamp; }
 
 	torrent_alert::torrent_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
+		, torrent_handle const& h
+		, void* userdata)
 		: handle(h)
+		, userdata(userdata)
 		, m_alloc(alloc)
 	{
 		std::shared_ptr<torrent> t = h.native_handle();
@@ -133,8 +135,9 @@ namespace libtorrent {
 	peer_alert::peer_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
 		, tcp::endpoint const& i
-		, peer_id const& pi)
-		: torrent_alert(alloc, h)
+		, peer_id const& pi
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, endpoint(i)
 		, pid(pi)
 #if TORRENT_ABI_VERSION == 1
@@ -149,8 +152,8 @@ namespace libtorrent {
 	}
 
 	tracker_alert::tracker_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, tcp::endpoint const& ep, string_view u)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, tcp::endpoint const& ep, string_view u, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, local_endpoint(ep)
 		, m_url_idx(alloc.copy_string(u))
 #if TORRENT_ABI_VERSION == 1
@@ -171,16 +174,16 @@ namespace libtorrent {
 
 	read_piece_alert::read_piece_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
-		, piece_index_t p, boost::shared_array<char> d, int s)
-		: torrent_alert(alloc, h)
+		, piece_index_t p, boost::shared_array<char> d, int s, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, buffer(std::move(d))
 		, piece(p)
 		, size(s)
 	{}
 
 	read_piece_alert::read_piece_alert(aux::stack_allocator& alloc
-		, torrent_handle h, piece_index_t p, error_code e)
-		: torrent_alert(alloc, h)
+		, torrent_handle h, piece_index_t p, error_code e, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 		, piece(p)
 		, size(0)
@@ -208,8 +211,9 @@ namespace libtorrent {
 
 	file_completed_alert::file_completed_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
-		, file_index_t idx)
-		: torrent_alert(alloc, h)
+		, file_index_t idx
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, index(idx)
 	{}
 
@@ -224,8 +228,8 @@ namespace libtorrent {
 	}
 
 	file_renamed_alert::file_renamed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, string_view n, file_index_t const idx)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, string_view n, file_index_t const idx, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, index(idx)
 		, m_name_idx(alloc.copy_string(n))
 #if TORRENT_ABI_VERSION == 1
@@ -252,8 +256,9 @@ namespace libtorrent {
 	file_rename_failed_alert::file_rename_failed_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
 		, file_index_t const idx
-		, error_code ec)
-		: torrent_alert(alloc, h)
+		, error_code ec
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, index(idx)
 		, error(ec)
 	{}
@@ -271,8 +276,9 @@ namespace libtorrent {
 
 	performance_alert::performance_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
-		, performance_warning_t w)
-		: torrent_alert(alloc, h)
+		, performance_warning_t w
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, warning_code(w)
 	{}
 
@@ -300,8 +306,9 @@ namespace libtorrent {
 	state_changed_alert::state_changed_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
 		, torrent_status::state_t st
-		, torrent_status::state_t prev_st)
-		: torrent_alert(alloc, h)
+		, torrent_status::state_t prev_st
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, state(st)
 		, prev_state(prev_st)
 	{}
@@ -319,8 +326,8 @@ namespace libtorrent {
 
 	tracker_error_alert::tracker_error_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep, int times
-		, string_view u, error_code const& e, string_view m)
-		: tracker_alert(alloc, h, ep, u)
+		, string_view u, error_code const& e, string_view m, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, times_in_row(times)
 		, error(e)
 		, m_msg_idx(alloc.copy_string(m))
@@ -349,8 +356,8 @@ namespace libtorrent {
 
 	tracker_warning_alert::tracker_warning_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
-		, string_view u, string_view m)
-		: tracker_alert(alloc, h, ep, u)
+		, string_view u, string_view m, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, m_msg_idx(alloc.copy_string(m))
 #if TORRENT_ABI_VERSION == 1
 		, msg(m)
@@ -371,8 +378,8 @@ namespace libtorrent {
 
 	scrape_reply_alert::scrape_reply_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
-		, int incomp, int comp, string_view u)
-		: tracker_alert(alloc, h, ep, u)
+		, int incomp, int comp, string_view u, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, incomplete(incomp)
 		, complete(comp)
 	{
@@ -389,8 +396,8 @@ namespace libtorrent {
 
 	scrape_failed_alert::scrape_failed_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
-		, string_view u, error_code const& e)
-		: tracker_alert(alloc, h, ep, u)
+		, string_view u, error_code const& e, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, error(e)
 		, m_msg_idx()
 #if TORRENT_ABI_VERSION == 1
@@ -402,8 +409,8 @@ namespace libtorrent {
 
 	scrape_failed_alert::scrape_failed_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
-		, string_view u, string_view m)
-		: tracker_alert(alloc, h, ep, u)
+		, string_view u, string_view m, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, error(errors::tracker_failure)
 		, m_msg_idx(alloc.copy_string(m))
 #if TORRENT_ABI_VERSION == 1
@@ -426,8 +433,8 @@ namespace libtorrent {
 
 	tracker_reply_alert::tracker_reply_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
-		, int np, string_view u)
-		: tracker_alert(alloc, h, ep, u)
+		, int np, string_view u, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, num_peers(np)
 	{
 		TORRENT_ASSERT(!u.empty());
@@ -443,8 +450,8 @@ namespace libtorrent {
 
 	dht_reply_alert::dht_reply_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h
-		, int np)
-		: tracker_alert(alloc, h, {}, "")
+		, int np, void* userdata)
+		: tracker_alert(alloc, h, {}, "", userdata)
 		, num_peers(np)
 	{}
 
@@ -457,8 +464,8 @@ namespace libtorrent {
 	}
 
 	tracker_announce_alert::tracker_announce_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, tcp::endpoint const& ep, string_view u, int e)
-		: tracker_alert(alloc, h, ep, u)
+		, torrent_handle const& h, tcp::endpoint const& ep, string_view u, int e, void* userdata)
+		: tracker_alert(alloc, h, ep, u, userdata)
 		, event(e)
 	{
 		TORRENT_ASSERT(!u.empty());
@@ -474,8 +481,9 @@ namespace libtorrent {
 	hash_failed_alert::hash_failed_alert(
 		aux::stack_allocator& alloc
 		, torrent_handle const& h
-		, piece_index_t index)
-		: torrent_alert(alloc, h)
+		, piece_index_t index
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, piece_index(index)
 	{
 		TORRENT_ASSERT(index >= piece_index_t(0));
@@ -491,8 +499,8 @@ namespace libtorrent {
 
 	peer_ban_alert::peer_ban_alert(aux::stack_allocator& alloc
 		, torrent_handle h, tcp::endpoint const& ep
-		, peer_id const& peer_id)
-		: peer_alert(alloc, h, ep, peer_id)
+		, peer_id const& peer_id, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 	{}
 
 	std::string peer_ban_alert::message() const
@@ -502,8 +510,8 @@ namespace libtorrent {
 
 	peer_unsnubbed_alert::peer_unsnubbed_alert(aux::stack_allocator& alloc
 		, torrent_handle h, tcp::endpoint const& ep
-		, peer_id const& peer_id)
-		: peer_alert(alloc, h, ep, peer_id)
+		, peer_id const& peer_id, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 	{}
 
 	std::string peer_unsnubbed_alert::message() const
@@ -513,8 +521,8 @@ namespace libtorrent {
 
 	peer_snubbed_alert::peer_snubbed_alert(aux::stack_allocator& alloc
 		, torrent_handle h, tcp::endpoint const& ep
-		, peer_id const& peer_id)
-		: peer_alert(alloc, h, ep, peer_id)
+		, peer_id const& peer_id, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 	{}
 
 	std::string peer_snubbed_alert::message() const
@@ -525,8 +533,8 @@ namespace libtorrent {
 	invalid_request_alert::invalid_request_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
 		, peer_id const& peer_id, peer_request const& r
-		, bool _have, bool _peer_interested, bool _withheld)
-		: peer_alert(alloc, h, ep, peer_id)
+		, bool _have, bool _peer_interested, bool _withheld, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, request(r)
 		, we_have(_have)
 		, peer_interested(_peer_interested)
@@ -550,8 +558,8 @@ namespace libtorrent {
 	}
 
 	torrent_finished_alert::torrent_finished_alert(aux::stack_allocator& alloc
-		, torrent_handle h)
-		: torrent_alert(alloc, h)
+		, torrent_handle h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string torrent_finished_alert::message() const
@@ -560,8 +568,8 @@ namespace libtorrent {
 	}
 
 	piece_finished_alert::piece_finished_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, piece_index_t piece_num)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, piece_index_t piece_num, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, piece_index(piece_num)
 	{}
 
@@ -575,8 +583,8 @@ namespace libtorrent {
 
 	request_dropped_alert::request_dropped_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-		, piece_index_t piece_num)
-		: peer_alert(alloc, h, ep, peer_id)
+		, piece_index_t piece_num, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, block_index(block_num)
 		, piece_index(piece_num)
 	{
@@ -593,8 +601,8 @@ namespace libtorrent {
 
 	block_timeout_alert::block_timeout_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-		, piece_index_t piece_num)
-		: peer_alert(alloc, h, ep, peer_id)
+		, piece_index_t piece_num, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, block_index(block_num)
 		, piece_index(piece_num)
 	{
@@ -611,8 +619,8 @@ namespace libtorrent {
 
 	block_finished_alert::block_finished_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-		, piece_index_t piece_num)
-		: peer_alert(alloc, h, ep, peer_id)
+		, piece_index_t piece_num, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, block_index(block_num)
 		, piece_index(piece_num)
 	{
@@ -629,8 +637,8 @@ namespace libtorrent {
 
 	block_downloading_alert::block_downloading_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep
-		, peer_id const& peer_id, int block_num, piece_index_t piece_num)
-		: peer_alert(alloc, h, ep, peer_id)
+		, peer_id const& peer_id, int block_num, piece_index_t piece_num, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, block_index(block_num)
 		, piece_index(piece_num)
 #if TORRENT_ABI_VERSION == 1
@@ -650,8 +658,8 @@ namespace libtorrent {
 
 	unwanted_block_alert::unwanted_block_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep
-		, peer_id const& peer_id, int block_num, piece_index_t piece_num)
-		: peer_alert(alloc, h, ep, peer_id)
+		, peer_id const& peer_id, int block_num, piece_index_t piece_num, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, block_index(block_num)
 		, piece_index(piece_num)
 	{
@@ -667,8 +675,8 @@ namespace libtorrent {
 	}
 
 	storage_moved_alert::storage_moved_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, string_view p)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, string_view p, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, m_path_idx(alloc.copy_string(p))
 #if TORRENT_ABI_VERSION == 1
 		, path(p)
@@ -688,8 +696,8 @@ namespace libtorrent {
 
 	storage_moved_failed_alert::storage_moved_failed_alert(
 		aux::stack_allocator& alloc, torrent_handle const& h, error_code const& e
-		, string_view f, operation_t const op_)
-		: torrent_alert(alloc, h)
+		, string_view f, operation_t const op_, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 		, op(op_)
 		, m_file_idx(alloc.copy_string(f))
@@ -712,8 +720,8 @@ namespace libtorrent {
 	}
 
 	torrent_deleted_alert::torrent_deleted_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, sha1_hash const& ih)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, sha1_hash const& ih, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, info_hash(ih)
 	{}
 
@@ -723,8 +731,8 @@ namespace libtorrent {
 	}
 
 	torrent_delete_failed_alert::torrent_delete_failed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, error_code const& e, sha1_hash const& ih)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, error_code const& e, sha1_hash const& ih, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 		, info_hash(ih)
 #if TORRENT_ABI_VERSION == 1
@@ -741,8 +749,9 @@ namespace libtorrent {
 
 	save_resume_data_alert::save_resume_data_alert(aux::stack_allocator& alloc
 		, add_torrent_params&& p
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, params(std::move(p))
 #if TORRENT_ABI_VERSION == 1
 		, resume_data(std::make_shared<entry>(write_resume_data(params)))
@@ -756,8 +765,8 @@ namespace libtorrent {
 	}
 
 	save_resume_data_failed_alert::save_resume_data_failed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, error_code const& e)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, error_code const& e, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 #if TORRENT_ABI_VERSION == 1
 		, msg(convert_from_native(error.message()))
@@ -772,8 +781,8 @@ namespace libtorrent {
 	}
 
 	torrent_paused_alert::torrent_paused_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string torrent_paused_alert::message() const
@@ -782,8 +791,8 @@ namespace libtorrent {
 	}
 
 	torrent_resumed_alert::torrent_resumed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string torrent_resumed_alert::message() const
@@ -792,8 +801,8 @@ namespace libtorrent {
 	}
 
 	torrent_checked_alert::torrent_checked_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string torrent_checked_alert::message() const
@@ -996,8 +1005,8 @@ namespace {
 	}
 
 	metadata_failed_alert::metadata_failed_alert(aux::stack_allocator& alloc
-		, const torrent_handle& h, error_code const& e)
-		: torrent_alert(alloc, h)
+		, const torrent_handle& h, error_code const& e, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 	{}
 
@@ -1007,8 +1016,8 @@ namespace {
 	}
 
 	metadata_received_alert::metadata_received_alert(aux::stack_allocator& alloc
-		, const torrent_handle& h)
-		: torrent_alert(alloc, h)
+		, const torrent_handle& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string metadata_received_alert::message() const
@@ -1155,8 +1164,9 @@ namespace {
 		, torrent_handle const& h
 		, error_code const& ec
 		, string_view f
-		, operation_t const op_)
-		: torrent_alert(alloc, h)
+		, operation_t const op_
+		, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(ec)
 		, op(op_)
 		, m_path_idx(alloc.copy_string(f))
@@ -1181,8 +1191,8 @@ namespace {
 	}
 
 	peer_blocked_alert::peer_blocked_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, tcp::endpoint const& ep, int r)
-		: peer_alert(alloc, h, ep, peer_id(nullptr))
+		, torrent_handle const& h, tcp::endpoint const& ep, int r, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id(nullptr), userdata)
 		, reason(r)
 	{}
 
@@ -1263,8 +1273,8 @@ namespace {
 	}
 
 	stats_alert::stats_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, int in, stat const& s)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, int in, stat const& s, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, transferred(stat_to_array(s))
 		, interval(in)
 	{}
@@ -1295,13 +1305,13 @@ namespace {
 	}
 
 	cache_flushed_alert::cache_flushed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h) {}
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata) {}
 
 #if TORRENT_ABI_VERSION == 1
 	anonymous_mode_alert::anonymous_mode_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, int k, string_view s)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, int k, string_view s, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, kind(k)
 		, str(s)
 	{}
@@ -1320,8 +1330,8 @@ namespace {
 #endif // TORRENT_ABI_VERSION
 
 	lsd_peer_alert::lsd_peer_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, tcp::endpoint const& i)
-		: peer_alert(alloc, h, i, peer_id(nullptr))
+		, tcp::endpoint const& i, void* userdata)
+		: peer_alert(alloc, h, i, peer_id(nullptr), userdata)
 	{}
 
 	std::string lsd_peer_alert::message() const
@@ -1337,8 +1347,9 @@ namespace {
 		, torrent_handle const& h
 		, tcp::endpoint const& ep
 		, string_view u
-		, const std::string& id)
-		: tracker_alert(alloc, h,  ep, u)
+		, const std::string& id
+		, void* userdata)
+		: tracker_alert(alloc, h,  ep, u, userdata)
 		, m_tracker_idx(alloc.copy_string(id))
 #if TORRENT_ABI_VERSION == 1
 		, trackerid(id)
@@ -1366,8 +1377,8 @@ namespace {
 	torrent_error_alert::torrent_error_alert(
 		aux::stack_allocator& alloc
 		, torrent_handle const& h
-		, error_code const& e, string_view f)
-		: torrent_alert(alloc, h)
+		, error_code const& e, string_view f, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 		, m_file_idx(alloc.copy_string(f))
 #if TORRENT_ABI_VERSION == 1
@@ -1398,8 +1409,8 @@ namespace {
 
 #if TORRENT_ABI_VERSION == 1
 	torrent_added_alert::torrent_added_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string torrent_added_alert::message() const
@@ -1409,8 +1420,8 @@ namespace {
 #endif
 
 	torrent_removed_alert::torrent_removed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h, sha1_hash const& ih)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, sha1_hash const& ih, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, info_hash(ih)
 	{}
 
@@ -1420,8 +1431,8 @@ namespace {
 	}
 
 	torrent_need_cert_alert::torrent_need_cert_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 	{}
 
 	std::string torrent_need_cert_alert::message() const
@@ -1447,8 +1458,8 @@ namespace {
 	}
 
 	peer_connect_alert::peer_connect_alert(aux::stack_allocator& alloc, torrent_handle h
-		, tcp::endpoint const& ep, peer_id const& peer_id, int type)
-		: peer_alert(alloc, h, ep, peer_id)
+		, tcp::endpoint const& ep, peer_id const& peer_id, int type, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, socket_type(type)
 	{}
 
@@ -1461,8 +1472,8 @@ namespace {
 	}
 
 	add_torrent_alert::add_torrent_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, add_torrent_params const& p, error_code const& ec)
-		: torrent_alert(alloc, h)
+		, add_torrent_params const& p, error_code const& ec, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, params(p)
 		, error(ec)
 	{}
@@ -1579,8 +1590,8 @@ namespace {
 
 	peer_error_alert::peer_error_alert(aux::stack_allocator& alloc, torrent_handle const& h
 		, tcp::endpoint const& ep, peer_id const& peer_id, operation_t const op_
-		, error_code const& e)
-		: peer_alert(alloc, h, ep, peer_id)
+		, error_code const& e, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, op(op_)
 		, error(e)
 #if TORRENT_ABI_VERSION == 1
@@ -1601,8 +1612,8 @@ namespace {
 
 #if TORRENT_ABI_VERSION == 1
 	torrent_update_alert::torrent_update_alert(aux::stack_allocator& alloc, torrent_handle h
-		, sha1_hash const& old_hash, sha1_hash const& new_hash)
-		: torrent_alert(alloc, h)
+		, sha1_hash const& old_hash, sha1_hash const& new_hash, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, old_ih(old_hash)
 		, new_ih(new_hash)
 	{}
@@ -1620,8 +1631,8 @@ namespace {
 	peer_disconnected_alert::peer_disconnected_alert(aux::stack_allocator& alloc
 		, torrent_handle const& h, tcp::endpoint const& ep
 		, peer_id const& peer_id, operation_t op_, int type, error_code const& e
-		, close_reason_t r)
-		: peer_alert(alloc, h, ep, peer_id)
+		, close_reason_t r, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, socket_type(type)
 		, op(op_)
 		, error(e)
@@ -1813,8 +1824,8 @@ namespace {
 	}
 
 	torrent_log_alert::torrent_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, char const* fmt, va_list v)
-		: torrent_alert(alloc, h)
+		, char const* fmt, va_list v, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, m_str_idx(alloc.format_string(fmt, v))
 	{}
 
@@ -1839,8 +1850,9 @@ namespace {
 		, torrent_handle const& h
 		, tcp::endpoint const& i, peer_id const& pi
 		, peer_log_alert::direction_t dir
-		, char const* event, char const* fmt, va_list v)
-		: peer_alert(alloc, h, i, pi)
+		, char const* event, char const* fmt, va_list v
+		, void* userdata)
+		: peer_alert(alloc, h, i, pi, userdata)
 		, event_type(event)
 		, direction(dir)
 		, m_str_idx(alloc.format_string(fmt, v))
@@ -1960,8 +1972,8 @@ namespace {
 	}
 
 	url_seed_alert::url_seed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, string_view u, error_code const& e)
-		: torrent_alert(alloc, h)
+		, string_view u, error_code const& e, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(e)
 		, m_url_idx(alloc.copy_string(u))
 		, m_msg_idx()
@@ -1972,8 +1984,8 @@ namespace {
 	{}
 
 	url_seed_alert::url_seed_alert(aux::stack_allocator& alloc, torrent_handle const& h
-		, string_view u, string_view m)
-		: torrent_alert(alloc, h)
+		, string_view u, string_view m, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, m_url_idx(alloc.copy_string(u))
 		, m_msg_idx(alloc.copy_string(m))
 #if TORRENT_ABI_VERSION == 1
@@ -2001,8 +2013,8 @@ namespace {
 
 	file_error_alert::file_error_alert(aux::stack_allocator& alloc
 		, error_code const& ec, string_view f, operation_t const op_
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h)
+		, torrent_handle const& h, void* userdata)
+		: torrent_alert(alloc, h, userdata)
 		, error(ec)
 		, op(op_)
 		, m_file_idx(alloc.copy_string(f))
@@ -2027,8 +2039,8 @@ namespace {
 
 	incoming_request_alert::incoming_request_alert(aux::stack_allocator& alloc
 		, peer_request r, torrent_handle h
-		, tcp::endpoint const& ep, peer_id const& peer_id)
-		: peer_alert(alloc, h, ep, peer_id)
+		, tcp::endpoint const& ep, peer_id const& peer_id, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, req(r)
 	{}
 
@@ -2221,8 +2233,8 @@ namespace {
 
 	picker_log_alert::picker_log_alert(aux::stack_allocator& alloc, torrent_handle const& h
 		, tcp::endpoint const& ep, peer_id const& peer_id, picker_flags_t const flags
-		, span<piece_block const> blocks)
-		: peer_alert(alloc, h, ep, peer_id)
+		, span<piece_block const> blocks, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, picker_flags(flags)
 		, m_array_idx(alloc.copy_buffer({reinterpret_cast<char const*>(blocks.data())
 			, blocks.size() * int(sizeof(piece_block))}))
@@ -2512,8 +2524,8 @@ namespace {
 
 	block_uploaded_alert::block_uploaded_alert(aux::stack_allocator& alloc, torrent_handle h
 		, tcp::endpoint const& ep, peer_id const& peer_id, int block_num
-		, piece_index_t piece_num)
-		: peer_alert(alloc, h, ep, peer_id)
+		, piece_index_t piece_num, void* userdata)
+		: peer_alert(alloc, h, ep, peer_id, userdata)
 		, block_index(block_num)
 		, piece_index(piece_num)
 	{

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2342,7 +2342,7 @@ namespace {
 		if (t->alerts().should_post<block_uploaded_alert>())
 		{
 			t->alerts().emplace_alert<block_uploaded_alert>(t->get_handle(),
-				remote(), pid(), r.start / t->block_size() , r.piece);
+				remote(), pid(), r.start / t->block_size() , r.piece, t->get_userdata());
 		}
 	}
 

--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -284,7 +284,7 @@ namespace libtorrent {
 						std::string const error_msg = to_string(m_parser.status_code()).data()
 							+ (" " + m_parser.message());
 						t->alerts().emplace_alert<url_seed_alert>(t->get_handle(), url()
-							, error_msg);
+							, error_msg, t->get_userdata());
 					}
 					received_bytes(0, int(bytes_transferred));
 					disconnect(error_code(m_parser.status_code(), http_category()), operation_t::bittorrent, failure);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -470,7 +470,7 @@ namespace libtorrent {
 		if (t && t->alerts().should_post<peer_connect_alert>())
 		{
 			t->alerts().emplace_alert<peer_connect_alert>(
-				t->get_handle(), remote(), pid(), m_socket->type());
+				t->get_handle(), remote(), pid(), m_socket->type(), t->get_userdata());
 		}
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log(peer_log_alert::info))
@@ -588,7 +588,7 @@ namespace libtorrent {
 		if (t) h = t->get_handle();
 
 		m_ses.alerts().emplace_alert<peer_log_alert>(
-			h, m_remote, m_peer_id, direction, event, fmt, v);
+			h, m_remote, m_peer_id, direction, event, fmt, v, t->get_userdata());
 
 		va_end(v);
 
@@ -2339,7 +2339,7 @@ namespace libtorrent {
 				bool const peer_interested = bool(m_peer_interested);
 				t->alerts().emplace_alert<invalid_request_alert>(
 					t->get_handle(), m_remote, m_peer_id, r
-					, t->has_piece_passed(r.piece), peer_interested, true);
+					, t->has_piece_passed(r.piece), peer_interested, true, t->get_userdata());
 			}
 			return;
 		}
@@ -2412,7 +2412,7 @@ namespace libtorrent {
 				t->alerts().emplace_alert<invalid_request_alert>(
 					t->get_handle(), m_remote, m_peer_id, r
 					, t->has_piece_passed(r.piece)
-					, false, false);
+					, false, false, t->get_userdata());
 			}
 
 			// be lenient and pretend that the peer said it was interested
@@ -2463,7 +2463,7 @@ namespace libtorrent {
 				bool const peer_interested = bool(m_peer_interested);
 				t->alerts().emplace_alert<invalid_request_alert>(
 					t->get_handle(), m_remote, m_peer_id, r
-					, t->has_piece_passed(r.piece), peer_interested, false);
+					, t->has_piece_passed(r.piece), peer_interested, false, t->get_userdata());
 			}
 
 			// every ten invalid request, remind the peer that it's choked
@@ -2539,7 +2539,7 @@ namespace libtorrent {
 			if (t->alerts().should_post<incoming_request_alert>())
 			{
 				t->alerts().emplace_alert<incoming_request_alert>(r, t->get_handle()
-					, m_remote, m_peer_id);
+					, m_remote, m_peer_id, t->get_userdata());
 			}
 
 			m_last_incoming_request = aux::time_now();
@@ -2645,7 +2645,7 @@ namespace libtorrent {
 				if (t->alerts().should_post<unwanted_block_alert>())
 				{
 					t->alerts().emplace_alert<unwanted_block_alert>(t->get_handle()
-						, m_remote, m_peer_id, b.block_index, b.piece_index);
+						, m_remote, m_peer_id, b.block_index, b.piece_index, t->get_userdata());
 				}
 #ifndef TORRENT_DISABLE_LOGGING
 				peer_log(peer_log_alert::info, "INVALID_REQUEST"
@@ -2760,7 +2760,7 @@ namespace libtorrent {
 			if (t->alerts().should_post<peer_error_alert>())
 			{
 				t->alerts().emplace_alert<peer_error_alert>(t->get_handle(), m_remote
-					, m_peer_id, operation_t::bittorrent, errors::peer_sent_empty_piece);
+					, m_peer_id, operation_t::bittorrent, errors::peer_sent_empty_piece, t->get_userdata());
 			}
 			// This is used as a reject-request by bitcomet
 			incoming_reject_request(p);
@@ -2803,7 +2803,7 @@ namespace libtorrent {
 			{
 				t->alerts().emplace_alert<unwanted_block_alert>(t->get_handle()
 					, m_remote, m_peer_id, block_finished.block_index
-					, block_finished.piece_index);
+					, block_finished.piece_index, t->get_userdata());
 			}
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, "INVALID_REQUEST", "The block we just got was not in the request queue");
@@ -2878,7 +2878,7 @@ namespace libtorrent {
 			if (t->alerts().should_post<peer_unsnubbed_alert>())
 			{
 				t->alerts().emplace_alert<peer_unsnubbed_alert>(t->get_handle()
-					, m_remote, m_peer_id);
+					, m_remote, m_peer_id, t->get_userdata());
 			}
 		}
 
@@ -2925,7 +2925,7 @@ namespace libtorrent {
 			&& t->alerts().should_post<performance_alert>())
 		{
 			t->alerts().emplace_alert<performance_alert>(t->get_handle()
-				, performance_alert::too_high_disk_queue_limit);
+				, performance_alert::too_high_disk_queue_limit, t->get_userdata());
 		}
 
 		m_request_time.add_sample(int(total_milliseconds(now - m_requested)));
@@ -3140,7 +3140,7 @@ namespace libtorrent {
 		{
 			t->alerts().emplace_alert<block_finished_alert>(t->get_handle(),
 				remote(), pid(), block_finished.block_index
-				, block_finished.piece_index);
+				, block_finished.piece_index, t->get_userdata());
 		}
 
 		disconnect_if_redundant();
@@ -3559,7 +3559,7 @@ namespace libtorrent {
 		if (t->alerts().should_post<block_downloading_alert>())
 		{
 			t->alerts().emplace_alert<block_downloading_alert>(t->get_handle()
-				, remote(), pid(), block.block_index, block.piece_index);
+				, remote(), pid(), block.block_index, block.piece_index, t->get_userdata());
 		}
 
 		pending_block pb(block);
@@ -4336,7 +4336,7 @@ namespace libtorrent {
 		{
 			if (t->alerts().should_post<performance_alert>())
 				t->alerts().emplace_alert<performance_alert>(
-					handle, performance_alert::too_few_outgoing_ports);
+					handle, performance_alert::too_few_outgoing_ports, t->get_userdata());
 		}
 
 		m_disconnecting = true;
@@ -4349,13 +4349,13 @@ namespace libtorrent {
 					&& t->alerts().should_post<peer_error_alert>())
 				{
 					t->alerts().emplace_alert<peer_error_alert>(handle, remote()
-						, pid(), op, ec);
+						, pid(), op, ec, t->get_userdata());
 				}
 
 				if (error <= failure && t->alerts().should_post<peer_disconnected_alert>())
 				{
 					t->alerts().emplace_alert<peer_disconnected_alert>(handle
-						, remote(), pid(), op, m_socket->type(), ec, close_reason);
+						, remote(), pid(), op, m_socket->type(), ec, close_reason, t->get_userdata());
 				}
 			}
 
@@ -4741,7 +4741,8 @@ namespace libtorrent {
 				t->alerts().emplace_alert<performance_alert>(t->get_handle()
 					, channel == peer_connection::download_channel
 					? performance_alert::download_limit_too_low
-					: performance_alert::upload_limit_too_low);
+					: performance_alert::upload_limit_too_low
+					, t->get_userdata());
 			}
 		}
 
@@ -4979,7 +4980,7 @@ namespace libtorrent {
 			&& t->alerts().should_post<performance_alert>())
 		{
 			t->alerts().emplace_alert<performance_alert>(t->get_handle()
-				, performance_alert::outstanding_request_limit_reached);
+				, performance_alert::outstanding_request_limit_reached, t->get_userdata());
 		}
 
 		int const piece_timeout = m_settings.get_int(settings_pack::piece_timeout);
@@ -5023,7 +5024,7 @@ namespace libtorrent {
 			if (t->alerts().should_post<peer_snubbed_alert>())
 			{
 				t->alerts().emplace_alert<peer_snubbed_alert>(t->get_handle()
-					, m_remote, m_peer_id);
+					, m_remote, m_peer_id, t->get_userdata());
 			}
 		}
 		m_desired_queue_size = 1;
@@ -5080,7 +5081,7 @@ namespace libtorrent {
 			{
 				t->alerts().emplace_alert<block_timeout_alert>(t->get_handle()
 					, remote(), pid(), qe.block.block_index
-					, qe.block.piece_index);
+					, qe.block.piece_index, t->get_userdata());
 			}
 
 			// request a new block before removing the previous
@@ -5339,7 +5340,7 @@ namespace libtorrent {
 			if (t->alerts().should_post<file_error_alert>())
 				t->alerts().emplace_alert<file_error_alert>(error.ec
 					, t->resolve_filename(error.file())
-					, error.operation, t->get_handle());
+					, error.operation, t->get_handle(), t->get_userdata());
 
 			++m_disk_read_failures;
 			if (m_disk_read_failures > 100) disconnect(error.ec, operation_t::file_read);
@@ -5595,7 +5596,7 @@ namespace libtorrent {
 				if (t && t->alerts().should_post<performance_alert>())
 				{
 					t->alerts().emplace_alert<performance_alert>(t->get_handle()
-						, performance_alert::send_buffer_watermark_too_low);
+						, performance_alert::send_buffer_watermark_too_low, t->get_userdata());
 				}
 			}
 		}

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -588,7 +588,7 @@ namespace libtorrent {
 		if (t) h = t->get_handle();
 
 		m_ses.alerts().emplace_alert<peer_log_alert>(
-			h, m_remote, m_peer_id, direction, event, fmt, v, t->get_userdata());
+			h, m_remote, m_peer_id, direction, event, fmt, v, t ? t->get_userdata() : nullptr);
 
 		va_end(v);
 

--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -187,7 +187,7 @@ namespace libtorrent {
 			&& !interesting_pieces.empty())
 		{
 			t.alerts().emplace_alert<picker_log_alert>(t.get_handle(), c.remote()
-				, c.pid(), flags, interesting_pieces);
+				, c.pid(), flags, interesting_pieces, t.get_userdata());
 		}
 		c.peer_log(peer_log_alert::info, "PIECE_PICKER"
 			, "prefer_contiguous: %d picked: %d"

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2214,7 +2214,7 @@ namespace aux {
 		if (ec)
 		{
 			if (m_alerts.should_post<i2p_alert>())
-				m_alerts.emplace_alert<i2p_alert>(ec);
+				m_alerts.emplace_alert<i2p_alert>(ec, nullptr);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			if (should_log())

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2609,7 +2609,7 @@ namespace aux {
 
 					if (m_alerts.should_post<performance_alert>())
 						m_alerts.emplace_alert<performance_alert>(
-							torrent_handle(), performance_alert::too_few_file_descriptors);
+							torrent_handle(), performance_alert::too_few_file_descriptors, nullptr);
 
 					if (i != m_torrents.end())
 					{
@@ -2707,7 +2707,7 @@ namespace aux {
 			if (m_alerts.should_post<peer_error_alert>())
 			{
 				m_alerts.emplace_alert<peer_error_alert>(torrent_handle(), endp
-					, peer_id(), operation_t::ssl_handshake, ec);
+					, peer_id(), operation_t::ssl_handshake, ec, nullptr);
 			}
 			return;
 		}
@@ -2754,7 +2754,7 @@ namespace aux {
 #endif
 			if (m_alerts.should_post<peer_blocked_alert>())
 				m_alerts.emplace_alert<peer_blocked_alert>(torrent_handle()
-					, endp, peer_blocked_alert::utp_disabled);
+					, endp, peer_blocked_alert::utp_disabled, nullptr);
 			return;
 		}
 
@@ -2766,7 +2766,7 @@ namespace aux {
 #endif
 			if (m_alerts.should_post<peer_blocked_alert>())
 				m_alerts.emplace_alert<peer_blocked_alert>(torrent_handle()
-					, endp, peer_blocked_alert::tcp_disabled);
+					, endp, peer_blocked_alert::tcp_disabled, nullptr);
 			return;
 		}
 
@@ -2799,7 +2799,7 @@ namespace aux {
 #endif
 				if (m_alerts.should_post<peer_blocked_alert>())
 					m_alerts.emplace_alert<peer_blocked_alert>(torrent_handle()
-						, endp, peer_blocked_alert::invalid_local_interface);
+						, endp, peer_blocked_alert::invalid_local_interface, nullptr);
 				return;
 			}
 			if (!verify_bound_address(local.address(), is_utp(*s), ec))
@@ -2826,7 +2826,7 @@ namespace aux {
 #endif
 				if (m_alerts.should_post<peer_blocked_alert>())
 					m_alerts.emplace_alert<peer_blocked_alert>(torrent_handle()
-						, endp, peer_blocked_alert::invalid_local_interface);
+						, endp, peer_blocked_alert::invalid_local_interface, nullptr);
 				return;
 			}
 		}
@@ -2850,7 +2850,7 @@ namespace aux {
 #endif
 			if (m_alerts.should_post<peer_blocked_alert>())
 				m_alerts.emplace_alert<peer_blocked_alert>(torrent_handle()
-					, endp, peer_blocked_alert::ip_filter);
+					, endp, peer_blocked_alert::ip_filter, nullptr);
 			return;
 		}
 
@@ -2892,7 +2892,7 @@ namespace aux {
 				m_alerts.emplace_alert<peer_disconnected_alert>(torrent_handle(), endp, peer_id()
 						, operation_t::bittorrent, s->type()
 						, error_code(errors::too_many_connections)
-						, close_reason_t::none);
+						, close_reason_t::none, nullptr);
 			}
 #ifndef TORRENT_DISABLE_LOGGING
 			if (should_log())
@@ -3385,7 +3385,7 @@ namespace aux {
 				&& m_alerts.should_post<performance_alert>())
 			{
 				m_alerts.emplace_alert<performance_alert>(torrent_handle()
-					, performance_alert::download_limit_too_low);
+					, performance_alert::download_limit_too_low, nullptr);
 			}
 
 			if (up_limit > 0
@@ -3393,7 +3393,7 @@ namespace aux {
 				&& m_alerts.should_post<performance_alert>())
 			{
 				m_alerts.emplace_alert<performance_alert>(torrent_handle()
-					, performance_alert::upload_limit_too_low);
+					, performance_alert::upload_limit_too_low, nullptr);
 			}
 		}
 
@@ -4245,7 +4245,7 @@ namespace aux {
 			max_upload_rate = std::max(20000, m_peak_up_rate + 10000);
 			if (m_alerts.should_post<performance_alert>())
 				m_alerts.emplace_alert<performance_alert>(torrent_handle()
-					, performance_alert::bittyrant_with_no_uplimit);
+					, performance_alert::bittyrant_with_no_uplimit, nullptr);
 		}
 
 		int const allowed_upload_slots = unchoke_sort(peers, max_upload_rate
@@ -4724,7 +4724,7 @@ namespace aux {
 		if (ec)
 		{
 			m_alerts.emplace_alert<add_torrent_alert>(torrent_handle()
-				, *params, ec);
+				, *params, ec, nullptr);
 			return;
 		}
 		TORRENT_ASSERT(params->ti->is_valid());
@@ -4763,7 +4763,7 @@ namespace aux {
 		std::tie(torrent_ptr, added) = add_torrent_impl(params, ec);
 
 		torrent_handle const handle(torrent_ptr);
-		m_alerts.emplace_alert<add_torrent_alert>(handle, params, ec);
+		m_alerts.emplace_alert<add_torrent_alert>(handle, params, ec, params.userdata);
 
 		if (!torrent_ptr) return handle;
 
@@ -4780,7 +4780,7 @@ namespace aux {
 
 #if TORRENT_ABI_VERSION == 1
 		if (m_alerts.should_post<torrent_added_alert>())
-			m_alerts.emplace_alert<torrent_added_alert>(handle);
+			m_alerts.emplace_alert<torrent_added_alert>(handle, params.userdata);
 #endif
 
 		// if this was an existing torrent, we can't start it again, or add
@@ -5104,7 +5104,7 @@ namespace aux {
 		if (!tptr) return;
 
 		m_alerts.emplace_alert<torrent_removed_alert>(tptr->get_handle()
-			, tptr->info_hash());
+			, tptr->info_hash(), tptr->get_userdata());
 
 		remove_torrent_impl(tptr, options);
 
@@ -5144,7 +5144,7 @@ namespace aux {
 			{
 				if (m_alerts.should_post<torrent_delete_failed_alert>())
 					m_alerts.emplace_alert<torrent_delete_failed_alert>(t.get_handle()
-						, error_code(), t.torrent_file().info_hash());
+						, error_code(), t.torrent_file().info_hash(), t.get_userdata());
 			}
 		}
 
@@ -5529,7 +5529,7 @@ namespace aux {
 		t->do_connect_boost();
 
 		if (m_alerts.should_post<lsd_peer_alert>())
-			m_alerts.emplace_alert<lsd_peer_alert>(t->get_handle(), peer);
+			m_alerts.emplace_alert<lsd_peer_alert>(t->get_handle(), peer, t->get_userdata());
 	}
 
 	void session_impl::start_natpmp(aux::listen_socket_t& s)
@@ -6309,7 +6309,7 @@ namespace aux {
 		{
 			if (m_alerts.should_post<performance_alert>())
 				m_alerts.emplace_alert<performance_alert>(torrent_handle()
-					, performance_alert::too_many_optimistic_unchoke_slots);
+					, performance_alert::too_many_optimistic_unchoke_slots, nullptr);
 		}
 
 		if (allowed_upload_slots == std::numeric_limits<int>::max())
@@ -6347,7 +6347,7 @@ namespace aux {
 			&& m_alerts.should_post<performance_alert>())
 		{
 			m_alerts.emplace_alert<performance_alert>(torrent_handle()
-				, performance_alert::too_high_disk_queue_limit);
+				, performance_alert::too_high_disk_queue_limit, nullptr);
 		}
 	}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2214,7 +2214,7 @@ namespace aux {
 		if (ec)
 		{
 			if (m_alerts.should_post<i2p_alert>())
-				m_alerts.emplace_alert<i2p_alert>(ec, nullptr);
+				m_alerts.emplace_alert<i2p_alert>(ec);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			if (should_log())

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6590,7 +6590,7 @@ bool is_downloading_state(int const st)
 				// we have an i2p torrent, but we're not connected to an i2p
 				// SAM proxy.
 				if (alerts().should_post<i2p_alert>())
-					alerts().emplace_alert<i2p_alert>(errors::no_i2p_router, m_userdata);
+					alerts().emplace_alert<i2p_alert>(errors::no_i2p_router);
 				return false;
 			}
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -99,13 +99,13 @@ namespace libtorrent {
 #ifndef BOOST_NO_EXCEPTIONS
 			} catch (system_error const& e) {
 				ses.alerts().emplace_alert<torrent_error_alert>(torrent_handle(m_torrent)
-					, e.code(), e.what());
+					, e.code(), e.what(), m_torrent.lock()->get_userdata());
 			} catch (std::exception const& e) {
 				ses.alerts().emplace_alert<torrent_error_alert>(torrent_handle(m_torrent)
-					, error_code(), e.what());
+					, error_code(), e.what(), m_torrent.lock()->get_userdata());
 			} catch (...) {
 				ses.alerts().emplace_alert<torrent_error_alert>(torrent_handle(m_torrent)
-					, error_code(), "unknown error");
+					, error_code(), "unknown error", m_torrent.lock()->get_userdata());
 			}
 #endif
 		} );

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -624,7 +624,7 @@ void web_peer_connection::handle_error(int const bytes_left)
 		std::string const error_msg = to_string(m_parser.status_code()).data()
 			+ (" " + m_parser.message());
 		t->alerts().emplace_alert<url_seed_alert>(t->get_handle(), m_url
-			, error_msg);
+			, error_msg, t->get_userdata());
 	}
 	received_bytes(0, bytes_left);
 	disconnect(error_code(m_parser.status_code(), http_category()), operation_t::bittorrent, failure);

--- a/test/test_alert_manager.cpp
+++ b/test/test_alert_manager.cpp
@@ -52,7 +52,7 @@ TORRENT_TEST(limit)
 	// try add 600 torrent_add_alert to make sure we honor the limit of 500
 	// alerts.
 	for (piece_index_t i{0}; i < piece_index_t{600}; ++i)
-		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i, nullptr);
 
 	TEST_EQUAL(mgr.pending(), true);
 
@@ -69,7 +69,7 @@ TORRENT_TEST(limit)
 	mgr.set_alert_queue_size_limit(200);
 
 	for (piece_index_t i{0}; i < piece_index_t{600}; ++i)
-		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i, nullptr);
 
 	TEST_EQUAL(mgr.pending(), true);
 
@@ -88,10 +88,10 @@ TORRENT_TEST(limit_int_max)
 	TEST_EQUAL(mgr.alert_queue_size_limit(), inf);
 
 	for (piece_index_t i{0}; i < piece_index_t{600}; ++i)
-		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i, nullptr);
 
 	for (piece_index_t i{0}; i < piece_index_t{600}; ++i)
-		mgr.emplace_alert<torrent_removed_alert>(torrent_handle(), sha1_hash());
+		mgr.emplace_alert<torrent_removed_alert>(torrent_handle(), sha1_hash(), nullptr);
 
 	std::vector<alert*> alerts;
 	mgr.get_all(alerts);
@@ -107,11 +107,11 @@ TORRENT_TEST(priority_limit)
 
 	// this should only add 100 because of the limit
 	for (piece_index_t i{0}; i < piece_index_t{200}; ++i)
-		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i);
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), i, nullptr);
 
 	// the limit is twice as high for priority alerts
 	for (file_index_t i(0); i < file_index_t(300); ++i)
-		mgr.emplace_alert<file_rename_failed_alert>(torrent_handle(), i, error_code());
+		mgr.emplace_alert<file_rename_failed_alert>(torrent_handle(), i, error_code(), nullptr);
 
 	std::vector<alert*> alerts;
 	mgr.get_all(alerts);
@@ -138,7 +138,7 @@ TORRENT_TEST(notify_function)
 	TEST_EQUAL(mgr.pending(), false);
 
 	for (int i = 0; i < 20; ++i)
-		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
+		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code(), nullptr);
 
 	TEST_EQUAL(mgr.pending(), true);
 
@@ -152,7 +152,7 @@ TORRENT_TEST(notify_function)
 	// subsequent posted alerts will not cause an edge (because there are
 	// already alerts queued)
 	for (int i = 0; i < 20; ++i)
-		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
+		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code(), nullptr);
 
 	TEST_EQUAL(mgr.pending(), true);
 	TEST_EQUAL(cnt, 1);
@@ -165,7 +165,7 @@ TORRENT_TEST(notify_function)
 	TEST_EQUAL(mgr.pending(), false);
 
 	for (int i = 0; i < 20; ++i)
-		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
+		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code(), nullptr);
 
 	TEST_EQUAL(mgr.pending(), true);
 	TEST_EQUAL(cnt, 2);
@@ -198,14 +198,14 @@ TORRENT_TEST(extensions)
 	mgr.add_extension(std::make_shared<test_plugin>(2));
 
 	for (int i = 0; i < 53; ++i)
-		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
+		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code(), nullptr);
 
 	TEST_EQUAL(plugin_alerts[0], 53);
 	TEST_EQUAL(plugin_alerts[1], 53);
 	TEST_EQUAL(plugin_alerts[2], 53);
 
 	for (int i = 0; i < 17; ++i)
-		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code());
+		mgr.emplace_alert<add_torrent_alert>(torrent_handle(), add_torrent_params(), error_code(), nullptr);
 
 	TEST_EQUAL(plugin_alerts[0], 70);
 	TEST_EQUAL(plugin_alerts[1], 70);
@@ -286,11 +286,11 @@ TORRENT_TEST(dropped_alerts)
 	alert_manager mgr(1, alert::all_categories);
 
 	// nothing has dropped yet
-	mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
+	mgr.emplace_alert<torrent_finished_alert>(torrent_handle(), nullptr);
 	// still nothing, there's space for one alert
-	mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
+	mgr.emplace_alert<torrent_finished_alert>(torrent_handle(), nullptr);
 	// still nothing, there's space for one alert
-	mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
+	mgr.emplace_alert<torrent_finished_alert>(torrent_handle(), nullptr);
 	// that last alert got dropped though, since it would have brought the queue
 	// size to 3
 	std::vector<alert*> alerts;
@@ -304,9 +304,9 @@ TORRENT_TEST(alerts_dropped_alert)
 {
 	alert_manager mgr(1, alert::all_categories);
 
-	mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
-	mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
-	mgr.emplace_alert<torrent_finished_alert>(torrent_handle());
+	mgr.emplace_alert<torrent_finished_alert>(torrent_handle(), nullptr);
+	mgr.emplace_alert<torrent_finished_alert>(torrent_handle(), nullptr);
+	mgr.emplace_alert<torrent_finished_alert>(torrent_handle(), nullptr);
 	// that last alert got dropped though, since it would have brought the queue
 	// size to 3
 	std::vector<alert*> alerts;
@@ -322,7 +322,7 @@ struct post_plugin : lt::plugin
 	void on_alert(alert const*)
 	{
 		if (++depth > 10) return;
-		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), piece_index_t{0});
+		mgr.emplace_alert<piece_finished_alert>(torrent_handle(), piece_index_t{0}, nullptr);
 	}
 
 	alert_manager& mgr;
@@ -337,7 +337,7 @@ TORRENT_TEST(recursive_alerts)
 	auto pl = std::make_shared<post_plugin>(mgr);
 	mgr.add_extension(pl);
 
-	mgr.emplace_alert<piece_finished_alert>(torrent_handle(), piece_index_t{0});
+	mgr.emplace_alert<piece_finished_alert>(torrent_handle(), piece_index_t{0}, nullptr);
 
 	TEST_EQUAL(pl->depth, 11);
 }


### PR DESCRIPTION
"add userdata to torrent_alert to skip searching for client data associated with torrent on every alert"

LT clients have data associated with torrents. Without that data, the alert system would be nearly worthless. Clients can associate their data with LT torrents via lt::torrent_handle, but the reverse association requires searching by comparing pointers or hashes. Efficient systems such as Windows Overlapped I/O and Linux epoll will accept a user pointer and provide that user pointer on events to help clients find their associated data.

With this change, LT alerts have a similar user data pointer so that every alert doesn't result in the client performing a binary search for associated data. This is nearly free in most cases and thus the client doesn't have to make a synchronous call to retrieve the pointer from the main LT thread.