### PR TITLE
simplify queue_tracker_request

### DIFF
--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -41,7 +41,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/socket.hpp"
-#include "libtorrent/aux_/listen_socket_handle.hpp"
 #include "libtorrent/aux_/array.hpp"
 #include "libtorrent/info_hash.hpp"
 

--- a/include/libtorrent/aux_/announce_entry.hpp
+++ b/include/libtorrent/aux_/announce_entry.hpp
@@ -135,9 +135,6 @@ namespace aux {
 	// this class holds information about one listen socket for one tracker
 	struct TORRENT_EXTRA_EXPORT announce_endpoint
 	{
-		friend struct lt::torrent;
-		friend struct announce_entry;
-
 		// internal
 		announce_endpoint(aux::listen_socket_handle const& s, bool completed);
 
@@ -159,7 +156,6 @@ namespace aux {
 		// set to false to not announce from this endpoint
 		bool enabled : 1;
 
-	private:
 		// internal
 		aux::listen_socket_handle socket;
 	};

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -67,6 +67,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/download_priority.hpp"
 #include "libtorrent/pex_flags.hpp"
 #include "libtorrent/client_data.hpp"
+#include "libtorrent/address.hpp" // for address_v4 and address_v6
 
 namespace libtorrent {
 namespace aux {

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1226,44 +1226,19 @@ namespace {
 		if (!use_ssl) req.ssl_ctx = &m_ssl_ctx;
 #endif
 
-		if (req.outgoing_socket)
-		{
+		TORRENT_ASSERT(req.outgoing_socket);
 			auto ls = req.outgoing_socket.get();
 
-			req.listen_port =
+		req.listen_port =
 #if TORRENT_USE_I2P
-				(req.kind == tracker_request::i2p) ? 1 :
+			(req.kind == tracker_request::i2p) ? 1 :
 #endif
 #ifdef TORRENT_SSL_PEERS
 			// SSL torrents use the SSL listen port
-				use_ssl ? make_announce_port(ssl_listen_port(ls)) :
+			use_ssl ? make_announce_port(ssl_listen_port(ls)) :
 #endif
-				make_announce_port(listen_port(ls));
-			m_tracker_manager.queue_request(get_context(), std::move(req), c);
-		}
-		else
-		{
-			for (auto& ls : m_listen_sockets)
-			{
-				if (!(ls->flags & listen_socket_t::accept_incoming)) continue;
-#ifdef TORRENT_SSL_PEERS
-				if ((ls->ssl == transport::ssl) != use_ssl) continue;
-#endif
-				tracker_request socket_req(req);
-				socket_req.listen_port =
-#if TORRENT_USE_I2P
-					(req.kind == tracker_request::i2p) ? 1 :
-#endif
-#ifdef TORRENT_SSL_PEERS
-				// SSL torrents use the SSL listen port
-					use_ssl ? make_announce_port(ssl_listen_port(ls.get())) :
-#endif
-					make_announce_port(listen_port(ls.get()));
-
-				socket_req.outgoing_socket = ls;
-				m_tracker_manager.queue_request(get_context(), std::move(socket_req), c);
-			}
-		}
+			make_announce_port(listen_port(ls));
+		m_tracker_manager.queue_request(get_context(), std::move(req), c);
 	}
 
 	void session_impl::set_peer_class(peer_class_t const cid, peer_class_info const& pci)


### PR DESCRIPTION
by assuming the outgoing_socket is always specified (and make it so)