### PR TITLE
remove hard coded piece-count limits and expose them to clients

### DIFF
--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -50,6 +50,9 @@ namespace boost
 using namespace boost::python;
 using namespace lt;
 
+// defined in torrent_info.cpp
+load_torrent_limits dict_to_limits(dict limits);
+
 namespace
 {
 #if TORRENT_ABI_VERSION == 1
@@ -675,14 +678,14 @@ namespace
     }
 #endif
 
-    add_torrent_params read_resume_data_wrapper(bytes const& b)
+    add_torrent_params read_resume_data_wrapper0(bytes const& b)
     {
-        error_code ec;
-        add_torrent_params p = read_resume_data(b.arr, ec);
-#ifndef BOOST_NO_EXCEPTIONS
-        if (ec) throw system_error(ec);
-#endif
-        return p;
+        return read_resume_data(b.arr);
+    }
+
+    add_torrent_params read_resume_data_wrapper1(bytes const& b, dict cfg)
+    {
+        return read_resume_data(b.arr, dict_to_limits(cfg));
     }
 
 	 int find_metric_idx_wrap(char const* name)
@@ -1148,7 +1151,8 @@ void bind_session()
     def("high_performance_seed", high_performance_seed_wrapper);
     def("min_memory_usage", min_memory_usage_wrapper);
     def("default_settings", default_settings_wrapper);
-    def("read_resume_data", read_resume_data_wrapper);
+    def("read_resume_data", read_resume_data_wrapper0);
+    def("read_resume_data", read_resume_data_wrapper1);
     def("write_resume_data", write_resume_data);
     def("write_resume_data_buf", write_resume_data_buf_);
 

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -186,6 +186,8 @@ namespace
     bool get_symlink_attribute(file_entry const& fe) { return fe.symlink_attribute; }
 #endif
 
+} // namespace unnamed
+
 load_torrent_limits dict_to_limits(dict limits)
 {
     load_torrent_limits ret;
@@ -221,8 +223,6 @@ load_torrent_limits dict_to_limits(dict limits)
     }
     return ret;
 }
-
-} // namespace unnamed
 
 std::shared_ptr<torrent_info> buffer_constructor0(bytes b)
 {

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -585,3 +585,4 @@ nginx
 SIGINT
 GNUTLS
 libgnutls
+0x200000

--- a/include/libtorrent/read_resume_data.hpp
+++ b/include/libtorrent/read_resume_data.hpp
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/aux_/export.hpp"
 #include "libtorrent/span.hpp"
+#include "libtorrent/torrent_info.hpp" // for load_torrent_limits
 
 namespace libtorrent {
 
@@ -48,12 +49,23 @@ namespace libtorrent {
 	// If the client wants to override any field that was loaded from the resume
 	// data, e.g. save_path, those fields must be changed after loading resume
 	// data but before adding the torrent.
+	//
+	// The ``piece_limit`` parameter determines the largest number of pieces
+	// allowed in the torrent that may be loaded as part of the resume data, if
+	// it contains an ``info`` field. The overloads that take a flat buffer are
+	// instead configured with limits on torrent sizes via load_torrent limits.
+	//
+	// In order to support large torrents, it may also be necessary to raise the
+	// settings_pack::max_piece_count setting and pass a higher limit to calls
+	// to torrent_info::parse_info_section().
 	TORRENT_EXPORT add_torrent_params read_resume_data(bdecode_node const& rd
-		, error_code& ec);
+		, error_code& ec, int piece_limit = 0x200000);
 	TORRENT_EXPORT add_torrent_params read_resume_data(span<char const> buffer
-		, error_code& ec);
-	TORRENT_EXPORT add_torrent_params read_resume_data(bdecode_node const& rd);
-	TORRENT_EXPORT add_torrent_params read_resume_data(span<char const> buffer);
+		, error_code& ec, load_torrent_limits const& cfg = {});
+	TORRENT_EXPORT add_torrent_params read_resume_data(bdecode_node const& rd
+		, int piece_limit = 0x200000);
+	TORRENT_EXPORT add_torrent_params read_resume_data(span<char const> buffer
+		, load_torrent_limits const& cfg = {});
 }
 
 #endif

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1931,6 +1931,13 @@ namespace aux {
 			// to clamp it in order to allow UDP packets go through
 			dht_max_infohashes_sample_count,
 
+			// ``max_piece_count`` is the maximum allowed number of pieces in
+			// metadata received via magnet links. Loading large torrents (with
+			// more pieces than the default limit) may also require passing in
+			// a higher limit to read_resume_data() and
+			// torrent_info::parse_info_section(), if those are used.
+			max_piece_count,
+
 			max_int_setting_internal
 		};
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -566,11 +566,17 @@ TORRENT_VERSION_NAMESPACE_3
 		// where we only have the info-dict. The bdecode_node ``e`` points to a
 		// parsed info-dictionary. ``ec`` returns an error code if something
 		// fails (typically if the info dictionary is malformed).
