### PR TITLE
Specify port=1 in announces via proxy

### DIFF
--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -353,7 +353,7 @@ void test_ipv6_support(char const* listen_interfaces
 
 	// if we're not listening we'll just report port 0
 	std::string const expect_port = (listen_interfaces && listen_interfaces == ""_sv)
-		? "&port=0" : "&port=6881";
+		? "&port=1" : "&port=6881";
 
 	http_v4.register_handler("/announce"
 	, [&v4_announces,expect_port](std::string method, std::string req

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -121,7 +121,7 @@ namespace libtorrent {
 				, escape_string({tracker_req().pid.data(), 20}).c_str()
 				// the i2p tracker seems to verify that the port is not 0,
 				// even though it ignores it otherwise
-				, i2p ? 1 : tracker_req().listen_port
+				, tracker_req().listen_port == 0 ? 1 : tracker_req().listen_port
 				, tracker_req().uploaded
 				, tracker_req().downloaded
 				, tracker_req().left


### PR DESCRIPTION
In case when proxy is enabled, libtorrent sends port=0 parameter in announce request. Some trackers (like [rutracker.org](https://rutracker.org)) reject announce requests when specified port is zero.

I've noticed there are already exception made for I2P to send fake port number, because non-zero port is required. As it appears to me in case when only passive downloads possible, just like in proxy case, and port number in announce is not meaningful, zero value of port doesn't help much and it can cause problems on it's own. Instead of it, some trivial value like `1` may pass tracker sanity checks where `0` don't.

Actual PR ensures port parameter in announce always has non-zero value, catching up all these cases with proxies and absence of real port number.

I'm not sure this patch is accurate, but that is what I have to use, so I've decided to share.
