### PR TITLE
GnuTLS prerequisite: Implement utp_stream::write_some()

### DIFF
--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -607,7 +607,7 @@ struct utp_socket_impl
 	void do_connect(tcp::endpoint const& ep);
 
 	std::size_t read_some(bool const clear_buffers);
-	std::size_t write_some(bool const clear_buffers);
+	std::size_t write_some(bool const clear_buffers); // Warning: non-blocking
 	int receive_buffer_size() const { return m_receive_buffer_size; }
 
 	bool null_buffers() const { return m_null_buffers; }

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -250,6 +250,7 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 	void add_write_buffer(void const* buf, std::size_t len);
 	void issue_write();
 	std::size_t read_some(bool clear_buffers);
+	std::size_t write_some(bool clear_buffers);
 
 	int send_delay() const;
 	int recv_delay() const;
@@ -365,11 +366,35 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 	}
 
 	template <class Const_Buffers>
-	std::size_t write_some(Const_Buffers const& /* buffers */, error_code& /* ec */)
+	std::size_t write_some(Const_Buffers const& buffers, error_code& ec)
 	{
-		TORRENT_ASSERT(false && "not implemented!");
-		// TODO: implement blocking write. Low priority since it's not used (yet)
-		return 0;
+		TORRENT_ASSERT(!m_write_handler);
+		if (m_impl == nullptr)
+		{
+			ec = boost::asio::error::not_connected;
+			return 0;
+		}
+
+#if TORRENT_USE_ASSERTS
+		size_t buf_size = 0;
+#endif
+
+		for (auto i = buffer_sequence_begin(buffers)
+			, end(buffer_sequence_end(buffers)); i != end; ++i)
+		{
+			add_write_buffer(i->data(), i->size());
+#if TORRENT_USE_ASSERTS
+			buf_size += i->size();
+#endif
+		}
+		std::size_t ret = write_some(true);
+		TORRENT_ASSERT(ret <= buf_size);
+		if(ret == 0)
+		{
+			ec = boost::asio::error::would_block;
+			return 0;
+		}
+		return ret;
 	}
 
 #ifndef BOOST_NO_EXCEPTIONS
@@ -582,6 +607,7 @@ struct utp_socket_impl
 	void do_connect(tcp::endpoint const& ep);
 
 	std::size_t read_some(bool const clear_buffers);
+	std::size_t write_some(bool const clear_buffers);
 	int receive_buffer_size() const { return m_receive_buffer_size; }
 
 	bool null_buffers() const { return m_null_buffers; }

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -472,6 +472,11 @@ std::size_t utp_stream::read_some(bool const clear_buffers)
 	return m_impl->read_some(clear_buffers);
 }
 
+std::size_t utp_stream::write_some(bool const clear_buffers)
+{
+	return m_impl->write_some(clear_buffers);
+}
+
 // this is called when all user provided write buffers have been
 // added. Start trying to send packets with the payload immediately.
 void utp_stream::issue_write()
@@ -650,6 +655,22 @@ void utp_socket_impl::issue_write()
 	while (send_pkt());
 
 	maybe_trigger_send_callback();
+}
+
+std::size_t utp_socket_impl::write_some(bool const clear_buffers)
+{
+	m_written = 0;
+
+	// try to write if the congestion window allows it
+	while (send_pkt());
+
+	if (clear_buffers)
+	{
+		m_write_buffer_size = 0;
+		m_write_buffer.clear();
+	}
+
+	return std::size_t(m_written);
 }
 
 void utp_socket_impl::do_connect(tcp::endpoint const& ep)

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -472,6 +472,8 @@ std::size_t utp_stream::read_some(bool const clear_buffers)
 	return m_impl->read_some(clear_buffers);
 }
 
+// Warning: this is always non-blocking, it only tries to send
+// immediately if there is some space in the congestion window.
 std::size_t utp_stream::write_some(bool const clear_buffers)
 {
 	return m_impl->write_some(clear_buffers);


### PR DESCRIPTION
This PR implements the previously unimplemented method `utp_stream::write_some()`.

Due to the lack of write buffer in the UTP socket, it is always non-blocking. It only tries to write as much as there is space available in the congestion window, and returns immediately.

This is a prerequisite for GnuTLS support #4588