### PR TITLE
[clang-tidy] use for range loops

### DIFF
--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -2474,11 +2474,10 @@ namespace {
 #ifndef NDEBUG
 		// make sure there are not conflicting extensions
 		std::set<int> ext;
-		for (entry::dictionary_type::const_iterator i = m.begin()
-			, end(m.end()); i != end; ++i)
+		for (auto const& i : m)
 		{
-			if (i->second.type() != entry::int_t) continue;
-			int val = int(i->second.integer());
+			if (i.second.type() != entry::int_t) continue;
+			int val = int(i.second.integer());
 			TORRENT_ASSERT(ext.find(val) == ext.end());
 			ext.insert(val);
 		}
@@ -3726,22 +3725,22 @@ namespace {
 			// the payload ranges they represent have been sent
 			auto first_to_keep = m_payloads.begin();
 
-			for (auto i = m_payloads.begin(); i != m_payloads.end(); ++i)
+			for (auto& p : m_payloads)
 			{
-				i->start -= int(bytes_transferred);
-				if (i->start < 0)
+				p.start -= int(bytes_transferred);
+				if (p.start < 0)
 				{
-					if (i->start + i->length <= 0)
+					if (p.start + p.length <= 0)
 					{
-						amount_payload += i->length;
-						TORRENT_ASSERT(first_to_keep == i);
+						amount_payload += p.length;
+						TORRENT_ASSERT(first_to_keep == p);
 						++first_to_keep;
 					}
 					else
 					{
-						amount_payload += -i->start;
-						i->length -= -i->start;
-						i->start = 0;
+						amount_payload += -p.start;
+						p.length -= -p.start;
+						p.start = 0;
 					}
 				}
 			}

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -727,12 +727,11 @@ namespace libtorrent {
 		// and also the number of pieces that have more than that.
 		int integer_part = 0;
 		int fraction_part = 0;
-		for (std::vector<piece_pos>::const_iterator i = m_piece_map.begin()
-			, end(m_piece_map.end()); i != end; ++i)
+		for (auto const& i : m_piece_map)
 		{
-			int peer_count = int(i->peer_count);
+			int peer_count = int(i.peer_count);
 			// take ourself into account
-			if (i->have()) ++peer_count;
+			if (i.have()) ++peer_count;
 			if (min_availability > peer_count)
 			{
 				min_availability = peer_count;

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -69,7 +69,7 @@ namespace aux {
 		dns_cache_entry& ce = m_cache[hostname];
 		ce.last_seen = time_now();
 		ce.addresses.clear();
-		for (auto i : ips)
+		for (auto const& i : ips)
 			ce.addresses.push_back(i.endpoint().address());
 
 		callback(h, ec, ce.addresses);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3763,9 +3763,9 @@ namespace {
 
 		// look at all unfinished pieces and add the completed
 		// blocks to our 'done' counter
-		for (auto i = dl_queue.begin(); i != dl_queue.end(); ++i)
+		for (auto const& i : dl_queue)
 		{
-			piece_index_t const index = i->index;
+			piece_index_t const index = i.index;
 
 			// completed pieces are already accounted for
 			if (m_picker->have_piece(index)) continue;
@@ -3773,7 +3773,7 @@ namespace {
 			TORRENT_ASSERT(i->finished + i->writing <= m_picker->blocks_in_piece(index));
 			TORRENT_ASSERT(i->finished + i->writing >= m_picker->pad_blocks_in_piece(index));
 
-			int const blocks = i->finished + i->writing - m_picker->pad_blocks_in_piece(index);
+			int const blocks = i.finished + i.writing - m_picker->pad_blocks_in_piece(index);
 			TORRENT_ASSERT(blocks >= 0);
 
 			auto const additional_bytes = std::int64_t(blocks) * block_size();

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -692,13 +692,13 @@ void upnp::try_map_upnp()
 	TORRENT_ASSERT(is_single_thread());
 	if (m_devices.empty()) return;
 
-	for (auto i = m_devices.begin(), end(m_devices.end()); i != end; ++i)
+	for (auto const& d : m_devices)
 	{
-		if (i->control_url.empty() && !i->upnp_connection && !i->disabled)
+		if (d.control_url.empty() && !d.upnp_connection && !d.disabled)
 		{
 			// we don't have a WANIP or WANPPP url for this device,
 			// ask for it
-			connect(const_cast<rootdevice&>(*i));
+			connect(const_cast<rootdevice&>(d));
 		}
 	}
 }

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -236,10 +236,9 @@ namespace libtorrent { namespace {
 			, m_message_index(0)
 			, m_first_time(true)
 		{
-			const int num_pex_timers = sizeof(m_last_pex) / sizeof(m_last_pex[0]);
-			for (int i = 0; i < num_pex_timers; ++i)
+			for (auto& i : m_last_pex)
 			{
-				m_last_pex[i] = min_time();
+				i = min_time();
 			}
 		}
 


### PR DESCRIPTION
Found with modernize-loop-convert

Signed-off-by: Rosen Penev <rosenp@gmail.com>