### PR TITLE
[clang-tidy] use bool literals

### DIFF
--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -65,7 +65,7 @@ namespace {
 	{
 		time_point added;
 		tcp::endpoint addr;
-		bool seed = 0;
+		bool seed = false;
 	};
 
 	// internal


### PR DESCRIPTION
Found with modernize-use-bool-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>