### PR TITLE
fix static builds of examples and tools on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,6 +633,12 @@ set_package_properties(OpenSSL
 )
 
 if(OPENSSL_FOUND)
+
+	# TODO: needed until https://gitlab.kitware.com/cmake/cmake/issues/19263 is fixed
+	if(WIN32 AND OPENSSL_USE_STATIC_LIBS)
+		target_link_libraries(OpenSSL::Crypto INTERFACE crypt32)
+	endif()
+
 	target_link_libraries(torrent-rasterbar PUBLIC OpenSSL::SSL)
 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_USE_OPENSSL)
 	target_sources(torrent-rasterbar PRIVATE src/pe_crypto)

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -484,6 +484,12 @@ Other build options are:
 
 Options are set on the ``cmake`` command line with the ``-D`` option or later on using ``ccmake`` or ``cmake-gui`` applications. ``cmake`` run outputs a summary of all available options and their current values.
 
+.. note::
+
+	If you are linking statically against OpenSSL on Windows and not using ``-Dstatic_runtime=ON``,
+	you should additionally use the option ``-DOPENSSL_USE_STATIC_LIBS=ON``.
+	If you use ``-Dstatic_runtime=ON``, ``-DOPENSSL_USE_STATIC_LIBS=ON`` is implied.
+
 Step 2: Building libtorrent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -647,4 +653,3 @@ in a command shell::
 
 This will also install the headers and library files in the visual studio directories to
 be picked up by libtorrent.
-

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -559,6 +559,5 @@ leecher
 6881l
 NOTSENT
 LOWAT
-tls11
-tls12
-tls13
+Dstatic
+DOPENSSL


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/10686.

~This is a draft PR because I am not sure if this is a good general solution. This is simply what I had to do to get it to build (static windows x64 builds) with `vcpkg`. @zeule comments appreciated.~ fixed.