### PR TITLE
[clang-tidy] remove bad const

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4709,7 +4709,7 @@ namespace {
 		// of it being copied by the torrent constructor
 		std::tie(torrent_ptr, added) = add_torrent_impl(params, ec);
 
-		torrent_handle const handle(torrent_ptr);
+		torrent_handle handle(torrent_ptr);
 		m_alerts.emplace_alert<add_torrent_alert>(handle, params, ec);
 
 		if (!torrent_ptr) return handle;


### PR DESCRIPTION
Found with performance-no-automatic-move

Signed-off-by: Rosen Penev <rosenp@gmail.com>