### PR TITLE
deprecate set_file_hash() in torrent creator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.0 release
 
+	* deprecate set_file_hash() in torrent creator, as it's superceded by v2 torrents
 	* deprecate mutable access to info_section in torrent_info
 	* removed deprecated lazy_entry/lazy_bdecode
 	* stats_alert deprecated

--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -25,10 +25,12 @@ namespace
         c.set_hash(p, sha1_hash(b.arr));
     }
 
+#if TORRENT_ABI_VERSION < 3
     void set_file_hash(create_torrent& c, file_index_t f, bytes const& b)
     {
         c.set_file_hash(f, sha1_hash(b.arr));
     }
+#endif
 
 #ifndef BOOST_NO_EXCEPTIONS
     void set_piece_hashes_callback(create_torrent& c, std::string const& p
@@ -218,7 +220,9 @@ void bind_create_torrent()
         .def("set_comment", &create_torrent::set_comment)
         .def("set_creator", &create_torrent::set_creator)
         .def("set_hash", &set_hash)
+#if TORRENT_ABI_VERSION < 3
         .def("set_file_hash", &set_file_hash)
+#endif
         .def("add_url_seed", &create_torrent::add_url_seed)
         .def("add_http_seed", &create_torrent::add_http_seed)
         .def("add_node", &add_node)

--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -259,13 +259,16 @@ namespace libtorrent {
 		// object constructed with the v1_only flag.
 		void set_hash2(file_index_t file, piece_index_t::diff_type piece, sha256_hash const& h);
 
+#if TORRENT_ABI_VERSION < 3
 		// This sets the sha1 hash for this file. This hash will end up under the key ``sha1``
 		// associated with this file (for multi-file torrents) or in the root info dictionary
 		// for single-file torrents.
 		// .. note::
 		//
 		// 	with bittorrent v2, this feature is obsolete
+		TORRENT_DEPRECATED
 		void set_file_hash(file_index_t index, sha1_hash const& h);
+#endif
 
 		// This adds a url seed to the torrent. You can have any number of url seeds. For a
 		// single file torrent, this should be an HTTP url, pointing to a file with identical
@@ -359,6 +362,8 @@ namespace libtorrent {
 
 		aux::vector<sha1_hash, piece_index_t> m_piece_hash;
 
+		// leave this here for now, to preserve ABI between building with
+		// deprecated functions and without
 		aux::vector<sha1_hash, file_index_t> m_filehashes;
 
 		mutable aux::vector<sha256_hash, file_index_t> m_fileroots;

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -761,10 +761,12 @@ namespace {
 						elems = lsplit_path(elems.second))
 						sympath_e.list().emplace_back(elems.first);
 				}
+#if TORRENT_ABI_VERSION < 3
 				if (!m_filehashes.empty())
 				{
 					info["sha1"] = m_filehashes[first].to_string();
 				}
+#endif
 			}
 
 			if (make_v2 && !info.find_key("file tree"))
@@ -819,10 +821,12 @@ namespace {
 							elems = lsplit_path(elems.second))
 							sympath_e.list().emplace_back(elems.first);
 					}
+#if TORRENT_ABI_VERSION < 3
 					if (!m_filehashes.empty() && m_filehashes[i] != sha1_hash())
 					{
 						file_e["sha1"] = m_filehashes[i].to_string();
 					}
+#endif
 				}
 			}
 
@@ -973,6 +977,7 @@ namespace {
 		fh[piece] = h;
 	}
 
+#if TORRENT_ABI_VERSION < 3
 	void create_torrent::set_file_hash(file_index_t index, sha1_hash const& h)
 	{
 		TORRENT_ASSERT(index >= file_index_t(0));
@@ -980,6 +985,7 @@ namespace {
 		if (m_filehashes.empty()) m_filehashes.resize(m_files.num_files());
 		m_filehashes[index] = h;
 	}
+#endif
 
 	void create_torrent::add_node(std::pair<std::string, int> node)
 	{


### PR DESCRIPTION
as it's superceded by v2 torrents