### PR TITLE
Optimize get hashes

### DIFF
--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -83,8 +83,11 @@ namespace libtorrent {
 	// given the leaf hashes, computes the merkle root hash. The pad is the hash
 	// to use for the right-side padding, in case the number of leaves is not a
 	// power of two.
-	TORRENT_EXTRA_EXPORT sha256_hash merkle_root(span<sha256_hash const> leaves
-		, int num_leafs, sha256_hash const& pad = {});
+	TORRENT_EXTRA_EXPORT sha256_hash merkle_root(span<sha256_hash const> leaves, sha256_hash const& pad = {});
+
+	TORRENT_EXTRA_EXPORT
+	sha256_hash merkle_root_scratch(span<sha256_hash const> leaves, int num_leafs
+		, sha256_hash const& pad, std::vector<sha256_hash>& scratch_space);
 
 	// given a flat index, return which layer the node is in
 	TORRENT_EXTRA_EXPORT int merkle_get_layer(int idx);

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -87,7 +87,7 @@ namespace libtorrent {
 
 	TORRENT_EXTRA_EXPORT
 	sha256_hash merkle_root_scratch(span<sha256_hash const> leaves, int num_leafs
-		, sha256_hash const& pad, std::vector<sha256_hash>& scratch_space);
+		, sha256_hash pad, std::vector<sha256_hash>& scratch_space);
 
 	// given a flat index, return which layer the node is in
 	TORRENT_EXTRA_EXPORT int merkle_get_layer(int idx);

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -110,6 +110,9 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	std::tuple<set_block_result, int, int> set_block(int block_index
 		, sha256_hash const& h);
 
+	std::vector<sha256_hash> get_hashes(int base
+		, int index, int count, int proof_layers) const;
+
 private:
 
 	int blocks_per_piece() const { return 1 << m_blocks_per_piece_log; }
@@ -117,6 +120,7 @@ private:
 	int block_layer_start() const;
 	int piece_layer_start() const;
 	int num_pieces() const;
+	int num_leafs() const;
 
 	void optimize_storage();
 	void allocate_full();

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -115,6 +115,8 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 
 private:
 
+	sha256_hash get_impl(int idx, std::vector<sha256_hash>& scratch_space) const;
+
 	int blocks_per_piece() const { return 1 << m_blocks_per_piece_log; }
 
 	int block_layer_start() const;

--- a/include/libtorrent/hash_picker.hpp
+++ b/include/libtorrent/hash_picker.hpp
@@ -98,10 +98,6 @@ namespace libtorrent
 
 	// the hash request represents a range of hashes in the merkle hash tree for
 	// a specific file ('file').
-	// base indicates which *level* of the tree we're referring to. 0 means the
-	// leaf level.
-	// index is the index of the first hash at the specified level.
-	// count is the number of hashes in the range
 	struct TORRENT_EXTRA_EXPORT hash_request
 	{
 		hash_request() = default;
@@ -119,8 +115,12 @@ namespace libtorrent
 		}
 
 		file_index_t file{0};
+		// indicates which *level* of the tree we're referring to. 0 means the
+		// leaf level.
 		int base = 0;
+		// the index of the first hash at the specified level.
 		int index = 0;
+		// the number of hashes in the range
 		int count = 0;
 		int proof_layers = 0;
 	};

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -194,8 +194,7 @@ namespace {
 				for (auto i = piece_blocks; i < padded_leafs; ++i)
 					v2_blocks[i].clear();
 				sha256_hash const piece_root = merkle_root(
-					span<sha256_hash>(v2_blocks).first(padded_leafs)
-					, merkle_num_leafs(padded_leafs));
+					span<sha256_hash>(v2_blocks).first(padded_leafs));
 				st->ct.set_hash2(current_file, file_piece_offset, piece_root);
 			}
 		}
@@ -632,8 +631,7 @@ namespace {
 				if (files().file_flags(fi) & file_storage::flag_pad_file) continue;
 				if (files().file_size(fi) == 0) continue;
 
-				m_fileroots[fi] = merkle_root(m_file_piece_hash[fi]
-					, merkle_num_leafs(int(m_file_piece_hash[fi].size())), pad_hash);
+				m_fileroots[fi] = merkle_root(m_file_piece_hash[fi], pad_hash);
 
 				if (m_file_piece_hash[fi].size() < 2) continue;
 				auto& pieces = file_pieces[m_fileroots[fi].to_string()].string();

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -381,6 +381,9 @@ TORRENT_TEST(merkle_root)
 
 	// very small tree
 	TEST_CHECK(merkle_root(v{a,b}, o) == ab);
+
+	// single hash-tree
+	TEST_CHECK(merkle_root(v{a}) == a);
 }
 
 TORRENT_TEST(merkle_root_scratch)

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -374,13 +374,30 @@ TORRENT_TEST(merkle_fill_tree)
 TORRENT_TEST(merkle_root)
 {
 	// all leaves in the tree
-	TEST_CHECK(merkle_root(v{a,b,c,d,e,f,g,h}, 8, o) == ah);
+	TEST_CHECK(merkle_root(v{a,b,c,d,e,f,g,h}, o) == ah);
 
 	// not power-of-two number of leaves
-	TEST_CHECK(merkle_root(v{a,b,c,d,e,f}, 8, o) == H(ad, H(ef, H(o, o))));
+	TEST_CHECK(merkle_root(v{a,b,c,d,e,f}, o) == H(ad, H(ef, H(o, o))));
 
 	// very small tree
-	TEST_CHECK(merkle_root(v{a,b}, 2, o) == ab);
+	TEST_CHECK(merkle_root(v{a,b}, o) == ab);
+}
+
+TORRENT_TEST(merkle_root_scratch)
+{
+	std::vector<sha256_hash> buf;
+
+	// all leaves in the tree
+	TEST_CHECK(merkle_root_scratch(v{a,b,c,d,e,f,g,h}, 8, o, buf) == ah);
+
+	// not power-of-two number of leaves
+	TEST_CHECK(merkle_root_scratch(v{a,b,c,d,e,f}, 8, o, buf) == H(ad, H(ef, H(o, o))));
+
+	// very small tree
+	TEST_CHECK(merkle_root_scratch(v{a,b}, 2, o, buf) == ab);
+
+	// unaligned leaf layer
+	TEST_CHECK(merkle_root_scratch(v{a,b,c}, 8, o, buf) == H(H(ab, H(c, o)), H(H(o,o), H(o,o))));
 }
 
 namespace {


### PR DESCRIPTION
This series of patches factor out the function `torrent::get_hashes()` into a member function of `merkle_tree`. This way it can be implemented slightly more efficiently, since it has knowledge about the internal representation of the tree.

It also fixes an issue in `get_hashes()` where it previously would fail if one requested leaf pad hashes (at the block layer).