### PR TITLE
set default build type for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(libtorrent
 )
 set (SOVERSION "10")
 
+set_default_build_type()
+
 include(GNUInstallDirs)
 include(GeneratePkgConfig)
 

--- a/cmake/Modules/LibtorrentMacros.cmake
+++ b/cmake/Modules/LibtorrentMacros.cmake
@@ -107,7 +107,7 @@ function(read_version _verFile _outVarMajor _outVarMinor _outVarTiny)
 	# the verFileContents variable contains something like the following:
 	# #define LIBTORRENT_VERSION_MAJOR 1;#define LIBTORRENT_VERSION_MINOR 2;#define LIBTORRENT_VERSION_TINY 0
 	set(_regex ".+_MAJOR +([0-9]+);.+_MINOR +([0-9]+);.+_TINY +([0-9]+)")
-	 # note quotes around _regex, they are needed because the variable contains semicolons
+	# note quotes around _regex, they are needed because the variable contains semicolons
 	string(REGEX MATCH "${_regex}" _tmp "${verFileContents}")
 	if (NOT _tmp)
 		message(FATAL_ERROR "Could not detect project version number from ${_verFile}")
@@ -118,4 +118,21 @@ function(read_version _verFile _outVarMajor _outVarMinor _outVarTiny)
 	set(${_outVarMajor} ${CMAKE_MATCH_1} PARENT_SCOPE)
 	set(${_outVarMinor} ${CMAKE_MATCH_2} PARENT_SCOPE)
 	set(${_outVarTiny} ${CMAKE_MATCH_3} PARENT_SCOPE)
+endfunction()
+
+# Set a default build type if none was specified
+function(set_default_build_type)
+	set(default_build_type "Release")
+	if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+		set(default_build_type "Debug")
+	endif()
+
+	if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+		message(STATUS "Setting build type to '${default_build_type}' as none was specified")
+		set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING
+			"Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel ..." FORCE)
+		# Set the possible values of build type for cmake-gui
+		set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+			"Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+	endif()
 endfunction()


### PR DESCRIPTION
Sets CMake build type, if none was selected with `-DCMAKE_BUILD_TYPE=` option, if the folder contains `.git` folder `Debug` is selected, otherwise `Release` is selected.

This is a good alternative, because if you download the package from GitHub from Release section eg `https://github.com/silverqx/libtorrent/archive/libtorrent-1_1_4.zip` or you download branch as zip file, in this cases package archive doesn't contain `.git` folder, so Linux distributions which are downloading this package this way eg for preparing this package for distro repositories, will not be affected to accidentally compile debug build.

I used code from this blog post https://blog.kitware.com/cmake-and-the-default-build-type/ where is everything described in detail.

I have tried shadow builds, builds with and without `.git` folder and of course with and without `-DCMAKE_BUILD_TYPE=` option and it works as expected.

Fixes #4416