### PR TITLE
fix examples' cmake linking errors

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.13)
 project(libtorrent-examples)
 
 set(single_file_examples
@@ -9,9 +10,12 @@ set(single_file_examples
     connection_tester
     upnp_test)
 
+find_package(Boost REQUIRED COMPONENTS system)
+find_package(Threads REQUIRED)
+
 foreach(example ${single_file_examples})
     add_executable(${example} "${example}.cpp")
-    target_link_libraries(${example} PRIVATE torrent-rasterbar)
+    target_link_libraries(${example} PRIVATE torrent-rasterbar ${Boost_SYSTEM_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 endforeach(example)
 
 add_executable(client_test
@@ -19,4 +23,4 @@ add_executable(client_test
     print.cpp
     torrent_view.cpp
     session_view.cpp)
-target_link_libraries(client_test PRIVATE torrent-rasterbar)
+target_link_libraries(client_test PRIVATE torrent-rasterbar ${Boost_SYSTEM_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
When building examples, it will report undeclared symbols and `error adding symbols: DSO missing from command line` error.

```
~/libtorrent/examples/build# make
Scanning dependencies of target client_test
[  5%] Building CXX object CMakeFiles/client_test.dir/client_test.o
[ 10%] Building CXX object CMakeFiles/client_test.dir/print.o
[ 15%] Building CXX object CMakeFiles/client_test.dir/torrent_view.o
[ 21%] Building CXX object CMakeFiles/client_test.dir/session_view.o
[ 26%] Linking CXX executable client_test
/usr/bin/ld: CMakeFiles/client_test.dir/client_test.o: undefined reference to symbol '_ZN5boost6system15system_categoryEv'
/usr/bin/ld: //lib/x86_64-linux-gnu/libboost_system.so.1.67.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/client_test.dir/build.make:129: client_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/client_test.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

It seems that when binutils>=2.22, `ld` won't prase the libraries recursively, so we need declare them explicitly.

Reference : https://blog.csdn.net/shangzh/article/details/49079685 (Chinese)
