### PR TITLE
[clang-tidy] use make-unique

### DIFF
--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2818,7 +2818,7 @@ namespace {
 				std::array<char, dh_key_len> const buffer = export_key(m_dh_key_exchange->get_secret());
 				hasher h(req1);
 				h.update(buffer);
-				m_sync_hash.reset(new sha1_hash(h.final()));
+				m_sync_hash = std::make_unique<sha1_hash>(h.final());
 
 #ifndef TORRENT_DISABLE_LOGGING
 				if (should_log(peer_log_alert::info))

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -55,7 +55,7 @@ namespace aux {
 		, m_save_path(std::move(p.path))
 		, m_part_file_name("." + to_hex(p.info_hash) + ".parts")
 	{
-		if (p.mapped_files) m_mapped_files.reset(new file_storage(*p.mapped_files));
+		if (p.mapped_files) m_mapped_files = std::make_unique<file_storage>(*p.mapped_files);
 	}
 
 	file_storage const& posix_storage::files() const { return m_mapped_files ? *m_mapped_files.get() : m_files; }
@@ -382,7 +382,7 @@ namespace aux {
 
 		if (!m_mapped_files)
 		{
-			m_mapped_files.reset(new file_storage(files()));
+			m_mapped_files = std::make_unique<file_storage>(files());
 		}
 		m_mapped_files->rename_file(index, new_filename);
 	}

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -50,10 +50,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdarg> // for va_list
 #include <ctime>
 #include <algorithm>
+
 #include <set>
 #include <map>
 #include <vector>
 #include <cctype>
+#include <memory>
 #include <numeric>
 #include <limits> // for numeric_limits
 #include <cstdio> // for snprintf
@@ -365,7 +367,7 @@ bool is_downloading_state(int const st)
 		}
 		else
 		{
-			if (!p.name.empty()) m_name.reset(new std::string(p.name));
+			if (!p.name.empty()) m_name = std::make_unique<std::string>(p.name);
 		}
 
 		TORRENT_ASSERT(is_single_thread());
@@ -1196,10 +1198,10 @@ bool is_downloading_state(int const st)
 
 		//INVARIANT_CHECK;
 
-		m_hash_picker.reset(new hash_picker(m_torrent_file->orig_files()
+		m_hash_picker = std::make_unique<hash_picker>(m_torrent_file->orig_files()
 			, m_torrent_file->internal_merkle_trees(), std::move(verified)
 			, m_torrent_file->v2_piece_hashes_verified()
-				&& m_torrent_file->piece_length() == default_block_size));
+				&& m_torrent_file->piece_length() == default_block_size);
 	}
 
 	struct piece_refcount


### PR DESCRIPTION
Found with modernize-make-unique

Signed-off-by: Rosen Penev <rosenp@gmail.com>