### PR TITLE
clean up association between listen_socket_t an port mappers

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1585,8 +1585,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		TORRENT_UNEXPORT portmap_error_alert(aux::stack_allocator& alloc, port_mapping_t i
-			, portmap_transport t
-			, error_code const& e);
+			, portmap_transport t, error_code const& e, address const& local);
 
 		TORRENT_DEFINE_ALERT(portmap_error_alert, 50)
 
@@ -1600,6 +1599,9 @@ TORRENT_VERSION_NAMESPACE_2
 
 		// UPnP or NAT-PMP
 		portmap_transport map_transport;
+
+		// the local network the port mapper is running on
+		aux::noexcept_movable<address> local_address;
 
 		// tells you what failed.
 		error_code const error;
@@ -1619,7 +1621,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		TORRENT_UNEXPORT portmap_alert(aux::stack_allocator& alloc, port_mapping_t i, int port
-			, portmap_transport t, portmap_protocol protocol);
+			, portmap_transport t, portmap_protocol protocol, address const& local);
 
 		TORRENT_DEFINE_ALERT(portmap_alert, 51)
 
@@ -1636,6 +1638,9 @@ TORRENT_VERSION_NAMESPACE_2
 		portmap_protocol const map_protocol;
 
 		portmap_transport const map_transport;
+
+		// the local network the port mapper is running on
+		aux::noexcept_movable<address> local_address;
 
 #if TORRENT_ABI_VERSION == 1
 		enum TORRENT_DEPRECATED_ENUM protocol_t
