### PR TITLE
Add remove_flags_t to python bindings.

### DIFF
--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -1138,6 +1138,9 @@ void bind_session()
     s.attr("local_peer_class_id") = session::local_peer_class_id;
 
     s.attr("reopen_map_ports") = lt::session::reopen_map_ports;
+
+    s.attr("delete_files") = lt::session::delete_files;
+    s.attr("delete_partfile") = lt::session::delete_partfile;
     }
 
 #if TORRENT_ABI_VERSION == 1


### PR DESCRIPTION
Add `remove_flags_t` to python bindings.

I guess `options_t` was sort of meant to be this, but the name is different and it never included `delete_partfile`. Maybe `options_t` could be a deprecated alias?

Nothing in test.py for this right now. I would like to refactor test.py once my other python3 PR is done.