### PR TITLE
check flags when matching listen sockets

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -221,6 +221,7 @@ namespace aux {
 				return ep.ssl == sock->ssl
 					&& ep.port == sock->original_port
 					&& ep.device == sock->device
+					&& ep.flags == sock->flags
 					&& ep.addr == sock->local_endpoint.address();
 			});
 


### PR DESCRIPTION
If the flags change the socket needs to be re-opened. This is
particularly important when the local_network flag changes so that
the socket will correctly be treated as global even if the gateway
was not configured when the address was first detected.

Don't just modify the flags of the existing listen socket because
some flags may influence how the socket is opened. Such flags could
be special cased, but it doesn't seem worth the trouble.