### PR TITLE
[clang-tidy] use raw strings

### DIFF
--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -597,7 +597,7 @@ namespace libtorrent {
 #ifndef TORRENT_DISABLE_LOGGING
 			if (i->connection != nullptr && c.should_log(peer_log_alert::info))
 			{
-				c.peer_log(peer_log_alert::info, "DUPLICATE PEER", "this: \"%s\" that: \"%s\""
+				c.peer_log(peer_log_alert::info, "DUPLICATE PEER", R"(this: "%s" that: "%s")"
 					, print_address(c.remote().address()).c_str()
 					, print_address(i->address()).c_str());
 			}

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -254,7 +254,7 @@ void upnp::discover_device_impl()
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log())
 		{
-			log("multicast send failed: \"%s\" and \"%s\". Aborting."
+			log(R"(multicast send failed: "%s" and "%s". Aborting.)"
 				, convert_from_native(mcast_ec.message()).c_str()
 				, convert_from_native(ucast_ec.message()).c_str());
 		}


### PR DESCRIPTION
Found with modernize-raw-string-literal

Signed-off-by: Rosen Penev <rosenp@gmail.com>