### PR TITLE
make create_torrent fail rather than produce invalid torrents

### DIFF
--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -58,6 +58,8 @@ class test_create_torrent(unittest.TestCase):
         ct.add_tracker('bar')
         ct.set_root_cert('1234567890')
         ct.add_collection('1337')
+        for i in range(ct.num_pieces()):
+            ct.set_hash(i, b'abababababababababab')
         entry = ct.generate()
         print(entry)
 

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -1105,7 +1105,7 @@ std::shared_ptr<torrent_info> make_torrent(bool priv)
 	ct.add_tracker("http://tracker.com:8080/announce");
 
 	for (piece_index_t i(0); i < piece_index_t(ct.num_pieces()); ++i)
-		ct.set_hash(i, sha1_hash(nullptr));
+		ct.set_hash(i, sha1_hash::max());
 
 	ct.set_priv(priv);
 

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -124,6 +124,7 @@ void test_checking(int const flags)
 	std::vector<char> buf;
 	bencode(std::back_inserter(buf), t.generate());
 	auto ti = std::make_shared<torrent_info>(buf, ec, from_span);
+	TEST_CHECK(ti->is_valid());
 
 	std::printf("generated torrent: %s test_torrent_dir\n"
 		, aux::to_hex(ti->info_hashes().v1).c_str());

--- a/test/test_resolve_links.cpp
+++ b/test/test_resolve_links.cpp
@@ -151,10 +151,13 @@ TORRENT_TEST(range_lookup_duplicated_files)
 	fs2.add_file("test_resolve_links_dir/tmp1", 1024);
 	fs2.add_file("test_resolve_links_dir/tmp2", 1024);
 
-	lt::create_torrent t1(fs1, 1024);
-	lt::create_torrent t2(fs2, 1024);
+	lt::create_torrent t1(fs1, 1024, lt::create_torrent::v1_only);
+	lt::create_torrent t2(fs2, 1024, lt::create_torrent::v1_only);
 
 	t1.set_hash(piece_index_t{0}, sha1_hash::max());
