### PR TITLE
separate announce_entry et.al into internal and public versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,6 +568,7 @@ HEADERS = \
   aux_/aligned_union.hpp            \
   aux_/alloca.hpp                   \
   aux_/allocating_handler.hpp       \
+  aux_/announce_entry.hpp           \
   aux_/array.hpp                    \
   aux_/bind_to_device.hpp           \
   aux_/buffer.hpp                   \

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -379,8 +379,10 @@ void bind_torrent_info()
         .def("can_announce", &can_announce)
         .def("is_working", &is_working)
 #endif
+#if TORRENT_ABI_VERSION <= 2
         .def("reset", &announce_entry::reset)
         .def("trim", &announce_entry::trim)
+#endif
         ;
 
     implicitly_convertible<std::shared_ptr<torrent_info>, std::shared_ptr<const torrent_info>>();

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -144,8 +144,8 @@ struct socks5_alert;
 TORRENT_VERSION_NAMESPACE_2_END
 
 // include/libtorrent/announce_entry.hpp
-struct announce_infohash;
 TORRENT_VERSION_NAMESPACE_2
+struct announce_infohash;
 struct announce_endpoint;
 struct announce_entry;
 TORRENT_VERSION_NAMESPACE_2_END

--- a/include/libtorrent/string_util.hpp
+++ b/include/libtorrent/string_util.hpp
@@ -132,6 +132,9 @@ namespace libtorrent {
 	// return value is an empty string_view.
 	TORRENT_EXTRA_EXPORT std::pair<string_view, string_view> split_string(string_view last, char sep);
 
+	// removes whitespaces at the beginning of the string, in-place
+	TORRENT_EXTRA_EXPORT void ltrim(std::string& s);
+
 #if TORRENT_USE_I2P
 
 	TORRENT_EXTRA_EXPORT bool is_i2p_url(std::string const& url);

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -86,6 +86,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/deferred_handler.hpp"
 #include "libtorrent/aux_/allocating_handler.hpp"
+#include "libtorrent/aux_/announce_entry.hpp"
 #include "libtorrent/extensions.hpp" // for add_peer_flags_t
 
 #ifdef TORRENT_SSL_PEERS
@@ -774,7 +775,7 @@ namespace libtorrent {
 		void set_tracker_login(std::string const& name, std::string const& pw);
 #endif
 
-		announce_entry* find_tracker(std::string const& url);
+		aux::announce_entry* find_tracker(std::string const& url);
 // --------------------------------------------
 		// PIECE MANAGEMENT
 
@@ -1035,8 +1036,7 @@ namespace libtorrent {
 
 		std::shared_ptr<const torrent_info> get_torrent_copy();
 
-		std::vector<announce_entry> const& trackers() const
-		{ return m_trackers; }
+		std::vector<announce_entry> trackers() const;
 
 		void replace_trackers(std::vector<announce_entry> const& urls);
 
@@ -1309,7 +1309,7 @@ namespace libtorrent {
 		// us.
 		aux::suggest_piece m_suggest_pieces;
 
-		aux::vector<announce_entry> m_trackers;
+		aux::vector<aux::announce_entry> m_trackers;
 
 		// this list is sorted by time_critical_piece::deadline
 		std::vector<time_critical_piece> m_time_critical_pieces;

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -789,7 +789,6 @@ TORRENT_TEST(test_error)
 			TEST_EQUAL(ae.endpoints.size(), 2);
 			for (auto const& aep : ae.endpoints)
 			{
-				TEST_EQUAL(aep.info_hashes[protocol_version::V1].is_working(), false);
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].message, "test");
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].last_error, error_code(errors::tracker_failure));
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].fails, 1);
@@ -815,7 +814,6 @@ TORRENT_TEST(test_warning)
 			TEST_EQUAL(ae.endpoints.size(), 2);
 			for (auto const& aep : ae.endpoints)
 			{
-				TEST_EQUAL(aep.info_hashes[protocol_version::V1].is_working(), true);
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].message, "test2");
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].last_error, error_code());
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].fails, 0);
@@ -842,7 +840,6 @@ TORRENT_TEST(test_scrape_data_in_announce)
 			TEST_EQUAL(ae.endpoints.size(), 2);
 			for (auto const& aep : ae.endpoints)
 			{
-				TEST_EQUAL(aep.info_hashes[protocol_version::V1].is_working(), true);
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].message, "");
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].last_error, error_code());
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].fails, 0);
@@ -902,7 +899,6 @@ TORRENT_TEST(test_http_status)
 			TEST_EQUAL(ae.endpoints.size(), 2);
 			for (auto const& aep : ae.endpoints)
 			{
-				TEST_EQUAL(aep.info_hashes[protocol_version::V1].is_working(), false);
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].message, "Not A Tracker");
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].last_error, error_code(410, http_category()));
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].fails, 1);
@@ -928,7 +924,6 @@ TORRENT_TEST(test_interval)
 			TEST_EQUAL(ae.endpoints.size(), 2);
 			for (auto const& aep : ae.endpoints)
 			{
-				TEST_EQUAL(aep.info_hashes[protocol_version::V1].is_working(), true);
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].message, "");
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].last_error, error_code());
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].fails, 0);
@@ -956,7 +951,6 @@ TORRENT_TEST(test_invalid_bencoding)
 			TEST_EQUAL(ae.endpoints.size(), 2);
 			for (auto const& aep : ae.endpoints)
 			{
-				TEST_EQUAL(aep.info_hashes[protocol_version::V1].is_working(), false);
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].message, "");
 				TEST_EQUAL(aep.info_hashes[protocol_version::V1].last_error, error_code(bdecode_errors::expected_value
 					, bdecode_category()));

