### PR TITLE
fix announcing port=0 when configured with no listen interfaces

### DIFF
--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -549,14 +549,14 @@ TORRENT_TEST(announce_no_listen)
 {
 	// if we don't listen on any sockets at all (but only make outgoing peer
 	// connections) we still need to make sure we announce to trackers
-	test_ipv6_support("", 2, 2);
+	test_ipv6_support("", num_interfaces * 2, num_interfaces * 2);
 }
 
 TORRENT_TEST(announce_udp_no_listen)
 {
 	// since there's no actual udp tracker in this test, we will only try to
 	// announce once, and fail. We won't announce the event=stopped
-	test_udpv6_support("", 1, 1);
+	test_udpv6_support("", num_interfaces * 1, num_interfaces * 1);
 }
 
 TORRENT_TEST(ipv6_support_bind_v4_v6_any)


### PR DESCRIPTION
The two main parts of this patch are:

1. when asking the session for our listen port, disregard `listen_socket_t` entries where the `accept_incoming` flag is not set. This effectively means we announce a `&port=0` if we specify an empty string for `listen_interfaces`. Once in master, some of these cases can most likely be removed, since I think we use `listen_socket_t` consistently now.

2. When we don't have listen interfaces configure, we still create `listen_socket_t` entries without the `accept_incoming` flag, so we can make *outgoing* uTP connections, for instance. In order to actually be able to use these `listen_socket_t` entries though, we still need to apply the `expand_unspecified_address()` and `expand_device()` on them. Otherwise the `netmask` won't be set correctly and connections will not be considered routable correctly. This patch fixes this by moving the calls to `expand_unspecified_address()` and `expand_devices()` to after adding these interfaces.