+	t1.set_hash(piece_index_t{1}, sha1_hash::max());
+	t2.set_hash(piece_index_t{0}, sha1_hash::max());
+	t2.set_hash(piece_index_t{1}, sha1_hash("01234567890123456789"));
 
 	std::vector<char> tmp1;
 	std::vector<char> tmp2;

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -523,8 +523,8 @@ void test_check_files(std::string const& test_path
 
 	lt::create_torrent t(fs, piece_size_check);
 	t.set_hash(piece_index_t(0), hasher(piece0).final());
-	t.set_hash(piece_index_t(1), {});
-	t.set_hash(piece_index_t(2), {});
+	t.set_hash(piece_index_t(1), sha1_hash::max());
+	t.set_hash(piece_index_t(2), sha1_hash::max());
 	t.set_hash(piece_index_t(3), hasher(piece2).final());
 
 	create_directory(combine_path(test_path, "temp_storage"), ec);

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -231,6 +231,11 @@ TORRENT_TEST(total_wanted)
 	fs.add_file("test_torrent_dir4/tmp4", default_block_size);
 
 	lt::create_torrent t(fs, default_block_size);
+	t.set_hash(piece_index_t{0}, sha1_hash::max());
+	t.set_hash(piece_index_t{1}, sha1_hash::max());
+	t.set_hash(piece_index_t{2}, sha1_hash::max());
+	t.set_hash(piece_index_t{3}, sha1_hash::max());
+
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
 	auto info = std::make_shared<torrent_info>(tmp, from_span);
@@ -270,6 +275,7 @@ TORRENT_TEST(added_peers)
 	fs.add_file("test_torrent_dir4/tmp1", 1024);
 
 	lt::create_torrent t(fs, 1024);
+	t.set_hash(piece_index_t{0}, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
 	auto info = std::make_shared<torrent_info>(tmp, from_span);
@@ -301,6 +307,7 @@ TORRENT_TEST(mismatching_info_hash)
 	file_storage fs;
 	fs.add_file("test_torrent_dir4/tmp1", 1024);
 	lt::create_torrent t(fs, 1024);
+	t.set_hash(piece_index_t{0}, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
 	auto info = std::make_shared<torrent_info>(tmp, from_span);
@@ -325,6 +332,7 @@ TORRENT_TEST(exceed_file_prio)
 	file_storage fs;
 	fs.add_file("test_torrent_dir4/tmp1", 1024);
 	lt::create_torrent t(fs, 1024);
+	t.set_hash(piece_index_t{0}, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
 	auto info = std::make_shared<torrent_info>(tmp, from_span);
@@ -346,6 +354,7 @@ TORRENT_TEST(exceed_piece_prio)
 	file_storage fs;
 	fs.add_file("test_torrent_dir4/tmp1", 1024);
 	lt::create_torrent t(fs, 1024);
+	t.set_hash(piece_index_t{0}, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
 	auto info = std::make_shared<torrent_info>(tmp, from_span);
@@ -402,8 +411,7 @@ TORRENT_TEST(torrent)
 			t.set_hash(i, ph);
 
 		std::vector<char> tmp;
-		std::back_insert_iterator<std::vector<char>> out(tmp);
-		bencode(out, t.generate());
+		bencode(std::back_inserter(tmp), t.generate());
 		error_code ec;
 		auto info = std::make_shared<torrent_info>(tmp, std::ref(ec), from_span);
 		TEST_CHECK(info->num_pieces() > 0);
@@ -430,8 +438,7 @@ TORRENT_TEST(torrent)
 		t.set_hash2(file_index_t{ 0 }, piece_index_t::diff_type{ 0 }, lt::hasher256(piece).final());
 
 		std::vector<char> tmp;
-		std::back_insert_iterator<std::vector<char>> out(tmp);
-		bencode(out, t.generate());
+		bencode(std::back_inserter(tmp), t.generate());
 		auto info = std::make_shared<torrent_info>(tmp, from_span);
 		test_running_torrent(info, default_block_size);
 	}
@@ -472,8 +479,7 @@ TORRENT_TEST(duplicate_is_not_error)
 		t.set_hash(i, ph);
 
 	std::vector<char> tmp;
-	std::back_insert_iterator<std::vector<char>> out(tmp);
-	bencode(out, t.generate());
+	bencode(std::back_inserter(tmp), t.generate());
 
 	int called = 0;
 	plugin_creator creator(called);
@@ -526,11 +532,11 @@ TORRENT_TEST(rename_file)
 
 	fs.add_file("test3/tmp1", 20);
 	fs.add_file("test3/tmp2", 20);
-	lt::create_torrent t(fs, 128 * 1024);
+	lt::create_torrent t(fs, 128 * 1024, lt::create_torrent::v1_only);
+	t.set_hash(piece_index_t{0}, sha1_hash::max());
 
 	std::vector<char> tmp;
-	std::back_insert_iterator<std::vector<char>> out(tmp);
-	bencode(out, t.generate());
+	bencode(std::back_inserter(tmp), t.generate());
 	auto info = std::make_shared<torrent_info>(tmp, from_span);
 
 	TEST_EQUAL(info->files().file_path(file_index_t(0)), combine_path("test3","tmp1"));
@@ -566,6 +572,7 @@ void test_queue(add_torrent_params)
 		file_path << "test_torrent_dir4/queue" << i;
 		fs.add_file(file_path.str(), 1024);
 		lt::create_torrent t(fs, 128 * 1024);
+		t.set_hash(piece_index_t{0}, sha1_hash::max());
 
 		std::vector<char> buf;
 		bencode(std::back_inserter(buf), t.generate());

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -60,9 +60,8 @@ TORRENT_TEST(mutable_torrents)
 	lt::create_torrent t(fs, 0x4000);
 
 	// calculate the hash for all pieces
-	sha1_hash ph;
 	for (auto const i : fs.piece_range())
-		t.set_hash(i, ph);
+		t.set_hash(i, sha1_hash::max());
 
 	t.add_collection("collection1");
 	t.add_collection("collection2");
@@ -70,11 +69,9 @@ TORRENT_TEST(mutable_torrents)
 	t.add_similar_torrent(sha1_hash("abababababababababab"));
 	t.add_similar_torrent(sha1_hash("babababababababababa"));
 
-	std::vector<char> tmp;
-	std::back_insert_iterator<std::vector<char>> out(tmp);
-
 	entry tor = t.generate();
-	bencode(out, tor);
+	std::vector<char> tmp;
+	bencode(std::back_inserter(tmp), tor);
 
 	torrent_info ti(tmp, from_span);
 
@@ -1092,10 +1089,8 @@ void test_resolve_duplicates(aux::vector<file_t, file_index_t> const& test)
 	// isn't supported by v2 torrents, so we can only test this with v1 torrents
 	lt::create_torrent t(fs, 0x4000, create_torrent::v1_only);
 
-	// calculate the hash for all pieces
-	sha1_hash ph;
 	for (auto const i : fs.piece_range())
-		t.set_hash(i, ph);
+		t.set_hash(i, sha1_hash::max());
 
 	std::vector<char> tmp;
 	std::back_insert_iterator<std::vector<char>> out(tmp);


### PR DESCRIPTION
By default, create a torrent corresponding to which hashes were set