### PR TITLE
Improve python cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,16 @@ install:
   - ccache --show-stats
   - ccache --zero-stats
 
+  # CMake from Kitware is installed in /usr/bin. TravisCI installs its own cmake to another location
+  # which overrides other installations if they don't call the new binary directly
+  # Install and prepend a symlink to the latest version to PATH so that it gets used instead.
   - if [[ "$cmake" == "1" ]]; then
+      wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null;
+      sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main';
+      sudo apt install cmake;
+      sudo mkdir -p /usr/local/cmake-latest/bin;
+      sudo ln -s /usr/bin/cmake /usr/local/cmake-latest/bin/cmake;
+      PATH=/usr/local/cmake-latest/bin:$PATH;
       which cmake;
       cmake --version;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,7 @@ feature_option(build_tests "build tests" OFF)
 feature_option(build_examples "build examples" OFF)
 feature_option(build_tools "build tools" OFF)
 feature_option(python-bindings "build python bindings" OFF)
+feature_option(python-egg-info "generate python egg info" OFF)
 
 # these options require existing target
 feature_option(dht "enable support for Mainline DHT" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,7 @@ feature_option(build_examples "build examples" OFF)
 feature_option(build_tools "build tools" OFF)
 feature_option(python-bindings "build python bindings" OFF)
 feature_option(python-egg-info "generate python egg info" OFF)
+feature_option(python-install-system-dir "Install python bindings to the system installation directory rather than the CMake installation prefix" OFF)
 
 # these options require existing target
 feature_option(dht "enable support for Mainline DHT" ON)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -90,21 +90,23 @@ endif()
 message(STATUS "Python 3 site packages: ${Python3_SITEARCH}")
 message(STATUS "Python 3 extension suffix: ${Python3_SOABI}")
 
-set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
-set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
-set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
-set(DEPS        python-libtorrent "${SETUP_PY}")
-
-configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
-
-add_custom_command(OUTPUT ${OUTPUT}
-                   COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} build -b "${CMAKE_CURRENT_SOURCE_DIR}"
-                   COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} egg_info -b "${CMAKE_CURRENT_SOURCE_DIR}"
-                   COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
-                   DEPENDS ${DEPS})
-
-add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
-
-
 install(TARGETS python-libtorrent DESTINATION "${Python3_SITEARCH}")
-install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${Python3_SITEARCH}")
+
+if (python-egg-info)
+	set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
+	set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
+	set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
+	set(DEPS        python-libtorrent "${SETUP_PY}")
+
+	configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
+
+	add_custom_command(OUTPUT ${OUTPUT}
+	                   COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} build -b "${CMAKE_CURRENT_SOURCE_DIR}"
+	                   COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} egg_info -b "${CMAKE_CURRENT_SOURCE_DIR}"
+	                   COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
+	                   DEPENDS ${DEPS})
+
+	add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
+
+	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${Python3_SITEARCH}")
+endif()

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,7 +1,8 @@
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 # To build python bindings we need a python executable and boost python module. Unfortunately,
 # their names might not be interlinked and we can not implement a general solution.
-# The code below assumes default boost installation, when the module for python 2 is named
-# 'python' and the module for python 3 is named 'python3'.
+# The code below assumes default boost installation, when the module for python 3 is named 'python3'.
 # To customize that one can provide a name for the Boost::python module via
 # 'boost-python-module-name' variable when invoking cmake.
 # E.g. on Gentoo with python 3.6 and Boost::python library name 'libboost_python-3.6.so'
@@ -15,13 +16,10 @@
 # Sets _ret to a list of python versions (major.minor) that use the same MSVC runtime as this build does
 # assumes MSVC was detected already
 # See https://en.wikipedia.org/wiki/Microsoft_Visual_C++#Internal_version_numbering
+# See https://devguide.python.org/#status-of-python-branches for supported python versions
 function(_get_compatible_python_versions _ret)
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
-		list(APPEND _tmp 2.6 2.7 3.0 3.1 3.2)
-	elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
-		list(APPEND _tmp 3.3 3.4)
-	elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20)
-		list(APPEND _tmp 3.5 3.6 3.7 3.8)
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20)
+		list(APPEND _tmp 3.6 3.7 3.8 3.9)
 	endif()
 	set(${_ret} ${_tmp} PARENT_SCOPE)
 endfunction()
@@ -31,31 +29,19 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND NOT skip-python-runtime-test)
 	_get_compatible_python_versions(Python_ADDITIONAL_VERSIONS)
 endif()
 