-		// the `piece_limit` parameter allows limiting the amount of memory
+		// The `max_pieces` parameter allows limiting the amount of memory
 		// dedicated to loading the torrent, and fails for torrents that exceed
-		// the limit
-		bool parse_info_section(bdecode_node const& info, error_code& ec);
+		// the limit. To load large torrents, this limit may also need to be
+		// raised in settings_pack::max_piece_count and in calls to
+		// read_resume_data().
 		bool parse_info_section(bdecode_node const& info, error_code& ec, int max_pieces);
+
+#if TORRENT_ABI_VERSION < 3
+		TORRENT_DEPRECATED
+		bool parse_info_section(bdecode_node const& info, error_code& ec);
+#endif
 
 		// This function looks up keys from the info-dictionary of the loaded
 		// torrent file. It can be used to access extension values put in the
@@ -628,7 +634,6 @@ TORRENT_VERSION_NAMESPACE_3
 		// populate the piece layers from the metadata
 		bool parse_piece_layers(bdecode_node const& e, error_code& ec);
 
-		bool parse_torrent_file(bdecode_node const& torrent_file, error_code& ec);
 		bool parse_torrent_file(bdecode_node const& torrent_file, error_code& ec, int piece_limit);
 
 		void resolve_duplicate_filenames();

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -362,6 +362,7 @@ namespace libtorrent {
 		SET(dht_item_lifetime, 0, nullptr),
 		SET(dht_sample_infohashes_interval, 21600, nullptr),
 		SET(dht_max_infohashes_sample_count, 20, nullptr),
+		SET(max_piece_count, 0x200000, nullptr),
 	}});
 
 #undef SET

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7229,7 +7229,8 @@ namespace {
 
 		error_code ec;
 		bdecode_node const metadata = bdecode(metadata_buf, ec);
-		if (ec || !m_torrent_file->parse_info_section(metadata, ec))
+		if (ec || !m_torrent_file->parse_info_section(metadata, ec
+			, settings().get_int(settings_pack::max_piece_count)))
 		{
 			update_gauge();
 			// this means the metadata is correct, since we


### PR DESCRIPTION
The main motivation of this patch is to remove the hard-coded constant that limits the number of pieces allowed in a torrent, and make sure clients are always able to raise the default limit.

torrents are not only parsed in `torrent_info`'s constructor, but also in the (publicly exposed) `torrent_info::parse_info_section()` which is used when loading just the info-section from a magnet link. It's also used when loading resume data that contains the info section (in `read_resume_data()`).

To enable loading large torrents via magnet links, I added a setting to `settings_pack`.

To enable loading large torrents from resume files, I added an extra parameter to all `load_resume_data()` overloads.

@FranciscoPombal @xloem does this seem reasonable? (not that I haven't merged the other patch in yet, it will come in a while)