### PR TITLE
fix IPv6 address change notification on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix IPv6 address change detection on Windows
+
 1.2.6 released
 
 	* fix peer timeout logic


### PR DESCRIPTION
The old NotifyAddrChange only detects IPv4 address changes. Use the newer
NotifyUnicastIpAddressChange function instead which supports both v4 and v6.