### PR TITLE
use weak pointers to hold http_tracker_connection

### DIFF
--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -411,7 +411,7 @@ namespace libtorrent {
 		// if a connection is erased while a timeout event is in the queue
 		std::unordered_map<std::uint32_t, std::shared_ptr<udp_tracker_connection>> m_udp_conns;
 
-		std::vector<std::shared_ptr<http_tracker_connection>> m_http_conns;
+		std::vector<std::weak_ptr<http_tracker_connection>> m_http_conns;
 		std::deque<std::shared_ptr<http_tracker_connection>> m_queued;
 
 		send_fun_t m_send_fun;

--- a/simulation/test_checking.cpp
+++ b/simulation/test_checking.cpp
@@ -116,7 +116,6 @@ std::shared_ptr<lt::torrent_info> create_multifile_torrent()
 	lt::create_torrent t(fs, 0x40000, -1, {});
 
 	// calculate the hash for all pieces
-	lt::error_code ec;
 	set_piece_hashes(t, ".");
 
 	std::vector<char> buf;

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -331,7 +331,6 @@ TORRENT_TEST(exceed_file_prio)
 	p.save_path = ".";
 
 	lt::session ses(settings());
-	error_code ec;
 	torrent_handle h = ses.add_torrent(std::move(p));
 	auto const prios = h.get_file_priorities();
 	TEST_CHECK(prios.size() == 1);
@@ -354,7 +353,6 @@ TORRENT_TEST(exceed_piece_prio)
 	p.save_path = ".";
 
 	lt::session ses(settings());
-	error_code ec;
 	torrent_handle h = ses.add_torrent(std::move(p));
 	auto const prios = h.get_piece_priorities();
 	TEST_CHECK(prios.size() == num_pieces);
@@ -368,7 +366,6 @@ TORRENT_TEST(exceed_piece_prio_magnet)
 	p.save_path = ".";
 
 	lt::session ses(settings());
-	error_code ec;
 	torrent_handle h = ses.add_torrent(std::move(p));
 	auto const prios = h.get_piece_priorities();
 	TEST_CHECK(prios.empty());


### PR DESCRIPTION
This is a bit of a hack, an experiment to narrow down the HTTPS tracker memory leak.