### PR TITLE
[clang-tidy] use nodiscard

### DIFF
--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -183,9 +183,9 @@ namespace aux {
 
 	struct bdecode_error_category final : boost::system::error_category
 	{
-		const char* name() const BOOST_SYSTEM_NOEXCEPT override;
-		std::string message(int ev) const override;
-		boost::system::error_condition default_error_condition(
+		[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override;
+		[[nodiscard]] std::string message(int ev) const override;
+		[[nodiscard]] boost::system::error_condition default_error_condition(
 			int ev) const BOOST_SYSTEM_NOEXCEPT override
 		{ return {ev, *this}; }
 	};

--- a/src/disabled_disk_io.cpp
+++ b/src/disabled_disk_io.cpp
@@ -179,7 +179,7 @@ struct TORRENT_EXTRA_EXPORT disabled_disk_io final
 	// here. The buffer is owned by the disabled_disk_io object itself
 	void free_disk_buffer(char*) override {}
 
-	std::vector<open_file_state> get_status(storage_index_t) const override
+	[[nodiscard]] std::vector<open_file_state> get_status(storage_index_t) const override
 	{ return {}; }
 
 	// this submits all queued up jobs to the thread

--- a/src/error_code.cpp
+++ b/src/error_code.cpp
@@ -43,9 +43,9 @@ namespace libtorrent {
 
 	struct libtorrent_error_category final : boost::system::error_category
 	{
-		const char* name() const BOOST_SYSTEM_NOEXCEPT override;
-		std::string message(int ev) const override;
-		boost::system::error_condition default_error_condition(int ev) const BOOST_SYSTEM_NOEXCEPT override
+		[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override;
+		[[nodiscard]] std::string message(int ev) const override;
+		[[nodiscard]] boost::system::error_condition default_error_condition(int ev) const BOOST_SYSTEM_NOEXCEPT override
 		{ return {ev, *this}; }
 	};
 
@@ -308,9 +308,9 @@ namespace libtorrent {
 
 	struct http_error_category final : boost::system::error_category
 	{
-		const char* name() const BOOST_SYSTEM_NOEXCEPT override
+		[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override
 		{ return "http"; }
-		std::string message(int ev) const override
+		[[nodiscard]] std::string message(int ev) const override
 		{
 			std::string ret;
 			ret += to_string(ev).data();
@@ -338,7 +338,7 @@ namespace libtorrent {
 			}
 			return ret;
 		}
-		boost::system::error_condition default_error_condition(
+		[[nodiscard]] boost::system::error_condition default_error_condition(
 			int ev) const BOOST_SYSTEM_NOEXCEPT override
 		{ return {ev, *this}; }
 	};

--- a/src/gzip.cpp
+++ b/src/gzip.cpp
@@ -58,9 +58,9 @@ namespace libtorrent {
 
 	struct gzip_error_category final : boost::system::error_category
 	{
-		const char* name() const BOOST_SYSTEM_NOEXCEPT override;
-		std::string message(int ev) const override;
-		boost::system::error_condition default_error_condition(int ev) const BOOST_SYSTEM_NOEXCEPT override
+		[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override;
+		[[nodiscard]] std::string message(int ev) const override;
+		[[nodiscard]] boost::system::error_condition default_error_condition(int ev) const BOOST_SYSTEM_NOEXCEPT override
 		{ return {ev, *this}; }
 	};
 

--- a/src/i2p_stream.cpp
+++ b/src/i2p_stream.cpp
@@ -53,9 +53,9 @@ namespace libtorrent {
 
 	struct i2p_error_category final : boost::system::error_category
 	{
-		const char* name() const BOOST_SYSTEM_NOEXCEPT override
+		[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override
 		{ return "i2p error"; }
-		std::string message(int ev) const override
+		[[nodiscard]] std::string message(int ev) const override
 		{
 			static char const* messages[] =
 			{
@@ -73,7 +73,7 @@ namespace libtorrent {
 			if (ev < 0 || ev >= i2p_error::num_errors) return "unknown error";
 			return messages[ev];
 		}
-		boost::system::error_condition default_error_condition(
+		[[nodiscard]] boost::system::error_condition default_error_condition(
 			int ev) const BOOST_SYSTEM_NOEXCEPT override
 		{ return {ev, *this}; }
 	};

--- a/src/ip_filter.cpp
+++ b/src/ip_filter.cpp
@@ -248,7 +248,7 @@ namespace aux {
 
 	template <typename Addr>
 	template <typename ExternalAddressType>
-	std::vector<ip_range<ExternalAddressType>> filter_impl<Addr>::export_filter() const
+	[[nodiscard]] std::vector<ip_range<ExternalAddressType>> filter_impl<Addr>::export_filter() const
 	{
 		std::vector<ip_range<ExternalAddressType>> ret;
 		ret.reserve(m_access_list.size());

--- a/src/kademlia/dht_storage.cpp
+++ b/src/kademlia/dht_storage.cpp
@@ -187,7 +187,7 @@ namespace {
 		aux::vector<sha1_hash> samples;
 		time_point created = min_time();
 
-		int count() const { return int(samples.size()); }
+		[[nodiscard]] int count() const { return int(samples.size()); }
 	};
 
 	class dht_default_storage final : public dht_storage_interface
@@ -206,8 +206,8 @@ namespace {
 		dht_default_storage& operator=(dht_default_storage const&) = delete;
 
 #if TORRENT_ABI_VERSION == 1
-		size_t num_torrents() const override { return m_map.size(); }
-		size_t num_peers() const override
+		[[nodiscard]] size_t num_torrents() const override { return m_map.size(); }
+		[[nodiscard]] size_t num_peers() const override
 		{
 			size_t ret = 0;
 			for (auto const& t : m_map)
@@ -541,7 +541,7 @@ namespace {
 			}
 		}
 
-		dht_storage_counters counters() const override
+		[[nodiscard]] dht_storage_counters counters() const override
 		{
 			return m_counters;
 		}

--- a/src/natpmp.cpp
+++ b/src/natpmp.cpp
@@ -67,9 +67,9 @@ namespace libtorrent {
 
 struct pcp_error_category final : boost::system::error_category
 {
-	const char* name() const BOOST_SYSTEM_NOEXCEPT override
+	[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override
 	{ return "pcp error"; }
-	std::string message(int ev) const override
+	[[nodiscard]] std::string message(int ev) const override
 	{
 		static char const* msgs[] =
 		{
@@ -92,7 +92,7 @@ struct pcp_error_category final : boost::system::error_category
 			return "Unknown error";
 		return msgs[ev];
 	}
-	boost::system::error_condition default_error_condition(
+	[[nodiscard]] boost::system::error_condition default_error_condition(
 		int ev) const BOOST_SYSTEM_NOEXCEPT override
 	{ return {ev, *this}; }
 };

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3904,7 +3904,7 @@ namespace {
 			std::vector<std::shared_ptr<plugin>>& plugins;
 #endif
 
-			uint64_t get_ext_priority(opt_unchoke_candidate const& peer) const
+			[[nodiscard]] uint64_t get_ext_priority(opt_unchoke_candidate const& peer) const
 			{
 #ifndef TORRENT_DISABLE_EXTENSIONS
 				if (peer.ext_priority == priority_undetermined)

--- a/src/socks5_stream.cpp
+++ b/src/socks5_stream.cpp
@@ -47,9 +47,9 @@ namespace libtorrent {
 
 	struct socks_error_category final : boost::system::error_category
 	{
-		const char* name() const BOOST_SYSTEM_NOEXCEPT override
+		[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override
 		{ return "socks"; }
-		std::string message(int ev) const override
+		[[nodiscard]] std::string message(int ev) const override
 		{
 			static char const* messages[] =
 			{
@@ -68,7 +68,7 @@ namespace libtorrent {
 			if (ev < 0 || ev >= socks_error::num_errors) return "unknown error";
 			return messages[ev];
 		}
-		boost::system::error_condition default_error_condition(
+		[[nodiscard]] boost::system::error_condition default_error_condition(
 			int ev) const BOOST_SYSTEM_NOEXCEPT override
 		{ return {ev, *this}; }
 	};

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1210,12 +1210,12 @@ namespace {
 
 struct upnp_error_category final : boost::system::error_category
 {
-	const char* name() const BOOST_SYSTEM_NOEXCEPT override
+	[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override
 	{
 		return "upnp";
 	}
 
-	std::string message(int ev) const override
+	[[nodiscard]] std::string message(int ev) const override
 	{
 		int num_errors = sizeof(error_codes) / sizeof(error_codes[0]);
 		error_code_t* end = error_codes + num_errors;
@@ -1232,7 +1232,7 @@ struct upnp_error_category final : boost::system::error_category
 		return msg;
 	}
 
-	boost::system::error_condition default_error_condition(
+	[[nodiscard]] boost::system::error_condition default_error_condition(
 		int ev) const BOOST_SYSTEM_NOEXCEPT override
 	{
 		return {ev, *this};

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -103,7 +103,7 @@ namespace {
 		std::shared_ptr<peer_plugin> new_connection(
 			peer_connection_handle const& pc) override;
 
-		span<char const> metadata() const
+		[[nodiscard]] span<char const> metadata() const
 		{
 			if (!m_metadata.empty()) return m_metadata;
 			if (!m_torrent.valid_metadata()) return {};

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -96,7 +96,7 @@ namespace libtorrent { namespace {
 			return m_ut_pex_msg;
 		}
 
-		int peers_in_msg() const
+		[[nodiscard]] int peers_in_msg() const
 		{
 			return m_peers_in_message;
 		}

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -182,12 +182,12 @@ namespace {
 
 		struct utf8_error_category final : boost::system::error_category
 		{
-			const char* name() const BOOST_SYSTEM_NOEXCEPT override
+			[[nodiscard]] const char* name() const BOOST_SYSTEM_NOEXCEPT override
 			{
 				return "UTF error";
 			}
 
-			std::string message(int ev) const override
+			[[nodiscard]] std::string message(int ev) const override
 			{
 				static char const* error_messages[] = {
 					"ok",
@@ -201,7 +201,7 @@ namespace {
 				return error_messages[ev];
 			}
 
-			boost::system::error_condition default_error_condition(
+			[[nodiscard]] boost::system::error_condition default_error_condition(
 				int ev) const BOOST_SYSTEM_NOEXCEPT override
 			{ return {ev, *this}; }
 		};


### PR DESCRIPTION
Found with modernize-use-nodiscard

Signed-off-by: Rosen Penev <rosenp@gmail.com>