-find_package(PythonInterp REQUIRED)
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND NOT skip-python-runtime-test)
-	message(STATUS "Testing found python version. Requested: ${Python_ADDITIONAL_VERSIONS}, found: ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
-	if (NOT "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" IN_LIST Python_ADDITIONAL_VERSIONS)
-		message(FATAL_ERROR "Incompatible Python and C runtime: MSVC ${CMAKE_CXX_COMPILER_VERSION} and Python ${PYTHON_VERSION_STRING}")
+	message(STATUS "Testing found python version. Requested: ${Python_ADDITIONAL_VERSIONS}, found: ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
+	if (NOT "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}" IN_LIST Python_ADDITIONAL_VERSIONS)
+		message(FATAL_ERROR "Incompatible Python and C runtime: MSVC ${CMAKE_CXX_COMPILER_VERSION} and Python ${Python3_VERSION}")
 	endif()
 endif()
 
-set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
-find_package(PythonLibs REQUIRED)
-
-if (NOT boost-python-module-name)
-	# use active python
-#	if (PYTHON_VERSION_STRING VERSION_GREATER_EQUAL "3")
-#		set(_boost-python-module-name "python${PYTHON_VERSION_MAJOR}")
-#	else()
-		set(_boost-python-module-name "python") # to overwrite possible value from a previous run
-#	endif()
-endif()
-
-set(boost-python-module-name ${_boost-python-module-name} CACHE STRING "Boost:python module name, e.g. 'python-3.6'")
+set(boost-python-module-name "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" CACHE STRING "Boost::python module name, e.g. 'python-3.6'")
 
 find_package(Boost REQUIRED COMPONENTS ${boost-python-module-name})
 
-python_add_module(python-libtorrent
+Python3_add_library(python-libtorrent MODULE WITH_SOABI
 	src/module.cpp
 	src/sha1_hash.cpp
 	src/converters.cpp
@@ -78,29 +64,19 @@ python_add_module(python-libtorrent
 	src/error_code.cpp
 )
 
-if (MSVC)
-	target_compile_options(python-libtorrent PRIVATE /bigobj)
-endif()
-
 set_target_properties(python-libtorrent
 	PROPERTIES
 		OUTPUT_NAME libtorrent
 )
 
-target_include_directories(python-libtorrent
-	PRIVATE
-		${PYTHON_INCLUDE_DIRS}
-)
+if (MSVC)
+	target_compile_options(python-libtorrent PRIVATE /bigobj)
+endif()
 
-string(TOUPPER "${boost-python-module-name}" boost_python_module_name_uppercase)
 target_link_libraries(python-libtorrent
 	PRIVATE
 		torrent-rasterbar
-		${Boost_${boost_python_module_name_uppercase}_LIBRARY}
-		# Boost::python adds that but without a path to the library. Therefore we have to either
-		# provide the path (but, unfortunately, FindPythonLibs.cmake does not return the library dir),
-		# or give the full file name here (this FindPythonLibs.cmake provides to us).
-		${PYTHON_LIBRARIES}
+		"Boost::${boost-python-module-name}"
 )
 
 # Bindings module uses deprecated libtorrent features, thus we disable these warnings
@@ -111,25 +87,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	endif()
 endif()
 
-execute_process(COMMAND
-  ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig;
-print(';'.join(map(str, [
-	distutils.sysconfig.get_python_lib(plat_specific=True, prefix=''),
-	distutils.sysconfig.get_config_var('EXT_SUFFIX')
-])))"
-	OUTPUT_VARIABLE _python_sysconfig_vars OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-list(GET _python_sysconfig_vars 0 PYTHON_SITE_PACKAGES)
-list(GET _python_sysconfig_vars 1 PYTHON_EXT_SUFFIX)
-
-message(STATUS "Python site packages: ${PYTHON_SITE_PACKAGES}")
-# python 2 does not provide the 'EXT_SUFFIX' sysconfig variable, so we use cmake default then
-if (NOT "${PYTHON_EXT_SUFFIX}" STREQUAL "None")
-	message(STATUS "Python extension suffix: ${PYTHON_EXT_SUFFIX}")
-	# we mimic the name, created by setuptools
-	# example: libtorrent.cpython-36m-x86_64-linux-gnu.so
-	set_target_properties(python-libtorrent PROPERTIES SUFFIX ${PYTHON_EXT_SUFFIX})
-endif()
+message(STATUS "Python 3 site packages: ${Python3_SITEARCH}")
+message(STATUS "Python 3 extension suffix: ${Python3_SOABI}")
 
 set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
 set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
@@ -139,13 +98,13 @@ set(DEPS        python-libtorrent "${SETUP_PY}")
 configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
 
 add_custom_command(OUTPUT ${OUTPUT}
-                   COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} build -b "${CMAKE_CURRENT_SOURCE_DIR}"
-                   COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} egg_info -b "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} build -b "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMAND ${Python3_EXECUTABLE} ${SETUP_PY} egg_info -b "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                    DEPENDS ${DEPS})
 
 add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
 
 
-install(TARGETS python-libtorrent DESTINATION "${PYTHON_SITE_PACKAGES}")
-install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${PYTHON_SITE_PACKAGES}")
+install(TARGETS python-libtorrent DESTINATION "${Python3_SITEARCH}")
+install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${Python3_SITEARCH}")

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -87,10 +87,23 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	endif()
 endif()
 
-message(STATUS "Python 3 site packages: ${Python3_SITEARCH}")
+if (python-install-system-dir)
+	set(_PYTHON3_SITE_ARCH "${Python3_SITEARCH}")
+else()
+	execute_process(
+		COMMAND "${Python3_EXECUTABLE}" -c [=[
+import distutils.sysconfig
+print(distutils.sysconfig.get_python_lib(prefix='', plat_specific=True))
+]=]
+		OUTPUT_VARIABLE _PYTHON3_SITE_ARCH
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+endif()
+
+message(STATUS "Python 3 site packages: ${_PYTHON3_SITE_ARCH}")
 message(STATUS "Python 3 extension suffix: ${Python3_SOABI}")
 
-install(TARGETS python-libtorrent DESTINATION "${Python3_SITEARCH}")
+install(TARGETS python-libtorrent DESTINATION "${_PYTHON3_SITE_ARCH}")
 
 if (python-egg-info)
 	set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
@@ -108,5 +121,5 @@ if (python-egg-info)
 
 	add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
 
-	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${Python3_SITEARCH}")
+	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
 endif()


### PR DESCRIPTION
Basically changes to use the new FindPython3: `https://cmake.org/cmake/help/v3.17/module/FindPython3.html`. Also drops EOL python versions.

---

Warning: slightly outdated info below. See https://github.com/arvidn/libtorrent/pull/4574#issuecomment-709481112 for updated info.

The first commit introduces changes that make it work the same as before (on Ubuntu 18.04, I have to specify `-Dboost-python-module-name=python36`).

The second commit makes further use of the new variables. One benefit is eliminating the build-time dependency on `python3-dev` and `python3-setuptools` packages. It requires the latest CMake version as of writing, but I don't think that's an issue, given how easy it is to install the latest version on basically any system. But I haven't managed to get the same results as before - the site-packages directory does not seems to respect the `CMAKE_INSTALL_PREFIX`.

Without this commit, the discovered site-packages directory is relative, while with it, it becomes absolute. Here are the differences in the configure output as well as the `install_manifest.txt`, for a run with the install prefix set to `/usr/local`:

- In the configure step:

`Python site packages: lib/python3/dist-packages` vs `Python site packages: /usr/lib/python3/dist-packages`

- Diff of the install manifests:

```diff
--- install_manifest_old.txt
+++ install_manifest_new.txt
@@ -253,8 +253,8 @@
 /usr/local/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarConfig.cmake
 /usr/local/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarConfigVersion.cmake
 /usr/local/share/cmake/Modules/FindLibtorrentRasterbar.cmake
-/usr/local/lib/python3/dist-packages/libtorrent.cpython-38-x86_64-linux-gnu.so
-/usr/local/lib/python3/dist-packages/libtorrent.egg-info/SOURCES.txt
-/usr/local/lib/python3/dist-packages/libtorrent.egg-info/top_level.txt
-/usr/local/lib/python3/dist-packages/libtorrent.egg-info/PKG-INFO
-/usr/local/lib/python3/dist-packages/libtorrent.egg-info/dependency_links.txt
\ No newline at end of file
+/usr/lib/python3/dist-packages/libtorrent.cpython-38-x86_64-linux-gnu.so
+/usr/lib/python3/dist-packages/libtorrent.egg-info/SOURCES.txt
+/usr/lib/python3/dist-packages/libtorrent.egg-info/top_level.txt
+/usr/lib/python3/dist-packages/libtorrent.egg-info/PKG-INFO
+/usr/lib/python3/dist-packages/libtorrent.egg-info/dependency_links.txt
\ No newline at end of file
```

Also, is it a problem if the `boost_python` module version is different from the python library version? e.g. `libboost_python36.so` with `libpython3.8.so`? I have found that this build script allows that, with or without this PR.

Finally, should `Python3_USE_STATIC_LIBS=ON` depend directly on the value of `BUILD_SHARED_LIBS`, or does it make sense to leave them independently configurable?
@zeule any tips?

---