### PR TITLE
Add node_id to dht_sample_infohashes_alert

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2771,6 +2771,7 @@ TORRENT_VERSION_NAMESPACE_2
 	{
 		// internal
 		TORRENT_UNEXPORT dht_sample_infohashes_alert(aux::stack_allocator& alloc
+			, sha1_hash const& nid
 			, udp::endpoint const& endp
 			, time_duration interval
 			, int num
@@ -2781,6 +2782,9 @@ TORRENT_VERSION_NAMESPACE_2
 		TORRENT_DEFINE_ALERT(dht_sample_infohashes_alert, 93)
 
 		std::string message() const override;
+
+		// id of the node the request was sent to (and this response was received from)
+		sha1_hash node_id;
 
 		// the node the request was sent to (and this response was received from)
 		aux::noexcept_movable<udp::endpoint> endpoint;

--- a/include/libtorrent/kademlia/dht_tracker.hpp
+++ b/include/libtorrent/kademlia/dht_tracker.hpp
@@ -117,7 +117,8 @@ namespace dht {
 			, std::function<void(std::vector<tcp::endpoint> const&)> f);
 
 		void sample_infohashes(udp::endpoint const& ep, sha1_hash const& target
-			, std::function<void(time_duration
+			, std::function<void(node_id
+				, time_duration
 				, int, std::vector<sha1_hash>
 				, std::vector<std::pair<sha1_hash, udp::endpoint>>)> f);
 

--- a/include/libtorrent/kademlia/node.hpp
+++ b/include/libtorrent/kademlia/node.hpp
@@ -169,7 +169,8 @@ public:
 		, std::function<void(item&)> data_cb);
 
 	void sample_infohashes(udp::endpoint const& ep, sha1_hash const& target
-		, std::function<void(time_duration
+		, std::function<void(sha1_hash
+			, time_duration
 			, int, std::vector<sha1_hash>
 			, std::vector<std::pair<sha1_hash, udp::endpoint>>)> f);
 

--- a/include/libtorrent/kademlia/sample_infohashes.hpp
+++ b/include/libtorrent/kademlia/sample_infohashes.hpp
@@ -46,7 +46,8 @@ class sample_infohashes final : public traversal_algorithm
 {
 public:
 
-	using data_callback = std::function<void(time_duration
+	using data_callback = std::function<void(sha1_hash
+		, time_duration
 		, int, std::vector<sha1_hash>
 		, std::vector<std::pair<sha1_hash, udp::endpoint>>)>;
 
@@ -56,7 +57,8 @@ public:
 
 	char const* name() const override;
 
-	void got_samples(time_duration interval
+	void got_samples(sha1_hash const& nid
+		, time_duration interval
 		, int num, std::vector<sha1_hash> samples
 		, std::vector<std::pair<sha1_hash, udp::endpoint>> nodes);
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2463,12 +2463,14 @@ namespace {
 	}
 
 	dht_sample_infohashes_alert::dht_sample_infohashes_alert(aux::stack_allocator& alloc
+		, sha1_hash const& nid
 		, udp::endpoint const& endp
 		, time_duration _interval
 		, int _num
 		, std::vector<sha1_hash> const& samples
 		, std::vector<std::pair<sha1_hash, udp::endpoint>> const& nodes)
-		: endpoint(endp)
+		: node_id(nid)
+		, endpoint(endp)
 		, interval(_interval)
 		, num_infohashes(_num)
 		, m_alloc(alloc)

--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -325,7 +325,8 @@ namespace libtorrent { namespace dht {
 	}
 
 	void dht_tracker::sample_infohashes(udp::endpoint const& ep, sha1_hash const& target
-		, std::function<void(time_duration
+		, std::function<void(node_id
+			, time_duration
 			, int, std::vector<sha1_hash>
 			, std::vector<std::pair<sha1_hash, udp::endpoint>>)> f)
 	{

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -575,7 +575,8 @@ void node::put_item(public_key const& pk, std::string const& salt
 }
 
 void node::sample_infohashes(udp::endpoint const& ep, sha1_hash const& target
-	, std::function<void(time_duration
+	, std::function<void(sha1_hash
+		, time_duration
 		, int, std::vector<sha1_hash>
 		, std::vector<std::pair<sha1_hash, udp::endpoint>>)> f)
 {

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5993,12 +5993,13 @@ namespace {
 	void session_impl::dht_sample_infohashes(udp::endpoint const& ep, sha1_hash const& target)
 	{
 		if (!m_dht) return;
-		m_dht->sample_infohashes(ep, target, [this, ep](time_duration const interval
+		m_dht->sample_infohashes(ep, target, [this, ep](sha1_hash const& nid
+			, time_duration const interval
 			, int const num, std::vector<sha1_hash> samples
 			, std::vector<std::pair<sha1_hash, udp::endpoint>> nodes)
 		{
-			m_alerts.emplace_alert<dht_sample_infohashes_alert>(ep
-				, interval, num, std::move(samples), std::move(nodes));
+			m_alerts.emplace_alert<dht_sample_infohashes_alert>(nid
+				, ep, interval, num, std::move(samples), std::move(nodes));
 		});
 	}
 

--- a/test/test_alert_types.cpp
+++ b/test/test_alert_types.cpp
@@ -280,6 +280,7 @@ TORRENT_TEST(dht_sample_infohashes_alert)
 
 	TEST_EQUAL(mgr.should_post<dht_sample_infohashes_alert>(), true);
 
+	sha1_hash const node_id = rand_hash();
 	udp::endpoint const endpoint = rand_udp_ep();
 	time_duration const interval = seconds(10);
 	int const num = 100;
@@ -308,11 +309,12 @@ TORRENT_TEST(dht_sample_infohashes_alert)
 	nv.emplace_back(nh4, nep4);
 	nv.emplace_back(nh5, nep5);
 
-	mgr.emplace_alert<dht_sample_infohashes_alert>(endpoint, interval, num, v, nv);
+	mgr.emplace_alert<dht_sample_infohashes_alert>(node_id, endpoint, interval, num, v, nv);
 
 	auto const* a = alert_cast<dht_sample_infohashes_alert>(mgr.wait_for_alert(seconds(0)));
 	TEST_CHECK(a != nullptr);
 
+	TEST_EQUAL(a->node_id, node_id);
 	TEST_EQUAL(a->endpoint, endpoint);
 	TEST_CHECK(a->interval == interval);
 	TEST_EQUAL(a->num_infohashes, num);

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -3687,6 +3687,7 @@ TORRENT_TEST(sample_infohashes)
 
 	g_sent_packets.clear();
 
+	node_id nid = generate_random_id();
 	udp::endpoint initial_node = rand_udp_ep();
 	t.dht_node.m_table.add_node(node_entry{initial_node});
 
@@ -3697,10 +3698,13 @@ TORRENT_TEST(sample_infohashes)
 	udp::endpoint const ep2 = rand_udp_ep(rand_v4);
 
 	t.dht_node.sample_infohashes(initial_node, items[0].target,
-		[h1, ep1, h2, ep2](time_duration interval, int num
+		[nid, h1, ep1, h2, ep2](node_id const& node_id
+			, time_duration interval
+			, int num
 			, std::vector<sha1_hash> samples
 			, std::vector<std::pair<sha1_hash, udp::endpoint>> const& nodes)
 	{
+		TEST_EQUAL(node_id, nid);
 		TEST_EQUAL(total_seconds(interval), 10);
 		TEST_EQUAL(num, 2);
 		TEST_EQUAL(samples.size(), 1);
@@ -3740,6 +3744,7 @@ TORRENT_TEST(sample_infohashes)
 	g_sent_packets.clear();
 	send_dht_response(t.dht_node, response, initial_node
 		, msg_args()
+			.nid(nid)
 			.interval(seconds(10))
 			.num(2)
 			.samples({to_hash("1000000000000000000000000000000000000001")})


### PR DESCRIPTION
This adds `node_id` to `dht_sample_infohashes_alert` to enable receiver of alert to determine which node sent the reply to an earlier request for info hash samples.

Tested via Python bindings, seems to work as expected.

I'm not sure I got the naming of attributes/arguments right - there are so many varieties in use, e.g. `endpoint` appears as `endpoint/ep/endp`... I opted for `node_id` for the alert attribute and `nid` for method arguments.

Related issue: #3917 