--- a/src/announce_entry.cpp
+++ b/src/announce_entry.cpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/time.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
 #include "libtorrent/aux_/listen_socket_handle.hpp"
+#include "libtorrent/aux_/announce_entry.hpp"
 
 namespace libtorrent {
 
@@ -56,20 +57,6 @@ namespace libtorrent {
 		, complete_sent(false)
 		, triggered_manually(false)
 	{}
-
-	announce_endpoint::announce_endpoint(aux::listen_socket_handle const& s, bool const completed)
-		: local_endpoint(s ? s.get_local_endpoint() : tcp::endpoint())
-#if TORRENT_ABI_VERSION <= 2
-		, fails(0)
-		, updating(false)
-		, start_sent(false)
-		, complete_sent(completed)
-#endif
-		, enabled(true)
-		, socket(s)
-	{
-		TORRENT_UNUSED(completed);
-	}
 
 	announce_entry::announce_entry(string_view u)
 		: url(u.to_string())
@@ -96,6 +83,137 @@ namespace libtorrent {
 		, triggered_manually(false)
 		, updating(false)
 #endif
+	{}
+
+	announce_entry::~announce_entry() = default;
+	announce_entry::announce_entry(announce_entry const&) = default;
+	announce_entry& announce_entry::operator=(announce_entry const&) & = default;
+
+#if TORRENT_ABI_VERSION <= 2
+	void announce_infohash::reset()
+	{
+		start_sent = false;
+		next_announce = time_point32::min();
+		min_announce = time_point32::min();
+	}
+
+	void announce_infohash::failed(int const backoff_ratio, seconds32 const retry_interval)
+	{
+		// fails is only 7 bits
+		if (fails < (1 << 7) - 1) ++fails;
+
+		// the exponential back-off ends up being:
+		// 7, 15, 27, 45, 95, 127, 165, ... seconds
+		// with the default tracker_backoff of 250
+		int const fail_square = int(fails) * int(fails);
+		seconds32 const delay = std::max(retry_interval
+			, std::min(duration_cast<seconds32>(tracker_retry_delay_max)
+				, tracker_retry_delay_min
+					+ fail_square * tracker_retry_delay_min * backoff_ratio / 100
+			));
+		if (!is_working()) next_announce = aux::time_now32() + delay;
+		updating = false;
+	}
+
+	bool announce_infohash::can_announce(time_point now, bool is_seed, std::uint8_t fail_limit) const
+	{
+		// if we're a seed and we haven't sent a completed
+		// event, we need to let this announce through
+		bool const need_send_complete = is_seed && !complete_sent;
+
+		// add some slack here for rounding errors
+		return now  + seconds(1) >= next_announce
+			&& (now >= min_announce || need_send_complete)
+			&& (fails < fail_limit || fail_limit == 0)
+			&& !updating;
+	}
+
+	void announce_endpoint::reset()
+	{
+		for (auto& ih : info_hashes)
+			ih.reset();
+
+		start_sent = false;
+		next_announce = time_point32::min();
+		min_announce = time_point32::min();
+	}
+
+	void announce_entry::reset()
+	{
+		for (auto& aep : endpoints)
+			aep.reset();
+	}
+
+	bool announce_endpoint::can_announce(time_point now, bool is_seed, std::uint8_t fail_limit) const
+	{
+		return std::any_of(std::begin(info_hashes), std::end(info_hashes)
+			, [&](announce_infohash const& ih) { return ih.can_announce(now, is_seed, fail_limit); });
+	}
+
+	bool announce_endpoint::is_working() const
+	{
+		return std::any_of(std::begin(info_hashes), std::end(info_hashes)
+			, [](announce_infohash const& ih) { return ih.is_working(); });
+	}
+
+	void announce_entry::trim()
+	{
+		while (!url.empty() && is_space(url[0]))
+			url.erase(url.begin());
+	}
+#endif
+#if TORRENT_ABI_VERSION == 1
+	bool announce_entry::can_announce(time_point now, bool is_seed) const
+	{
+		return std::any_of(endpoints.begin(), endpoints.end()
+			, [&](announce_endpoint const& aep) { return aep.can_announce(now, is_seed, fail_limit); });
+	}
+
+	bool announce_entry::is_working() const
+	{
+		return std::any_of(endpoints.begin(), endpoints.end()
+			, [](announce_endpoint const& aep) { return aep.is_working(); });
+	}
+#endif
+
+namespace aux {
+
+	announce_infohash::announce_infohash()
+		: fails(0)
+		, updating(false)
+		, start_sent(false)
+		, complete_sent(false)
+		, triggered_manually(false)
+	{}
+
+	announce_endpoint::announce_endpoint(aux::listen_socket_handle const& s, bool const completed)
+		: local_endpoint(s ? s.get_local_endpoint() : tcp::endpoint())
+		, enabled(true)
+		, socket(s)
+	{
+		TORRENT_UNUSED(completed);
+	}
+
+	announce_entry::announce_entry(string_view u)
+		: url(u.to_string())
+		, source(0)
+		, verified(false)
+	{}
+
+	announce_entry::announce_entry(lt::announce_entry const& ae)
+		: url(ae.url)
+		, trackerid(ae.trackerid)
+		, tier(ae.tier)
+		, fail_limit(ae.fail_limit)
+		, source(ae.source)
+		, verified(false)
+	{
+		if (source == 0) source = lt::announce_entry::source_client;
+	}
+
+	announce_entry::announce_entry()
+		: source(0)
+		, verified(false)
 	{}
 
 	announce_entry::~announce_entry() = default;
@@ -144,12 +262,6 @@ namespace libtorrent {
 	{
 		for (auto& ih : info_hashes)
 			ih.reset();
-
-#if TORRENT_ABI_VERSION <= 2
-		start_sent = false;
-		next_announce = time_point32::min();
-		min_announce = time_point32::min();
-#endif
 	}
 
 	void announce_entry::reset()
@@ -157,45 +269,13 @@ namespace libtorrent {
 		for (auto& aep : endpoints)
 			aep.reset();
 	}
-#if TORRENT_ABI_VERSION <= 2
-	bool announce_endpoint::can_announce(time_point now, bool is_seed, std::uint8_t fail_limit) const
-	{
-		return std::any_of(std::begin(info_hashes), std::end(info_hashes)
-			, [&](announce_infohash const& ih) { return ih.can_announce(now, is_seed, fail_limit); });
-	}
-
-	bool announce_endpoint::is_working() const
-	{
-		return std::any_of(std::begin(info_hashes), std::end(info_hashes)
-			, [](announce_infohash const& ih) { return ih.is_working(); });
-	}
-#endif
-#if TORRENT_ABI_VERSION == 1
-	bool announce_entry::can_announce(time_point now, bool is_seed) const
-	{
-		return std::any_of(endpoints.begin(), endpoints.end()
-			, [&](announce_endpoint const& aep) { return aep.can_announce(now, is_seed, fail_limit); });
-	}
-
-	bool announce_entry::is_working() const
-	{
-		return std::any_of(endpoints.begin(), endpoints.end()
-			, [](announce_endpoint const& aep) { return aep.is_working(); });
-	}
-#endif
 
 	announce_endpoint* announce_entry::find_endpoint(aux::listen_socket_handle const& s)
 	{
 		auto aep = std::find_if(endpoints.begin(), endpoints.end()
-			, [&](announce_endpoint const& a) { return a.socket == s; });
+			, [&](aux::announce_endpoint const& a) { return a.socket == s; });
 		if (aep != endpoints.end()) return &*aep;
 		else return nullptr;
 	}
-
-	void announce_entry::trim()
-	{
-		while (!url.empty() && is_space(url[0]))
-			url.erase(url.begin());
-	}
-
-}
+} // aux
+} // libtorrent

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -380,6 +380,12 @@ namespace libtorrent {
 		return {last.substr(0, pos), last.substr(pos + found_sep)};
 	}
 
+	void ltrim(std::string& s)
+	{
+		while (!s.empty() && is_space(s.front()))
+			s.erase(s.begin());
+	}
+
 #if TORRENT_USE_I2P
 
 	bool is_i2p_url(std::string const& url)

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1751,7 +1751,7 @@ namespace {
 				for (int k = 0, end2(tier.list_size()); k < end2; ++k)
 				{
 					announce_entry e(tier.list_string_value_at(k).to_string());
-					e.trim();
+					ltrim(e.url);
 					if (e.url.empty()) continue;
 					e.tier = std::uint8_t(j);
 					e.fail_limit = 0;
@@ -1778,7 +1778,7 @@ namespace {
 			announce_entry e(torrent_file.dict_find_string_value("announce"));
 			e.fail_limit = 0;
 			e.source = announce_entry::source_torrent;
-			e.trim();
+			ltrim(e.url);
 #if TORRENT_USE_I2P
 			if (is_i2p_url(e.url)) m_flags |= i2p;
 #endif

--- a/test/test_primitives.cpp
+++ b/test/test_primitives.cpp
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/entry.hpp"
 #include "libtorrent/socket_io.hpp" // for print_endpoint
-#include "libtorrent/announce_entry.hpp"
+#include "libtorrent/aux_/announce_entry.hpp"
 #include "libtorrent/hex.hpp" // from_hex
 #include "libtorrent/fingerprint.hpp"
 #include "libtorrent/client_data.hpp"
@@ -48,7 +48,7 @@ TORRENT_TEST(retry_interval)
 {
 	// make sure the retry interval keeps growing
 	// on failing announces
-	announce_entry ae("dummy");
+	aux::announce_entry ae("dummy");
 	ae.endpoints.emplace_back(aux::listen_socket_handle(), false);
 	int last = 0;
 	auto const tracker_backoff = 250;


### PR DESCRIPTION
This greatly simplifies internal changes without altering ABI