### PR TITLE
Fix possible output truncation in test_dht

### DIFF
--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -2610,7 +2610,7 @@ TORRENT_TEST(traversal_done)
 			TEST_ERROR(t.error_string);
 			continue;
 		}
-		char tok[10];
+		char tok[11];
 		std::snprintf(tok, sizeof(tok), "%02d", i);
 
 		msg_args args;


### PR DESCRIPTION
NOTE: I was not sure which branch to target so I just chose `RC_1_2`, but let me know if it should be `master`.

From the `printf(3)` man page (emphasis mine, the same applies to `std::snprintf`):

> int snprintf(char *str, size_t size, const char *format, ...);

> The functions **snprintf()** and vsnprintf() **write at most size bytes (including the terminating null byte** ('\0')) to str

Thus, to write something that is at most 10 chars in length to str, `sizeof(str)` must be at least 11, to account for the terminating null byte.

This fixes the warning I was getting when compiling (C++14 mode).

```
/home/francisco/Documents/libtorrent/test/test_dht.cpp: In function ‘void unit_test_traversal_done()’:
/home/francisco/Documents/libtorrent/test/test_dht.cpp:2614:35: warning: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
   std::snprintf(tok, sizeof(tok), "%02d", i);
                                   ^~~~~~
In file included from /usr/include/stdio.h:862,
                 from /usr/include/c++/8/cstdio:42,
                 from /usr/include/c++/8/ext/string_conversions.h:43,
                 from /usr/include/c++/8/bits/basic_string.h:6400,
                 from /usr/include/c++/8/string:52,
                 from /opt/boost/include/boost/utility/string_view_fwd.hpp:21,
                 from /opt/boost/include/boost/utility/string_view.hpp:24,
                 from /home/francisco/Documents/libtorrent/include/libtorrent/string_view.hpp:73,
                 from /home/francisco/Documents/libtorrent/include/libtorrent/address.hpp:39,
                 from /home/francisco/Documents/libtorrent/test/test.hpp:36,
                 from /home/francisco/Documents/libtorrent/test/test_dht.cpp:33:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:35: note: ‘__builtin___snprintf_chk’ output between 3 and 11 bytes into a destination of size 10
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
$ gcc --version
gcc (Ubuntu 8.3.0-6ubuntu1~18.04.1) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```