### PR TITLE
fix binding of outgoing interface, when configured

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix binding sockets to outgoing interface
 	* add new socks5_alert to trouble shoot SOCKS5 proxies
 
 1.2.3 release

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5035,6 +5035,7 @@ namespace aux {
 			bind_ep.address(bind_socket_to_device(m_io_service, s
 				, remote_address.is_v4() ? tcp::v4() : tcp::v6()
 				, ifname.c_str(), bind_ep.port(), ec));
+			s.bind(bind_ep, ec);
 			return bind_ep;
 		}
 


### PR DESCRIPTION
I believe this was a regression from 1.1