### PR TITLE
deprecate bittyrant choking algorithm

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* deprecate the bittyrant choking algorithm
 	* add build option to disable streaming
 
 1.2.5 release

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -842,7 +842,9 @@ void bind_alert()
         .value("download_limit_too_low", performance_alert::download_limit_too_low)
         .value("send_buffer_watermark_too_low", performance_alert::send_buffer_watermark_too_low)
         .value("too_many_optimistic_unchoke_slots", performance_alert::too_many_optimistic_unchoke_slots)
+#if TORRENT_ABI_VERSION == 1
         .value("bittyrant_with_no_uplimit", performance_alert::bittyrant_with_no_uplimit)
+#endif
         .value("too_high_disk_queue_limit", performance_alert::too_high_disk_queue_limit)
         .value("too_few_outgoing_ports", performance_alert::too_few_outgoing_ports)
         .value("too_few_file_descriptors", performance_alert::too_few_file_descriptors)

--- a/bindings/python/src/peer_info.cpp
+++ b/bindings/python/src/peer_info.cpp
@@ -104,7 +104,9 @@ void bind_peer_info()
         .def_readonly("upload_rate_peak", &peer_info::upload_rate_peak)
         .def_readonly("progress", &peer_info::progress)
         .def_readonly("progress_ppm", &peer_info::progress_ppm)
+#if TORRENT_ABI_VERSION == 1
         .def_readonly("estimated_reciprocation_rate", &peer_info::estimated_reciprocation_rate)
+#endif
         .add_property("local_endpoint", get_local_endpoint)
         ;
 

--- a/bindings/python/src/session_settings.cpp
+++ b/bindings/python/src/session_settings.cpp
@@ -17,7 +17,9 @@ void bind_session_settings()
         .value("auto_expand_choker", settings_pack::rate_based_choker)
 #endif
         .value("rate_based_choker", settings_pack::rate_based_choker)
+#if TORRENT_ABI_VERSION == 1
         .value("bittyrant_choker", settings_pack::bittyrant_choker)
+#endif
     ;
 
     enum_<settings_pack::seed_choking_algorithm_t>("seed_choking_algorithm_t")

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -195,7 +195,6 @@ bool print_ip = true;
 bool print_local_ip = false;
 bool print_timers = false;
 bool print_block = false;
-bool print_peer_rate = false;
 bool print_fails = false;
 bool print_send_bufs = true;
 bool print_disk_stats = false;
@@ -322,7 +321,6 @@ int print_peer_info(std::string& out
 	if (print_timers) out += "inactive wait timeout q-time ";
 	out += "  v disk ^    rtt  ";
 	if (print_block) out += "block-progress ";
-	if (print_peer_rate) out += "est.rec.rate ";
 	out += "client \x1b[K\n";
 	++pos;
 
@@ -453,14 +451,6 @@ int print_peer_info(std::string& out
 			}
 		}
 
-		if (print_peer_rate)
-		{
-			bool const unchoked = !(i->flags & lt::peer_info::choked);
-
-			std::snprintf(str, sizeof(str), " %s"
-				, unchoked ? add_suffix(i->estimated_reciprocation_rate, "/s").c_str() : "      ");
-			out += str;
-		}
 		out += " ";
 
 		if (i->flags & lt::peer_info::handshake)
@@ -1617,7 +1607,6 @@ example alert_masks:
 				if (c == '2') print_connecting_peers = !print_connecting_peers;
 				if (c == '3') print_timers = !print_timers;
 				if (c == '4') print_block = !print_block;
-				if (c == '5') print_peer_rate = !print_peer_rate;
 				if (c == '6') print_fails = !print_fails;
 				if (c == '7') print_send_bufs = !print_send_bufs;
 				if (c == '8') print_local_ip = !print_local_ip;
@@ -1662,7 +1651,7 @@ up/down arrow keys: select torrent
 COLUMN OPTIONS
 [1] toggle IP column                            [2] toggle show peer connection attempts
 [3] toggle timers column                        [4] toggle block progress column
-[5] toggle peer rate column                     [6] toggle failures column
+                                                [6] toggle failures column
 [7] toggle send buffers column                  [8] toggle local IP column
 )");
 					int tmp;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -458,7 +458,11 @@ TORRENT_VERSION_NAMESPACE_2
 			too_high_disk_queue_limit,
 
 			aio_limit_reached,
