### PR TITLE
Post peer_connect_alert on both in/out

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -782,19 +782,27 @@ TORRENT_VERSION_NAMESPACE_2
 #endif
 	};
 
-	// This alert is posted every time an outgoing peer connect attempts succeeds.
+	// This alert is posted every time an incoming peer connection both
+	// successfully passes the protocol handshake and is associated with a
+	// torrent, or an outgoing peer connection attempt succeeds. For arbitrary
+	// incoming connections, see incoming_connection_alert.
 	struct TORRENT_EXPORT peer_connect_alert final : peer_alert
 	{
+		enum class direction_t { in, out };
+
 		// internal
 		TORRENT_UNEXPORT peer_connect_alert(aux::stack_allocator& alloc, torrent_handle h
-			, tcp::endpoint const& ep, peer_id const& peer_id, socket_type_t type);
+			, tcp::endpoint const& ep, peer_id const& peer_id, socket_type_t type, direction_t direction);
 
 		TORRENT_DEFINE_ALERT(peer_connect_alert, 23)
 
 		static constexpr alert_category_t static_category = alert_category::connect;
 		std::string message() const override;
 
-		socket_type_t const socket_type;
+		// Tells you if the peer was incoming or outgoing
+		direction_t direction;
+
+		socket_type_t socket_type;
 	};
 
 	// This alert is generated when a peer is disconnected for any reason (other than the ones

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1463,16 +1463,18 @@ namespace {
 	}
 
 	peer_connect_alert::peer_connect_alert(aux::stack_allocator& alloc, torrent_handle h
-		, tcp::endpoint const& ep, peer_id const& peer_id, socket_type_t const type)
+		, tcp::endpoint const& ep, peer_id const& peer_id, socket_type_t const type, direction_t const dir)
 		: peer_alert(alloc, h, ep, peer_id)
+		, direction(dir)
 		, socket_type(type)
 	{}
 
 	std::string peer_connect_alert::message() const
 	{
 		char msg[600];
-		std::snprintf(msg, sizeof(msg), "%s connecting to peer (%s)"
-			, peer_alert::message().c_str(), socket_type_name(socket_type));
+		char const* direction_str = direction == direction_t::in ? "incoming" : "outgoing";
+		std::snprintf(msg, sizeof(msg), "%s %s connection to peer (%s)"
+			, peer_alert::message().c_str(), direction_str, socket_type_name(socket_type));
 		return msg;
 	}
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -463,7 +463,7 @@ namespace libtorrent {
 		if (t && t->alerts().should_post<peer_connect_alert>())
 		{
 			t->alerts().emplace_alert<peer_connect_alert>(
-				t->get_handle(), remote(), pid(), socket_type_idx(m_socket));
+				t->get_handle(), remote(), pid(), socket_type_idx(m_socket), peer_connect_alert::direction_t::out);
 		}
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log(peer_log_alert::info))
@@ -1346,6 +1346,12 @@ namespace libtorrent {
 		// of the torrent and peer_connection::disconnect() will fail if it
 		// think it is
 		m_torrent = t;
+
+		if (t && t->alerts().should_post<peer_connect_alert>())
+		{
+			t->alerts().emplace_alert<peer_connect_alert>(
+				t->get_handle(), remote(), pid(), socket_type_idx(m_socket), peer_connect_alert::direction_t::in);
+		}
 
 		if (t->info_hash().has_v2() && (t->info_hash().get(protocol_version::V2) == ih.v1
 			|| t->info_hash().v2 == ih.v2))


### PR DESCRIPTION
Changes the peer_connect_alert to post on both incoming and outgoing connections and
also adds a field to specify the direction. This helps existing usages to still work
as they expect (ie. only react to outgoing connections).

I mentioned this a few years ago in #1437. Also, I'm not really sure if I'm posting the incoming alert at the right place, i.e if it has all the necessary info to be posted at that moment. So please have a look and see if it makes sense.