### PR TITLE
remove some seemingly unnecessary TORRENT_TRY and TORRENT_CATCH

### DIFF
--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -55,63 +55,53 @@ namespace libtorrent {
 
 	bool is_local(address const& a)
 	{
-		TORRENT_TRY {
-			if (a.is_v6())
-			{
-				// NOTE: site local is deprecated but by
-				// https://www.ietf.org/rfc/rfc3879.txt:
-				// routers SHOULD be configured to prevent
-				// routing of this prefix by default.
+		if (a.is_v6())
+		{
+			// NOTE: site local is deprecated but by
+			// https://www.ietf.org/rfc/rfc3879.txt:
+			// routers SHOULD be configured to prevent
+			// routing of this prefix by default.
 
-				address_v6 const a6 = a.to_v6();
-				return a6.is_loopback()
-					|| a6.is_link_local()
-					|| a6.is_site_local()
-					|| a6.is_multicast_link_local()
-					|| a6.is_multicast_site_local()
-					//  fc00::/7, unique local address
-					|| (a6.to_bytes()[0] & 0xfe) == 0xfc;
-			}
-			address_v4 a4 = a.to_v4();
-			unsigned long ip = a4.to_ulong();
-			return ((ip & 0xff000000) == 0x0a000000 // 10.x.x.x
-				|| (ip & 0xfff00000) == 0xac100000 // 172.16.x.x
-				|| (ip & 0xffff0000) == 0xc0a80000 // 192.168.x.x
-				|| (ip & 0xffff0000) == 0xa9fe0000 // 169.254.x.x
-				|| (ip & 0xff000000) == 0x7f000000); // 127.x.x.x
-		} TORRENT_CATCH(std::exception const&) { return false; }
+			address_v6 const a6 = a.to_v6();
+			return a6.is_loopback()
+				|| a6.is_link_local()
+				|| a6.is_site_local()
+				|| a6.is_multicast_link_local()
+				|| a6.is_multicast_site_local()
+				//  fc00::/7, unique local address
+				|| (a6.to_bytes()[0] & 0xfe) == 0xfc;
+		}
+		address_v4 a4 = a.to_v4();
+		unsigned long ip = a4.to_ulong();
+		return ((ip & 0xff000000) == 0x0a000000 // 10.x.x.x
+			|| (ip & 0xfff00000) == 0xac100000 // 172.16.x.x
+			|| (ip & 0xffff0000) == 0xc0a80000 // 192.168.x.x
+			|| (ip & 0xffff0000) == 0xa9fe0000 // 169.254.x.x
+			|| (ip & 0xff000000) == 0x7f000000); // 127.x.x.x
 	}
 
+	// TODO: this function is pointless
 	bool is_loopback(address const& addr)
 	{
-		TORRENT_TRY {
-			if (addr.is_v4())
-				return addr.to_v4() == address_v4::loopback();
-			else
-				return addr.to_v6() == address_v6::loopback();
-		} TORRENT_CATCH(std::exception const&) { return false; }
+		return addr.is_loopback();
 	}
 
 	bool is_any(address const& addr)
 	{
-		TORRENT_TRY {
 		if (addr.is_v4())
 			return addr.to_v4() == address_v4::any();
 		else if (addr.to_v6().is_v4_mapped())
 			return (addr.to_v6().to_v4() == address_v4::any());
 		else
 			return addr.to_v6() == address_v6::any();
-		} TORRENT_CATCH(std::exception const&) { return false; }
 	}
 
 	bool is_teredo(address const& addr)
 	{
-		TORRENT_TRY {
-			if (!addr.is_v6()) return false;
-			static const std::uint8_t teredo_prefix[] = {0x20, 0x01, 0, 0};
-			address_v6::bytes_type b = addr.to_v6().to_bytes();
-			return std::memcmp(b.data(), teredo_prefix, 4) == 0;
-		} TORRENT_CATCH(std::exception const&) { return false; }
+		if (!addr.is_v6()) return false;
+		static const std::uint8_t teredo_prefix[] = {0x20, 0x01, 0, 0};
+		address_v6::bytes_type b = addr.to_v6().to_bytes();
+		return std::memcmp(b.data(), teredo_prefix, 4) == 0;
 	}
 
 	bool supports_ipv6()


### PR DESCRIPTION
from is_local(), is_any() and is_teredo(). simplify is_loopback()