### PR TITLE
Backport dishonest peer antileech choking to RC_1_1

### DIFF
--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -38,6 +38,14 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/bind.hpp>
 
+// Workaround due to MSVC's absence of std::abs (int64_t) before C++11
+template <typename T>
+inline T
+prec11_abs (T x)
+{
+	return (x >= 0 ? x : -x);
+}
+
 namespace libtorrent {
 
 namespace {
@@ -134,18 +142,8 @@ namespace {
 		return lhs->time_of_last_unchoke() < rhs->time_of_last_unchoke();
 	}
 
-	// return true if 'lhs' peer should be preferred to be unchoke over 'rhs'
-	bool unchoke_compare_anti_leech(peer_connection const* lhs
-		, peer_connection const* rhs)
+	int anti_leech_score(peer_connection const* peer)
 	{
-		int const cmp = compare_peers(lhs, rhs);
-		if (cmp != 0) return cmp > 0;
-
-		boost::shared_ptr<torrent> const t1 = lhs->associated_torrent().lock();
-		boost::shared_ptr<torrent> const t2 = rhs->associated_torrent().lock();
-		TORRENT_ASSERT(t1);
-		TORRENT_ASSERT(t2);
-
 		// the anti-leech seeding algorithm is based on the paper "Improving
 		// BitTorrent: A Simple Approach" from Chow et. al. and ranks peers based
 		// on how many pieces they have, preferring to unchoke peers that just
@@ -166,13 +164,25 @@ namespace {
 		//   |             V             |
 		//   +---------------------------+
 		//   0%    num have pieces     100%
-		int const t1_total = t1->torrent_file().num_pieces();
-		int const t2_total = t2->torrent_file().num_pieces();
-		int const score1 = t1_total == 0 ? 0 : ((lhs->num_have_pieces() < t1_total / 2
-			? t1_total - lhs->num_have_pieces() : lhs->num_have_pieces()) * 1000 / t1_total);
-		int const score2 = t2_total == 0 ? 0 : ((rhs->num_have_pieces() < t2_total / 2
-			? t2_total - rhs->num_have_pieces() : rhs->num_have_pieces()) * 1000 / t2_total);
+		boost::shared_ptr<torrent> const t = peer->associated_torrent().lock();
+		TORRENT_ASSERT(t);
 
+		boost::int64_t const total_size = t->torrent_file().total_size();
+		if (total_size == 0) return 0;
+		boost::int64_t const have_size = std::max(peer->statistics().total_payload_upload()
+			, boost::int64_t(t->torrent_file().piece_length()) * peer->num_have_pieces());
+		return int(prec11_abs((have_size - total_size / 2) * 2000 / total_size));
+	}
+
+	// return true if 'lhs' peer should be preferred to be unchoke over 'rhs'
+	bool unchoke_compare_anti_leech(peer_connection const* lhs
+		, peer_connection const* rhs)
+	{
+		int const cmp = compare_peers(lhs, rhs);
+		if (cmp != 0) return cmp > 0;
+
+		int const score1 = anti_leech_score(lhs);
+		int const score2 = anti_leech_score(rhs);
 		if (score1 != score2) return score1 > score2;
 
 		// prioritize the one that has waited the longest to be unchoked
@@ -232,10 +242,6 @@ namespace {
 		}
 #endif
 
-		int upload_slots = sett.get_int(settings_pack::unchoke_slots_limit);
-		if (upload_slots < 0)
-			upload_slots = (std::numeric_limits<int>::max)();
-
 		// ==== BitTyrant ====
 		//
 		// if we're using the bittyrant unchoker, go through all peers that
@@ -277,7 +283,7 @@ namespace {
 			// now, figure out how many peers should be unchoked. We deduct the
 			// estimated reciprocation rate from our upload_capacity estimate
 			// until there none left
-			upload_slots = 0;
+			int upload_slots = 0;
 
 			for (std::vector<peer_connection*>::iterator i = peers.begin()
 				, end(peers.end()); i != end; ++i)
@@ -293,6 +299,10 @@ namespace {
 
 			return upload_slots;
 		}
+
+		int upload_slots = sett.get_int(settings_pack::unchoke_slots_limit);
+		if (upload_slots < 0)
+			upload_slots = std::numeric_limits<int>::max();
 
 		// ==== rate-based ====
 		//
@@ -347,34 +357,36 @@ namespace {
 		// we use partial sort here, because we only care about the top
 		// upload_slots peers.
 
+		int const slots = std::min(upload_slots, int(peers.size()));
+
 		if (sett.get_int(settings_pack::seed_choking_algorithm)
 			== settings_pack::round_robin)
 		{
 			int const pieces = sett.get_int(settings_pack::seeding_piece_quota);
 
 			std::partial_sort(peers.begin(), peers.begin()
-				+ (std::min)(upload_slots, int(peers.size())), peers.end()
+				+ slots, peers.end()
 				, boost::bind(&unchoke_compare_rr, _1, _2, pieces));
 		}
 		else if (sett.get_int(settings_pack::seed_choking_algorithm)
 			== settings_pack::fastest_upload)
 		{
 			std::partial_sort(peers.begin(), peers.begin()
-				+ (std::min)(upload_slots, int(peers.size())), peers.end()
+				+ slots, peers.end()
 				, boost::bind(&unchoke_compare_fastest_upload, _1, _2));
 		}
 		else if (sett.get_int(settings_pack::seed_choking_algorithm)
 			== settings_pack::anti_leech)
 		{
 			std::partial_sort(peers.begin(), peers.begin()
-				+ (std::min)(upload_slots, int(peers.size())), peers.end()
+				+ slots, peers.end()
 				, boost::bind(&unchoke_compare_anti_leech, _1, _2));
 		}
 		else
 		{
 			int const pieces = sett.get_int(settings_pack::seeding_piece_quota);
 			std::partial_sort(peers.begin(), peers.begin()
-				+ (std::min)(upload_slots, int(peers.size())), peers.end()
+				+ slots, peers.end()
 				, boost::bind(&unchoke_compare_rr, _1, _2, pieces));
 
 			TORRENT_ASSERT(false);

--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -38,41 +38,37 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/bind.hpp>
 
-namespace libtorrent
-{
+namespace libtorrent {
 
-	namespace {
+namespace {
+
+	int compare_peers(peer_connection const* lhs, peer_connection const* rhs)
+	{
+		int const prio1 = lhs->get_priority(peer_connection::upload_channel);
+		int const prio2 = rhs->get_priority(peer_connection::upload_channel);
+
+		if (prio1 != prio2) return prio1 > prio2 ? 1 : -1;
+
+		// compare how many bytes they've sent us
+		boost::int64_t const c1 = lhs->downloaded_in_last_round();
+		boost::int64_t const c2 = rhs->downloaded_in_last_round();
+
+		if (c1 != c2) return c1 > c2 ? 1 : -1;
+		return 0;
+	}
 
 	// return true if 'lhs' peer should be preferred to be unchoke over 'rhs'
 	bool unchoke_compare_rr(peer_connection const* lhs
 		, peer_connection const* rhs, int pieces)
 	{
-		// if one peer belongs to a higher priority torrent than the other one
-		// that one should be unchoked.
-		boost::shared_ptr<torrent> t1 = lhs->associated_torrent().lock();
-		TORRENT_ASSERT(t1);
-		boost::shared_ptr<torrent> t2 = rhs->associated_torrent().lock();
-		TORRENT_ASSERT(t2);
-
-		int prio1 = lhs->get_priority(peer_connection::upload_channel);
-		int prio2 = rhs->get_priority(peer_connection::upload_channel);
-
-		if (prio1 != prio2)
-			return prio1 > prio2;
-
-		// compare how many bytes they've sent us
-		boost::int64_t c1;
-		boost::int64_t c2;
-		c1 = lhs->downloaded_in_last_round();
-		c2 = rhs->downloaded_in_last_round();
-
-		if (c1 != c2) return c1 > c2;
+		int const cmp = compare_peers(lhs, rhs);
+		if (cmp != 0) return cmp > 0;
 
 		// when seeding, rotate which peer is unchoked in a round-robin fasion
 
 		// the amount uploaded since unchoked (not just in the last round)
-		c1 = lhs->uploaded_since_unchoked();
-		c2 = rhs->uploaded_since_unchoked();
+		boost::int64_t const u1 = lhs->uploaded_since_unchoked();
+		boost::int64_t const u2 = rhs->uploaded_since_unchoked();
 
 		// the way the round-robin unchoker works is that it,
 		// by default, prioritizes any peer that is already unchoked.
@@ -80,20 +76,25 @@ namespace libtorrent
 		// peers that are unchoked, but have sent more than one quota
 		// since they were unchoked, they get de-prioritized.
 
+		boost::shared_ptr<torrent> const t1 = lhs->associated_torrent().lock();
+		boost::shared_ptr<torrent> const t2 = rhs->associated_torrent().lock();
+		TORRENT_ASSERT(t1);
+		TORRENT_ASSERT(t2);
+
 		// if a peer is already unchoked, the number of bytes sent since it was unchoked
 		// is greater than the send quanta, and it has been unchoked for at least one minute
 		// then it's done with its upload slot, and we can de-prioritize it
-		bool c1_quota_complete = !lhs->is_choked()
-			&& c1 > boost::int64_t(t1->torrent_file().piece_length()) * pieces
+		bool const c1_quota_complete = !lhs->is_choked()
+			&& u1 > boost::int64_t(t1->torrent_file().piece_length()) * pieces
 			&& aux::time_now() - lhs->time_of_last_unchoke() > minutes(1);
-		bool c2_quota_complete = !rhs->is_choked()
-			&& c2 > boost::int64_t(t2->torrent_file().piece_length()) * pieces
+		bool const c2_quota_complete = !rhs->is_choked()
+			&& u2 > boost::int64_t(t2->torrent_file().piece_length()) * pieces
 			&& aux::time_now() - rhs->time_of_last_unchoke() > minutes(1);
 
 		// if c2 has completed a quanta, it should be de-prioritized
 		// and vice versa
-		if (c1_quota_complete < c2_quota_complete) return true;
-		if (c1_quota_complete > c2_quota_complete) return false;
+		if (c1_quota_complete != c2_quota_complete)
+			return int(c1_quota_complete) < int(c2_quota_complete);
 
 		// when seeding, prefer the peer we're uploading the fastest to
 
@@ -102,11 +103,10 @@ namespace libtorrent
 		// there may have been a residual transfer which was already
 		// in-flight at the time and we don't want that to cause the peer
 		// to be ranked at the top of the choked peers
-		c1 = lhs->is_choked() ? 0 : lhs->uploaded_in_last_round();
-		c2 = rhs->is_choked() ? 0 : rhs->uploaded_in_last_round();
+		boost::int64_t const c1 = lhs->is_choked() ? 0 : lhs->uploaded_in_last_round();
+		boost::int64_t const c2 = rhs->is_choked() ? 0 : rhs->uploaded_in_last_round();
 
-		if (c1 > c2) return true;
-		if (c2 > c1) return false;
+		if (c1 != c2) return c1 > c2;
 
 		// if the peers are still identical (say, they're both waiting to be unchoked)
 		// prioritize the one that has waited the longest to be unchoked
@@ -119,33 +119,14 @@ namespace libtorrent
 	bool unchoke_compare_fastest_upload(peer_connection const* lhs
 		, peer_connection const* rhs)
 	{
-		// if one peer belongs to a higher priority torrent than the other one
-		// that one should be unchoked.
-		boost::shared_ptr<torrent> t1 = lhs->associated_torrent().lock();
-		TORRENT_ASSERT(t1);
-		boost::shared_ptr<torrent> t2 = rhs->associated_torrent().lock();
-		TORRENT_ASSERT(t2);
-
-		int prio1 = lhs->get_priority(peer_connection::upload_channel);
-		int prio2 = rhs->get_priority(peer_connection::upload_channel);
-
-		if (prio1 != prio2)
-			return prio1 > prio2;
-
-		// compare how many bytes they've sent us
-		boost::int64_t c1;
-		boost::int64_t c2;
-		c1 = lhs->downloaded_in_last_round();
-		c2 = rhs->downloaded_in_last_round();
-
-		if (c1 != c2) return c1 > c2;
+		int const cmp = compare_peers(lhs, rhs);
+		if (cmp != 0) return cmp > 0;
 
 		// when seeding, prefer the peer we're uploading the fastest to
-		c1 = lhs->uploaded_in_last_round();
-		c2 = rhs->uploaded_in_last_round();
+		boost::int64_t const c1 = lhs->uploaded_in_last_round();
+		boost::int64_t const c2 = rhs->uploaded_in_last_round();
 
-		if (c1 > c2) return true;
-		if (c2 > c1) return false;
+		if (c1 != c2) return c1 > c2;
 
 		// prioritize the one that has waited the longest to be unchoked
 		// the round-robin unchoker relies on this logic. Don't change it
@@ -157,26 +138,13 @@ namespace libtorrent
 	bool unchoke_compare_anti_leech(peer_connection const* lhs
 		, peer_connection const* rhs)
 	{
-		// if one peer belongs to a higher priority torrent than the other one
-		// that one should be unchoked.
-		boost::shared_ptr<torrent> t1 = lhs->associated_torrent().lock();
+		int const cmp = compare_peers(lhs, rhs);
+		if (cmp != 0) return cmp > 0;
+
+		boost::shared_ptr<torrent> const t1 = lhs->associated_torrent().lock();
+		boost::shared_ptr<torrent> const t2 = rhs->associated_torrent().lock();
 		TORRENT_ASSERT(t1);
-		boost::shared_ptr<torrent> t2 = rhs->associated_torrent().lock();
 		TORRENT_ASSERT(t2);
-
-		int prio1 = lhs->get_priority(peer_connection::upload_channel);
-		int prio2 = rhs->get_priority(peer_connection::upload_channel);
-
-		if (prio1 != prio2)
-			return prio1 > prio2;
-
-		// compare how many bytes they've sent us
-		boost::int64_t c1;
-		boost::int64_t c2;
-		c1 = lhs->downloaded_in_last_round();
-		c2 = rhs->downloaded_in_last_round();
-
-		if (c1 != c2) return c1 > c2;
 
 		// the anti-leech seeding algorithm is based on the paper "Improving
 		// BitTorrent: A Simple Approach" from Chow et. al. and ranks peers based
@@ -198,14 +166,14 @@ namespace libtorrent
 		//   |             V             |
 		//   +---------------------------+
 		//   0%    num have pieces     100%
-		int t1_total = t1->torrent_file().num_pieces();
-		int t2_total = t2->torrent_file().num_pieces();
-		int score1 = t1_total == 0 ? 0 : ((lhs->num_have_pieces() < t1_total / 2
+		int const t1_total = t1->torrent_file().num_pieces();
+		int const t2_total = t2->torrent_file().num_pieces();
+		int const score1 = t1_total == 0 ? 0 : ((lhs->num_have_pieces() < t1_total / 2
 			? t1_total - lhs->num_have_pieces() : lhs->num_have_pieces()) * 1000 / t1_total);
-		int score2 = t2_total == 0 ? 0 : ((rhs->num_have_pieces() < t2_total / 2
+		int const score2 = t2_total == 0 ? 0 : ((rhs->num_have_pieces() < t2_total / 2
 			? t2_total - rhs->num_have_pieces() : rhs->num_have_pieces()) * 1000 / t2_total);
-		if (score1 > score2) return true;
-		if (score2 > score1) return false;
+
+		if (score1 != score2) return score1 > score2;
 
 		// prioritize the one that has waited the longest to be unchoked
 		// the round-robin unchoker relies on this logic. Don't change it
@@ -216,15 +184,11 @@ namespace libtorrent
 	bool upload_rate_compare(peer_connection const* lhs
 		, peer_connection const* rhs)
 	{
-		boost::int64_t c1;
-		boost::int64_t c2;
-
-		c1 = lhs->uploaded_in_last_round();
-		c2 = rhs->uploaded_in_last_round();
-
 		// take torrent priority into account
-		c1 *= lhs->get_priority(peer_connection::upload_channel);
-		c2 *= rhs->get_priority(peer_connection::upload_channel);
+		boost::int64_t const c1 = lhs->uploaded_in_last_round()
+			* lhs->get_priority(peer_connection::upload_channel);
+		boost::int64_t const c2 = rhs->uploaded_in_last_round()
+			* rhs->get_priority(peer_connection::upload_channel);
 
 		return c1 > c2;
 	}
@@ -232,14 +196,12 @@ namespace libtorrent
 	bool bittyrant_unchoke_compare(peer_connection const* lhs
 		, peer_connection const* rhs)
 	{
-		boost::int64_t d1, d2, u1, u2;
-
 		// first compare how many bytes they've sent us
-		d1 = lhs->downloaded_in_last_round();
-		d2 = rhs->downloaded_in_last_round();
+		boost::int64_t d1 = lhs->downloaded_in_last_round();
+		boost::int64_t d2 = rhs->downloaded_in_last_round();
 		// divided by the number of bytes we've sent them
-		u1 = lhs->uploaded_in_last_round();
-		u2 = rhs->uploaded_in_last_round();
+		boost::int64_t u1 = lhs->uploaded_in_last_round();
+		boost::int64_t u2 = rhs->uploaded_in_last_round();
 
 		// take torrent priority into account
 		d1 *= lhs->get_priority(peer_connection::upload_channel);
@@ -247,8 +209,7 @@ namespace libtorrent
 
 		d1 = d1 * 1000 / (std::max)(boost::int64_t(1), u1);
 		d2 = d2 * 1000 / (std::max)(boost::int64_t(1), u2);
-		if (d1 > d2) return true;
-		if (d1 < d2) return false;
+		if (d1 != d2) return d1 > d2;
 
 		// if both peers are still in their send quota or not in their send quota
 		// prioritize the one that has waited the longest to be unchoked


### PR DESCRIPTION
Backport the choking of dishonest peers in the anti-leech seeding algorithm #3833 to libtorrent 1.1 for any potential future release, or for others who just want it themselves. Still using Deluge 1.3 pending some Deluge 2.0 issues.

Per https://github.com/arvidn/libtorrent/pull/3833#issuecomment-538783555 patches welcomed. 

