### PR TITLE
reduce include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,7 +669,6 @@ if (dht)
 		src/hasher512
 		src/sha512
 	)
-	target_include_directories(torrent-rasterbar PRIVATE ed25519/src)
 else()
 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_DISABLE_DHT)
 endif()

--- a/Jamfile
+++ b/Jamfile
@@ -757,7 +757,6 @@ lib torrent
 	src/$(SOURCES).cpp
 
 	: # requirements
-	<include>./ed25519/src
 	<threading>multi
 	<define>TORRENT_BUILDING_LIBRARY
 	<link>shared:<define>TORRENT_BUILDING_SHARED

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -30,7 +30,6 @@ upnp_test_SOURCES = upnp_test.cpp
 
 LDADD = $(top_builddir)/src/libtorrent-rasterbar.la
 
-AM_CPPFLAGS = -ftemplate-depth-50 -I$(top_srcdir)/include @DEBUGFLAGS@ @OPENSSL_INCLUDES@
-
+AM_CPPFLAGS = -ftemplate-depth-50 @DEBUGFLAGS@
 AM_LDFLAGS = @BOOST_SYSTEM_LIB@ @OPENSSL_LDFLAGS@ @OPENSSL_LIBS@
-
+DEFAULT_INCLUDES = -I$(top_srcdir)/include @OPENSSL_INCLUDES@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -165,9 +165,9 @@ libtorrent_rasterbar_la_SOURCES = \
   \
   $(KADEMLIA_SOURCES)
 
-AM_CFLAGS = -I$(top_srcdir)/ed25519/src -std=c99
-AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY -I$(top_srcdir)/include -I$(top_srcdir)/ed25519/src @DEBUGFLAGS@ @OPENSSL_INCLUDES@
+AM_CPPFLAGS = -DTORRENT_BUILDING_LIBRARY @DEBUGFLAGS@
 AM_LDFLAGS = @OPENSSL_LDFLAGS@
+DEFAULT_INCLUDES = -I$(top_srcdir)/include @OPENSSL_INCLUDES@
 
 libtorrent_rasterbar_la_LDFLAGS = -version-info $(INTERFACE_VERSION_INFO)
 libtorrent_rasterbar_la_LIBADD = @OPENSSL_LIBS@
@@ -181,5 +181,3 @@ if HAVE_WINDOWS
 libtorrent_rasterbar_la_LIBADD += -liphlpapi -lws2_32 -lwsock32
 libtorrent_rasterbar_la_CPPFLAGS += -DWIN32_LEAN_AND_MEAN -D__USE_W32_SOCKETS -DWIN32 -D_WIN32
 endif
-
-

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -279,7 +279,6 @@ test_alloca_SOURCES = test_alloca.cpp
 LDADD = libtest.la $(top_builddir)/src/libtorrent-rasterbar.la
 
 #AM_CXXFLAGS=-ftemplate-depth-50 -I$(top_srcdir)/include -I$(top_srcdir)/include/libtorrent @DEBUGFLAGS@ @PTHREAD_CFLAGS@
-AM_CPPFLAGS=-ftemplate-depth-50 -I$(top_srcdir)/include @DEBUGFLAGS@ @OPENSSL_INCLUDES@
-
+AM_CPPFLAGS=-ftemplate-depth-50 @DEBUGFLAGS@
 AM_LDFLAGS=@BOOST_SYSTEM_LIB@ @PTHREAD_LIBS@ @OPENSSL_LDFLAGS@ @OPENSSL_LIBS@
-
+DEFAULT_INCLUDES = -I$(top_srcdir)/include @OPENSSL_INCLUDES@

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,8 +22,9 @@ dht_put_SOURCES = dht_put.cpp
 
 LDADD = $(top_builddir)/src/libtorrent-rasterbar.la
 
-AM_CPPFLAGS = -ftemplate-depth-50 -I$(top_srcdir)/include @DEBUGFLAGS@
+AM_CPPFLAGS = -ftemplate-depth-50 @DEBUGFLAGS@
 
 AM_LDFLAGS = @BOOST_SYSTEM_LIB@
 #AM_LDFLAGS = $(LDFLAGS) @BOOST_SYSTEM_LIB@ @OPENSSL_LDFLAGS@ @OPENSSL_LIBS@
 #AM_LDFLAGS = @OPENSSL_LDFLAGS@
+DEFAULT_INCLUDES = -I$(top_srcdir)/include


### PR DESCRIPTION
This removes -I src -I test -I tools from the autotools build and -I ed25519/src from all build systems.

---

libtorrent consistently uses either relative includes or includes from its `include` directory, yet the build systems, especially autotools whose DEFAULT_INCLUDES by default includes the directory of the `Makefile.am` file, pass additional -I flags that make it look like libtorrent needs them.

Tested with autotools (both in the source tree and from a separate build directory), cmake, and bjam.