### PR TITLE
Compress resume trees

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -519,6 +519,12 @@ The file format is a bencoded dictionary containing the following fields:
 |                          | |              | hashes may be all zeros, if we haven't    | |
 |                          | |              | downloaded them yet.                      | |
 |                          | +--------------+-------------------------------------------+ |
+|                          | | ``mask``     | string. When present, a bitmask (of ``0`` | |
+|                          | |              | and ``1`` characters, indicating which    | |
+|                          | |              | hashes of the full tree are included in   | |
+|                          | |              | the ``hashes`` key. This is used to avoid | |
+|                          | |              | storing large numbers of zeros.           | |
+|                          | +--------------+-------------------------------------------+ |
 |                          | | ``verified`` | string. This indicates which leaf nodes   | |
 |                          | |              | in the tree have been verified correct.   | |
 |                          | |              | There is one character per leaf, ``0``    | |

--- a/fuzzers/Jamfile
+++ b/fuzzers/Jamfile
@@ -75,6 +75,7 @@ fuzzer utp ;
 fuzzer resume_data ;
 fuzzer peer_conn ;
 fuzzer session_params ;
+fuzzer add_torrent ;
 
 local LARGE_TARGETS =
 	torrent_info
@@ -88,6 +89,7 @@ local LARGE_TARGETS =
 	upnp
 	peer_conn
 	session_params
+	add_torrent
 	;
 
 install stage : $(TARGETS) : <install-type>EXE <location>fuzzers ;

--- a/fuzzers/src/add_torrent.cpp
+++ b/fuzzers/src/add_torrent.cpp
@@ -1,0 +1,243 @@
+/*
+
+Copyright (c) 2020, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <memory>
+#include <iostream>
+#include <boost/optional.hpp>
+
+#include "libtorrent/session.hpp"
+#include "libtorrent/session_params.hpp"
+#include "libtorrent/settings_pack.hpp"
+#include "libtorrent/create_torrent.hpp"
+#include "libtorrent/torrent_info.hpp"
+#include "libtorrent/alert_types.hpp"
+#include "libtorrent/random.hpp"
+#include "libtorrent/deadline_timer.hpp"
+#include "libtorrent/disk_interface.hpp" // for default_block_size
+#include "libtorrent/aux_/merkle.hpp"
+#include "libtorrent/hasher.hpp"
+#include "libtorrent/disabled_disk_io.hpp"
+#include "read_bits.hpp"
+
+using namespace lt;
+
+lt::session_params g_params;
+io_context g_ioc;
+std::shared_ptr<lt::torrent_info> g_torrent;
+std::vector<sha256_hash> g_tree;
+
+int const piece_size = 1024 * 1024;
+int const blocks_per_piece = piece_size / lt::default_block_size;
+int const num_pieces = 10;
+int const num_leafs = merkle_num_leafs(num_pieces * blocks_per_piece);
+int const num_nodes = merkle_num_nodes(num_leafs);
+int const first_leaf = merkle_first_leaf(num_leafs);
+
+extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+	lt::settings_pack& pack = g_params.settings;
+	// set up settings pack we'll be using
+	pack.set_int(settings_pack::tick_interval, 1);
+	pack.set_int(settings_pack::alert_mask, 0);
+	pack.set_int(settings_pack::out_enc_policy, settings_pack::pe_disabled);
+	pack.set_int(settings_pack::in_enc_policy, settings_pack::pe_disabled);
+	pack.set_int(settings_pack::aio_threads, 0);
+
+	// don't waste time making outbound connections
+	pack.set_bool(settings_pack::enable_outgoing_tcp, false);
+	pack.set_bool(settings_pack::enable_outgoing_utp, false);
+	pack.set_bool(settings_pack::enable_upnp, false);
+	pack.set_bool(settings_pack::enable_natpmp, false);
+	pack.set_bool(settings_pack::enable_dht, false);
+	pack.set_bool(settings_pack::enable_lsd, false);
+	pack.set_bool(settings_pack::enable_ip_notifier, false);
+	pack.set_str(settings_pack::listen_interfaces, "127.0.0.1:0");
+
+	g_params.disk_io_constructor = lt::disabled_disk_io_constructor;
+
+	// create a torrent
+	file_storage fs;
+	std::int64_t const total_size = std::int64_t(piece_size) * num_pieces;
+	fs.add_file("test_file", total_size);
+
+	g_tree.resize(num_nodes);
+
+	create_torrent t(fs, piece_size);
+
+	std::vector<char> piece(piece_size, 0);
+	lt::span<char const> piece_span(piece);
+	std::vector<sha256_hash> piece_tree(merkle_num_nodes(blocks_per_piece));
+	for (piece_index_t i : fs.piece_range())
+	{
+		std::memset(piece.data(), char(static_cast<int>(i) & 0xff), piece.size());
+		t.set_hash(piece_index_t(i), lt::hasher(piece).final());
+
+		for (int k = 0; k < blocks_per_piece; ++k)
+		{
+			auto const h = lt::hasher256(piece_span.subspan(
+				k * lt::default_block_size, lt::default_block_size)).final();
+			piece_tree[std::size_t(k)] = h;
+			g_tree[std::size_t(first_leaf + static_cast<int>(i) * blocks_per_piece + k)] = h;
+		}
+
+		auto const r = merkle_root(piece_tree);
+		t.set_hash2(file_index_t{0}, piece_index_t::diff_type(i), r);
+	}
+
+	merkle_fill_tree(g_tree, num_leafs);
+
+	std::vector<char> buf;
+	bencode(std::back_inserter(buf), t.generate());
+	g_torrent = std::make_shared<torrent_info>(buf, from_span);
+
+	return 0;
+}
+
+lt::add_torrent_params generate_atp(std::uint8_t const* data, size_t size)
+{
+	read_bits bits(data, size);
+	lt::add_torrent_params ret;
+	ret.ti = g_torrent;
+	ret.info_hash = g_torrent->info_hashes();
+	ret.save_path = ".";
+	ret.file_priorities.resize(bits.read(2));
+	for (auto& p : ret.file_priorities)
+		p = lt::download_priority_t(bits.read(3));
+	ret.flags = lt::torrent_flags_t(bits.read(24));
+	int const num_unfinished = bits.read(4);
+	for (int i = 0; i < num_unfinished; ++i)
+	{
+		auto& mask = ret.unfinished_pieces[piece_index_t(bits.read(32))];
+		mask.resize(bits.read(5));
+		for (int i = 0; i < mask.size(); ++i)
+			if (bits.read(1)) mask.set_bit(i); else mask.set_bit(i);
+	}
+	ret.have_pieces.resize(bits.read(6));
+	for (int i = 0; i < ret.have_pieces.size(); ++i)
+		if (bits.read(1)) ret.have_pieces.set_bit(i); else ret.have_pieces.set_bit(i);
+
+	ret.verified_pieces.resize(bits.read(6));
+	for (int i = 0; i < ret.verified_pieces.size(); ++i)
+		if (bits.read(1)) ret.verified_pieces.set_bit(i); else ret.verified_pieces.set_bit(i);
+
+	ret.piece_priorities.resize(bits.read(6));
+	for (auto& p : ret.piece_priorities)
+		p = lt::download_priority_t(bits.read(1));
+
+	// if we read a 1 here, initialize the merkle tree fields correctly
+	if (bits.read(1))
+	{
+		ret.merkle_trees.resize(1);
+		ret.merkle_tree_mask.resize(1);
+		ret.verified_leaf_hashes.resize(1);
+		ret.verified_leaf_hashes[0].resize(num_leafs, true);
+
+		auto& t = ret.merkle_trees[0];
+		auto& mask = ret.merkle_tree_mask[0];
+		mask.resize(num_nodes, false);
+		int idx = -1;
+		for (auto const& h : g_tree)
+		{
+			++idx;
+			if (h.is_all_zeros()) continue;
+			mask[std::size_t(idx)] = true;
+			t.push_back(g_tree[std::size_t(idx)]);
+		}
+	}
+	else
+	{
+		ret.merkle_trees.resize(bits.read(2));
+		for (auto& t : ret.merkle_trees)
+		{
+			std::size_t block = 0;
+			t.resize(bits.read(13));
+			for (auto& h : t)
+			{
+				h = g_tree[block++];
+				if (block >= g_tree.size()) block = 0;
+			}
+		}
+		ret.merkle_tree_mask.resize(bits.read(2));
+		for (auto& m : ret.merkle_tree_mask)
+		{
+			m.resize(bits.read(13));
+			for (std::size_t i = 0; i < m.size(); ++i)
+				m[i] = bits.read(1);
+		}
+		ret.verified_leaf_hashes.resize(bits.read(2));
+		for (auto& m : ret.verified_leaf_hashes)
+		{
+			m.resize(bits.read(4));
+			for (std::size_t i = 0; i < m.size(); ++i)
+				m[i] = bits.read(1);
+		}
+	}
+
+	ret.max_uploads = bits.read(32);
+	ret.max_connections = bits.read(32);
+	ret.upload_limit = bits.read(32);
+	ret.download_limit = bits.read(32);
+	ret.active_time = bits.read(32);
+	ret.finished_time = bits.read(32);
+	ret.seeding_time = bits.read(32);
+	ret.last_seen_complete = bits.read(32);
+	ret.num_complete = bits.read(32);
+	ret.num_incomplete = bits.read(32);
+	ret.num_downloaded = bits.read(32);
+
+	return ret;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
+{
+	g_ioc.restart();
+	boost::optional<lt::session> ses(lt::session{g_params, g_ioc});
+
+	lt::add_torrent_params atp = generate_atp(data, size);
+
+	ses->async_add_torrent(atp);
+	auto proxy = ses->abort();
+	post(g_ioc, [&]{ ses.reset(); });
+
+	g_ioc.run_for(seconds(2));
+
+#if defined TORRENT_ASIO_DEBUGGING
+	lt::log_async();
+	lt::_async_ops.clear();
+	lt::_async_ops_nthreads = 0;
+	lt::_wakeups.clear();
+#endif
+
+	return 0;
+}
+
+

--- a/fuzzers/src/peer_conn.cpp
+++ b/fuzzers/src/peer_conn.cpp
@@ -40,7 +40,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/random.hpp"
 
-
 #include "libtorrent/io_context.hpp"
 
 using namespace lt;

--- a/fuzzers/tools/generate_initial_corpus.py
+++ b/fuzzers/tools/generate_initial_corpus.py
@@ -10,7 +10,7 @@ corpus_dirs = [
     'dht_node', 'escape_path', 'escape_string', 'file_storage_add_file',
     'http_parser', 'lazy_bdecode', 'parse_int', 'parse_magnet_uri', 'resume_data',
     'sanitize_path', 'utf8_codepoint', 'utf8_wchar', 'utp',
-    'verify_encoding', 'wchar_utf8', 'peer_conn']
+    'verify_encoding', 'wchar_utf8', 'peer_conn', 'add_torrent']
 
 for p in corpus_dirs:
     try:

--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -328,6 +328,14 @@ TORRENT_VERSION_NAMESPACE_2
 		// v2 hashes, if known
 		aux::vector<std::vector<sha256_hash>, file_index_t> merkle_trees;
 
+		// if set, indicates which hashes are included in the corresponding
+		// vector of ``merkle_trees``. These bitmasks always cover the full
+		// tree, a cleared bit means the hash is all zeros (i.e. not set) and
+		// set bit means the next hash in the corresponding vector in
+		// ``merkle_trees`` is the hash for that node. This is an optimization
+		// to avoid storing a lot of zeros.
+		aux::vector<std::vector<bool>, file_index_t> merkle_tree_mask;
+
 		// bit-fields indicating which v2 leaf hashes have been verified
 		// against the root hash. If this vector is empty and merkle_trees is
 		// non-empty it implies that all hashes in merkle_trees are verified.

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -74,6 +74,11 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs, int level_start);
 	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs);
 
+	// fills in nodes that can be computed from a tree with arbitrary nodes set
+	// all "orphan" hashes, i.e ones that do not contribute towards computing
+	// the root, will be cleared.
+	TORRENT_EXTRA_EXPORT void merkle_fill_partial_tree(span<sha256_hash> tree);
+
 	// given a merkle tree (`tree`), clears all hashes in the range of nodes:
 	// [ level_start, level_start+ num_leafs), as well as all of their parents,
 	// within the sub-tree. It does not clear the root of the sub-tree.

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -69,6 +69,7 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	sha256_hash root() const;
 
 	void load_tree(span<sha256_hash const> t);
+	void load_sparse_tree(span<sha256_hash const> t, std::vector<bool> const& mask);
 
 	std::size_t size() const;
 	int end_index() const { return int(size()); }
@@ -80,6 +81,7 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	sha256_hash operator[](int idx) const;
 
 	std::vector<sha256_hash> build_vector() const;
+	std::pair<std::vector<sha256_hash>, aux::vector<bool>> build_sparse_vector() const;
 
 	bool load_piece_layer(span<char const> piece_layer);
 
@@ -114,6 +116,9 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 		, int index, int count, int proof_layers) const;
 
 private:
+
+	// set to an empty tree
+	void clear();
 
 	sha256_hash get_impl(int idx, std::vector<sha256_hash>& scratch_space) const;
 

--- a/include/libtorrent/hash_picker.hpp
+++ b/include/libtorrent/hash_picker.hpp
@@ -136,7 +136,7 @@ namespace libtorrent
 	public:
 		hash_picker(file_storage const& files
 			, aux::vector<aux::merkle_tree, file_index_t>& trees
-			, aux::vector<aux::vector<bool>, file_index_t> verified = {}
+			, aux::vector<std::vector<bool>, file_index_t> verified = {}
 			, bool all_verified = false);
 
 		hash_request pick_hashes(typed_bitfield<piece_index_t> const& pieces);
@@ -153,7 +153,7 @@ namespace libtorrent
 		bool have_all(file_index_t file) const;
 		bool have_all() const;
 		// get bits indicating if each leaf hash is verified
-		aux::vector<aux::vector<bool>, file_index_t> const& verified_leafs() const
+		aux::vector<std::vector<bool>, file_index_t> const& verified_leafs() const
 		{ return m_hash_verified; }
 		bool piece_verified(piece_index_t piece) const;
 
@@ -204,7 +204,7 @@ namespace libtorrent
 
 		file_storage const& m_files;
 		aux::vector<aux::merkle_tree, file_index_t>& m_merkle_trees;
-		aux::vector<aux::vector<bool>, file_index_t> m_hash_verified;
+		aux::vector<std::vector<bool>, file_index_t> m_hash_verified;
 
 		// information about every 512-piece span of each file. We request hashes
 		// for 512 pieces at a time

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1025,7 +1025,7 @@ namespace libtorrent {
 			return *m_hash_picker;
 		}
 
-		void need_hash_picker(aux::vector<aux::vector<bool>, file_index_t> verified = {});
+		void need_hash_picker(aux::vector<std::vector<bool>, file_index_t> verified = {});
 		bool has_hash_picker() const
 		{
 			return m_hash_picker.get() != nullptr;

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -590,7 +590,8 @@ TORRENT_VERSION_NAMESPACE_3
 
 		// internal
 		aux::vector<aux::merkle_tree, file_index_t>& internal_merkle_trees();
-		void internal_load_merkle_trees(std::vector<std::vector<sha256_hash>> t);
+		void internal_load_merkle_trees(aux::vector<std::vector<sha256_hash>, file_index_t> t
+			, aux::vector<std::vector<bool>, file_index_t> mask);
 
 		// internal
 		void internal_set_creator(string_view);

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -93,7 +93,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 	hash_picker::hash_picker(file_storage const& files
 		, aux::vector<aux::merkle_tree, file_index_t>& trees
-		, aux::vector<aux::vector<bool>, file_index_t> verified
+		, aux::vector<std::vector<bool>, file_index_t> verified
 		, bool all_verified)
 		: m_files(files)
 		, m_merkle_trees(trees)
@@ -111,7 +111,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 			// TODO: allocate m_hash_verified lazily when a hash conflist occurs?
 			// would save memory in the common case of no hash failures
-			m_hash_verified[f].resize(m_files.file_num_blocks(f), all_verified);
+			m_hash_verified[f].resize(std::size_t(m_files.file_num_blocks(f)), all_verified);
 			if (m_hash_verified[f].size() == 1)
 			{
 				// the root hash comes from the metadata so it is always verified
@@ -139,7 +139,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 						m_piece_hash_requested[f][i].have = true;
 						break;
 					}
-					if ((m_files.piece_length() == default_block_size && !m_hash_verified[f][j])
+					if ((m_files.piece_length() == default_block_size && !m_hash_verified[f][std::size_t(j)])
 						|| (m_files.piece_length() > default_block_size
 							&& !tree.has_node(piece_layer_start + j)))
 						break;
@@ -353,7 +353,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 		}
 
 		// if this blocks's hash is already known, check the passed-in hash against it
-		if (m_hash_verified[f][block_index])
+		if (m_hash_verified[f][std::size_t(block_index)])
 		{
 			TORRENT_ASSERT(merkle_tree.has_node(block_tree_index));
 			if (block_tree_index > 0)

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -158,13 +158,17 @@ namespace {
 					ret.merkle_trees.back().emplace_back(hashes);
 				}
 
-				auto verified = de.dict_find_string_value("verified");
+				auto const verified = de.dict_find_string_value("verified");
 				ret.verified_leaf_hashes.emplace_back();
 				ret.verified_leaf_hashes.back().reserve(verified.size());
 				for (auto const bit : verified)
-				{
 					ret.verified_leaf_hashes.back().emplace_back(bit == '1');
-				}
+
+				auto const mask = de.dict_find_string_value("mask");
+				ret.merkle_tree_mask.emplace_back();
+				ret.merkle_tree_mask.back().reserve(mask.size());
+				for (auto const bit : mask)
+					ret.merkle_tree_mask.back().emplace_back(bit == '1');
 			}
 		}
 

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -519,7 +519,8 @@ namespace libtorrent { namespace aux {
 
 		// parse have bitmask. Verify that the files we expect to have
 		// actually do exist
-		for (piece_index_t i(0); i < piece_index_t(rd.have_pieces.size()); ++i)
+		piece_index_t const end_piece = std::min(rd.have_pieces.end_index(), fs.end_piece());
+		for (piece_index_t i(0); i < end_piece; ++i)
 		{
 			if (rd.have_pieces.get_bit(i) == false) continue;
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8551,9 +8551,9 @@ namespace {
 	void torrent::set_max_uploads(int limit, bool const state_update)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		TORRENT_ASSERT(limit >= -1);
+		// TODO: perhaps 0 should actially mean 0
 		if (limit <= 0) limit = (1 << 24) - 1;
-		if (int(m_max_uploads)!= limit && state_update) state_updated();
+		if (int(m_max_uploads) != limit && state_update) state_updated();
 		m_max_uploads = aux::numeric_cast<std::uint32_t>(limit);
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log() && state_update)
@@ -8567,7 +8567,7 @@ namespace {
 	void torrent::set_max_connections(int limit, bool const state_update)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		TORRENT_ASSERT(limit >= -1);
+		// TODO: perhaps 0 should actially mean 0
 		if (limit <= 0) limit = (1 << 24) - 1;
 		if (int(m_max_connections) != limit && state_update) state_updated();
 		m_max_connections = aux::numeric_cast<std::uint32_t>(limit);
@@ -8609,8 +8609,7 @@ namespace {
 	void torrent::set_limit_impl(int limit, int const channel, bool const state_update)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		TORRENT_ASSERT(limit >= -1);
-		if (limit <= 0) limit = 0;
+		if (limit <= 0 || limit == aux::bandwidth_channel::inf) limit = 0;
 
 		if (m_peer_class == peer_class_t{0})
 		{

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -120,7 +120,7 @@ namespace libtorrent {
 			ret_trees.reserve(atp.merkle_trees.size());
 			for (file_index_t f(0); f < file_index_t{int(atp.merkle_trees.size())}; ++f)
 			{
-				auto& tree = trees[f];
+				auto const& tree = trees[f];
 				ret_trees.emplace_back(entry::dictionary_t);
 				auto& ret_dict = ret_trees.back().dict();
 				auto& ret_tree = ret_dict["hashes"].string();
@@ -129,14 +129,27 @@ namespace libtorrent {
 				for (auto const& n : tree)
 					ret_tree.append(n.data(), n.size());
 
-				if (!atp.verified_leaf_hashes.empty())
+				if (f < atp.verified_leaf_hashes.end_index())
 				{
-					auto& verified = atp.verified_leaf_hashes[f];
+					auto const& verified = atp.verified_leaf_hashes[f];
 					if (!verified.empty())
 					{
 						auto& ret_verified = ret_dict["verified"].string();
+						ret_verified.reserve(verified.size());
 						for (auto const bit : verified)
 							ret_verified.push_back(bit ? '1' : '0');
+					}
+				}
+
+				if (f < atp.merkle_tree_mask.end_index())
+				{
+					auto const& mask = atp.merkle_tree_mask[f];
+					if (!mask.empty())
+					{
+						auto& ret_mask = ret_dict["mask"].string();
+						ret_mask.reserve(mask.size());
+						for (auto const bit : mask)
+							ret_mask.push_back(bit ? '1' : '0');
 					}
 				}
 			}

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -371,6 +371,208 @@ TORRENT_TEST(merkle_fill_tree)
 	}
 }
 
+TORRENT_TEST(merkle_fill_partial_tree)
+{
+	// fill whole tree
+	{
+		v tree{o,
+		   o,      o,
+		  o, o,   o, o,
+		a,b,c,d,e,f,g,h};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 ab, cd, ef, gh,
+		a,b,c,d,e,f,g,h}));
+	}
+
+	// fill left side of the tree
+	{
+		v tree{o,
+		   o,      eh,
+		 ab,cd,   o, o,
+		a,b,c,d,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,    eh,
+		 ab, cd, o, o,
+		a,b,c,d,o,o,o,o}));
+	}
+
+	// fill right side of the tree
+	{
+		v tree{o,
+		   ad,     o,
+		 o,  o,   o, o,
+		o,o,o,o,e,f,g,h};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 o,  o,  ef,gh,
+		o,o,o,o,e,f,g,h}));
+	}
+
+	// fill shallow left of the tree
+	{
+		v tree{
+		       o,
+		   o,      eh,
+		 ab, cd,   o, o,
+		o,o,o,o,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,    eh,
+		 ab, cd,   o, o,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// fill shallow right of the tree
+	{
+		v tree{
+		       o,
+		   ad,     o,
+		 o,  o,   ef,gh,
+		o,o,o,o,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 o,  o,   ef, gh,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// fill uneven tree
+	{
+		v tree{
+		       o,
+		   ad,     o,
+		 o,  o,  ef, gh,
+		o,o,o,o,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 o,  o,  ef, gh,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// clear orphans
+	{
+		v tree{
+		       o,
+		   ad,    ah,
+		 o,  o,  ef, gh,
+		a,o,c,o,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 o,  o,   ef,gh,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// clear orphan sub-tree
+	{
+		v tree{o,
+		   o,     o,
+		 o, o,   o, o,
+		a,b,c,d,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		    v{o,
+		   o,     o,
+		 o, o,   o, o,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// fill sub-tree
+	{
+		v tree{o,
+		   o,     eh,
+		 o, o,   o, o,
+		a,b,c,d,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		    v{ah,
+		   ad,   eh,
+		 ab,cd,   o, o,
+		a,b,c,d,o,o,o,o}));
+	}
+
+	// clear no-siblings left
+	{
+		v tree{
+		       o,
+		   ad,    ah,
+		 o,  o,  ef, gh,
+		o,o,o,o,o,o,o,h};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 o,  o,  ef, gh,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// clear no-siblings right
+	{
+		v tree{
+		       o,
+		   ad,    ah,
+		 o,  o,  ef, gh,
+		o,o,o,o,o,o,g,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 o,  o,  ef, gh,
+		o,o,o,o,o,o,o,o}));
+	}
+
+	// fill gaps
+	{
+		v tree{
+		       o,
+		   ad,    ah,
+		 o,  o,  ef,gh,
+		a,b,c,d,o,o,o,o};
+
+		merkle_fill_partial_tree(tree);
+
+		TEST_CHECK((tree ==
+		     v{ah,
+		   ad,     eh,
+		 ab,cd,   ef,gh,
+		a,b,c,d,o,o,o,o}));
+	}
+}
+
 TORRENT_TEST(merkle_root)
 {
 	// all leaves in the tree

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -362,6 +362,17 @@ TORRENT_TEST(round_trip_merkle_trees)
 	test_roundtrip(atp);
 }
 
+TORRENT_TEST(round_trip_merkle_tree_mask)
+{
+	add_torrent_params atp;
+	atp.merkle_trees = aux::vector<std::vector<sha256_hash>, file_index_t>{
+		{sha256_hash{"01010101010101010101010101010101"}, sha256_hash{"21212121212121212121212121212121"}}
+		, {sha256_hash{"23232323232323232323232323232323"}, sha256_hash{"43434343434343434343434343434343"}}
+		};
+	atp.merkle_tree_mask = aux::vector<std::vector<bool>, file_index_t>{{false, false, false, true, true, true, true}};
+	test_roundtrip(atp);
+}
+
 TORRENT_TEST(round_trip_verified_leaf_hashes)
 {
 	add_torrent_params atp;

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -1075,9 +1075,17 @@ TORRENT_TEST(merkle_trees)
 	if (a == nullptr) return;
 
 	TEST_EQUAL(a->params.merkle_trees.size(), 3);
+	TEST_EQUAL(a->params.merkle_tree_mask.size(), 3);
 	TEST_EQUAL(p.ti->internal_merkle_trees().size(), 3);
 	for (file_index_t const i : p.ti->files().file_range())
-		TEST_CHECK(a->params.merkle_trees[i] == p.ti->internal_merkle_trees()[i].build_vector());
+	{
+		// use stuctured binding in C++17
+		std::vector<bool> mask;
+		std::vector<sha256_hash> sparse_tree;
+		std::tie(sparse_tree, mask) = p.ti->internal_merkle_trees()[i].build_sparse_vector();
+		TEST_CHECK(a->params.merkle_trees[i] == sparse_tree);
+		TEST_CHECK(a->params.merkle_tree_mask[i] == mask);
+	}
 }
 
 TORRENT_TEST(resume_info_dict)


### PR DESCRIPTION
This is meant to address https://github.com/arvidn/libtorrent/issues/4720

It does so by not storing the full merkle trees in the resume data. A new mask field is added that specifies which hashes are included in the tree, and the tree can then be reconstructed from the hashes that are included. If only the piece-layer or block layer is included, there's a short circuit to go directly into an internal sparse representation as well.

Since there's a fair amount of logic and opportunities to run into trouble when adding a torrent now (since `add_torrent_params` has more invariants) I also added a new fuzzer that adds torrents with random resume data.

I also took the opportunity to make the internal representation of `verified_leaf_hashes` match the one in `add_torrent_params`, so we don't have to copy it into a new type.