### PR TITLE
fix checking files of v2-only torrent

### DIFF
--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -144,7 +144,7 @@ namespace libtorrent {
 	void merkle_clear_tree(span<sha256_hash> tree, int const num_leafs, int level_start)
 	{
 		TORRENT_ASSERT(num_leafs >= 1);
-		TORRENT_ASSERT(level_start > 0);
+		TORRENT_ASSERT(level_start >= 0);
 		TORRENT_ASSERT(level_start < tree.size());
 		TORRENT_ASSERT(level_start + num_leafs <= tree.size());
 		// the range of nodes must be within a single level

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -416,11 +416,8 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode
 {
 	// you can't create an mmap of size 0, so we just set it to null. We
 	// still need to create the empty file.
-	if (file_size > 0 && m_mapping == nullptr)
-	{
-		fprintf(stderr, "MapViewOfFile failed: %d\n", GetLastError());
+	if (m_size > 0 && m_mapping == nullptr)
 		throw_ex<system_error>(error_code(GetLastError(), system_category()));
-	}
 }
 
 void file_mapping::close()

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -849,6 +849,7 @@ namespace libtorrent {
 		, aux::open_mode_t mode
 		, error_code& ec) const
 	{
+		TORRENT_ASSERT(!files().pad_file_at(file));
 		if (!m_allocate_files) mode |= aux::open_mode::sparse;
 
 		// files with priority 0 should always be sparse

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -80,17 +80,23 @@ enum
 	// force-recheck. Make sure the stat cache is cleared and let us pick up the
 	// new files
 	force_recheck = 8,
+
+	v2 = 16,
+
+	single_file = 32,
 };
 
-void test_checking(int flags)
+void test_checking(int const flags)
 {
 	using namespace lt;
 
-	std::printf("\n==== TEST CHECKING %s%s%s%s=====\n\n"
+	std::printf("\n==== TEST CHECKING %s%s%s%s%s%s=====\n\n"
 		, (flags & read_only_files) ? "read-only-files ":""
 		, (flags & corrupt_files) ? "corrupt ":""
 		, (flags & incomplete_files) ? "incomplete ":""
-		, (flags & force_recheck) ? "force_recheck ":"");
+		, (flags & force_recheck) ? "force_recheck ":""
+		, (flags & v2) ? "v2 ":""
+		, (flags & single_file) ? "single_file ":"");
 
 	error_code ec;
 	create_directory("test_torrent_dir", ec);
@@ -99,15 +105,16 @@ void test_checking(int flags)
 
 	file_storage fs;
 	std::srand(10);
-	int piece_size = 0x4000;
+	int const piece_size = (flags & single_file) ? 0x8000 : 0x4000;
 
-	static std::array<const int, 46> const file_sizes
-	{{ 0, 5, 16 - 5, 16000, 17, 10, 8000, 8000, 1,1,1,1,1,100,1,1,1,1,100,1,1,1,1,1,1
-		,1,1,1,1,1,1,13,65000,34,75,2,30,400,500,23000,900,43000,400,4300,6, 4 }};
+	auto const file_sizes = (flags & single_file)
+		? std::vector<int>{500000}
+		: std::vector<int>{0, 5, 16 - 5, 16000, 17, 10, 8000, 8000, 1,1,1,1,1,100,1,1,1,1,100,1,1,1,1,1,1
+		,1,1,1,1,1,1,13,65000,34,75,2,30,400,50000,73000,900,43000,400,4300,6, 4 };
 
 	create_random_files("test_torrent_dir", file_sizes, &fs);
 
-	lt::create_torrent t(fs, piece_size);
+	lt::create_torrent t(fs, piece_size, (flags & v2) ? create_torrent::v2_only : create_torrent::v1_only);
 
 	// calculate the hash for all pieces
 	set_piece_hashes(t, ".", ec);
@@ -126,6 +133,7 @@ void test_checking(int flags)
 	{
 		for (std::size_t i = 0; i < file_sizes.size(); ++i)
 		{
+			if ((i & 1) == 1) continue;
 			char name[1024];
 			std::snprintf(name, sizeof(name), "test%d", int(i));
 			char dirname[200];
@@ -136,7 +144,7 @@ void test_checking(int flags)
 			file f(path, aux::open_mode::write, ec);
 			if (ec) std::printf("ERROR: opening file \"%s\": (%d) %s\n"
 				, path.c_str(), ec.value(), ec.message().c_str());
-			f.set_size(file_sizes[i] / 2, ec);
+			f.set_size(file_sizes[i] * 2 / 3, ec);
 			if (ec) std::printf("ERROR: truncating file \"%s\": (%d) %s\n"
 				, path.c_str(), ec.value(), ec.message().c_str());
 		}
@@ -148,10 +156,10 @@ void test_checking(int flags)
 		std::printf("corrupt file test. overwriting files\n");
 		// increase the size of some files. When they're read only that forces
 		// the checker to open them in write-mode to truncate them
-			static std::array<const int, 46> const file_sizes2
+		std::vector<int> const file_sizes2
 		{{ 0, 5, 16 - 5, 16001, 30, 10, 8000, 8000, 1,1,1,1,1,100,1,1,1,1,100,1,1,1,1,1,1
 			,1,1,1,1,1,1,13,65000,34,75,2,30,400,500,23000,900,43000,400,4300,6, 4}};
-		create_random_files("test_torrent_dir", file_sizes2);
+		create_random_files("test_torrent_dir", (flags & single_file) ? file_sizes : file_sizes2);
 	}
 
 	// make the files read only
@@ -227,26 +235,34 @@ void test_checking(int flags)
 		std::this_thread::sleep_for(lt::milliseconds(500));
 	}
 
-	if (flags & incomplete_files)
+	if (flags & (incomplete_files | corrupt_files))
 	{
 		TEST_CHECK(!st.is_seeding);
 
 		std::this_thread::sleep_for(lt::milliseconds(500));
 		st = tor1.status();
-		TEST_CHECK(!st.is_seeding);
-	}
-
-	if (flags & corrupt_files)
-	{
-		TEST_CHECK(!st.is_seeding);
 
 		TEST_CHECK(!st.errc);
 		if (st.errc)
 			std::printf("error: %s\n", st.errc.message().c_str());
+		std::vector<std::int64_t> file_progress;
+		tor1.file_progress(file_progress);
+		bool one_incomplete = false;
+		file_storage const& fs1 = ti->files();
+		for (file_index_t i : fs1.file_range())
+		{
+			if (fs1.pad_file_at(i)) continue;
+			std::printf("file: %d progress: %" PRId64 " / %" PRId64 "\n", static_cast<int>(i)
+				, file_progress[std::size_t(static_cast<int>(i))], fs1.file_size(i));
+			if (fs1.file_size(i) == file_progress[std::size_t(static_cast<int>(i))]) continue;
+			one_incomplete = true;
+		}
+		TEST_CHECK(one_incomplete);
+		TEST_CHECK(st.num_pieces < ti->num_pieces());
 	}
-
-	if ((flags & (incomplete_files | corrupt_files)) == 0)
+	else
 	{
+		TEST_CHECK(st.num_pieces == ti->num_pieces());
 		TEST_CHECK(st.is_seeding);
 		if (st.errc)
 			std::printf("error: %s\n", st.errc.message().c_str());
@@ -307,6 +323,51 @@ TORRENT_TEST(corrupt)
 TORRENT_TEST(force_recheck)
 {
 	test_checking(force_recheck);
+}
+
+TORRENT_TEST(checking_v2)
+{
+	test_checking(v2);
+}
+
+TORRENT_TEST(read_only_corrupt_v2)
+{
+	test_checking(read_only_files | corrupt_files | v2);
+}
+
+TORRENT_TEST(read_only_v2)
+{
+	test_checking(read_only_files | v2);
+}
+
+TORRENT_TEST(incomplete_v2)
+{
+	test_checking(incomplete_files | v2);
+}
+
+TORRENT_TEST(corrupt_v2)
+{
+	test_checking(corrupt_files | v2);
+}
+
+TORRENT_TEST(single_file_v2)
+{
+	test_checking(v2 | single_file);
+}
+
+TORRENT_TEST(single_file_corrupt_v2)
+{
+	test_checking(corrupt_files | v2 | single_file);
+}
+
+TORRENT_TEST(single_file_incomplete_v2)
+{
+	test_checking(incomplete_files | v2 | single_file);
+}
+
+TORRENT_TEST(force_recheck_v2)
+{
+	test_checking(force_recheck | v2);
 }
 
 TORRENT_TEST(discrete_checking)


### PR DESCRIPTION
related to this issue: https://github.com/arvidn/libtorrent/issues/4721

The symptom if this problem was that pieces whose *piece hash* failed, would instead turn into `download_piece`es in the piece picker, where every block was finished. But the piece was not marked as "have".

With this change, the piece is identified as failing the hash check immediately and puts the piece bitfield in a correct state after a full check.

@ssiloti please verify/confirm that my understanding is correct, and this was the intended check here