### PR TITLE
simplify and increase default HTTP tracker timeout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* increase default tracker timeout
 	* retry failed socks5 server connections
 	* allow UPnP lease duration to be changed after device discovery
 	* fix IPv6 address change detection on Windows

--- a/include/libtorrent/http_connection.hpp
+++ b/include/libtorrent/http_connection.hpp
@@ -178,7 +178,6 @@ private:
 	http_filter_handler m_filter_handler;
 	deadline_timer m_timer;
 
-	time_duration m_read_timeout;
 	time_duration m_completion_timeout;
 
 	// the timer fires every 250 millisecond as long

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -83,7 +83,6 @@ http_connection::http_connection(io_service& ios
 	, m_connect_handler(ch)
 	, m_filter_handler(fh)
 	, m_timer(ios)
-	, m_read_timeout(seconds(5))
 	, m_completion_timeout(seconds(5))
 	, m_limiter_timer(ios)
 	, m_last_receive(aux::time_now())
@@ -236,11 +235,8 @@ void http_connection::start(std::string const& hostname, int port
 	std::shared_ptr<http_connection> me(shared_from_this());
 
 	m_completion_timeout = timeout;
-	m_read_timeout = seconds(5);
-	if (m_read_timeout < timeout / 5) m_read_timeout = timeout / 5;
 	error_code ec;
-	m_timer.expires_from_now(std::min(
-		m_read_timeout, m_completion_timeout), ec);
+	m_timer.expires_from_now(m_completion_timeout, ec);
 	ADD_OUTSTANDING_ASYNC("http_connection::on_timeout");
 	m_timer.async_wait(std::bind(&http_connection::on_timeout
 		, std::weak_ptr<http_connection>(me), _1));
@@ -290,7 +286,6 @@ void http_connection::start(std::string const& hostname, int port
 			// quadruple the timeout for i2p destinations
 			// because i2p is sloooooow
 			m_completion_timeout *= 4;
-			m_read_timeout *= 4;
 
 #if TORRENT_USE_I2P
 			if (i2p_conn->proxy().type != settings_pack::i2p_proxy)
@@ -401,8 +396,7 @@ void http_connection::on_timeout(std::weak_ptr<http_connection> p
 
 	time_point const now = clock_type::now();
 
-	if (c->m_start_time + c->m_completion_timeout <= now
-		|| c->m_last_receive + c->m_read_timeout <= now)
+	if (c->m_start_time + c->m_completion_timeout <= now)
 	{
 		// the connection timed out. If we have more endpoints to try, just
 		// close this connection. The on_connect handler will try the next
@@ -432,9 +426,7 @@ void http_connection::on_timeout(std::weak_ptr<http_connection> p
 
 	ADD_OUTSTANDING_ASYNC("http_connection::on_timeout");
 	error_code ec;
-	c->m_timer.expires_at(std::min(
-		c->m_last_receive + c->m_read_timeout
-		, c->m_start_time + c->m_completion_timeout), ec);
+	c->m_timer.expires_at(c->m_start_time + c->m_completion_timeout, ec);
 	c->m_timer.async_wait(std::bind(&http_connection::on_timeout, p, _1));
 }
 


### PR DESCRIPTION
Specifically, the "read timeout" is removed. The remaining timeout logic is simply checking to see if the whole announce is complete after the timeout, and closes the connection if it isn't.