### PR TITLE
[clang-tidy] use emplace_back

### DIFF
--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -220,7 +220,7 @@ namespace aux {
 			}
 			else
 			{
-				passed_pieces.push_back(piece_index_t{file_piece_offset + piece});
+				passed_pieces.emplace_back(file_piece_offset + piece);
 			}
 		}
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -653,7 +653,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		{
 			std::lock_guard<std::mutex> l(m_need_tick_mutex);
 			if (!j->storage->set_need_tick())
-				m_need_tick.push_back({aux::time_now() + minutes(2), j->storage});
+				m_need_tick.emplace_back(aux::time_now() + minutes(2), j->storage);
 		}
 
 		m_store_buffer.erase({j->storage->storage_index(), j->piece, j->d.io.offset});

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -253,7 +253,7 @@ namespace libtorrent {
 			place_barrier = true;
 
 		if (crypto)
-			m_send_barriers.push_back(barrier(crypto, INT_MAX));
+			m_send_barriers.emplace_back(crypto, INT_MAX);
 
 		return place_barrier;
 	}

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -1014,7 +1014,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(is_single_thread());
 		INVARIANT_CHECK;
 
-		iterator const iter = std::lower_bound(m_peers.begin(), m_peers.end()
+		auto const iter = std::lower_bound(m_peers.begin(), m_peers.end()
 				, peer_id, peer_address_compare());
 
 		torrent_peer* p = m_peer_allocator.allocate_peer_entry(

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -457,7 +457,7 @@ namespace {
 		TORRENT_ASSERT_PRECOND(!save_path.empty());
 
 		add_torrent_params p;
-		p.trackers.push_back(tracker_url);
+		p.trackers.emplace_back(tracker_url);
 		p.info_hash.v1 = info_hash;
 		p.save_path = save_path;
 		p.storage_mode = storage_mode;


### PR DESCRIPTION
Found with modernize-use-emplace

Signed-off-by: Rosen Penev <rosenp@gmail.com>