### PR TITLE
Install cmake find module

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -788,12 +788,21 @@ lib torrent
 
 headers = [ path.glob-tree include/libtorrent : *.hpp ] ;
 
-package.install install
+package.install install-torrent-lib
 	: <install-source-root>libtorrent
 	:
 	: torrent
 	: $(headers)
 	;
+
+package.install-data install-cmake-module
+	: cmake/Modules
+	: examples/cmake/FindLibtorrentRasterbar.cmake
+	;
+
+alias install : install-torrent-lib install-cmake-module ;
+
+explicit install ;
 
 local header_targets ;
 for local target in $(headers)

--- a/LibtorrentRasterbarConfig.cmake.in
+++ b/LibtorrentRasterbarConfig.cmake.in
@@ -1,7 +1,5 @@
 # - Config file for the @PROJECT_NAME@ package
-# It defines the following variables
-#  @PROJECT_NAME@_INCLUDE_DIRS - include directories for @PROJECT_NAME@
-#  @PROJECT_NAME@_LIBRARIES    - libraries to link against
+# It defines the LibtorrentRasterbar::torrent-rasterbar target to link against
 
 @PACKAGE_INIT@
 
@@ -9,8 +7,3 @@ include(CMakeFindDependencyMacro)
 @_find_dependency_calls@
 
 include("${CMAKE_CURRENT_LIST_DIR}/LibtorrentRasterbarTargets.cmake")
-
-get_target_property(@PROJECT_NAME@_INCLUDE_DIRS LibtorrentRasterbar::torrent-rasterbar INTERFACE_INCLUDE_DIRECTORIES)
-get_target_property(_lt_iface_link_libraries LibtorrentRasterbar::torrent-rasterbar INTERFACE_LINK_LIBRARIES)
-get_target_property(_lt_imported_location LibtorrentRasterbar::torrent-rasterbar IMPORTED_LOCATION)
-set(@PROJECT_NAME@_LIBRARIES "${_lt_imported_location};${_lt_iface_link_libraries}")

--- a/Makefile.am
+++ b/Makefile.am
@@ -140,3 +140,5 @@ EXTRA_DIST = \
 pkgconfigdir   = $(libdir)/pkgconfig
 pkgconfig_DATA = libtorrent-rasterbar.pc
 
+cmakemoduledir = $(datarootdir)/cmake/Modules
+cmakemodule_DATA = examples/cmake/FindLibtorrentRasterbar.cmake


### PR DESCRIPTION
Refactor a bit the example CMake find module file to make it more readable and install it with autotools and b2 builds. Thus CMake-based clients can expect it to be present, and those who do not want to use it can use the config mode for `find_package()`. 