### PR TITLE
don't open any listen sockets if listen_interfaces is empty

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* don't open any listen sockets if listen_interfaces is empty or misconfigured
 	* fix bug in auto disk cache size logic
 	* fix issue with outgoing_interfaces setting, where bind() would be called twice
 	* add build option to disable share-mode

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -215,7 +215,10 @@ namespace aux {
 
 			// a comma-separated list of (IP or device name, port) pairs. These are
 			// the listen ports that will be opened for accepting incoming uTP and
-			// TCP connections. It is possible to listen on multiple interfaces and
+			// TCP connections. These are also used for *outgoing* uTP and UDP
+			// tracker connections and DHT nodes.
+			//
+			// It is possible to listen on multiple interfaces and
 			// multiple ports. Binding to port 0 will make the operating system
 			// pick the port.
 			//
@@ -227,17 +230,29 @@ namespace aux {
 			//    you use and hand that port out to other peers trying to connect
 			//    to you, as well as trying to connect to you themselves.
 			//
-			// a port that has an "s" suffix will accept SSL connections. (note
+			// A port that has an "s" suffix will accept SSL connections. (note
 			// that SSL sockets are not enabled by default).
 			//
-			// a port that has an "l" suffix will be considered a local network.
+			// A port that has an "l" suffix will be considered a local network.
 			// i.e. it's assumed to only be able to reach hosts in the same local
 			// network as the IP address (based on the netmask associated with the
 			// IP, queried from the operating system).
 			//
-			// if binding fails, the listen_failed_alert is posted. If or once a
-			// socket binding succeeds, the listen_succeeded_alert is posted. There
-			// may be multiple failures before a success.
+			// if binding fails, the listen_failed_alert is posted. Once a
+			// socket binding succeeds (if it does), the listen_succeeded_alert
+			// is posted. There may be multiple failures before a success.
+			//
+			// If a device name that does not exist is configured, no listen
+			// socket will be opened for that interface. If this is the only
+			// interface configured, it will be as if no listen ports are
+			// configured.
+			//
+			// If no listen ports are configured (e.g. listen_interfaces is an
+			// empty string), networking will be disabled. No DHT will start, no
+			// outgoing uTP or tracker connections will be made. No incoming TCP
+			// or uTP connections will be accepted. (outgoing TCP connections
+			// will still be possible, depending on
+			// settings_pack::outgoing_interfaces).
 			//
 			// For example:
 			// ``[::1]:8888`` - will only accept connections on the IPv6 loopback
@@ -257,7 +272,7 @@ namespace aux {
 			// not announced to trackers, unless the tracker is also on the same
 			// local network.
 			//
-			// Windows OS network adapter device name can be specified with GUID.
+			// Windows OS network adapter device name must be specified with GUID.
 			// It can be obtained from "netsh lan show interfaces" command output.
 			// GUID must be uppercased string embraced in curly brackets.
 			// ``{E4F0B674-0DFC-48BB-98A5-2AA730BDB6D6}::7777`` - will accept

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -547,16 +547,14 @@ TORRENT_TEST(ipv6_support)
 
 TORRENT_TEST(announce_no_listen)
 {
-	// if we don't listen on any sockets at all (but only make outgoing peer
-	// connections) we still need to make sure we announce to trackers
-	test_ipv6_support("", num_interfaces * 2, num_interfaces * 2);
+	// if we don't listen on any sockets at all we should not announce to trackers
+	test_ipv6_support("", 0, 0);
 }
 
 TORRENT_TEST(announce_udp_no_listen)
 {
-	// since there's no actual udp tracker in this test, we will only try to
-	// announce once, and fail. We won't announce the event=stopped
-	test_udpv6_support("", num_interfaces * 1, num_interfaces * 1);
+	// if we don't listen on any sockets at all we should not announce to trackers
+	test_udpv6_support("", 0, 0);
 }
 
 TORRENT_TEST(ipv6_support_bind_v4_v6_any)

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1866,14 +1866,11 @@ namespace {
 			interface_to_endpoints(iface, flags, ifs, eps);
 		}
 
-		// if no listen interfaces are specified, create sockets to use
-		// any interface
 		if (eps.empty())
 		{
-			eps.emplace_back(address_v4(), 0, "", transport::plaintext
-				, listen_socket_flags_t{});
-			eps.emplace_back(address_v6(), 0, "", transport::plaintext
-				, listen_socket_flags_t{});
+#ifndef TORRENT_DISABLE_LOGGING
+			session_log("no listen sockets");
+#endif
 		}
 
 		expand_unspecified_address(ifs, routes, eps);
@@ -5003,8 +5000,6 @@ namespace {
 		{
 			if (m_interface_index >= m_outgoing_interfaces.size()) m_interface_index = 0;
 			std::string const& ifname = m_outgoing_interfaces[m_interface_index++];
-
-			if (ec) return bind_ep;
 
 			bind_ep.address(bind_socket_to_device(m_io_service, s
 				, remote_address.is_v4() ? tcp::v4() : tcp::v6()


### PR DESCRIPTION
or misconfigured.

@ssiloti I keep forgetting why it's important to open the "default" listen sockets in case none are configured (or if the configured interface doesn't exist). I seem to recall it's because `listen_interfaces` ought to be just for *listening*, and this would prevent outgoing connections as well. I'm having second thoughts on these semantics.

I'm imagining heading in a direction where `listen_interfaces` and `outgoing_interfaces` are merged, and the behavior of actually performing a bind-to-device can be controlled by a boolean setting instead. But there wouldn't be two separate lists of interfaces.

In such future, it *would* make sense to allow having no listen sockets. The main rationale for this is if `listen_interfaces` is configured with a VPN interface that is currently offline (not available).