### PR TITLE
Raise default piece limit to meet the needs of larger torrents

### DIFF
--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -131,7 +131,7 @@ namespace aux {
 	{
 		int max_buffer_size = 6000000;
 		// the max number of pieces allowed in the torrent
-		int max_pieces = 0x100000;
+		int max_pieces = 0x1000000;
 		// the max recursion depth in the bdecoded structure
 		int max_decode_depth = 100;
 		// the max number of bdecode tokens

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -80,10 +80,10 @@ namespace libtorrent {
 	// this is an arbitrary limit to avoid malicious torrents causing
 	// unreasaonably large allocations for the merkle hash tree
 	// the size of the tree would be max_pieces * sizeof(int) * 2
-	// which is about 8 MB with this limit
+	// which is about 256 MB on a 64-bit system with this limit
 	// TODO: remove this limit and the overloads that imply it, in favour of
 	// using load_torrent_limits
-	constexpr int default_piece_limit = 0x100000;
+	constexpr int default_piece_limit = 0x1000000;
 
 	bool valid_path_character(std::int32_t const c)
 	{

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -80,7 +80,7 @@ namespace libtorrent {
 	// this is an arbitrary limit to avoid malicious torrents causing
 	// unreasaonably large allocations for the merkle hash tree
 	// the size of the tree would be max_pieces * sizeof(int) * 2
-	// which is about 256 MB on a 64-bit system with this limit
+	// which is about 128 MB with this limit
 	// TODO: remove this limit and the overloads that imply it, in favour of
 	// using load_torrent_limits
 	constexpr int default_piece_limit = 0x1000000;


### PR DESCRIPTION
I was working with a tool that doesn't provide for configuring the max piece limit and found I couldn't download very large torrents at all.

This patch raises the limit to be less restrictive, providing compatibility with very large torrents.