### PR TITLE
store stop_when_ready flag in fastresume data

### DIFF
--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -156,6 +156,7 @@ namespace {
 		apply_flag(ret.flags, rd, "auto_managed", torrent_flags::auto_managed);
 		apply_flag(ret.flags, rd, "sequential_download", torrent_flags::sequential_download);
 		apply_flag(ret.flags, rd, "paused", torrent_flags::paused);
+		apply_flag(ret.flags, rd, "stop_when_ready", torrent_flags::stop_when_ready);
 
 		ret.save_path = rd.dict_find_string_value("save_path").to_string();
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6199,6 +6199,7 @@ bool is_downloading_state(int const st)
 		if (m_super_seeding ) ret.flags |= torrent_flags::super_seeding;
 		if (is_torrent_paused()) ret.flags |= torrent_flags::paused;
 		if (m_auto_managed ) ret.flags |= torrent_flags::auto_managed;
+		if (m_stop_when_ready) ret.flags |= torrent_flags::stop_when_ready;
 
 		ret.added_time = m_added_time;
 		ret.completed_time = m_completed_time;

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -218,6 +218,7 @@ namespace libtorrent {
 		ret["max_uploads"] = atp.upload_limit;
 		ret["paused"] = bool(atp.flags & torrent_flags::paused);
 		ret["auto_managed"] = bool(atp.flags & torrent_flags::auto_managed);
+		ret["stop_when_ready"] = bool(atp.flags & torrent_flags::stop_when_ready);
 
 		if (!atp.file_priorities.empty())
 		{


### PR DESCRIPTION
When checking is triggered with stop_when_ready flag set it's expected that torrent won't start downloading after checking has done even if was interrupted (due to application close) and then resumed in new session.