### PR TITLE
remove use of boost::noncopyable

### DIFF
--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -71,12 +71,15 @@ namespace aux {
 	TORRENT_EXTRA_EXPORT file_open_mode_t to_file_open_mode(open_mode_t const);
 
 	// this is an internal cache of open file mappings.
-	struct TORRENT_EXTRA_EXPORT file_view_pool : boost::noncopyable
+	struct TORRENT_EXTRA_EXPORT file_view_pool
 	{
 		// ``size`` specifies the number of allowed files handles
 		// to hold open at any given time.
 		explicit file_view_pool(int size = 40);
 		~file_view_pool();
+
+		file_view_pool(file_view_pool const&) = delete;
+		file_view_pool& operator=(file_view_pool const&) = delete;
 
 		// return an open file handle to file at ``file_index`` in the
 		// file_storage ``fs`` opened at save path ``p``. ``m`` is the

--- a/include/libtorrent/aux_/path.hpp
+++ b/include/libtorrent/aux_/path.hpp
@@ -44,8 +44,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include <boost/noncopyable.hpp>
-
 #ifdef TORRENT_WINDOWS
 // windows part
 #include "libtorrent/aux_/windows.hpp"

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -288,7 +288,6 @@ namespace aux {
 			, dht::dht_observer
 			, aux::portmap_callback
 			, aux::lsd_callback
-			, boost::noncopyable
 			, single_threaded
 			, aux::error_handler_interface
 			, std::enable_shared_from_this<session_impl>
@@ -312,6 +311,9 @@ namespace aux {
 
 			session_impl(io_context&, settings_pack const&, disk_io_constructor_type);
 			~session_impl() override;
+
+			session_impl(session_impl const&) = delete;
+			session_impl& operator=(session_impl const&) = delete;
 
 			void start_session();
 

--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -47,8 +47,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
-#include <boost/noncopyable.hpp>
-
 #ifdef TORRENT_WINDOWS
 // windows part
 #include "libtorrent/aux_/windows.hpp"
@@ -94,11 +92,14 @@ namespace libtorrent {
 	bool is_sparse(HANDLE file);
 #endif
 
-	class TORRENT_EXTRA_EXPORT directory : public boost::noncopyable
+	struct TORRENT_EXTRA_EXPORT directory
 	{
-	public:
 		directory(std::string const& path, error_code& ec);
 		~directory();
+
+		directory(directory const&) = delete;
+		directory& operator=(directory const&) = delete;
+
 		void next(error_code& ec);
 		std::string file() const;
 		bool done() const { return m_done; }
@@ -113,11 +114,14 @@ namespace libtorrent {
 		bool m_done;
 	};
 
-	struct TORRENT_EXTRA_EXPORT file : boost::noncopyable
+	struct TORRENT_EXTRA_EXPORT file
 	{
 		file();
 		file(std::string const& p, aux::open_mode_t m, error_code& ec);
 		~file();
+
+		file(file const&) = delete;
+		file& operator=(file const&) = delete;
 
 		bool open(std::string const& p, aux::open_mode_t m, error_code& ec);
 		bool is_open() const;

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -67,7 +67,6 @@ namespace aux {
 	struct TORRENT_EXTRA_EXPORT mmap_storage
 		: std::enable_shared_from_this<mmap_storage>
 		, aux::disk_job_fence
-		, boost::noncopyable
 	{
 		// constructs the mmap_storage based on the give file_storage (fs).
 		// ``mapped`` is an optional argument (it may be nullptr). If non-nullptr it
@@ -84,6 +83,8 @@ namespace aux {
 
 		// hidden
 		~mmap_storage();
+		mmap_storage(mmap_storage const&) = delete;
+		mmap_storage& operator=(mmap_storage const&) = delete;
 
 		bool has_any_file(storage_error&);
 		void set_file_priority(settings_interface const&


### PR DESCRIPTION
in favour of just deleting special members. This helps in exported/public classes, which will generate a warning on MSVC if all base classes are not also exported