### PR TITLE
rename error_message() to failure_reason() on tracker_error_alert

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -476,6 +476,7 @@ void bind_alert()
         .def_readonly("status_code", &tracker_error_alert::status_code)
 #endif
         .def("error_message", &tracker_error_alert::error_message)
+        .def("failure_reason", &tracker_error_alert::failure_reason)
         .def_readonly("times_in_row", &tracker_error_alert::times_in_row)
         .def_readonly("error", &tracker_error_alert::error)
         ;

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -516,11 +516,6 @@ TORRENT_VERSION_NAMESPACE_2
 	// This alert is generated on tracker time outs, premature disconnects,
 	// invalid response or a HTTP response other than "200 OK". From the alert
 	// you can get the handle to the torrent the tracker belongs to.
-	//
-	// The ``times_in_row`` member says how many times in a row this tracker has
-	// failed. ``status_code`` is the code returned from the HTTP server. 401
-	// means the tracker needs authentication, 404 means not found etc. If the
-	// tracker timed out, the code will be set to 0.
 	struct TORRENT_EXPORT tracker_error_alert final : tracker_alert
 	{
 		// internal
@@ -533,13 +528,23 @@ TORRENT_VERSION_NAMESPACE_2
 		static constexpr alert_category_t static_category = alert_category::tracker | alert_category::error;
 		std::string message() const override;
 
+		// This member says how many times in a row this tracker has failed.
 		int const times_in_row;
+
+		// the error code indicating why the tracker announce failed. If it is
+		// is ``lt::errors::tracker_failure`` the failure_reason() might contain
+		// a more detailed description of why the tracker rejected the request.
+		// HTTP status codes indicating errors are also set in this field.
 		error_code const error;
 
 		operation_t op;
 
-		// the message associated with this error
-		char const* error_message() const;
+		// if the tracker sent a "failure reason" string, it will be returned
+		// here.
+		char const* failure_reason() const;
+
+		// hidden
+		char const* error_message() const { return failure_reason(); }
 
 	private:
 		aux::allocation_slot m_msg_idx;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -356,7 +356,7 @@ namespace libtorrent {
 		TORRENT_ASSERT(!u.empty());
 	}
 
-	char const* tracker_error_alert::error_message() const
+	char const* tracker_error_alert::failure_reason() const
 	{
 		return m_alloc.get().ptr(m_msg_idx);
 	}


### PR DESCRIPTION
and improve documentation