### PR TITLE
ensure we don't keep redundant copies of merkle trees around

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -2030,8 +2030,21 @@ TORRENT_VERSION_NAMESPACE_2
 		static constexpr alert_category_t static_category = alert_category::status;
 		std::string message() const override;
 
-		// a copy of the parameters used when adding the torrent, it can be used
-		// to identify which invocation to ``async_add_torrent()`` caused this alert.
+		// This contains copies of the most important fields from the original
+		// add_torrent_params object, passed to add_torrent() or
+		// async_add_torrent(). Specifically, these fields are copied:
+		//
+		// * version
+		// * ti
+		// * name
+		// * save_path
+		// * userdata
+		// * tracker_id
+		// * flags
+		// * info_hash
+		//
+		// the info_hash field will be updated with the info-hash of the torrent
+		// specified by ``ti``.
 		add_torrent_params params;
 
 		// set to the error, if one occurred while adding the torrent.

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -596,8 +596,10 @@ namespace aux {
 
 			// second return value is true if the torrent was added and false if an
 			// existing one was found.
-			std::pair<std::shared_ptr<torrent>, bool>
-			add_torrent_impl(add_torrent_params& p, error_code& ec);
+			std::tuple<std::shared_ptr<torrent>, info_hash_t, bool>
+			add_torrent_impl(add_torrent_params&& p, error_code& ec);
+			std::tuple<std::shared_ptr<torrent>, info_hash_t, bool>
+			add_torrent_impl(add_torrent_params const& p, error_code& ec) = delete;
 			void async_add_torrent(add_torrent_params* params);
 
 			void remove_torrent(torrent_handle const& h, remove_flags_t options) override;

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -344,8 +344,10 @@ namespace libtorrent {
 		, peer_class_set
 		, std::enable_shared_from_this<torrent>
 	{
-		torrent(aux::session_interface& ses
-			, bool session_paused, add_torrent_params const& p);
+		// add_torrent_params may contain large merkle trees that are best
+		// moved. Deleting the const& overload ensures that it's always moved in.
+		torrent(aux::session_interface& ses, bool session_paused, add_torrent_params&& p);
+		torrent(aux::session_interface&, bool, add_torrent_params const& p) = delete;
 		~torrent() override;
 
 		// This may be called from multiple threads

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -590,7 +590,7 @@ TORRENT_VERSION_NAMESPACE_3
 
 		// internal
 		aux::vector<aux::merkle_tree, file_index_t>& internal_merkle_trees();
-		void internal_load_merkle_trees(std::vector<std::vector<sha256_hash>> const& t);
+		void internal_load_merkle_trees(std::vector<std::vector<sha256_hash>> t);
 
 		// internal
 		void internal_set_creator(string_view);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4711,33 +4711,41 @@ namespace {
 	torrent_handle session_impl::add_torrent(add_torrent_params&& params
 		, error_code& ec)
 	{
-		// params is updated by add_torrent_impl()
 		std::shared_ptr<torrent> torrent_ptr;
 
 		// in case there's an error, make sure to abort the torrent before leaving
 		// the scope
 		auto abort_torrent = aux::scope_end([&]{ if (torrent_ptr) torrent_ptr->abort(); });
 
-		bool added;
-		// TODO: 3 perhaps params could be moved into the torrent object, instead
-		// of it being copied by the torrent constructor
-		std::tie(torrent_ptr, added) = add_torrent_impl(params, ec);
+#ifndef TORRENT_DISABLE_EXTENSIONS
+		auto extensions = std::move(params.extensions);
+		auto const userdata = std::move(params.userdata);
+#endif
 
-		torrent_handle const handle(torrent_ptr);
-		m_alerts.emplace_alert<add_torrent_alert>(handle, params, ec);
+		// copy the most important fields from params to pass back in the
+		// add_torrent_alert
+		add_torrent_params alert_params;
+		alert_params.flags = params.flags;
+		alert_params.ti = params.ti;
+		alert_params.name = params.name;
+		alert_params.save_path = params.save_path;
+		alert_params.userdata = params.userdata;
+		alert_params.trackerid = params.trackerid;
+
+		auto const flags = params.flags;
+
+		info_hash_t info_hash;
+		bool added;
+		std::tie(torrent_ptr, info_hash, added) = add_torrent_impl(std::move(params), ec);
+
+		alert_params.info_hash = info_hash;
+
+		torrent_handle handle(torrent_ptr);
+		m_alerts.emplace_alert<add_torrent_alert>(handle, std::move(alert_params), ec);
 
 		if (!torrent_ptr) return handle;
 
-		// params.info_hash should have been initialized by add_torrent_impl()
-		TORRENT_ASSERT(params.info_hash.has_v1() || params.info_hash.has_v2());
-
-#ifndef TORRENT_DISABLE_DHT
-		if (params.ti)
-		{
-			for (auto const& n : params.ti->nodes())
-				add_dht_node_name(n);
-		}
-#endif
+		TORRENT_ASSERT(info_hash.has_v1() || info_hash.has_v2());
 
 #if TORRENT_ABI_VERSION == 1
 		if (m_alerts.should_post<torrent_added_alert>())
@@ -4756,17 +4764,17 @@ namespace {
 		torrent_ptr->start();
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-		for (auto& ext : params.extensions)
+		for (auto& ext : extensions)
 		{
-			std::shared_ptr<torrent_plugin> tp(ext(handle, params.userdata));
+			std::shared_ptr<torrent_plugin> tp(ext(handle, userdata));
 			if (tp) torrent_ptr->add_extension(std::move(tp));
 		}
 
-		add_extensions_to_torrent(torrent_ptr, params.userdata);
+		add_extensions_to_torrent(torrent_ptr, userdata);
 #endif
 
-		TORRENT_ASSERT(params.info_hash == torrent_ptr->torrent_file().info_hashes());
-		insert_torrent(params.info_hash, torrent_ptr);
+		TORRENT_ASSERT(info_hash == torrent_ptr->torrent_file().info_hashes());
+		insert_torrent(info_hash, torrent_ptr);
 
 		// once we successfully add the torrent, we can disarm the abort action
 		abort_torrent.disarm();
@@ -4776,7 +4784,7 @@ namespace {
 		// we want to put it off again anyway. So that while we're adding
 		// a boat load of torrents, we postpone the recalculation until
 		// we're done adding them all (since it's kind of an expensive operation)
-		if (params.flags & torrent_flags::auto_managed)
+		if (flags & torrent_flags::auto_managed)
 		{
 			const int max_downloading = settings().get_int(settings_pack::active_downloads);
 			const int max_seeds = settings().get_int(settings_pack::active_seeds);
@@ -4802,8 +4810,8 @@ namespace {
 		return handle;
 	}
 
-	std::pair<std::shared_ptr<torrent>, bool>
-	session_impl::add_torrent_impl(add_torrent_params& params, error_code& ec)
+	std::tuple<std::shared_ptr<torrent>, info_hash_t, bool>
+	session_impl::add_torrent_impl(add_torrent_params&& params, error_code& ec)
 	{
 		TORRENT_ASSERT(!params.save_path.empty());
 
@@ -4813,7 +4821,7 @@ namespace {
 		if (string_begins_no_case("magnet:", params.url.c_str()))
 		{
 			parse_magnet_uri(params.url, params, ec);
-			if (ec) return std::make_pair(ptr_t(), false);
+			if (ec) return {ptr_t(), params.info_hash, false};
 			params.url.clear();
 		}
 #endif
@@ -4821,13 +4829,13 @@ namespace {
 		if (params.ti && !params.ti->is_valid())
 		{
 			ec = errors::no_metadata;
-			return std::make_pair(ptr_t(), false);
+			return {ptr_t(), params.info_hash, false};
 		}
 
 		if (params.ti && params.ti->is_valid() && params.ti->num_files() == 0)
 		{
 			ec = errors::no_files_in_torrent;
-			return std::make_pair(ptr_t(), false);
+			return {ptr_t(), params.info_hash, false};
 		}
 
 		if (params.ti
@@ -4836,13 +4844,19 @@ namespace {
 			))
 		{
 			ec = errors::mismatching_info_hash;
-			return std::make_pair(ptr_t(), false);
+			return {ptr_t(), params.info_hash, false};
 		}
 
 #ifndef TORRENT_DISABLE_DHT
 		// add params.dht_nodes to the DHT, if enabled
 		for (auto const& n : params.dht_nodes)
 			add_dht_node_name(n);
+
+		if (params.ti)
+		{
+			for (auto const& n : params.ti->nodes())
+				add_dht_node_name(n);
+		}
 #endif
 
 		INVARIANT_CHECK;
@@ -4850,7 +4864,7 @@ namespace {
 		if (is_aborted())
 		{
 			ec = errors::session_is_closing;
-			return std::make_pair(ptr_t(), false);
+			return {ptr_t(), params.info_hash, false};
 		}
 
 		// figure out the info hash of the torrent and make sure params.info_hash
@@ -4860,7 +4874,7 @@ namespace {
 		if (!params.info_hash.has_v1() && !params.info_hash.has_v2())
 		{
 			ec = errors::missing_info_hash_in_uri;
-			return std::make_pair(ptr_t(), false);
+			return {ptr_t(), params.info_hash, false};
 		}
 
 		// is the torrent already active?
@@ -4869,10 +4883,10 @@ namespace {
 		if (torrent_ptr)
 		{
 			if (!(params.flags & torrent_flags::duplicate_is_error))
-				return std::make_pair(torrent_ptr, false);
+				return {torrent_ptr, params.info_hash, false};
 
 			ec = errors::duplicate_torrent;
-			return std::make_pair(ptr_t(), false);
+			return {ptr_t(), params.info_hash, false};
 		}
 
 		// make sure we have enough memory in the torrent lists up-front,
@@ -4884,10 +4898,12 @@ namespace {
 			l.reserve(num_torrents + 1);
 		}
 
-		torrent_ptr = std::make_shared<torrent>(*this, m_paused, params);
+		torrent_ptr = std::make_shared<torrent>(*this, m_paused, std::move(params));
 		torrent_ptr->set_queue_position(m_download_queue.end_index());
 
-		return std::make_pair(torrent_ptr, true);
+		// it's fine to copy this moved-from info_hash_t object, since its move
+		// construction is just a copy.
+		return {torrent_ptr, params.info_hash, true};
 	}
 
 	void session_impl::update_outgoing_interfaces()

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1135,7 +1135,7 @@ namespace {
 		return m_merkle_trees;
 	}
 
-	void torrent_info::internal_load_merkle_trees(std::vector<std::vector<sha256_hash>> const& trees_import)
+	void torrent_info::internal_load_merkle_trees(std::vector<std::vector<sha256_hash>> trees_import)
 	{
 		for (file_index_t i{0}; i < orig_files().end_file(); ++i)
 		{


### PR DESCRIPTION
in an add_torrent_params object by moving it all the way down into the torrent constructor. Clearly document which fields in add_torrent_alert's params field can be relied upon to be preserved