### PR TITLE
merkle tree abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ set(libtorrent_aux_include_files
 	listen_socket_handle
 	lsd
 	merkle
+	merkle_tree
 	noexcept_movable
 	numeric_cast
 	packet_buffer
@@ -328,6 +329,7 @@ set(sources
 	peer_connection_handle
 	instantiate_connection
 	merkle
+	merkle_tree
 	natpmp
 	part_file
 	packet_buffer

--- a/Jamfile
+++ b/Jamfile
@@ -746,6 +746,7 @@ SOURCES =
 	ip_voter
 	listen_socket_handle
 	merkle
+	merkle_tree
 	peer_connection
 	platform_util
 	bt_peer_connection

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,7 @@ SOURCES = \
   lsd.cpp                         \
   magnet_uri.cpp                  \
   merkle.cpp                      \
+  merkle_tree.cpp                 \
   mmap.cpp                        \
   mmap_disk_io.cpp                \
   mmap_storage.cpp                \
@@ -602,6 +603,7 @@ HEADERS = \
   aux_/listen_socket_handle.hpp     \
   aux_/lsd.hpp                      \
   aux_/merkle.hpp                   \
+  aux_/merkle_tree.hpp              \
   aux_/mmap.hpp                     \
   aux_/noexcept_movable.hpp         \
   aux_/numeric_cast.hpp             \

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -101,6 +101,19 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT
 	std::pair<aux::vector<std::pair<sha256_hash, sha256_hash>>, sha256_hash>
 	merkle_check_proofs(sha256_hash to_validate, span<sha256_hash const> hashes, int index);
+
+	TORRENT_EXTRA_EXPORT
+	bool merkle_validate_node(sha256_hash const& left, sha256_hash const& right
+		, sha256_hash const& paremt);
+
+	// validates hashes from src and copies the valid ones to dst given root as
+	// the expected root of the tree (i.e. index 0)
+	// src and dst must be the same size. dst is expected to be initialized
+	// cleared (or only have valid hashes set), this function will not clear
+	// hashes in dst that are invalid in src.
+	TORRENT_EXTRA_EXPORT
+	void merkle_validate_copy(span<sha256_hash const> src, span<sha256_hash> dst
+		, sha256_hash const& root);
 }
 
 #endif

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -103,6 +103,10 @@ namespace libtorrent {
 	merkle_check_proofs(sha256_hash to_validate, span<sha256_hash const> hashes, int index);
 
 	TORRENT_EXTRA_EXPORT
+	bool merkle_validate_proofs(int start_idx
+		, span<std::pair<sha256_hash, sha256_hash> const> proofs);
+
+	TORRENT_EXTRA_EXPORT
 	bool merkle_validate_node(sha256_hash const& left, sha256_hash const& right
 		, sha256_hash const& paremt);
 

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -126,6 +126,18 @@ namespace libtorrent {
 
 	TORRENT_EXTRA_EXPORT
 	bool merkle_validate_single_layer(span<sha256_hash const> tree);
+
+	// given a leaf index (0-based index in the leaf layer) and a tree, return
+	// the leafs_start, leafs_size and root_index representing a subtree that
+	// can be validated. The leaf_index and leaf_size is the range of the leaf
+	// layer that can be verified, and the root_index is the node that needs to
+	// be known in (tree) to do so. The num_valid_leafs specifies how many of
+	// the leafs that are actually *supposed* to be non-zero. Any leafs beyond
+	// thses are padding and expected to be zero.
+	// The caller must validate the hash at root_index.
+	TORRENT_EXTRA_EXPORT
+	std::tuple<int, int, int> merkle_find_known_subtree(span<sha256_hash const> const tree
+		, int leaf_index, int num_valid_leafs);
 }
 
 #endif

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -56,6 +56,10 @@ namespace libtorrent {
 	// returns the number of nodes in the tree, given the number of leaves
 	TORRENT_EXTRA_EXPORT int merkle_num_nodes(int);
 
+	// given the number of leafs in the tree, returns the index to the first
+	// leaf
+	TORRENT_EXTRA_EXPORT int merkle_first_leaf(int num_leafs);
+
 	// takes the number of leaves and returns the height of the merkle tree.
 	// does not include the root node in the layer count. i.e. if there's only a
 	// root hash, there are 0 layers. Note that the number of leaves must be
@@ -79,7 +83,8 @@ namespace libtorrent {
 	// given the leaf hashes, computes the merkle root hash. The pad is the hash
 	// to use for the right-side padding, in case the number of leaves is not a
 	// power of two.
-	TORRENT_EXTRA_EXPORT sha256_hash merkle_root(span<sha256_hash const> leaves, sha256_hash const& pad = {});
+	TORRENT_EXTRA_EXPORT sha256_hash merkle_root(span<sha256_hash const> leaves
+		, int num_leafs, sha256_hash const& pad = {});
 
 	// given a flat index, return which layer the node is in
 	TORRENT_EXTRA_EXPORT int merkle_get_layer(int idx);
@@ -118,6 +123,9 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT
 	void merkle_validate_copy(span<sha256_hash const> src, span<sha256_hash> dst
 		, sha256_hash const& root);
+
+	TORRENT_EXTRA_EXPORT
+	bool merkle_validate_single_layer(span<sha256_hash const> tree);
 }
 
 #endif

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -115,10 +115,6 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 
 private:
 
-	void fill(int piece_layer_size);
-	void fill(int piece_layer_size, int level_start);
-	void clear(int num_leafs, int level_start);
-
 	char const* m_root = nullptr;
 	aux::vector<sha256_hash> m_tree;
 	int m_num_blocks = 0;

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -103,6 +103,13 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	void add_proofs(int dest_start_idx
 		, span<std::pair<sha256_hash, sha256_hash> const> proofs);
 
+
+	// returns the index of the pieces that passed the hash check
+	std::vector<piece_index_t> check_pieces(int base
+		, int index, int blocks_per_piece, int file_piece_offset
+		, span<sha256_hash const> hashes);
+
+
 private:
 	char const* m_root = nullptr;
 	aux::vector<sha256_hash> m_tree;

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -36,10 +36,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 
 #include "libtorrent/sha1_hash.hpp" // for sha256_hash
-
-#include "libtorrent/aux_/merkle.hpp"
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/export.hpp"
+#include "libtorrent/span.hpp"
 
 namespace libtorrent {
 namespace aux {
@@ -79,6 +78,8 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	void fill(int piece_layer_size);
 	void fill(int piece_layer_size, int level_start);
 	void clear(int num_leafs, int level_start);
+
+	bool load_piece_layer(span<char const> piece_layer);
 
 private:
 	char const* m_root = nullptr;

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 #include <map>
 #include <utility> // for pair
+#include <tuple>
 
 #include "libtorrent/sha1_hash.hpp" // for sha256_hash
 #include "libtorrent/aux_/vector.hpp"
@@ -76,14 +77,9 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 
 	bool compare_node(int idx, sha256_hash const& h) const;
 
-	sha256_hash& operator[](int const idx) { return m_tree[idx]; }
 	sha256_hash const& operator[](int const idx) const { return m_tree[idx]; }
 
 	std::vector<sha256_hash> build_vector() const;
-
-	void fill(int piece_layer_size);
-	void fill(int piece_layer_size, int level_start);
-	void clear(int num_leafs, int level_start);
 
 	bool load_piece_layer(span<char const> piece_layer);
 
@@ -109,8 +105,20 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 		, int index, int blocks_per_piece, int file_piece_offset
 		, span<sha256_hash const> hashes);
 
+	enum class set_block_result
+	{
+		ok, unknown, hash_failed
+	};
+
+	std::tuple<set_block_result, int, int> set_block(int block_index
+		, sha256_hash const& h);
 
 private:
+
+	void fill(int piece_layer_size);
+	void fill(int piece_layer_size, int level_start);
+	void clear(int num_leafs, int level_start);
+
 	char const* m_root = nullptr;
 	aux::vector<sha256_hash> m_tree;
 	int m_num_blocks = 0;

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -99,7 +99,7 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 
 	// returns the index of the pieces that passed the hash check
 	std::vector<piece_index_t> check_pieces(int base
-		, int index, int blocks_per_piece, int file_piece_offset
+		, int index, int file_piece_offset
 		, span<sha256_hash const> hashes);
 
 	enum class set_block_result

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -1,0 +1,92 @@
+/*
+
+Copyright (c) 2020, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_MERKLE_TREE_HPP_INCLUDED
+#define TORRENT_MERKLE_TREE_HPP_INCLUDED
+
+#include <cstdint>
+
+#include "libtorrent/sha1_hash.hpp" // for sha256_hash
+
+#include "libtorrent/aux_/merkle.hpp"
+#include "libtorrent/aux_/vector.hpp"
+#include "libtorrent/aux_/export.hpp"
+
+namespace libtorrent {
+namespace aux {
+
+// represents the merkle tree for files belonging to a torrent.
+// Each file has a root-hash and a "piece layer", i.e. the level in the tree
+// representing whole pieces. Those hashes are likely to be included in .torrent
+// files and known up-front.
+
+// while downloading, we need to store interior nodes of this tree. However, we
+// don't need to store the padding. a SHA-256 is 32 bytes. Instead of storing
+// the full (padded) tree of SHA-256 hashes, store the full tree of 32 bit
+// signed integers, being indices into the actual storage for the tree. We could
+// even grow the storage lazily. Instead of storing the padding hashes, use
+// negative indices to refer to fixed SHA-256(0), and SHA-256(SHA-256(0)) and so
+// on
+struct TORRENT_EXTRA_EXPORT merkle_tree
+{
+	// TODO: remove this constructor. Don't support "uninitialized" trees. This
+	// also requires not constructing these for pad-files and small files as
+	// well. So, a sparse hash list in torrent_info
+	merkle_tree() = default;
+	merkle_tree(int num_blocks, char const* r);
+
+	sha256_hash root() const;
+
+	void load_tree(span<sha256_hash const> t);
+
+	std::size_t size() const;
+	int end_index() const { return int(size()); }
+
+	sha256_hash& operator[](int const idx) { return m_tree[idx]; }
+	sha256_hash const& operator[](int const idx) const { return m_tree[idx]; }
+
+	std::vector<sha256_hash> build_vector() const;
+
+	void fill(int piece_layer_size);
+	void fill(int piece_layer_size, int level_start);
+	void clear(int num_leafs, int level_start);
+
+private:
+	char const* m_root = nullptr;
+	aux::vector<sha256_hash> m_tree;
+	int m_num_blocks = 0;
+};
+
+}
+}
+
+#endif

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -70,6 +70,8 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	std::size_t size() const;
 	int end_index() const { return int(size()); }
 
+	bool has_node(int idx) const;
+
 	sha256_hash& operator[](int const idx) { return m_tree[idx]; }
 	sha256_hash const& operator[](int const idx) const { return m_tree[idx]; }
 

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -87,11 +87,8 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	// tree). This function inserts those hashes as well as the nodes up the
 	// tree. The destination start index is the index, in this tree, to the first leaf
 	// where "tree" will be inserted.
-	// the "blocks_per_piece" parameter is used to map any hash failures to a
-	// piece index, for the returned vector
 	std::map<piece_index_t, std::vector<int>> add_hashes(
-		int dest_start_idx, int blocks_per_piece
-		, span<sha256_hash const> tree);
+		int dest_start_idx, span<sha256_hash const> tree);
 
 	// inserts the nodes in "proofs" as a path up the tree starting at
 	// "dest_start_idx". The proofs are sibling hashes, as they are returned

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -476,6 +476,10 @@ namespace aux {
 		//
 		// ``root()`` returns the SHA-256 merkle tree root of the specified file,
 		// in case this is a v2 torrent. Otherwise returns zeros.
+		// ``root_ptr()`` returns a pointer to the SHA-256 merkle tree root hash
+		// for the specified file. The pointer points into storage referred to
+		// when the file was added, it is not owned by this object. Torrents
+		// that are not v2 torrents return nullptr.
 		//
 		// The ``mtime()`` is the modification time is the posix
 		// time when a file was last modified when the torrent
@@ -497,6 +501,7 @@ namespace aux {
 		// index (given the piece size).
 		sha1_hash hash(file_index_t index) const;
 		sha256_hash root(file_index_t index) const;
+		char const* root_ptr(file_index_t const index) const;
 		std::string symlink(file_index_t index) const;
 		std::time_t mtime(file_index_t index) const;
 		std::string file_path(file_index_t index, std::string const& save_path = "") const;

--- a/include/libtorrent/hash_picker.hpp
+++ b/include/libtorrent/hash_picker.hpp
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/aux_/vector.hpp"
+#include "libtorrent/aux_/merkle_tree.hpp"
 #include "libtorrent/sha1_hash.hpp"
 #include "libtorrent/file_storage.hpp"
 #include "libtorrent/bitfield.hpp"
@@ -134,7 +135,7 @@ namespace libtorrent
 	{
 	public:
 		hash_picker(file_storage const& files
-			, aux::vector<aux::vector<sha256_hash>, file_index_t>& trees
+			, aux::vector<aux::merkle_tree, file_index_t>& trees
 			, aux::vector<aux::vector<bool>, file_index_t> verified = {}
 			, bool all_verified = false);
 
@@ -202,7 +203,7 @@ namespace libtorrent
 		};
 
 		file_storage const& m_files;
-		aux::vector<aux::vector<sha256_hash>, file_index_t>& m_merkle_trees;
+		aux::vector<aux::merkle_tree, file_index_t>& m_merkle_trees;
 		aux::vector<aux::vector<bool>, file_index_t> m_hash_verified;
 
 		// information about every 512-piece span of each file. We request hashes

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -60,6 +60,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/file_storage.hpp"
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/announce_entry.hpp"
+#include "libtorrent/aux_/merkle_tree.hpp"
 
 namespace libtorrent {
 
@@ -575,7 +576,8 @@ TORRENT_VERSION_NAMESPACE_3
 		{ return m_info_section; }
 
 		// internal
-		aux::vector<aux::vector<sha256_hash>, file_index_t>& internal_merkle_trees();
+		aux::vector<aux::merkle_tree, file_index_t>& internal_merkle_trees();
+		void internal_load_merkle_trees(std::vector<std::vector<sha256_hash>> const& t);
 
 		// internal
 		void internal_set_creator(string_view);
@@ -679,7 +681,7 @@ TORRENT_VERSION_NAMESPACE_3
 		// once in torrent), or they would have to be moved out of torrent_info as
 		// the torrent is added. Storing it twice can use a lot of memory. Moving
 		// it out leaves a "one-time-use" API on torrent_info class.
-		aux::vector<aux::vector<sha256_hash>, file_index_t> m_merkle_trees;
+		aux::vector<aux::merkle_tree, file_index_t> m_merkle_trees;
 
 		// this is a copy of the info section from the torrent.
 		// it use maintained in this flat format in order to

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -834,6 +834,12 @@ namespace aux {
 		return sha256_hash(m_files[index].root);
 	}
 
+	char const* file_storage::root_ptr(file_index_t const index) const
+	{
+		TORRENT_ASSERT_PRECOND(index >= file_index_t{} && index < end_file());
+		return m_files[index].root;
+	}
+
 	std::string file_storage::symlink(file_index_t const index) const
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t{} && index < end_file());

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -312,7 +312,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 		add_hashes_result ret(true);
 
 		int const dest_start_idx = merkle_to_flat_index(base_layer_idx, req.index);
-		ret.hash_failed = dst_tree.add_hashes(dest_start_idx, m_files.piece_length() / default_block_size, tree);
+		ret.hash_failed = dst_tree.add_hashes(dest_start_idx, tree);
 		dst_tree.add_proofs(dest_start_idx >> base_num_layers, proofs);
 
 		if (req.base == 0)

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -326,7 +326,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 			int const file_piece_offset = int(m_files.file_offset(req.file) / m_files.piece_length());
 
 			ret.hash_passed = dst_tree.check_pieces(req.base, req.index
-				, m_files.piece_length() / default_block_size, file_piece_offset, hashes);
+				, file_piece_offset, hashes);
 		}
 
 		return ret;

--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -84,6 +84,13 @@ namespace libtorrent {
 		return ((leafs - 1) << 1) + 1;
 	}
 
+	int merkle_first_leaf(int num_leafs)
+	{
+		// num_leafs must be a power of 2
+		TORRENT_ASSERT(((num_leafs - 1) & num_leafs) == 0);
+		return num_leafs - 1;
+	}
+
 	int merkle_num_leafs(int const blocks)
 	{
 		TORRENT_ASSERT(blocks > 0);
@@ -157,11 +164,13 @@ namespace libtorrent {
 
 	// compute the merkle tree root, given the leaves and the has to use for
 	// padding
-	sha256_hash merkle_root(span<sha256_hash const> leaves, sha256_hash const& pad)
+	sha256_hash merkle_root(span<sha256_hash const> leaves, int const num_leafs
+		, sha256_hash const& pad)
 	{
+		TORRENT_ASSERT(((num_leafs - 1) & num_leafs) == 0);
+
 		// TODO this can be optimized to use at least half as much memory
 		int const num_blocks = int(leaves.size());
-		int const num_leafs = merkle_num_leafs(num_blocks);
 		int const num_nodes = merkle_num_nodes(num_leafs);
 		int const first_leaf = num_nodes - num_leafs;
 		aux::vector<sha256_hash> merkle_tree(num_nodes);
@@ -271,6 +280,25 @@ namespace libtorrent {
 				dst[right_child] = src[right_child];
 			}
 		}
+	}
+
+	bool merkle_validate_single_layer(span<sha256_hash const> tree)
+	{
+		if (tree.size() == 1) return true;
+		int const num_leafs = int((tree.size() + 1) / 2);
+		int const end = int(tree.size());
+		TORRENT_ASSERT((num_leafs & (num_leafs - 1)) == 0);
+
+		int idx = merkle_first_leaf(num_leafs);
+		TORRENT_ASSERT(idx >= 1);
+
+		while (idx < end)
+		{
+			if (!merkle_validate_node(tree[idx], tree[idx + 1], tree[merkle_get_parent(idx)]))
+				return false;
+			idx += 2;
+		}
+		return true;
 	}
 }
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -140,6 +140,7 @@ namespace aux {
 	void merkle_tree::add_proofs(int dest_start_idx
 		, span<std::pair<sha256_hash, sha256_hash> const> proofs)
 	{
+		TORRENT_ASSERT(merkle_validate_proofs(dest_start_idx, proofs));
 		// now copy the string of proof hashes
 		for (auto proof : proofs)
 		{

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -1,0 +1,89 @@
+/*
+
+Copyright (c) 2020, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/aux_/merkle_tree.hpp"
+#include "libtorrent/aux_/vector.hpp"
+
+namespace libtorrent {
+namespace aux {
+
+	merkle_tree::merkle_tree(int const num_blocks, char const* r)
+		: m_root(r)
+		, m_tree(merkle_num_nodes(merkle_num_leafs(num_blocks)))
+		, m_num_blocks(num_blocks)
+	{
+		TORRENT_ASSERT(m_root != nullptr);
+		m_tree[0] = root();
+	}
+
+	sha256_hash merkle_tree::root() const { return sha256_hash(m_root); }
+
+	void merkle_tree::load_tree(span<sha256_hash const> t)
+	{
+		if (t.empty()) return;
+		if (root() != t[0]) return;
+		if (size() != static_cast<std::size_t>(t.size())) return;
+
+		// TODO: If t has a complete block layer, just store that
+		// otherwise, if t has a complete piece layer, just store that
+
+		m_tree.assign(t.begin(), t.end());
+	}
+
+	std::size_t merkle_tree::size() const
+	{
+		return static_cast<std::size_t>(merkle_num_nodes(merkle_num_leafs(m_num_blocks)));
+	}
+
+	std::vector<sha256_hash> merkle_tree::build_vector() const
+	{
+		std::vector<sha256_hash> ret(m_tree.begin(), m_tree.end());
+		return ret;
+	}
+
+	void merkle_tree::fill(int const piece_layer_size)
+	{
+		merkle_fill_tree(m_tree, piece_layer_size);
+	}
+
+	void merkle_tree::fill(int const piece_layer_size, int const level_start)
+	{
+		merkle_fill_tree(m_tree, piece_layer_size, level_start);
+	}
+
+	void merkle_tree::clear(int num_leafs, int level_start)
+	{
+		merkle_clear_tree(m_tree, num_leafs, level_start);
+	}
+
+}
+}

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -96,11 +96,8 @@ namespace aux {
 		return true;
 	}
 
-	// TODO: blocks_per_piece does not need to be passed in, we already know
-	// m_blocks_per_piece_log
 	std::map<piece_index_t, std::vector<int>> merkle_tree::add_hashes(
-		int dest_start_idx, int const blocks_per_piece
-		, span<sha256_hash const> tree)
+		int dest_start_idx, span<sha256_hash const> tree)
 	{
 		std::map<piece_index_t, std::vector<int>> failed_blocks;
 
@@ -137,10 +134,10 @@ namespace aux {
 					// leaf layer of the file tree
 					TORRENT_ASSERT(dst_idx >= first_leaf);
 
-					// TODO: blocks_per_piece is guaranteed to be a power of 2,
-					// so this could just be a shift and AND
-					std::div_t const pos = std::div(dst_idx - first_leaf, blocks_per_piece);
-					failed_blocks[piece_index_t{pos.quot}].push_back(pos.rem);
+					int const pos = dst_idx - first_leaf;
+					int const piece = pos >> m_blocks_per_piece_log;
+					int const block = pos & ((1 << m_blocks_per_piece_log) - 1);
+					failed_blocks[piece_index_t{piece}].push_back(block);
 				}
 
 				m_tree[dst_idx] = tree[src_idx];

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -93,6 +93,11 @@ namespace aux {
 		return static_cast<std::size_t>(merkle_num_nodes(merkle_num_leafs(m_num_blocks)));
 	}
 
+	bool merkle_tree::has_node(int const idx) const
+	{
+		return !m_tree[idx].is_all_zeros();
+	}
+
 	std::vector<sha256_hash> merkle_tree::build_vector() const
 	{
 		std::vector<sha256_hash> ret(m_tree.begin(), m_tree.end());

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -168,20 +168,17 @@ namespace aux {
 	}
 
 	std::vector<piece_index_t> merkle_tree::check_pieces(int const base
-		, int const index, int const blocks_per_piece, int const file_piece_offset
+		, int const index, int const file_piece_offset
 		, span<sha256_hash const> hashes)
 	{
 		std::vector<piece_index_t> passed_pieces;
 
 		allocate_full();
 
-		// blocks per piece must be a power of 2
-		TORRENT_ASSERT((blocks_per_piece & (blocks_per_piece - 1)) == 0);
-
 		int const count = static_cast<int>(hashes.size());
 		auto const file_num_leafs = merkle_num_leafs(m_num_blocks);
 		auto const file_first_leaf = merkle_first_leaf(file_num_leafs);
-		int const first_piece = file_first_leaf / blocks_per_piece;
+		int const first_piece = file_first_leaf >> m_blocks_per_piece_log;
 
 		int const base_layer_index = merkle_num_layers(file_num_leafs) - base;
 		int const base_layer_start = merkle_to_flat_index(base_layer_index, index);
@@ -217,7 +214,7 @@ namespace aux {
 			{
 				merkle_clear_tree(m_tree, num_leafs / 2, merkle_get_parent(file_first_leaf + first_leaf));
 				m_tree[base_layer_start + i] = hashes[i];
-				TORRENT_ASSERT(num_leafs == blocks_per_piece);
+				TORRENT_ASSERT(num_leafs == blocks_per_piece());
 				//verify_block_hashes(m_files.file_offset(req.file) / m_files.piece_length() + index);
 				// TODO: add to failed hashes
 			}

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -57,7 +57,7 @@ namespace aux {
 		// TODO: If t has a complete block layer, just store that
 		// otherwise, if t has a complete piece layer, just store that
 
-		m_tree.assign(t.begin(), t.end());
+		merkle_validate_copy(t, m_tree, root());
 	}
 
 	// returns false if the piece layer fails to validate against the root hash

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -77,7 +77,7 @@ namespace aux {
 		for (int n = num_pieces; n < piece_layer_size; ++n)
 			m_tree[first_piece_node + n] = pad_hash;
 
-		fill(piece_layer_size);
+		merkle_fill_tree(m_tree, piece_layer_size);
 
 		if (m_tree[0] != r)
 		{
@@ -262,12 +262,12 @@ namespace aux {
 
 		// save the root hash because merkle_fill_tree will overwrite it
 		sha256_hash const root = m_tree[root_index];
-		fill(leafs_size, file_first_leaf + leafs_index);
+		merkle_fill_tree(m_tree, leafs_size, file_first_leaf + leafs_index);
 
 		if (root != m_tree[root_index])
 		{
 			// hash failure, clear all the internal nodes
-			clear(leafs_size / 2, merkle_get_parent(file_first_leaf + leafs_index));
+			merkle_clear_tree(m_tree, leafs_size / 2, merkle_get_parent(file_first_leaf + leafs_index));
 			m_tree[root_index] = root;
 			return std::make_tuple(set_block_result::hash_failed, leafs_index, leafs_size);
 		}
@@ -293,21 +293,6 @@ namespace aux {
 	{
 		std::vector<sha256_hash> ret(m_tree.begin(), m_tree.end());
 		return ret;
-	}
-
-	void merkle_tree::fill(int const piece_layer_size)
-	{
-		merkle_fill_tree(m_tree, piece_layer_size);
-	}
-
-	void merkle_tree::fill(int const piece_layer_size, int const level_start)
-	{
-		merkle_fill_tree(m_tree, piece_layer_size, level_start);
-	}
-
-	void merkle_tree::clear(int num_leafs, int level_start)
-	{
-		merkle_clear_tree(m_tree, num_leafs, level_start);
 	}
 
 }

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -396,13 +396,7 @@ bool is_downloading_state(int const st)
 		if (m_torrent_file->is_valid() && m_torrent_file->info_hash().has_v2())
 		{
 			if (!p.merkle_trees.empty())
-			{
-				auto& trees = m_torrent_file->internal_merkle_trees();
-				trees.clear();
-				trees.reserve(p.merkle_trees.size());
-				for (auto const& t : p.merkle_trees)
-					trees.emplace_back(t.begin(), t.end());
-			}
+				m_torrent_file->internal_load_merkle_trees(p.merkle_trees);
 
 			if (!p.verified_leaf_hashes.empty())
 			{
@@ -6801,7 +6795,7 @@ namespace {
 			ret.merkle_trees.clear();
 			ret.merkle_trees.reserve(m_torrent_file->internal_merkle_trees().size());
 			for (auto const& t : m_torrent_file->internal_merkle_trees())
-				ret.merkle_trees.emplace_back(t.begin(), t.end());
+				ret.merkle_trees.emplace_back(t.build_vector());
 
 			if (has_hash_picker())
 			{
@@ -7272,16 +7266,6 @@ namespace {
 		{
 			m_ses.alerts().emplace_alert<metadata_received_alert>(
 				get_handle());
-		}
-
-		// for v2 torrents the root hashes need to be copied to the merkle trees
-		if (m_torrent_file->info_hash().has_v2())
-		{
-			auto& merkle_trees = m_torrent_file->internal_merkle_trees();
-			for (file_index_t f(0); f != m_torrent_file->files().end_file(); ++f)
-			{
-				merkle_trees[f][0] = m_torrent_file->files().root(f);
-			}
 		}
 
 		// we have to initialize the torrent before we start

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6455,7 +6455,7 @@ namespace {
 
 		for (int i = 0; i < req.count; ++i)
 		{
-			if (f[layer_start_idx + i].is_all_zeros())
+			if (!f.has_node(layer_start_idx + i))
 				return {};
 			ret.push_back(f[layer_start_idx + i]);
 		}
@@ -6477,8 +6477,7 @@ namespace {
 			{
 				int const sibling = merkle_get_sibling(layer_start_idx);
 
-				if (f[layer_start_idx].is_all_zeros()
-					|| f[sibling].is_all_zeros())
+				if (!f.has_node(layer_start_idx) || !f.has_node(sibling))
 					return {};
 
 				ret.push_back(f[sibling]);

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1477,7 +1477,8 @@ namespace {
 				if (files.pad_file_at(i) || files.file_size(i) == 0)
 					m_merkle_trees.emplace_back();
 				else
-					m_merkle_trees.emplace_back(files.file_num_blocks(i), files.root_ptr(i));
+					m_merkle_trees.emplace_back(files.file_num_blocks(i)
+						, files.piece_length() / default_block_size, files.root_ptr(i));
 			}
 		}
 

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -332,7 +332,11 @@ TORRENT_TEST(discrete_checking)
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), t.generate());
 	auto ti = std::make_shared<torrent_info>(buf, ec, from_span);
-	printf("generated torrent: %s test_torrent_dir\n", aux::to_hex(ti->info_hash().v1.to_string()).c_str());
+	printf("generated torrent: %s test_torrent_dir result: %s\n"
+		, aux::to_hex(ti->info_hash().v1.to_string()).c_str()
+		, ec.message().c_str());
+
+	TEST_CHECK(ti->is_valid());
 
 	// we have two files, but there's a padfile now too
 	TEST_EQUAL(ti->num_files(), 3);

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -324,8 +324,11 @@ TORRENT_TEST(bad_block_hash)
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	trees.emplace_back(4 * 512, full_tree[0].data());
 
+	sha256_hash hash;
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001"
-		, trees.front()[trees.front().end_index() - merkle_num_leafs(4 * 512) + 1].data());
+		, hash.data());
+
+	trees.front().set_block(1, hash);
 
 	hash_picker picker(fs, trees);
 
@@ -378,7 +381,7 @@ TORRENT_TEST(set_block_hash)
 	// zero out the inner nodes for a piece along with a single leaf node
 	// then add a bogus hash for the leaf
 	{
-		auto mutable_tree = trees.front().build_vector();
+		aux::vector<sha256_hash> mutable_tree(trees.front().build_vector());
 		mutable_tree[merkle_get_parent(first_leaf + 12)].clear();
 		mutable_tree[merkle_get_parent(first_leaf + 14)].clear();
 		mutable_tree[first_leaf + 13].clear();
@@ -721,7 +724,7 @@ TORRENT_TEST(add_hashes_fail1)
 	aux::merkle_tree t(13, f[0].data());
 
 	// this is an invalid hash
-	t[16] = sha256_hash("01234567890123456789012345678901");
+	t.set_block(1, sha256_hash("01234567890123456789012345678901"));
 
 	auto const failed = t.add_hashes(15, 1, subtree);
 	TEST_CHECK((failed == p{{piece_index_t{1}, {0}}}));
@@ -746,9 +749,9 @@ TORRENT_TEST(add_hashes_fail2)
 	aux::merkle_tree t(13, f[0].data());
 
 	// this is an invalid hash
-	t[16] = sha256_hash("01234567890123456789012345678901");
-	t[17] = sha256_hash("01234567890123456789012345678901");
-	t[18] = sha256_hash("01234567890123456789012345678901");
+	t.set_block(1, sha256_hash("01234567890123456789012345678901"));
+	t.set_block(2, sha256_hash("01234567890123456789012345678901"));
+	t.set_block(3, sha256_hash("01234567890123456789012345678901"));
 
 	auto const failed = t.add_hashes(15, 2, subtree);
 	TEST_CHECK((failed == p{{piece_index_t{0}, {1}}, {piece_index_t{1}, {0, 1}}}));

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -550,12 +550,12 @@ TORRENT_TEST(load_tree)
 		t.load_tree(f);
 		for (int i = 0; i < num_nodes - num_pad_leafs; ++i)
 		{
-			TEST_CHECK(!t[i].is_all_zeros());
+			TEST_CHECK(t.has_node(i));
 			TEST_CHECK(t[i] == f[i]);
 		}
 		for (int i = num_nodes - num_pad_leafs; i < num_nodes; ++i)
 		{
-			TEST_CHECK(t[i].is_all_zeros());
+			TEST_CHECK(!t.has_node(i));
 			TEST_CHECK(t[i] == f[i]);
 		}
 	}
@@ -565,18 +565,18 @@ TORRENT_TEST(load_tree)
 		sha256_hash const bad_root("01234567890123456789012345678901");
 		aux::merkle_tree t(260, bad_root.data());
 		t.load_tree(f);
-		TEST_CHECK(!t[0].is_all_zeros());
+		TEST_CHECK(t.has_node(0));
 		for (int i = 1; i < num_nodes; ++i)
-			TEST_CHECK(t[i].is_all_zeros());
+			TEST_CHECK(!t.has_node(i));
 	}
 
 	// mismatching size
 	{
 		aux::merkle_tree t(260, f[0].data());
 		t.load_tree(span<sha256_hash const>(f).first(f.end_index() - 1));
-		TEST_CHECK(!t[0].is_all_zeros());
+		TEST_CHECK(t.has_node(0));
 		for (int i = 1; i < num_nodes; ++i)
-			TEST_CHECK(t[i].is_all_zeros());
+			TEST_CHECK(!t.has_node(i));
 	}
 }
 

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -107,11 +107,11 @@ TORRENT_TEST(pick_piece_layer)
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 	fs.add_file("test/tmp2", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	aux::vector<aux::merkle_tree, file_index_t> trees;
 
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	trees.push_back(aux::merkle_tree(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	trees.push_back(aux::merkle_tree(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
 
 	hash_picker picker(fs, trees);
@@ -175,6 +175,15 @@ TORRENT_TEST(pick_piece_layer)
 }
 #endif
 
+namespace {
+sha256_hash from_hex(span<char const> str)
+{
+	sha256_hash ret;
+	aux::from_hex(str, ret.data());
+	return ret;
+}
+}
+
 TORRENT_TEST(reject_piece_request)
 {
 	file_storage fs;
@@ -182,9 +191,9 @@ TORRENT_TEST(reject_piece_request)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
-	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
+	trees.emplace_back(4 * 512, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -204,17 +213,16 @@ TORRENT_TEST(add_leaf_hashes)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
-
-	aux::vector<sha256_hash> const full_tree = build_tree(4 * 512);
-	trees.front()[0] = full_tree[0];
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const full_tree = build_tree(4 * 512);
+	sha256_hash const root = full_tree[0];
+	trees.emplace_back(4 * 512, root.data());
 
 	hash_picker picker(fs, trees);
 
 	std::vector<sha256_hash> hashes;
-	auto leafs_start = full_tree.end() - merkle_num_leafs(4 * 512);
-	std::copy(leafs_start, leafs_start + 512, std::back_inserter(hashes));
+	auto const pieces_start = full_tree.end_index() - merkle_num_leafs(4 * 512);
+	for (int i = 0; i < 512; ++i) hashes.push_back(full_tree[pieces_start + i]);
 	for (int i = 3; i > 0; i = merkle_get_parent(i))
 	{
 		hashes.push_back(full_tree[merkle_get_sibling(i)]);
@@ -228,7 +236,7 @@ TORRENT_TEST(add_leaf_hashes)
 	TEST_CHECK(result.valid);
 
 	hashes.clear();
-	std::copy(leafs_start + 1024, leafs_start + 1536, std::back_inserter(hashes));
+	for (int i = 1024; i < 1536; ++i) hashes.push_back(full_tree[pieces_start + i]);
 	for (int i = 5; i > 0; i = merkle_get_parent(i))
 	{
 		hashes.push_back(full_tree[merkle_get_sibling(i)]);
@@ -242,7 +250,7 @@ TORRENT_TEST(add_leaf_hashes)
 		, span<sha256_hash const>(full_tree).last(merkle_num_leafs(4 * 512) - 1536).first(512));
 	TEST_CHECK(result.valid);
 
-	TEST_CHECK(trees.front() == full_tree);
+	TEST_CHECK(trees.front().build_vector() == full_tree);
 }
 
 TORRENT_TEST(add_piece_hashes)
@@ -252,11 +260,10 @@ TORRENT_TEST(add_piece_hashes)
 
 	fs.add_file("test/tmp1", 4 * 1024 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 1024))));
-
-	aux::vector<sha256_hash> const full_tree = build_tree(4 * 1024);
-	trees.front()[0] = full_tree[0];
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const full_tree = build_tree(4 * 1024);
+	sha256_hash const root = full_tree[0];
+	trees.emplace_back(4 * 1024, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -273,7 +280,8 @@ TORRENT_TEST(add_piece_hashes)
 	result = picker.add_hashes(hash_request(0_file, 2, 512, 512, 8), hashes);
 	TEST_CHECK(result.valid);
 
-	TEST_CHECK(std::equal(trees.front().begin(), trees.front().begin() + merkle_num_nodes(1024), full_tree.begin()));
+	auto const cmp = trees.front().build_vector();
+	TEST_CHECK(std::equal(cmp.begin(), cmp.begin() + merkle_num_nodes(1024), full_tree.begin()));
 }
 
 TORRENT_TEST(add_bad_hashes)
@@ -283,11 +291,10 @@ TORRENT_TEST(add_bad_hashes)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
-
-	aux::vector<sha256_hash> const full_tree = build_tree(4 * 512);
-	trees.front()[0] = full_tree[0];
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const full_tree = build_tree(4 * 512);
+	sha256_hash const root = full_tree[0];
+	trees.emplace_back(4 * 512, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -298,8 +305,8 @@ TORRENT_TEST(add_bad_hashes)
 
 	// bad proof hash
 	hashes.clear();
-	auto pieces_start = full_tree.begin() + merkle_num_nodes(512) - 512;
-	std::copy(pieces_start, pieces_start + 512, std::back_inserter(hashes));
+	auto const pieces_start = full_tree.end_index() - 512;
+	for (int i = 0; i < 512; ++i) hashes.push_back(full_tree[pieces_start + i]);
 	hashes.back()[1] ^= 0xaa;
 	result = picker.add_hashes(hash_request(0_file, 2, 0, 512, 0), hashes);
 	TEST_CHECK(!result.valid);
@@ -312,11 +319,10 @@ TORRENT_TEST(bad_block_hash)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	auto const full_tree = build_tree(4 * 512);
 
-	aux::vector<sha256_hash> const full_tree = build_tree(4 * 512);
-	trees.front()[0] = full_tree[0];
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	trees.emplace_back(4 * 512, full_tree[0].data());
 
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001"
 		, trees.front()[trees.front().end_index() - merkle_num_leafs(4 * 512) + 1].data());
@@ -349,11 +355,10 @@ TORRENT_TEST(set_block_hash)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
-
-	aux::vector<sha256_hash> const full_tree = build_tree(4 * 512);
-	trees.front() = full_tree;
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const full_tree = build_tree(4 * 512);
+	trees.emplace_back(4 * 512, full_tree[0].data());
+	trees.front().load_tree(full_tree);
 
 	int const first_leaf = full_tree.end_index() - merkle_num_leafs(4 * 512);
 
@@ -372,9 +377,13 @@ TORRENT_TEST(set_block_hash)
 
 	// zero out the inner nodes for a piece along with a single leaf node
 	// then add a bogus hash for the leaf
-	trees.front()[merkle_get_parent(first_leaf + 12)].clear();
-	trees.front()[merkle_get_parent(first_leaf + 14)].clear();
-	trees.front()[first_leaf + 13].clear();
+	{
+		auto mutable_tree = trees.front().build_vector();
+		mutable_tree[merkle_get_parent(first_leaf + 12)].clear();
+		mutable_tree[merkle_get_parent(first_leaf + 14)].clear();
+		mutable_tree[first_leaf + 13].clear();
+		trees.front().load_tree(mutable_tree);
+	}
 
 	result = picker.set_block_hash(3_piece, default_block_size, sha256_hash("01234567890123456789012345678901"));
 	TEST_CHECK(result.status == set_block_hash_result::result::piece_hash_failed);
@@ -390,11 +399,11 @@ TORRENT_TEST(pass_piece)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	auto const full_tree = build_tree(4 * 512);
 
-	aux::vector<sha256_hash> const full_tree = build_tree(4 * 512);
-	trees.front()[0] = full_tree[0];
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	sha256_hash root = full_tree[0];
+	trees.emplace_back(4 * 512, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -407,7 +416,7 @@ TORRENT_TEST(pass_piece)
 		TEST_CHECK(result.status == set_block_hash_result::result::unknown);
 	}
 
-	auto pieces_start = full_tree.begin() + merkle_num_nodes(512) - 512;
+	auto const pieces_start = full_tree.begin() + merkle_num_nodes(512) - 512;
 
 	std::vector<sha256_hash> hashes;
 	std::copy(pieces_start, pieces_start + 512, std::back_inserter(hashes));
@@ -427,9 +436,9 @@ TORRENT_TEST(only_pick_have_pieces)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
-	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	sha256_hash root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
+	trees.emplace_back(4 * 512, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -522,5 +531,52 @@ TORRENT_TEST(validate_hash_request)
 	// proof_layers in-range
 	TEST_CHECK(validate_hash_request(hash_request(file_index_t{0}, 0, 0, 1, num_layers - 1), fs));
 	TEST_CHECK(validate_hash_request(hash_request(file_index_t{0}, 1, 0, 1, num_layers - 2), fs));
+}
+
+namespace {
+
+auto const f = build_tree(260);
+int const num_leafs = merkle_num_leafs(260);
+int const num_nodes = merkle_num_nodes(num_leafs);
+int const num_pad_leafs = num_leafs - 260;
+
+}
+
+TORRENT_TEST(load_tree)
+{
+	// test with full tree and valid root
+	{
+		aux::merkle_tree t(260, f[0].data());
+		t.load_tree(f);
+		for (int i = 0; i < num_nodes - num_pad_leafs; ++i)
+		{
+			TEST_CHECK(!t[i].is_all_zeros());
+			TEST_CHECK(t[i] == f[i]);
+		}
+		for (int i = num_nodes - num_pad_leafs; i < num_nodes; ++i)
+		{
+			TEST_CHECK(t[i].is_all_zeros());
+			TEST_CHECK(t[i] == f[i]);
+		}
+	}
+
+	// mismatching root hash
+	{
+		sha256_hash const bad_root("01234567890123456789012345678901");
+		aux::merkle_tree t(260, bad_root.data());
+		t.load_tree(f);
+		TEST_CHECK(!t[0].is_all_zeros());
+		for (int i = 1; i < num_nodes; ++i)
+			TEST_CHECK(t[i].is_all_zeros());
+	}
+
+	// mismatching size
+	{
+		aux::merkle_tree t(260, f[0].data());
+		t.load_tree(span<sha256_hash const>(f).first(f.end_index() - 1));
+		TEST_CHECK(!t[0].is_all_zeros());
+		for (int i = 1; i < num_nodes; ++i)
+			TEST_CHECK(t[i].is_all_zeros());
+	}
 }
 

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -32,6 +32,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <iostream>
+
 #include "libtorrent/hash_picker.hpp"
 #include "libtorrent/peer_connection_interface.hpp"
 #include "libtorrent/stat.hpp"
@@ -193,7 +195,7 @@ TORRENT_TEST(reject_piece_request)
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
-	trees.emplace_back(4 * 512, root.data());
+	trees.emplace_back(4 * 512, 1, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -216,7 +218,7 @@ TORRENT_TEST(add_leaf_hashes)
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
 	sha256_hash const root = full_tree[0];
-	trees.emplace_back(4 * 512, root.data());
+	trees.emplace_back(4 * 512, 1, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -263,7 +265,7 @@ TORRENT_TEST(add_piece_hashes)
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 1024);
 	sha256_hash const root = full_tree[0];
-	trees.emplace_back(4 * 1024, root.data());
+	trees.emplace_back(4 * 1024, 4, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -294,7 +296,7 @@ TORRENT_TEST(add_bad_hashes)
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
 	sha256_hash const root = full_tree[0];
-	trees.emplace_back(4 * 512, root.data());
+	trees.emplace_back(4 * 512, 4, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -322,7 +324,7 @@ TORRENT_TEST(bad_block_hash)
 	auto const full_tree = build_tree(4 * 512);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
-	trees.emplace_back(4 * 512, full_tree[0].data());
+	trees.emplace_back(4 * 512, 1, full_tree[0].data());
 
 	sha256_hash hash;
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001"
@@ -360,7 +362,7 @@ TORRENT_TEST(set_block_hash)
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
-	trees.emplace_back(4 * 512, full_tree[0].data());
+	trees.emplace_back(4 * 512, 4, full_tree[0].data());
 	trees.front().load_tree(full_tree);
 
 	int const first_leaf = full_tree.end_index() - merkle_num_leafs(4 * 512);
@@ -388,7 +390,7 @@ TORRENT_TEST(set_block_hash_fail)
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto full_tree = build_tree(4 * 512);
-	trees.emplace_back(4 * 512, full_tree[0].data());
+	trees.emplace_back(4 * 512, 4, full_tree[0].data());
 
 	// zero out the inner nodes for a piece along with a single leaf node
 	// then add a bogus hash for the leaf
@@ -432,7 +434,7 @@ TORRENT_TEST(pass_piece)
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	sha256_hash root = full_tree[0];
-	trees.emplace_back(4 * 512, root.data());
+	trees.emplace_back(4 * 512, 4, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -467,7 +469,7 @@ TORRENT_TEST(only_pick_have_pieces)
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	sha256_hash root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
-	trees.emplace_back(4 * 512, root.data());
+	trees.emplace_back(4 * 512, 1, root.data());
 
 	hash_picker picker(fs, trees);
 
@@ -575,7 +577,7 @@ TORRENT_TEST(load_tree)
 {
 	// test with full tree and valid root
 	{
-		aux::merkle_tree t(260, f[0].data());
+		aux::merkle_tree t(260, 1, f[0].data());
 		t.load_tree(f);
 		for (int i = 0; i < num_nodes - num_pad_leafs; ++i)
 		{
@@ -592,7 +594,7 @@ TORRENT_TEST(load_tree)
 	// mismatching root hash
 	{
 		sha256_hash const bad_root("01234567890123456789012345678901");
-		aux::merkle_tree t(260, bad_root.data());
+		aux::merkle_tree t(260, 1, bad_root.data());
 		t.load_tree(f);
 		TEST_CHECK(t.has_node(0));
 		for (int i = 1; i < num_nodes; ++i)
@@ -601,7 +603,7 @@ TORRENT_TEST(load_tree)
 
 	// mismatching size
 	{
-		aux::merkle_tree t(260, f[0].data());
+		aux::merkle_tree t(260, 1, f[0].data());
 		t.load_tree(span<sha256_hash const>(f).first(f.end_index() - 1));
 		TEST_CHECK(t.has_node(0));
 		for (int i = 1; i < num_nodes; ++i)
@@ -618,7 +620,7 @@ TORRENT_TEST(load_tree)
 
 TORRENT_TEST(add_proofs_left_path)
 {
-	aux::merkle_tree t(260, f[0].data());
+	aux::merkle_tree t(260, 1, f[0].data());
 
 	std::vector<std::pair<sha256_hash, sha256_hash>> const proofs{
 		{f[19], f[20]},
@@ -641,7 +643,7 @@ TORRENT_TEST(add_proofs_left_path)
 
 TORRENT_TEST(add_proofs_right_path)
 {
-	aux::merkle_tree t(260, f[0].data());
+	aux::merkle_tree t(260, 1, f[0].data());
 
 	std::vector<std::pair<sha256_hash, sha256_hash>> const proofs{
 		{f[19], f[20]},
@@ -666,7 +668,7 @@ TORRENT_TEST(add_proofs_right_path)
 
 TORRENT_TEST(add_proofs_far_left_path)
 {
-	aux::merkle_tree t(260, f[0].data());
+	aux::merkle_tree t(260, 1, f[0].data());
 
 	std::vector<std::pair<sha256_hash, sha256_hash>> const proofs{
 		{f[15], f[16]},
@@ -689,7 +691,7 @@ TORRENT_TEST(add_proofs_far_left_path)
 
 TORRENT_TEST(add_proofs_far_right_path)
 {
-	aux::merkle_tree t(260, f[0].data());
+	aux::merkle_tree t(260, 1, f[0].data());
 
 	std::vector<std::pair<sha256_hash, sha256_hash>> const proofs{
 		{f[29], f[30]},
@@ -718,7 +720,7 @@ TORRENT_TEST(add_hashes_pass)
 		f[15], f[16], f[17], f[18],
 	};
 
-	aux::merkle_tree t(260, f[0].data());
+	aux::merkle_tree t(260, 1, f[0].data());
 	auto const failed = t.add_hashes(15, 1, subtree);
 	TEST_CHECK(failed.empty());
 
@@ -747,7 +749,7 @@ TORRENT_TEST(add_hashes_fail1)
 		f[15], f[16], f[17], f[18],
 	};
 
-	aux::merkle_tree t(13, f[0].data());
+	aux::merkle_tree t(13, 1, f[0].data());
 
 	// this is an invalid hash
 	t.set_block(1, sha256_hash("01234567890123456789012345678901"));
@@ -772,7 +774,7 @@ TORRENT_TEST(add_hashes_fail2)
 		f[15], f[16], f[17], f[18],
 	};
 
-	aux::merkle_tree t(13, f[0].data());
+	aux::merkle_tree t(13, 2, f[0].data());
 
 	// this is an invalid hash
 	t.set_block(1, sha256_hash("01234567890123456789012345678901"));
@@ -791,3 +793,22 @@ TORRENT_TEST(add_hashes_fail2)
 	TEST_CHECK(t[18] == f[18]);
 }
 
+// the 4 layers of the tree:
+//                        0
+//             1                     2
+//       3          4            5         6
+//   7     8     9    10    11    12     13   14
+// 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+
+TORRENT_TEST(sparse_merkle_tree_block_layer)
+{
+	aux::merkle_tree t(260, 2, f[0].data());
+
+	t.load_tree(span<sha256_hash const>(f).first(int(t.size())));
+
+	for (int i = 0; i < int(t.size()); ++i)
+	{
+		std::cout << i << '\n';
+		TEST_CHECK(t[i] == f[i]);
+	}
+}

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -721,7 +721,7 @@ TORRENT_TEST(add_hashes_pass)
 	};
 
 	aux::merkle_tree t(260, 1, f[0].data());
-	auto const failed = t.add_hashes(15, 1, subtree);
+	auto const failed = t.add_hashes(15, subtree);
 	TEST_CHECK(failed.empty());
 
 	TEST_CHECK(t[3]  == f[3]);
@@ -754,7 +754,7 @@ TORRENT_TEST(add_hashes_fail1)
 	// this is an invalid hash
 	t.set_block(1, sha256_hash("01234567890123456789012345678901"));
 
-	auto const failed = t.add_hashes(15, 1, subtree);
+	auto const failed = t.add_hashes(15, subtree);
 	TEST_CHECK((failed == p{{piece_index_t{1}, {0}}}));
 
 	TEST_CHECK(t[3]  == f[3]);
@@ -781,7 +781,7 @@ TORRENT_TEST(add_hashes_fail2)
 	t.set_block(2, sha256_hash("01234567890123456789012345678901"));
 	t.set_block(3, sha256_hash("01234567890123456789012345678901"));
 
-	auto const failed = t.add_hashes(15, 2, subtree);
+	auto const failed = t.add_hashes(15, subtree);
 	TEST_CHECK((failed == p{{piece_index_t{0}, {1}}, {piece_index_t{1}, {0, 1}}}));
 
 	TEST_CHECK(t[3]  == f[3]);

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -785,3 +785,74 @@ TORRENT_TEST(merkle_validate_single_layer)
 	TEST_CHECK(merkle_validate_single_layer(src));
 }
 
+TORRENT_TEST(is_subtree_known_full)
+{
+	v const src{
+	        ah,
+	    ad,     eh,
+	  ab, cd, ef,gh,
+	a,b,c,d,e,f,g,h};
+
+	TEST_CHECK(merkle_find_known_subtree(src, 1, 8) == std::make_tuple(0, 2, 3));
+}
+
+TORRENT_TEST(is_subtree_known_two_levels)
+{
+	v const src{
+	        ah,
+	    ad,     eh,
+	  o, o, ef,gh,
+	a,b,c,d,e,f,g,h};
+
+	TEST_CHECK(merkle_find_known_subtree(src, 1, 8) == std::make_tuple(0, 4, 1));
+}
+
+TORRENT_TEST(is_subtree_known_unknown)
+{
+	v const src{
+	        ah,
+	    ad,     eh,
+	  o, o, ef,gh,
+	a,b,o,d,e,f,g,h};
+
+	TEST_CHECK(merkle_find_known_subtree(src, 1, 8) == std::make_tuple(0, 2, 3));
+}
+
+TORRENT_TEST(is_subtree_known_padding)
+{
+	// the last leaf is padding, it should be assumed to be correct despite
+	// being zero
+	v const src{
+	        ah,
+	    ad,     eh,
+	  o, o, ef,gh,
+	a,b,o,d,e,f,g,o};
+
+	TEST_CHECK(merkle_find_known_subtree(src, 6, 7) == std::make_tuple(6, 2, 6));
+}
+
+TORRENT_TEST(is_subtree_known_padding_two_levels)
+{
+	// the last leaf is padding, it should be assumed to be correct despite
+	// being zero
+	v const src{
+	        ah,
+	    ad,     eh,
+	  o, o,  o, o,
+	a,b,o,d,e,f,g,o};
+
+	TEST_CHECK(merkle_find_known_subtree(src, 6, 7) == std::make_tuple(4, 4, 2));
+}
+
+TORRENT_TEST(is_subtree_known_more_padding_two_levels)
+{
+	// the last two leafs are padding, they should be assumed to be correct despite
+	// being zero
+	v const src{
+	        ah,
+	    ad,     eh,
+	  o, o,  o, o,
+	a,b,o,d,e,f,o,o};
+
+	TEST_CHECK(merkle_find_known_subtree(src, 5, 6) == std::make_tuple(4, 4, 2));
+}

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -613,3 +613,99 @@ TORRENT_TEST(merkle_check_proofs_far_right)
 	TEST_CHECK(tree_root == ah);
 	TEST_CHECK((proofs == std::vector<std::pair<sha256_hash, sha256_hash>>{{g, h}, {ef, gh}, {ad, eh}}));
 }
+
+TORRENT_TEST(merkle_validate_node)
+{
+	TEST_CHECK(merkle_validate_node(a, b, ab));
+	TEST_CHECK(merkle_validate_node(c, d, cd));
+	TEST_CHECK(merkle_validate_node(e, f, ef));
+	TEST_CHECK(merkle_validate_node(g, h, gh));
+
+	TEST_CHECK(merkle_validate_node(ab, cd, ad));
+	TEST_CHECK(merkle_validate_node(ef, gh, eh));
+
+	TEST_CHECK(merkle_validate_node(ad, eh, ah));
+
+	TEST_CHECK(!merkle_validate_node(b, a, ab));
+	TEST_CHECK(!merkle_validate_node(d, c, cd));
+	TEST_CHECK(!merkle_validate_node(f, e, ef));
+	TEST_CHECK(!merkle_validate_node(h, g, gh));
+}
+
+TORRENT_TEST(merkle_validate_copy_full)
+{
+
+	v const src{
+	       ah,
+	   ad,     eh,
+	 ab, cd, ef, gh,
+	a,b,c,d,e,f,g,h};
+
+	v empty_tree(15);
+
+	merkle_validate_copy(src, empty_tree, ah);
+
+	TEST_CHECK(empty_tree == src);
+}
+
+TORRENT_TEST(merkle_validate_copy_partial)
+{
+
+	v const src{
+	       ah,
+	   ad,     eh,
+	 ab, cd, ef, o,
+	a,b,c,o,o,o,o,o};
+
+	v empty_tree(15);
+
+	merkle_validate_copy(src, empty_tree, ah);
+
+	v const expected{
+	       ah,
+	   ad,     eh,
+	 ab, cd,  o, o,
+	a,b,o,o,o,o,o,o};
+
+	TEST_CHECK(empty_tree == expected);
+}
+
+TORRENT_TEST(merkle_validate_copy_invalid_root)
+{
+
+	v const src{
+	       ah,
+	   ad,     eh,
+	 ab, cd, ef, o,
+	a,b,c,o,o,o,o,o};
+
+	v empty_tree(15);
+
+	merkle_validate_copy(src, empty_tree, a);
+
+	v const expected(15);
+
+	TEST_CHECK(empty_tree == expected);
+}
+
+TORRENT_TEST(merkle_validate_copy_root_only)
+{
+
+	v const src{
+	       ah,
+	    o,      o,
+	  o,  o,  o, o,
+	o,o,o,o,o,o,o,o};
+
+	v empty_tree(15);
+
+	merkle_validate_copy(src, empty_tree, ah);
+
+	v const expected{
+	       ah,
+	    o,      o,
+	  o,  o,  o, o,
+	o,o,o,o,o,o,o,o};
+
+	TEST_CHECK(empty_tree == expected);
+}

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -709,3 +709,19 @@ TORRENT_TEST(merkle_validate_copy_root_only)
 
 	TEST_CHECK(empty_tree == expected);
 }
+
+TORRENT_TEST(merkle_validate_proofs)
+{
+/*
+	       ah
+	   ad      eh
+	 ab  cd  ef  gh
+	a b c d  e f g h
+*/
+	using p = std::vector<std::pair<sha256_hash, sha256_hash>>;
+	TEST_CHECK(merkle_validate_proofs(5, p{{ef, gh},{ad, eh}}));
+	TEST_CHECK(merkle_validate_proofs(6, p{{ef, gh},{ad, eh}}));
+	TEST_CHECK(merkle_validate_proofs(9, p{{c, d}, {ab, cd}, {ad, eh}}));
+	TEST_CHECK(merkle_validate_proofs(7, p{{a, b}, {ab, cd}, {ad, eh}}));
+	TEST_CHECK(merkle_validate_proofs(8, p{{a, b}, {ab, cd}, {ad, eh}}));
+}

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -1078,7 +1078,7 @@ TORRENT_TEST(merkle_trees)
 	TEST_EQUAL(a->params.merkle_trees.size(), 3);
 	TEST_EQUAL(p.ti->internal_merkle_trees().size(), 3);
 	for (file_index_t const i : p.ti->files().file_range())
-		TEST_CHECK(a->params.merkle_trees[i] == p.ti->internal_merkle_trees()[i]);
+		TEST_CHECK(a->params.merkle_trees[i] == p.ti->internal_merkle_trees()[i].build_vector());
 }
 
 TORRENT_TEST(resume_info_dict)


### PR DESCRIPTION
This is a proposed abstraction for the per-file merkle tree. Currently this tree is a `std::vector<sha256_hash>` that's allocated to fit the full tree.

The goal of this abstraction is to enable a sparse representation of this tree, but this is not implemented yet. The `aux::merkle_tree` class does not allow direct write access to the tree, but the tree can only be mutated via a few high level operations. I believe these operations are at somewhat reasonable levels.

I've divided up the patch in bite-sized commits that can be reviewed individually.

@ssiloti I'm interested in whether you think this is a reasonable abstraction, or if you anticipate problems I may run into going further in this direction.