### PR TITLE
WIP: don't start DHT on loopback

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* don't start DHT nodes on loopback device (when explicitly listening on loopback)
 	* add new socks5_alert to trouble shoot SOCKS5 proxies
 
 1.2.3 release

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -174,7 +174,7 @@ namespace aux {
 		// If there are active NAT mappings the return value will be
 		// the external port returned by the NAT router, otherwise the
 		// local listen port is returned
-		int tcp_external_port()
+		int tcp_external_port() const
 		{
 			for (auto const& m : tcp_port_mapping)
 			{
@@ -183,7 +183,7 @@ namespace aux {
 			return local_endpoint.port();
 		}
 
-		int udp_external_port()
+		int udp_external_port() const
 		{
 			for (auto const& m : udp_port_mapping)
 			{

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -119,8 +119,13 @@ namespace libtorrent { namespace dht {
 		if (s.is_ssl()) return;
 
 		address const local_address = s.get_local_endpoint().address();
+
+		// don't start DHT nodes on loopback address
+		if (local_address.is_loopback()) return;
+
 		// don't try to start dht nodes on non-global IPv6 addresses
-		// with IPv4 the interface might be behind NAT so we can't skip them based on the scope of the local address
+		// with IPv4 the interface might be behind NAT so we can't skip them
+		// based on the scope of the local address
 		// and we might not have the external address yet
 		if (local_address.is_v6() && is_local(local_address))
 			return;

--- a/test/test_direct_dht.cpp
+++ b/test/test_direct_dht.cpp
@@ -99,9 +99,9 @@ TORRENT_TEST(direct_dht_request)
 	sp.set_bool(settings_pack::enable_upnp, false);
 	sp.set_str(settings_pack::dht_bootstrap_nodes, "");
 	sp.set_int(settings_pack::max_retry_port_bind, 800);
-	sp.set_str(settings_pack::listen_interfaces, "127.0.0.1:42434");
+	sp.set_str(settings_pack::listen_interfaces, "0.0.0.0:42434");
 	lt::session responder(sp, {});
-	sp.set_str(settings_pack::listen_interfaces, "127.0.0.1:45434");
+	sp.set_str(settings_pack::listen_interfaces, "0.0.0.0:45434");
 	lt::session requester(sp, {});
 
 	responder.add_extension(std::make_shared<test_plugin>());

--- a/test/test_privacy.cpp
+++ b/test/test_privacy.cpp
@@ -102,7 +102,7 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, flags_t flags)
 	// pipelining of the tests) they actually need to use different ports
 	static int listen_port = 10000 + int(lt::random(50000));
 	char iface[200];
-	std::snprintf(iface, sizeof(iface), "127.0.0.1:%d", listen_port);
+	std::snprintf(iface, sizeof(iface), "0.0.0.0:%d", listen_port);
 	listen_port += lt::random(10) + 1;
 	sett.set_str(settings_pack::listen_interfaces, iface);
 


### PR DESCRIPTION
if a loopback IP address, or the loopback device, is explicitly specified in `listen_interfaces`, don't start a DHT node on it.