### PR TITLE
undeprecate the upnp_ignore_nonrouters setting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* undeprecate upnp_ignore_nonrouters (but refering to devices on our subnet)
 	* increase default tracker timeout
 	* retry failed socks5 server connections
 	* allow UPnP lease duration to be changed after device discovery

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -367,15 +367,11 @@ namespace aux {
 			// trackers fail or not.
 			use_dht_as_fallback,
 
-#if TORRENT_ABI_VERSION == 1
 			// ``upnp_ignore_nonrouters`` indicates whether or not the UPnP
 			// implementation should ignore any broadcast response from a device
-			// whose address is not the configured router for this machine. i.e.
+			// whose address is not on our subnet. i.e.
 			// it's a way to not talk to other people's routers by mistake.
-			upnp_ignore_nonrouters TORRENT_DEPRECATED_ENUM,
-#else
-			deprecated_upnp_ignore_nonrouters,
-#endif
+			upnp_ignore_nonrouters,
 
 			// ``use_parole_mode`` specifies if parole mode should be used. Parole
 			// mode means that peers that participate in pieces that fail the hash

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -135,7 +135,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		SET(send_redundant_have, true, nullptr),
 		DEPRECATED_SET(lazy_bitfields, false, nullptr),
 		SET(use_dht_as_fallback, false, nullptr),
-		DEPRECATED_SET(upnp_ignore_nonrouters, false, nullptr),
+		SET(upnp_ignore_nonrouters, false, nullptr),
 		SET(use_parole_mode, true, nullptr),
 		SET(use_read_cache, true, nullptr),
 		DEPRECATED_SET(use_write_cache, true, nullptr),

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -500,7 +500,8 @@ void upnp::on_reply(udp::socket& s, error_code const& ec)
 
 	if (err) return;
 
-	if (!match_addr_mask(m_listen_address, from.address(), m_netmask))
+	if (m_settings.get_bool(settings_pack::upnp_ignore_nonrouters)
+		&& !match_addr_mask(m_listen_address, from.address(), m_netmask))
 	{
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log())


### PR DESCRIPTION
with a slightly different meaning. still default to false and make it mean to ignore routers outside of the local subnet