### PR TITLE
GnuTLS prerequisite: TORRENT_USE_SSL compilation flag

### DIFF
--- a/bindings/python/src/error_code.cpp
+++ b/bindings/python/src/error_code.cpp
@@ -48,7 +48,7 @@ namespace boost
 }
 
 #include <boost/asio/error.hpp>
-#if defined TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #include <boost/asio/ssl.hpp>
 #endif
 #if TORRENT_USE_I2P
@@ -109,7 +109,7 @@ namespace {
 				ec.assign(value, boost::asio::error::get_misc_category());
 			else if (category == "asio.misc")
 				ec.assign(value, boost::asio::error::get_misc_category());
-#if defined TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			else if (category == "asio.ssl")
 				ec.assign(value, boost::asio::error::get_ssl_category());
 #endif

--- a/include/libtorrent/aux_/allocating_handler.hpp
+++ b/include/libtorrent/aux_/allocating_handler.hpp
@@ -62,7 +62,7 @@ namespace libtorrent { namespace aux {
 	constexpr std::size_t debug_read_iter = 0;
 	constexpr std::size_t debug_write_iter = 0;
 #endif
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	constexpr std::size_t openssl_read_cost = 94;
 	constexpr std::size_t openssl_write_cost = 94;
 #else
@@ -91,7 +91,7 @@ namespace libtorrent { namespace aux {
 	constexpr std::size_t debug_write_iter = 0;
 #endif
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #ifdef __APPLE__
 	constexpr std::size_t openssl_read_cost = 264;
 	constexpr std::size_t openssl_write_cost = 216;

--- a/include/libtorrent/aux_/openssl.hpp
+++ b/include/libtorrent/aux_/openssl.hpp
@@ -33,9 +33,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_OPENSSL_HPP_INCLUDED
 #define TORRENT_OPENSSL_HPP_INCLUDED
 
-#ifdef TORRENT_USE_LIBCRYPTO
-
 #include "libtorrent/config.hpp"
+
+#ifdef TORRENT_USE_LIBCRYPTO
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <openssl/opensslv.h> // for OPENSSL_VERSION_NUMBER
@@ -43,7 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #endif // TORRENT_USE_LIBCRYPTO
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 
 #if OPENSSL_VERSION_NUMBER < 0x1000000fL
 #error OpenSSL too old, use a recent version with SNI support
@@ -97,6 +97,6 @@ TORRENT_EXTRA_EXPORT GENERAL_NAME* openssl_general_name_value(GENERAL_NAMES* gen
 } // aux
 } // libtorrent
 
-#endif // TORRENT_USE_OPENSSL
+#endif // TORRENT_USE_SSL
 
 #endif // TORRENT_OPENSSL_HPP_INCLUDED

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -892,7 +892,7 @@ namespace aux {
 
 			io_context& m_io_context;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			// this is a generic SSL context used when talking to HTTPS servers
 			ssl::context m_ssl_ctx;
 #endif
@@ -1029,7 +1029,7 @@ namespace aux {
 			boost::optional<socket_type> m_i2p_listen_socket;
 #endif
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			ssl::context* ssl_ctx() override { return &m_ssl_ctx; }
 #endif
 #ifdef TORRENT_SSL_PEERS

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -290,7 +290,7 @@ namespace aux {
 #ifdef TORRENT_SSL_PEERS
 		virtual libtorrent::aux::utp_socket_manager* ssl_utp_socket_manager() = 0;
 #endif
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		virtual boost::asio::ssl::context* ssl_ctx() = 0 ;
 #endif
 

--- a/include/libtorrent/aux_/socket_type.hpp
+++ b/include/libtorrent/aux_/socket_type.hpp
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/polymorphic_socket.hpp"
 #include "libtorrent/socket_type.hpp"
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #include "libtorrent/ssl_stream.hpp"
 #endif
 
@@ -59,7 +59,7 @@ namespace aux {
 #if TORRENT_USE_I2P
 		, i2p_stream
 #endif
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		, ssl_stream<tcp::socket>
 		, ssl_stream<socks5_stream>
 		, ssl_stream<http_stream>

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -575,7 +575,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif // TORRENT_HAS_ARM_CRC32
 
-#if defined TORRENT_SSL_PEERS && !defined TORRENT_USE_OPENSSL
+#if defined TORRENT_USE_OPENSSL
+#define TORRENT_USE_SSL 1
+#else
+#define TORRENT_USE_SSL 0
+#endif
+
+#if defined TORRENT_SSL_PEERS && !TORRENT_USE_SSL
 #error compiling with TORRENT_SSL_PEERS requires TORRENT_USE_OPENSSL
 #endif
 

--- a/include/libtorrent/http_connection.hpp
+++ b/include/libtorrent/http_connection.hpp
@@ -36,7 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_HTTP_CONNECTION
 #define TORRENT_HTTP_CONNECTION
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 // there is no forward declaration header for asio
 namespace boost {
 namespace asio {
@@ -93,7 +93,7 @@ struct TORRENT_EXTRA_EXPORT http_connection
 		, int max_bottled_buffer_size
 		, http_connect_handler ch
 		, http_filter_handler fh
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		, ssl::context* ssl_ctx
 #endif
 		);
@@ -171,7 +171,7 @@ private:
 
 	boost::optional<aux::socket_type> m_sock;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	ssl::context* m_ssl_ctx;
 #endif
 

--- a/include/libtorrent/http_connection.hpp
+++ b/include/libtorrent/http_connection.hpp
@@ -36,6 +36,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_HTTP_CONNECTION
 #define TORRENT_HTTP_CONNECTION
 
+#include "libtorrent/config.hpp" // for TORRENT_USE_SSL
+
 #if TORRENT_USE_SSL
 // there is no forward declaration header for asio
 namespace boost {

--- a/include/libtorrent/ssl_stream.hpp
+++ b/include/libtorrent/ssl_stream.hpp
@@ -34,7 +34,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_SSL_STREAM_HPP_INCLUDED
 #define TORRENT_SSL_STREAM_HPP_INCLUDED
 
-#ifdef TORRENT_USE_OPENSSL
+#include "libtorrent/config.hpp" // for TORRENT_USE_SSL
+
+#if TORRENT_USE_SSL
 
 #include "libtorrent/socket.hpp"
 #include "libtorrent/error_code.hpp"
@@ -324,6 +326,6 @@ private:
 
 }
 
-#endif // TORRENT_USE_OPENSSL
+#endif // TORRENT_USE_SSL
 
 #endif

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -48,7 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <unordered_map>
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 // there is no forward declaration header for asio
 namespace boost {
 namespace asio {
@@ -146,7 +146,7 @@ enum class event_t : std::uint8_t
 		// scrape_tracker() or force_reannounce()
 		bool triggered_manually = false;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		boost::asio::ssl::context* ssl_ctx = nullptr;
 #endif
 #if TORRENT_USE_I2P

--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -366,7 +366,7 @@ private:
 	address_v4 m_netmask;
 	std::string m_device;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	ssl::context m_ssl_ctx;
 #endif
 

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -129,7 +129,7 @@ std::shared_ptr<http_connection> test_request(io_context& ios
 {
 	std::printf(" ===== TESTING: %s =====\n", url.c_str());
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	ssl::context ssl_ctx(ssl::context::sslv23_client);
 	ssl_ctx.set_verify_mode(ssl::context::verify_none);
 #endif
@@ -182,7 +182,7 @@ std::shared_ptr<http_connection> test_request(io_context& ios
 			std::printf("CONNECTED: %s\n", url.c_str());
 		}
 		, lt::http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		, &ssl_ctx
 #endif
 		);
@@ -626,7 +626,7 @@ TORRENT_TEST(http_connection_ssl_proxy)
 			return sim::send_response(403, "Not supported", 1337);
 		});
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	lt::ssl::context ssl_ctx(ssl::context::sslv23_client);
 	ssl_ctx.set_verify_mode(ssl::context::verify_none);
 #endif
@@ -641,7 +641,7 @@ TORRENT_TEST(http_connection_ssl_proxy)
 		}
 		, true, 1024*1024, lt::http_connect_handler()
 		, http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		, &ssl_ctx
 #endif
 		);

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -58,7 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <sstream>
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/asio/ssl/context.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
@@ -75,13 +75,13 @@ http_connection::http_connection(io_context& ios
 	, int max_bottled_buffer_size
 	, http_connect_handler ch
 	, http_filter_handler fh
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	, ssl::context* ssl_ctx
 #endif
 	)
 	: m_ios(ios)
 	, m_next_ep(0)
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	, m_ssl_ctx(ssl_ctx)
 #endif
 #if TORRENT_USE_I2P
@@ -156,7 +156,7 @@ void http_connection::get(std::string const& url, time_duration timeout, int pri
 	}
 
 	if (protocol != "http"
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		&& protocol != "https"
 #endif
 		)
@@ -254,7 +254,7 @@ void http_connection::start(std::string const& hostname, int port
 	m_read_pos = 0;
 	m_priority = prio;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	TORRENT_ASSERT(!ssl || m_ssl_ctx != nullptr);
 #endif
 
@@ -314,7 +314,7 @@ void http_connection::start(std::string const& hostname, int port
 		aux::proxy_settings null_proxy;
 
 		void* userdata = nullptr;
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		if (m_ssl)
 		{
 			TORRENT_ASSERT(m_ssl_ctx != nullptr);
@@ -464,7 +464,7 @@ void http_connection::close(bool force)
 void http_connection::connect_i2p_tracker(char const* destination)
 {
 	TORRENT_ASSERT(boost::get<i2p_stream>(m_sock.get_ptr()));
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	TORRENT_ASSERT(m_ssl == false);
 #endif
 	boost::get<i2p_stream>(*m_sock).set_destination(destination);
@@ -551,7 +551,7 @@ void http_connection::connect()
 		{
 			// we're using a socks proxy and we're resolving
 			// hostnames through it
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			if (m_ssl)
 			{
 				TORRENT_ASSERT(boost::get<ssl_stream<socks5_stream>>(m_sock.get_ptr()));

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -213,7 +213,7 @@ namespace libtorrent {
 			, true, settings.get_int(settings_pack::max_http_recv_buffer_size)
 			, std::bind(&http_tracker_connection::on_connect, shared_from_this(), _1)
 			, std::bind(&http_tracker_connection::on_filter, shared_from_this(), _1, _2)
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			, tracker_req().ssl_ctx
 #endif
 			);

--- a/src/instantiate_connection.cpp
+++ b/src/instantiate_connection.cpp
@@ -48,13 +48,13 @@ namespace libtorrent { namespace aux {
 		, bool peer_connection
 		, bool tracker_connection)
 	{
-#ifndef TORRENT_USE_OPENSSL
+#if !TORRENT_USE_SSL
 		TORRENT_UNUSED(ssl_context);
 #endif
 
 		if (sm)
 		{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			if (ssl_context)
 			{
 				ssl_stream<utp_stream> s(ios, *static_cast<ssl::context*>(ssl_context));
@@ -83,7 +83,7 @@ namespace libtorrent { namespace aux {
 			|| (peer_connection && !ps.proxy_peer_connections)
 			|| (tracker_connection && !ps.proxy_tracker_connections))
 		{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			if (ssl_context)
 			{
 				return socket_type(ssl_stream<tcp::socket>(ios, *static_cast<ssl::context*>(ssl_context)));
@@ -97,7 +97,7 @@ namespace libtorrent { namespace aux {
 		else if (ps.type == settings_pack::http
 			|| ps.type == settings_pack::http_pw)
 		{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			if (ssl_context)
 			{
 				ssl_stream<http_stream> s(ios, *static_cast<ssl::context*>(ssl_context));
@@ -122,7 +122,7 @@ namespace libtorrent { namespace aux {
 			|| ps.type == settings_pack::socks5_pw
 			|| ps.type == settings_pack::socks4)
 		{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			if (ssl_context)
 			{
 				ssl_stream<socks5_stream> s(ios, *static_cast<ssl::context*>(ssl_context));

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 namespace aux {
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 
 // all of OpenSSL causes warnings, so we just have to disable them
 #include "libtorrent/aux_/disable_warnings_push.hpp"
@@ -76,7 +76,7 @@ GENERAL_NAME* openssl_general_name_value(GENERAL_NAMES* gens, int i)
 
 #endif // OPENSSL_VERSION_NUMBER
 
-#endif // TORRENT_USE_OPENSSL
+#endif // TORRENT_USE_SSL
 
 }
 }

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -156,7 +156,7 @@ namespace {
 
 #endif // TORRENT_USE_LIBGCRYPT
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 
 #include <openssl/crypto.h>
 
@@ -176,7 +176,7 @@ namespace {
 }
 #endif
 
-#endif // TORRENT_USE_OPENSSL
+#endif // TORRENT_USE_SSL
 
 #ifdef TORRENT_WINDOWS
 // for ERROR_SEM_TIMEOUT
@@ -502,7 +502,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		, disk_io_constructor_type disk_io_constructor)
 		: m_settings(pack)
 		, m_io_context(ioc)
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #if BOOST_VERSION >= 106400
 		, m_ssl_ctx(ssl::context::tls_client)
 #endif
@@ -592,7 +592,7 @@ void apply_deprecated_dht_settings(settings_pack& sett, bdecode_node const& s)
 		session_log("start session");
 #endif
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		error_code ec;
 		m_ssl_ctx.set_default_verify_paths(ec);
 #endif
@@ -1958,7 +1958,7 @@ namespace {
 			// expand device names and populate eps
 			for (auto const& iface : m_listen_interfaces)
 			{
-#ifndef TORRENT_USE_OPENSSL
+#if !TORRENT_USE_SSL
 				if (iface.ssl)
 				{
 #ifndef TORRENT_DISABLE_LOGGING
@@ -4951,7 +4951,7 @@ namespace {
 
 			utp_socket_impl* impl = nullptr;
 			transport ssl = transport::plaintext;
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			if (boost::get<ssl_stream<utp_stream>>(&s) != nullptr)
 			{
 				impl = boost::get<ssl_stream<utp_stream>>(s).next_layer().get_impl();
@@ -6518,7 +6518,7 @@ namespace {
 
 	void session_impl::update_validate_https()
 	{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		using boost::asio::ssl::context;
 		auto const flags = m_settings.get_bool(settings_pack::validate_https_trackers)
 			? context::verify_peer

--- a/src/socket_type.cpp
+++ b/src/socket_type.cpp
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/array.hpp"
 #include "libtorrent/deadline_timer.hpp"
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/rfc2818_verification.hpp>
 
@@ -60,7 +60,7 @@ namespace libtorrent {
 #else
 			"",
 #endif
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			"SSL/TCP",
 			"SSL/Socks5",
 			"SSL/HTTP",
@@ -75,7 +75,7 @@ namespace libtorrent {
 namespace aux {
 
 	struct is_ssl_visitor {
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		template <typename T>
 		bool operator()(ssl_stream<T> const&) const { return true; }
 #endif
@@ -91,7 +91,7 @@ namespace aux {
 	bool is_utp(socket_type const& s)
 	{
 		return boost::get<utp_stream>(&s)
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			|| boost::get<ssl_stream<utp_stream>>(&s)
 #endif
 			;
@@ -112,7 +112,7 @@ namespace aux {
 #if TORRENT_USE_I2P
 		socket_type_t operator()(i2p_stream const&) { return socket_type_t::i2p; }
 #endif
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		socket_type_t operator()(ssl_stream<tcp::socket> const&) { return socket_type_t::tcp_ssl; }
 		socket_type_t operator()(ssl_stream<socks5_stream> const&) { return socket_type_t::socks5_ssl; }
 		socket_type_t operator()(ssl_stream<http_stream> const&) { return socket_type_t::http_ssl; }
@@ -132,7 +132,7 @@ namespace aux {
 
 	struct set_close_reason_visitor {
 		close_reason_t code_;
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		void operator()(ssl_stream<utp_stream>& s) const
 		{ s.next_layer().set_close_reason(code_); }
 #endif
@@ -148,7 +148,7 @@ namespace aux {
 	}
 
 	struct get_close_reason_visitor {
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		close_reason_t operator()(ssl_stream<utp_stream>& s) const
 		{ return s.next_layer().get_close_reason(); }
 #endif
@@ -163,7 +163,7 @@ namespace aux {
 		return boost::apply_visitor(get_close_reason_visitor{}, s);
 	}
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	struct set_ssl_hostname_visitor
 	{
 		set_ssl_hostname_visitor(char const* h, error_code& ec) : hostname_(h), ec_(&ec) {}
@@ -186,7 +186,7 @@ namespace aux {
 
 	void setup_ssl_hostname(socket_type& s, std::string const& hostname, error_code& ec)
 	{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		// for SSL connections, make sure to authenticate the hostname
 		// of the certificate
 
@@ -211,7 +211,7 @@ namespace aux {
 #endif
 	}
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 
 	struct socket_closer
 	{
@@ -269,13 +269,13 @@ namespace aux {
 	// will keep the socket (s) alive for the duration of the async operation
 	void async_shutdown(socket_type& s, std::shared_ptr<void> holder)
 	{
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		boost::apply_visitor(issue_async_shutdown_visitor{&s, std::move(holder)}, s);
 #else
 		TORRENT_UNUSED(holder);
 		error_code e;
 		s.close(e);
-#endif // TORRENT_USE_OPENSSL
+#endif // TORRENT_USE_SSL
 	}
 }
 }

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1581,7 +1581,7 @@ bool is_downloading_state(int const st)
 		// tell the client we need a cert for this torrent
 		alerts().emplace_alert<torrent_need_cert_alert>(get_handle());
 	}
-#endif // TORRENT_OPENSSL
+#endif // TORRENT_SSL_PEERS
 
 	void torrent::construct_storage()
 	{
@@ -6001,7 +6001,7 @@ namespace {
 			return;
 		}
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		if (protocol != "http" && protocol != "https")
 #else
 		if (protocol != "http")
@@ -6281,7 +6281,7 @@ namespace {
 			&& web->have_files.none_set()) return;
 
 		void* userdata = nullptr;
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		const bool ssl = string_begins_no_case("https://", web->url.c_str());
 		if (ssl)
 		{
@@ -6320,7 +6320,7 @@ namespace {
 
 		if (proxy_hostnames
 			&& (boost::get<socks5_stream>(&s)
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 				|| boost::get<ssl_stream<socks5_stream>>(&s)
 #endif
 				))
@@ -6328,7 +6328,7 @@ namespace {
 			// we're using a socks proxy and we're resolving
 			// hostnames through it
 			socks5_stream& str =
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 				ssl ? boost::get<ssl_stream<socks5_stream>>(s).next_layer() :
 #endif
 			boost::get<socks5_stream>(s);

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -268,7 +268,7 @@ constexpr tracker_request_flags_t tracker_request::i2p;
 
 		std::string const protocol = req.url.substr(0, req.url.find(':'));
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		if (protocol == "http" || protocol == "https")
 #else
 		if (protocol == "http")

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -57,7 +57,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/ip/multicast.hpp>
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 #include <boost/asio/ssl/context.hpp>
 #endif
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
@@ -123,12 +123,12 @@ upnp::upnp(io_context& ios
 	, m_listen_address(listen_address)
 	, m_netmask(netmask)
 	, m_device(std::move(listen_device))
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	, m_ssl_ctx(ssl::context::sslv23_client)
 #endif
 	, m_listen_handle(std::move(ls))
 {
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	m_ssl_ctx.set_verify_mode(ssl::context::verify_none);
 #endif
 }
@@ -440,7 +440,7 @@ void upnp::connect(rootdevice& d)
 				, std::ref(d), _4), true, default_max_bottled_buffer_size
 			, http_connect_handler()
 			, http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			, &m_ssl_ctx
 #endif
 			);
@@ -852,7 +852,7 @@ void upnp::update_map(rootdevice& d, port_mapping_t const i)
 				, std::ref(d), i, _4), true, default_max_bottled_buffer_size
 			, std::bind(&upnp::create_port_mapping, self(), _1, std::ref(d), i)
 			, http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			, &m_ssl_ctx
 #endif
 			);
@@ -869,7 +869,7 @@ void upnp::update_map(rootdevice& d, port_mapping_t const i)
 				, std::ref(d), i, _4), true, default_max_bottled_buffer_size
 			, std::bind(&upnp::delete_port_mapping, self(), std::ref(d), i)
 			, http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 			, &m_ssl_ctx
 #endif
 			);
@@ -1087,7 +1087,7 @@ void upnp::on_upnp_xml(error_code const& e
 			, std::ref(d), _4), true, default_max_bottled_buffer_size
 		, std::bind(&upnp::get_ip_address, self(), std::ref(d))
 		, http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		, &m_ssl_ctx
 #endif
 		);

--- a/src/web_connection_base.cpp
+++ b/src/web_connection_base.cpp
@@ -79,7 +79,7 @@ namespace libtorrent {
 		if (m_port == -1 && protocol == "http")
 			m_port = 80;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		if (protocol == "https")
 		{
 			m_ssl = true;

--- a/test/test_http_connection.cpp
+++ b/test/test_http_connection.cpp
@@ -127,7 +127,7 @@ void run_test(std::string const& url, int size, int status, int connected
 		<< " connected: " << connected
 		<< " error: " << (ec?ec->message():"no error") << std::endl;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	ssl::context ssl_ctx(ssl::context::sslv23_client);
 	ssl_ctx.set_verify_mode(ssl::context::verify_none);
 #endif
@@ -135,7 +135,7 @@ void run_test(std::string const& url, int size, int status, int connected
 	std::shared_ptr<http_connection> h = std::make_shared<http_connection>(ios
 		, res, &::http_handler_test, true, 1024*1024, &::http_connect_handler_test
 		, http_filter_handler()
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 		, &ssl_ctx
 #endif
 		);
@@ -245,7 +245,7 @@ void run_suite(std::string const& protocol
 
 } // anonymous namespace
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(no_proxy_ssl) { run_suite("https", settings_pack::none); }
 TORRENT_TEST(http_ssl) { run_suite("https", settings_pack::http); }
 TORRENT_TEST(http_pw_ssl) { run_suite("https", settings_pack::http_pw); }

--- a/test/test_url_seed.cpp
+++ b/test/test_url_seed.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::none;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(url_seed_ssl_keepalive)
 {
 		run_http_suite(proxy, "https", 1, 0, 0, 1);

--- a/test/test_web_seed.cpp
+++ b/test/test_web_seed.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::none;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(web_seed_ssl)
 {
 	run_http_suite(proxy, "https", false);

--- a/test/test_web_seed_ban.cpp
+++ b/test/test_web_seed_ban.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::none;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(http_seed_ssl)
 {
 	run_http_suite(proxy, "https", 0, 0, 1);

--- a/test/test_web_seed_chunked.cpp
+++ b/test/test_web_seed_chunked.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::none;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(web_seed_ssl)
 {
 	run_http_suite(proxy, "https", 0, 1, 0);

--- a/test/test_web_seed_http.cpp
+++ b/test/test_web_seed_http.cpp
@@ -48,7 +48,7 @@ TORRENT_TEST(url_seed_http)
 	run_http_suite(proxy, "http", true);
 }
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(web_seed_https)
 {
 	run_http_suite(proxy, "https", false);

--- a/test/test_web_seed_http_pw.cpp
+++ b/test/test_web_seed_http_pw.cpp
@@ -48,7 +48,7 @@ TORRENT_TEST(url_seed_http_pw)
 	run_http_suite(proxy, "http", true);
 }
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(web_seed_http_pw_ssl)
 {
 	run_http_suite(proxy, "https", false);

--- a/test/test_web_seed_socks4.cpp
+++ b/test/test_web_seed_socks4.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::socks4;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(http_seed_ssl)
 {
 	run_http_suite(proxy, "https", 0);

--- a/test/test_web_seed_socks5.cpp
+++ b/test/test_web_seed_socks5.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::socks5;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(http_seed_ssl)
 {
 	run_http_suite(proxy, "https", 0);

--- a/test/test_web_seed_socks5_no_peers.cpp
+++ b/test/test_web_seed_socks5_no_peers.cpp
@@ -40,7 +40,7 @@ const int proxy = lt::settings_pack::socks5;
 
 TORRENT_TEST(web_seed_socks5_no_peers_ssl)
 {
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 	run_http_suite(proxy, "https", false, false, false, false, false, false);
 #endif
 }

--- a/test/test_web_seed_socks5_pw.cpp
+++ b/test/test_web_seed_socks5_pw.cpp
@@ -38,7 +38,7 @@ using namespace lt;
 
 const int proxy = lt::settings_pack::socks5_pw;
 
-#ifdef TORRENT_USE_OPENSSL
+#if TORRENT_USE_SSL
 TORRENT_TEST(http_seed_ssl)
 {
 	run_http_suite(proxy, "https", 0);


### PR DESCRIPTION
This PR introduces the compilation flag `TORRENT_USE_SSL`, defined to 1 iff `TORRENT_USE_OPENSSL` is defined else 0 in `config.hpp`.

This is a prerequisite for GnuTLS support https://github.com/arvidn/libtorrent/pull/4588