### PR TITLE
suppress announces with incompatible address family

### DIFF
--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -120,6 +120,9 @@ namespace libtorrent {
 		// internal
 		bool triggered_manually : 1;
 
+		// set to false to not announce from this endpoint
+		bool enabled : 1;
+
 		// reset announce counters and clears the started sent flag.
 		// The announce_endpoint will look like we've never talked to
 		// the tracker.

--- a/src/announce_entry.cpp
+++ b/src/announce_entry.cpp
@@ -55,6 +55,7 @@ namespace libtorrent {
 		, start_sent(false)
 		, complete_sent(completed)
 		, triggered_manually(false)
+		, enabled(true)
 	{}
 
 	announce_entry::announce_entry(string_view u)
@@ -97,7 +98,9 @@ namespace libtorrent {
 
 	void announce_endpoint::failed(int const backoff_ratio, seconds32 const retry_interval)
 	{
-		++fails;
+		// fails is only 7 bits
+		if (fails < (1 << 7) - 1) ++fails;
+
 		// the exponential back-off ends up being:
 		// 7, 15, 27, 45, 95, 127, 165, ... seconds
 		// with the default tracker_backoff of 250

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2940,6 +2940,12 @@ bool is_downloading_state(int const st)
 
 			for (auto& aep : ae.endpoints)
 			{
+				if (!aep.enabled)
+				{
+					aep.next_announce = now + seconds(60);
+					continue;
+				}
+
 				auto aep_state_iter = std::find_if(listen_socket_states.begin(), listen_socket_states.end()
 					, [&](announce_state const& s) { return s.socket == aep.socket; });
 				if (aep_state_iter == listen_socket_states.end())
@@ -5319,7 +5325,6 @@ bool is_downloading_state(int const st)
 			{ return lhs.tier < rhs.tier; });
 		if (k - m_trackers.begin() < m_last_working_tracker) ++m_last_working_tracker;
 		k = m_trackers.insert(k, url);
-		k->endpoints.clear();
 		if (k->source == 0) k->source = announce_entry::source_client;
 		if (m_announcing && !m_trackers.empty()) announce_with_tracker();
 		return true;
@@ -10983,6 +10988,9 @@ bool is_downloading_state(int const st)
 #ifndef TORRENT_DISABLE_LOGGING
 					debug_log("*** increment tracker fail count [%d]", aep->fails);
 #endif
+					// don't try to announce from this endpoint again
+					if (ec == boost::system::errc::address_family_not_supported)
+						aep->enabled = false;
 				}
 				else if (r.outgoing_socket)
 				{


### PR DESCRIPTION
suppress future attempts to announce to a tracker from an interface with an incompatible address family