### PR TITLE
Jamfile: Add win10 option for UWP development

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -410,9 +410,10 @@ feature.compose <asserts>on : <define>TORRENT_USE_ASSERTS=1 ;
 feature.compose <asserts>production : <define>TORRENT_USE_ASSERTS=1 <define>TORRENT_PRODUCTION_ASSERTS=1 ;
 feature.compose <asserts>system : <define>TORRENT_USE_ASSERTS=1 <define>TORRENT_USE_SYSTEM_ASSERTS=1 ;
 
-feature windows-version : vista win7 xp : composite propagated ;
+feature windows-version : vista win7 win10 xp : composite propagated ;
 feature.compose <windows-version>vista : <define>_WIN32_WINNT=0x0600 ;
 feature.compose <windows-version>win7 : <define>_WIN32_WINNT=0x0601 ;
+feature.compose <windows-version>win10 : <define>_WIN32_WINNT=0x0A00 ;
 feature.compose <windows-version>xp : <define>_WIN32_WINNT=0x0501 ;
 
 feature extensions : on off : composite propagated link-incompatible ;


### PR DESCRIPTION
Windows Store (UWP) apps require the latest required version to be set to Windows 10 (defined by _WIN32_WINNT).