### PR TITLE
enable redundant preprocessor directive check in travis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-clang-analyzer-core.*,readability-redundant-smartptr-get,readability-redundant-declaration,readability-redundant-control-flow,readability-delete-null-pointer,performance-faster-string-find,misc-uniqueptr-reset-release,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,modernize-redundant-void-arg,google-runtime-operator,modernize-use-equals-delete,modernize-use-using,modernize-use-nullptr,readability-const-return-type,modernize-use-noexcept,readability-avoid-const-params-in-decls,readability-redundant-string-cstr,readability-redundant-member-init,modernize-pass-by-value,modernize-use-auto,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list'
+Checks:          '-clang-analyzer-core.*,readability-redundant-smartptr-get,readability-redundant-declaration,readability-redundant-control-flow,readability-delete-null-pointer,performance-faster-string-find,misc-uniqueptr-reset-release,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,modernize-redundant-void-arg,google-runtime-operator,modernize-use-equals-delete,modernize-use-using,modernize-use-nullptr,readability-const-return-type,modernize-use-noexcept,readability-avoid-const-params-in-decls,readability-redundant-string-cstr,readability-redundant-member-init,modernize-pass-by-value,modernize-use-auto,modernize-use-default-member-init,hicpp-deprecated-headers,readability-inconsistent-declaration-parameter-name,modernize-return-braced-init-list,readability-redundant-preprocessor'
 CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes
     value:           'L;LL;LU;LLU'
@@ -28,4 +28,3 @@ CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
 ...
-

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -282,14 +282,12 @@ void http_connection::start(std::string const& hostname, int port
 			// because i2p is sloooooow
 			m_completion_timeout *= 4;
 
-#if TORRENT_USE_I2P
 			if (i2p_conn->proxy().type != settings_pack::i2p_proxy)
 			{
 				post(m_ios, std::bind(&http_connection::callback
 					, me, error_code(errors::no_i2p_router), span<char>{}));
 				return;
 			}
-#endif
 
 			i2p_proxy = i2p_conn->proxy();
 			proxy = &i2p_proxy;

--- a/src/kademlia/routing_table.cpp
+++ b/src/kademlia/routing_table.cpp
@@ -315,9 +315,7 @@ void routing_table::status(session_status& s) const
 		dht_routing_bucket b;
 		b.num_nodes = int(i.live_nodes.size());
 		b.num_replacements = int(i.replacements.size());
-#if TORRENT_ABI_VERSION == 1
 		b.last_active = 0;
-#endif
 		s.dht_routing_table.push_back(b);
 	}
 }

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -779,9 +779,7 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 #endif
 
 		if ((flags & session_handle::save_settings)
-#if TORRENT_ABI_VERSION <= 2
 			|| (flags & session_handle::save_dht_settings)
-#endif
 			)
 		{
 			settings = e->dict_find_dict("settings");
@@ -805,9 +803,7 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 			}
 		}
 
-#if TORRENT_ABI_VERSION <= 2
 		if (flags & session_handle::save_dht_settings)
-#endif
 		{
 			// This is here for backwards compatibility, to support loading state
 			// files in the previous file format, where the DHT settings were in
@@ -829,12 +825,10 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 #endif
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-#if TORRENT_ABI_VERSION <= 2
 		for (auto& ext : m_ses_extensions[plugins_all_idx])
 		{
 			ext->load_state(*e);
 		}
-#endif
 #endif
 	}
 #endif
@@ -5704,7 +5698,6 @@ namespace {
 #if TORRENT_ABI_VERSION <= 2
 	void session_impl::set_dht_settings(dht::dht_settings const& settings)
 	{
-#ifndef TORRENT_DISABLE_DHT
 #define SET_BOOL(name) m_settings.set_bool(settings_pack::dht_ ## name, settings.name)
 #define SET_INT(name) m_settings.set_int(settings_pack::dht_ ## name, settings.name)
 
@@ -5732,13 +5725,11 @@ namespace {
 #undef SET_BOOL
 #undef SET_INT
 		update_dht_upload_rate_limit();
-#endif
 	}
 
 	dht::dht_settings session_impl::get_dht_settings() const
 	{
 		dht::dht_settings sett;
-#ifndef TORRENT_DISABLE_DHT
 #define SET_BOOL(name) \
 		sett.name = m_settings.get_bool( settings_pack::dht_ ## name )
 #define SET_INT(name) \
@@ -5767,7 +5758,6 @@ namespace {
 		SET_INT(max_infohashes_sample_count);
 #undef SET_BOOL
 #undef SET_INT
-#endif
 		return sett;
 	}
 #endif


### PR DESCRIPTION
Just to see what happens. Noticed while looking at `http_connection.cpp` (`#if TORRENT_USE_I2P`).