### PR TITLE
when generating documentation, don't only highlight function names bu…

### DIFF
--- a/docs/gen_reference_doc.py
+++ b/docs/gen_reference_doc.py
@@ -203,6 +203,27 @@ def highlight_signature(s):
     return '('.join(name)
 
 
+def highlight_name(s):
+    print('highlight: %s' % s)
+    if '=' in s:
+        splitter = ' = '
+    elif '{' in s:
+        splitter = '{'
+    else:
+        return s
+
+    name = s.split(splitter, 1)
+    print('split: ', name)
+    name2 = name[0].split(' ')
+    print('split2: ', name2)
+    if len(name2[-1]) == 0:
+        return s
+
+    name2[-1] = '**' + name2[-1] + '** '
+    name[0] = ' '.join(name2)
+    return splitter.join(name)
+
+
 def html_sanitize(s):
     ret = ''
     for i in s:
@@ -1346,7 +1367,7 @@ __ reference.html
 
         for f in c['fields']:
             for s in f['signatures']:
-                block += '   %s\n' % s
+                block += '   %s\n' % highlight_name(s)
 
         block += '};'
 

--- a/include/libtorrent/peer_info.hpp
+++ b/include/libtorrent/peer_info.hpp
@@ -394,8 +394,9 @@ TORRENT_VERSION_NAMESPACE_2
 		static constexpr bandwidth_state_flags_t bw_disk = 4_bit;
 
 		// bitmasks indicating what state this peer
-		// is in with regards to sending and receiving data. The states are declared in the
-		// bw_state enum.
+		// is in with regards to sending and receiving data. The states are
+		// defined as independent flags of type bandwidth_state_flags_t, in this
+		// class.
 		bandwidth_state_flags_t read_state;
 		bandwidth_state_flags_t write_state;
 

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -69,7 +69,8 @@ namespace libtorrent {
 	// this class provides a non-owning handle to a session and a subset of the
 	// interface of the session class. If the underlying session is destructed
 	// any handle to it will no longer be valid. is_valid() will return false and
-	// any operation on it will throw an invalid_session_handle.
+	// any operation on it will throw a system_error exception, with error code
+	// invalid_session_handle.
 	struct TORRENT_EXPORT session_handle
 	{
 		friend class session;
@@ -138,7 +139,7 @@ namespace libtorrent {
 		// which determines if a torrent should be included in the returned set
 		// or not. Returning true means it should be included and false means
 		// excluded. The ``flags`` argument is the same as to
-		// ``torrent_handle::status()``. Since ``pred`` is guaranteed to be
+		// torrent_handle::status(). Since ``pred`` is guaranteed to be
 		// called for every torrent, it may be used to count the number of
 		// torrents of different categories as well.
 		//
@@ -178,7 +179,7 @@ namespace libtorrent {
 		// Only torrents who has the state subscription flag set will be
 		// included. This flag is on by default. See add_torrent_params.
 		// the ``flags`` argument is the same as for torrent_handle::status().
-		// see torrent_handle::status_flags_t.
+		// see status_flags_t in torrent_handle.
 		void post_torrent_updates(status_flags_t flags = status_flags_t::all());
 
 		// This function will post a session_stats_alert object, containing a

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -340,7 +340,7 @@ namespace aux {
 		// filter them out.
 		//
 		// By default everything is included. The flags you can use to decide
-		// what to *include* are defined in the status_flags_t enum.
+		// what to *include* are defined in this class.
 		torrent_status status(status_flags_t flags = status_flags_t::all()) const;
 
 		// ``get_download_queue()`` takes a non-const reference to a vector which


### PR DESCRIPTION
…t also data members and constants