@@ -1661,7 +1666,8 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT portmap_log_alert final : alert
 	{
 		// internal
-		TORRENT_UNEXPORT portmap_log_alert(aux::stack_allocator& alloc, portmap_transport t, const char* m);
+		TORRENT_UNEXPORT portmap_log_alert(aux::stack_allocator& alloc, portmap_transport t
+			, const char* m, address const& local);
 
 		TORRENT_DEFINE_ALERT(portmap_log_alert, 52)
 
@@ -1669,6 +1675,9 @@ TORRENT_VERSION_NAMESPACE_2
 		std::string message() const override;
 
 		portmap_transport const map_transport;
+
+		// the local network the port mapper is running on
+		aux::noexcept_movable<address> local_address;
 
 		// the message associated with this log line
 		char const* log_message() const;
@@ -2450,12 +2459,17 @@ TORRENT_VERSION_NAMESPACE_2
 	struct TORRENT_EXPORT lsd_error_alert final : alert
 	{
 		// internal
-		TORRENT_UNEXPORT lsd_error_alert(aux::stack_allocator& alloc, error_code const& ec);
+		TORRENT_UNEXPORT lsd_error_alert(aux::stack_allocator& alloc, error_code const& ec
+			, address const& local);
 
 		TORRENT_DEFINE_ALERT(lsd_error_alert, 82)
 
 		static constexpr alert_category_t static_category = alert::error_notification;
 		std::string message() const override;
+
+		// the local network the corresponding local service discovery is running
+		// on
+		aux::noexcept_movable<address> local_address;
 
 		// The error code
 		error_code error;

--- a/include/libtorrent/aux_/portmap.hpp
+++ b/include/libtorrent/aux_/portmap.hpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/address.hpp"
 #include "libtorrent/time.hpp"
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/aux_/listen_socket_handle.hpp"
 
 namespace libtorrent {
 namespace aux {
@@ -56,10 +57,12 @@ namespace aux {
 		// error_code: error, an empty error means success
 		// int: transport is 0 for NAT-PMP and 1 for UPnP
 		virtual void on_port_mapping(port_mapping_t mapping, address const& ip, int port
-			, portmap_protocol proto, error_code const& ec, portmap_transport transport) = 0;
+			, portmap_protocol proto, error_code const& ec, portmap_transport transport
+			, listen_socket_handle const& ls) = 0;
 #ifndef TORRENT_DISABLE_LOGGING
 		virtual bool should_log_portmap(portmap_transport transport) const = 0;
-		virtual void log_portmap(portmap_transport transport, char const* msg) const = 0;
+		virtual void log_portmap(portmap_transport transport, char const* msg
+			, listen_socket_handle const&) const = 0;
 #endif
 
 	protected:

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -540,7 +540,7 @@ namespace aux {
 			// a failure to map a port
 			void on_port_mapping(port_mapping_t mapping, address const& ip, int port
 				, portmap_protocol proto, error_code const& ec
-				, portmap_transport transport) override;
+				, portmap_transport transport, listen_socket_handle const&) override;
 
 			bool is_aborted() const override { return m_abort; }
 			bool is_paused() const { return m_paused; }
@@ -760,7 +760,8 @@ namespace aux {
 				, udp::endpoint const& node) override;
 
 			bool should_log_portmap(portmap_transport transport) const override;
-			void log_portmap(portmap_transport transport, char const* msg) const override;
+			void log_portmap(portmap_transport transport, char const* msg
+				, listen_socket_handle const&) const override;
 
 			bool should_log_lsd() const override;
 			void log_lsd(char const* msg) const override;
@@ -867,8 +868,8 @@ namespace aux {
 
 			void on_lsd_peer(tcp::endpoint const& peer, sha1_hash const& ih) override;
 
-			void start_natpmp(aux::listen_socket_t& s);
-			void start_upnp(aux::listen_socket_t& s);
+			void start_natpmp(std::shared_ptr<aux::listen_socket_t> const&  s);
+			void start_upnp(std::shared_ptr<aux::listen_socket_t> const& s);
 
 			void set_external_address(std::shared_ptr<listen_socket_t> const& sock, address const& ip
 				, ip_source_t source_type, address const& source);

--- a/include/libtorrent/natpmp.hpp
+++ b/include/libtorrent/natpmp.hpp
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/portmap.hpp"
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/enum_net.hpp" // for ip_interface
+#include "libtorrent/aux_/listen_socket_handle.hpp"
 
 namespace libtorrent {
 
@@ -88,7 +89,7 @@ struct TORRENT_EXTRA_EXPORT natpmp final
 	: std::enable_shared_from_this<natpmp>
 	, single_threaded
 {
-	natpmp(io_context& ios, aux::portmap_callback& cb);
+	natpmp(io_context& ios, aux::portmap_callback& cb, aux::listen_socket_handle ls);
 
 	void start(ip_interface const& ip);
 
@@ -205,6 +206,8 @@ private:
 	port_mapping_t m_next_refresh{-1};
 
 	io_context& m_ioc;
+
+	aux::listen_socket_handle m_listen_handle;
 
 	bool m_disabled = false;
 

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -45,6 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/string_util.hpp"
 #include "libtorrent/aux_/portmap.hpp"
 #include "libtorrent/aux_/vector.hpp"
+#include "libtorrent/aux_/listen_socket_handle.hpp"
 
 #include <memory>
 #include <functional>
@@ -153,7 +154,8 @@ struct TORRENT_EXTRA_EXPORT upnp final
 		, aux::portmap_callback& cb
 		, address_v4 const& listen_address
 		, address_v4 const& netmask
-		, std::string listen_device);
+		, std::string listen_device
+		, aux::listen_socket_handle ls);
 	~upnp();
 
 	void set_user_agent(std::string const& v) { m_user_agent = v; }
@@ -363,6 +365,8 @@ private:
 	address_v4 m_listen_address;
 	address_v4 m_netmask;
 	std::string m_device;
+
+	aux::listen_socket_handle m_listen_handle;
 };
 
 } // namespace libtorrent

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -135,7 +135,7 @@ std::list<callback_info> callbacks;
 		void on_port_mapping(port_mapping_t const mapping
 			, address const& ip, int port
 			, portmap_protocol const protocol, error_code const& err
-			, portmap_transport) override
+			, portmap_transport, aux::listen_socket_handle const&) override
 		{
 			callback_info info = {mapping, port, err};
 			callbacks.push_back(info);
@@ -150,7 +150,8 @@ std::list<callback_info> callbacks;
 			return true;
 		}
 
-		void log_portmap(portmap_transport, char const* msg) const override
+		void log_portmap(portmap_transport, char const* msg
+			, aux::listen_socket_handle const&) const override
 		{
 			std::cout << "UPnP: " << msg << std::endl;
 			//TODO: store the log and verify that some key messages are there
@@ -242,7 +243,7 @@ void run_upnp_test(char const* root_filename, char const* control_name, int igd_
 
 	upnp_callback cb;
 	auto upnp_handler = std::make_shared<upnp>(ios, user_agent, cb
-		, ipf.interface_address.to_v4(), ipf.netmask.to_v4(), ipf.name);
+		, ipf.interface_address.to_v4(), ipf.netmask.to_v4(), ipf.name, aux::listen_socket_handle());
 	upnp_handler->start();
 
 	for (int i = 0; i < 20; ++i)
@@ -315,7 +316,7 @@ TORRENT_TEST(upnp_max_mappings)
 
 	upnp_callback cb;
 	auto upnp_handler = std::make_shared<upnp>(ios, "", cb
-		, ipf.interface_address.to_v4(), ipf.netmask.to_v4(), ipf.name);
+		, ipf.interface_address.to_v4(), ipf.netmask.to_v4(), ipf.name, aux::listen_socket_handle());
 
 	for (int i = 0; i < 50; ++i)
 	{


### PR DESCRIPTION
(upnp and natpmp) to atribute responses to the correct one. Also include local address in port map alerts and lsd alerts