### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -483,7 +483,7 @@ If you enabled test in the configuration step, to run them, run::
 
 building with VCPKG
 
-You can download and install libtorrent  using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+You can download and install libtorrent using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -481,6 +481,19 @@ If you enabled test in the configuration step, to run them, run::
 
 	ctest -j8
 
+building with VCPKG
+
+You can download and install libtorrent  using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libtorrent
+
+The libtorrent port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 building with other build systems
 ---------------------------------
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -482,14 +482,15 @@ If you enabled test in the configuration step, to run them, run::
 	ctest -j8
 
 building with VCPKG
+-------------------
 
-You can download and install libtorrent using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+You can download and install libtorrent using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager::
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install libtorrent
+	git clone https://github.com/Microsoft/vcpkg.git
+	cd vcpkg
+	./bootstrap-vcpkg.sh
+	./vcpkg integrate install
+	./vcpkg install libtorrent
 
 The libtorrent port in vcpkg is kept up to date by Microsoft team members and community contributors.
 If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
Libtorrent is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build libtorrent, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for libtorrent and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.