### PR TITLE
fix assertion failure when detroying moved-from session

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -384,8 +384,9 @@ namespace {
 
 	session::~session()
 	{
+		if (!m_impl) return;
+
 		aux::dump_call_profile();
-		TORRENT_ASSERT(m_impl);
 
 		// capture the shared_ptr in the dispatched function
 		// to keep the session_impl alive


### PR DESCRIPTION
When a session object is moved, all of its shared_ptrs become empty.
Don't assert in the dtor due to this, just do nothing.