-			bittyrant_with_no_uplimit,
+#if TORRENT_ABI_VERSION == 1
+			bittyrant_with_no_uplimit TORRENT_DEPRECATED_ENUM,
+#else
+			deprecated_bittyrant_with_no_uplimit,
+#endif
 
 			// This is generated if outgoing peer connections are failing because of *address in use*
 			// errors, indicating that ``settings_pack::outgoing_ports`` is set and is too small of

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -640,8 +640,6 @@ namespace aux {
 			// ``num_peers_half_open`` instead.
 			int num_connections() const override { return int(m_connections.size()); }
 
-			int peak_up_rate() const { return m_peak_up_rate; }
-
 			void trigger_unchoke() noexcept override
 			{
 				TORRENT_ASSERT(is_single_thread());
@@ -1072,8 +1070,9 @@ namespace aux {
 			void sent_syn(bool ipv6) override;
 			void received_synack(bool ipv6) override;
 
+#if TORRENT_ABI_VERSION == 1
 			int m_peak_up_rate = 0;
-			int m_peak_down_rate = 0;
+#endif
 
 			void on_tick(error_code const& e);
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -513,9 +513,11 @@ namespace aux {
 		// returns true if the connection was disconnected
 		bool disconnect_if_redundant();
 
+#if TORRENT_ABI_VERSION == 1
 		void increase_est_reciprocation_rate();
 		void decrease_est_reciprocation_rate();
 		int est_reciprocation_rate() const { return m_est_reciprocation_rate; }
+#endif
 
 #ifndef TORRENT_DISABLE_LOGGING
 		bool should_log(peer_log_alert::direction_t direction) const final;
@@ -1029,11 +1031,13 @@ namespace aux {
 		int m_download_rate_peak = 0;
 		int m_upload_rate_peak = 0;
 
+#if TORRENT_ABI_VERSION == 1
 		// when using the BitTyrant choker, this is our
 		// estimated reciprocation rate. i.e. the rate
 		// we need to send to this peer for it to unchoke
 		// us
 		int m_est_reciprocation_rate;
+#endif
 
 		// stop sending data after this many bytes, INT_MAX = inf
 		int m_send_barrier = INT_MAX;

--- a/include/libtorrent/peer_info.hpp
+++ b/include/libtorrent/peer_info.hpp
@@ -64,6 +64,13 @@ TORRENT_VERSION_NAMESPACE_2
 	// that libtorrent is connected to
 	struct TORRENT_EXPORT peer_info
 	{
+		// hidden
+		peer_info();
+		~peer_info();
+		peer_info(peer_info const&);
+		peer_info(peer_info&&);
+		peer_info& operator=(peer_info const&);
+
 		// a string describing the software at the other end of the connection.
 		// In some cases this information is not available, then it will contain
 		// a string that may give away something about which software is running
@@ -133,7 +140,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// The connection is currently queued for a connection
 		// attempt. This may happen if there is a limit set on
 		// the number of half-open TCP connections.
-		static constexpr peer_flags_t queued = 8_bit;
+		TORRENT_DEPRECATED_MEMBER static constexpr peer_flags_t queued = 8_bit;
 #endif
 
 		// The peer has participated in a piece that failed the
@@ -325,7 +332,7 @@ TORRENT_VERSION_NAMESPACE_2
 #if TORRENT_ABI_VERSION == 1
 		// an estimate of the rate this peer is downloading at, in
 		// bytes per second.
-		int remote_dl_rate;
+		TORRENT_DEPRECATED_MEMBER int remote_dl_rate;
 #endif
 
 		// the number of bytes this peer has pending in the disk-io thread.
@@ -364,11 +371,15 @@ TORRENT_VERSION_NAMESPACE_2
 		// (parts per million).
 		int progress_ppm;
 
+#if TORRENT_ABI_VERSION == 1
 		// this is an estimation of the upload rate, to this peer, where it will
 		// unchoke us. This is a coarse estimation based on the rate at which
 		// we sent right before we were choked. This is primarily used for the
 		// bittyrant choking algorithm.
-		int estimated_reciprocation_rate;
+		TORRENT_DEPRECATED_MEMBER int estimated_reciprocation_rate;
+#else
+		int deprecated_estimated_reciprocation_rate;
+#endif
 
 		// the IP-address to this peer. The type is an asio endpoint. For
 		// more info, see the asio_ documentation.
@@ -406,21 +417,21 @@ TORRENT_VERSION_NAMESPACE_2
 		bandwidth_state_flags_t write_state;
 
 #if TORRENT_ABI_VERSION == 1
-		static constexpr bandwidth_state_flags_t bw_torrent = bw_limit;
-		static constexpr bandwidth_state_flags_t bw_global = bw_limit;
+		TORRENT_DEPRECATED_MEMBER static constexpr bandwidth_state_flags_t bw_torrent = bw_limit;
+		TORRENT_DEPRECATED_MEMBER static constexpr bandwidth_state_flags_t bw_global = bw_limit;
 
 		// the number of bytes per second we are allowed to send to or receive
 		// from this peer. It may be -1 if there's no local limit on the peer.
 		// The global limit and the torrent limit may also be enforced.
-		int upload_limit;
-		int download_limit;
+		TORRENT_DEPRECATED_MEMBER int upload_limit;
+		TORRENT_DEPRECATED_MEMBER int download_limit;
 
 		// a measurement of the balancing of free download (that we get) and free
 		// upload that we give. Every peer gets a certain amount of free upload,
 		// but this member says how much *extra* free upload this peer has got.
 		// If it is a negative number it means that this was a peer from which we
 		// have got this amount of free download.
-		std::int64_t load_balancing;
+		TORRENT_DEPRECATED_MEMBER std::int64_t load_balancing;
 #endif
 	};
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1004,7 +1004,9 @@ namespace aux {
 			send_buffer_watermark_factor,
 
 			// ``choking_algorithm`` specifies which algorithm to use to determine
-			// which peers to unchoke.
+			// how many peers to unchoke. The unchoking algorithm for
+			// downloading torrents is always "tit-for-tat", i.e. the peers we
+			// download the fastest from are unchoked.
 			//
 			// The options for choking algorithms are:
 			//
@@ -1016,20 +1018,10 @@ namespace aux {
 			//   rate achieved to peers. The more slots that are opened, the
 			//   marginal upload rate required to open up another slot increases.
 			//
-			// * ``bittyrant_choker`` attempts to optimize download rate by
-			//   finding the reciprocation rate of each peer individually and
-			//   prefers peers that gives the highest *return on investment*. It
-			//   still allocates all upload capacity, but shuffles it around to
-			//   the best peers first. For this choker to be efficient, you need
-			//   to set a global upload rate limit
-			//   (``settings_pack::upload_rate_limit``). For more information
-			//   about this choker, see the paper_. This choker is not fully
-			//   implemented nor tested.
-			//
-			// .. _paper: http://bittyrant.cs.washington.edu/#papers
-			//
 			// ``seed_choking_algorithm`` controls the seeding unchoke behavior.
-			// The available options are:
+			// i.e. How we select which peers to unchoke for seeding torrents.
+			// Since a seeding torrent isn't downloading anything, the
+			// tit-for-tat mechanism cannot be used. The available options are:
 			//
 			// * ``round_robin`` which round-robins the peers that are unchoked
 			//   when seeding. This distributes the upload bandwidth uniformly and
@@ -1043,6 +1035,9 @@ namespace aux {
 			// * ``anti_leech`` prioritizes peers who have just started or are
 			//   just about to finish the download. The intention is to force
 			//   peers in the middle of the download to trade with each other.
+			//   This does not just take into account the pieces a peer is
+			//   reporting having downloaded, but also the pieces we have sent
+			//   to it.
 			choking_algorithm,
 			seed_choking_algorithm,
 
@@ -1320,6 +1315,7 @@ namespace aux {
 			// allowed upload slots as optimistic unchoke slots.
 			num_optimistic_unchoke_slots,
 
+#if TORRENT_ABI_VERSION == 1
 			// ``default_est_reciprocation_rate`` is the assumed reciprocation
 			// rate from peers when using the BitTyrant choker. If set too high,
 			// you will over-estimate your peers and be
@@ -1336,9 +1332,14 @@ namespace aux {
 			// estimated reciprocation rate should be decreased by each unchoke
 			// interval a peer unchokes us. This only applies
 			// to the BitTyrant choker.
-			default_est_reciprocation_rate,
-			increase_est_reciprocation_rate,
-			decrease_est_reciprocation_rate,
+			default_est_reciprocation_rate TORRENT_DEPRECATED_ENUM,
+			increase_est_reciprocation_rate TORRENT_DEPRECATED_ENUM,
+			decrease_est_reciprocation_rate TORRENT_DEPRECATED_ENUM,
+#else
+			deprecated_default_est_reciprocation_rate,
+			deprecated_increase_est_reciprocation_rate,
+			deprecated_decrease_est_reciprocation_rate,
+#endif
 
 			// the max number of peers we accept from pex messages from a single
 			// peer. this limits the number of concurrent peers any of our peers
@@ -1751,7 +1752,11 @@ namespace aux {
 		{
 			fixed_slots_choker = 0,
 			rate_based_choker = 2,
-			bittyrant_choker = 3
+#if TORRENT_ABI_VERSION == 1
+			bittyrant_choker TORRENT_DEPRECATED_ENUM = 3
+#else
+			deprecated_bittyrant_choker = 3
+#endif
 		};
 
 		enum seed_choking_algorithm_t : std::uint8_t

--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -197,6 +197,7 @@ namespace {
 		return c1 > c2;
 	}
 
+#if TORRENT_ABI_VERSION == 1
 	bool bittyrant_unchoke_compare(peer_connection const* lhs
 		, peer_connection const* rhs)
 	{
@@ -219,6 +220,7 @@ namespace {
 		// prioritize the one that has waited the longest to be unchoked
 		return lhs->time_of_last_unchoke() < rhs->time_of_last_unchoke();
 	}
+#endif
 
 	} // anonymous namespace
 
@@ -235,6 +237,7 @@ namespace {
 		}
 #endif
 
+#if TORRENT_ABI_VERSION == 1
 		// ==== BitTyrant ====
 		//
 		// if we're using the bittyrant unchoker, go through all peers that
@@ -289,6 +292,9 @@ namespace {
 
 			return upload_slots;
 		}
+#else
+		TORRENT_UNUSED(max_upload_rate);
+#endif
 
 		int upload_slots = sett.get_int(settings_pack::unchoke_slots_limit);
 		if (upload_slots < 0)

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -167,7 +167,9 @@ namespace libtorrent {
 		// if t is nullptr, we better not be connecting, since
 		// we can't decrement the connecting counter
 		TORRENT_ASSERT(t || !m_connecting);
+#if TORRENT_ABI_VERSION == 1
 		m_est_reciprocation_rate = m_settings.get_int(settings_pack::default_est_reciprocation_rate);
+#endif
 
 		m_channel_state[upload_channel] = peer_info::bw_idle;
 		m_channel_state[download_channel] = peer_info::bw_idle;
@@ -268,6 +270,7 @@ namespace libtorrent {
 		disconnect(ec, operation_t::unknown, peer_error);
 	}
 
+#if TORRENT_ABI_VERSION == 1
 	void peer_connection::increase_est_reciprocation_rate()
 	{
 		TORRENT_ASSERT(is_single_thread());
@@ -281,6 +284,7 @@ namespace libtorrent {
 		m_est_reciprocation_rate -= m_est_reciprocation_rate
 			* m_settings.get_int(settings_pack::decrease_est_reciprocation_rate) / 100;
 	}
+#endif
 
 	int peer_connection::get_priority(int const channel) const
 	{
@@ -4590,7 +4594,9 @@ namespace libtorrent {
 			p.progress_ppm = int(std::int64_t(p.pieces.count()) * 1000000 / p.pieces.size());
 		}
 
+#if TORRENT_ABI_VERSION == 1
 		p.estimated_reciprocation_rate = m_est_reciprocation_rate;
+#endif
 
 		error_code ec;
 		p.local_endpoint = get_socket()->local_endpoint(ec);

--- a/src/peer_info.cpp
+++ b/src/peer_info.cpp
@@ -34,6 +34,12 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
+	peer_info::peer_info() = default;
+	peer_info::~peer_info() = default;
+	peer_info::peer_info(peer_info const&) = default;
+	peer_info::peer_info(peer_info&&) = default;
+	peer_info& peer_info::operator=(peer_info const&) = default;
+
 	// This will no longer be necessary with C++17
 	constexpr peer_flags_t peer_info::interesting;
 	constexpr peer_flags_t peer_info::choked;

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3335,8 +3335,9 @@ namespace {
 			}
 		}
 
+#if TORRENT_ABI_VERSION == 1
 		m_peak_up_rate = std::max(m_stat.upload_rate(), m_peak_up_rate);
-		m_peak_down_rate = std::max(m_stat.download_rate(), m_peak_down_rate);
+#endif
 
 		m_stat.second_tick(tick_interval_ms);
 
@@ -4170,6 +4171,7 @@ namespace {
 			peers.push_back(p.get());
 		}
 
+#if TORRENT_ABI_VERSION == 1
 		// the unchoker wants an estimate of our upload rate capacity
 		// (used by bittyrant)
 		int max_upload_rate = upload_rate_limit(m_global_class);
@@ -4185,6 +4187,9 @@ namespace {
 				m_alerts.emplace_alert<performance_alert>(torrent_handle()
 					, performance_alert::bittyrant_with_no_uplimit);
 		}
+#else
+		int const max_upload_rate = 0;
+#endif
 
 		int const allowed_upload_slots = unchoke_sort(peers, max_upload_rate
 			, unchoke_interval, m_settings);


### PR DESCRIPTION
the bittyrant choker relies on being able to set upload rate limits *per connection*. This feature was removed a long time ago in an attempt to simplify things. The bittyrant dependency on this feature was overlooked and effectively broke this choking algorithm. Rather than fixing it, I'm tempted to remove it. If there is interest (and effort) to research choking algorithms, I'm open to add something back in the future.