### PR TITLE
improve CMake - sync documentation with #4627 and fixup #4547

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,7 +636,7 @@ if(OPENSSL_FOUND)
 
 	# TODO: needed until https://gitlab.kitware.com/cmake/cmake/issues/19263 is fixed
 	if(WIN32 AND OPENSSL_USE_STATIC_LIBS)
-		target_link_libraries(OpenSSL::Crypto INTERFACE crypt32)
+		target_link_libraries(torrent-rasterbar PRIVATE crypt32)
 	endif()
 
 	target_link_libraries(torrent-rasterbar PUBLIC OpenSSL::SSL)

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -484,12 +484,6 @@ Other build options are:
 
 Options are set on the ``cmake`` command line with the ``-D`` option or later on using ``ccmake`` or ``cmake-gui`` applications. ``cmake`` run outputs a summary of all available options and their current values.
 
-.. note::
-
-	If you are linking statically against OpenSSL on Windows and not using ``-Dstatic_runtime=ON``,
-	you should additionally use the option ``-DOPENSSL_USE_STATIC_LIBS=ON``.
-	If you use ``-Dstatic_runtime=ON``, ``-DOPENSSL_USE_STATIC_LIBS=ON`` is implied.
-
 Step 2: Building libtorrent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
About documentation: since #4627, `OPENSSL_USE_STATIC_LIBS` is fully independent of `static runtime`. `OPENSSL_USE_STATIC_LIBS` is automatically set to `TRUE` if `BUILD_SHARED_LIBS` is `FALSE`.

About fixing up #4547 - according to https://gitlab.kitware.com/cmake/cmake/issues/19263, `crypt32` should be linked against the project, not against the imported OpenSSL targets. With this fix, the generated target file `LibtorrentRasterbarTargets.cmake` look good (`crypt32` appears as a `LINK_ONLY` interface link library alongside other system libraries like `ws2_32`), and I now no longer get link errors when linking statically with dynamic runtime (previously I had only tested static runtime).

To reproduce the link errors on Windows (static libs+dynamic runtime) without this patch:
- Build libtorrent with static linkage but dynamic runtime (for example, using the `vcpkg` triplet `x64-windows-static-md`)
- Try to use libtorrent's imported CMake targets to build a project that would use crypto facilities in libtorrent. The `examples` directory modified to be a standalone project will do:

```
# examples/CMakeLists.txt
cmake_minimum_required(VERSION 3.12)
project(libtorrent-examples)

set(single_file_examples
    simple_client
    custom_storage
    stats_counters
    dump_torrent
    make_torrent
    connection_tester
    upnp_test)

find_package(LibtorrentRasterbar CONFIG REQUIRED)

foreach(example ${single_file_examples})
    add_executable(${example} "${example}.cpp")
    target_link_libraries(${example} PRIVATE LibtorrentRasterbar::torrent-rasterbar)
endforeach(example)

add_executable(client_test
    client_test.cpp
    print.cpp
    torrent_view.cpp
    session_view.cpp)
target_link_libraries(client_test PRIVATE LibtorrentRasterbar::torrent-rasterbar)
```

```
$ cd examples
$ cmake -S . -B build -G "Visual Studio 16 2019" -A x64 -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
$ cmake --build build --config RelWithDebInfo
```

- This should yield link errors related to `libcrypto`. The fix is either this PR, or to explicitly add a dependency on `crypt32` for every project that uses libtorrent (obviously not desirable). In this example, it would involve changing both the `target_link_libraries` lines to ` target_link_libraries(${example} PRIVATE LibtorrentRasterbar::torrent-rasterbar crypt32)` and `target_link_libraries(client_test PRIVATE LibtorrentRasterbar::torrent-rasterbar crypt32)`, respectively.

Curiously, with or without this patch or with or without `crypt32` as an explicit dependency of the executables, building libtorrent itself with `-Dbuild_examples` works fine. I assume because in this case the `examples` are in a subdirectory, and the required dependency was propagated from somewhere else. Same for qBittorrent, but in this latter case I suspect it comes from the fact that Qt also uses OpenSSL, and so the appropriately configured dependency on `crypt32` must get propagated from that somehow.