### PR TITLE
setting a proxy overrides listen_interfaces

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* simplify proxy handling. A proxy now overrides listen_interfaces
 	* fix issues when configured to use a non-default choking algorithm
 	* fix issue in reading resume data
 	* revert NXDOMAIN change from 1.2.4

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -151,6 +151,10 @@ namespace aux {
 		// listen on an unspecified address (either IPv4 or IPv6)
 		static constexpr listen_socket_flags_t was_expanded = 2_bit;
 
+		// there's a proxy configured, and this is the only one interface
+		// representing that one proxy
+		static constexpr listen_socket_flags_t proxy = 3_bit;
+
 		listen_socket_t() = default;
 
 		// listen_socket_t should not be copied or moved because

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -284,7 +284,14 @@ namespace aux {
 			listen_interfaces,
 
 			// when using a proxy, this is the hostname where the proxy is running
-			// see proxy_type.
+			// see proxy_type. Note that when using a proxy, the
+			// settings_pack::listen_interfaces setting is overridden and only a
+			// single interface is created, just to contact the proxy. This
+			// means a proxy cannot be combined with SSL torrents or multiple
+			// listen interfaces. This proxy listen interface will not accept
+			// incoming TCP connections, will not map ports with any gateway and
+			// will not enable local service discovery. All traffic is supposed
+			// to be channeled through the proxy.
 			proxy_hostname,
 
 			// when using a proxy, these are the credentials (if any) to use when

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1837,7 +1837,7 @@ namespace {
 		if (m_settings.get_int(settings_pack::proxy_type) != settings_pack::none)
 		{
 			// we will be able to accept incoming connections over UDP. so use
-			// one of the ports the user specified to use a constistent port
+			// one of the ports the user specified to use a consistent port
 			// across sessions. If the user did not specify any ports, pick one
 			// at random
 			int const port = m_listen_interfaces.empty()

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -922,6 +922,8 @@ void socks5::hung_up(error_code const& e)
 void socks5::retry_socks_connect(error_code const& e)
 {
 	if (e) return;
+	error_code ignore;
+	m_socks5_sock.close(ignore);
 	start(m_proxy_settings);
 }
 


### PR DESCRIPTION
The idea with this patch is to simplify the proxy handling. Instead of a proxy being treated as something independent from the network interfaces, it's treated as a network interface itself.

It makes sense that a single proxy really acts as an access point to the internet and when configuring one, whether your machine is multi-homed or not is not relevant, everything is funneled through the proxy.

It simplifies things like:

* UPnP, NAT-PMP, PCP and local service discovery can easily be disabled entirely when using a proxy
* Trackers will only announce once, via the proxy
* There will only be a single DHT running, via the proxy

This change, while cleaning up some common cases, also bans some rare cases. With this patch it will not be possible to combine running SSL torrents with a proxy. The SSL listen socket is also treated as a `listen_socket_t`. It will no longer be possible to combine multiple listen sockets with a proxy (mostly because there's only one proxy that can be configured).

To make this fully generic, each listen interface (i.e. entry in `listen_interfaces` setting) would have to have its own proxy configuration. That hardly seems worth the trouble though.