### PR TITLE
fix assert when receiving a dht port message

### DIFF
--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -1236,7 +1236,7 @@ namespace {
 			m_supports_dht_port = true;
 			// if we're done with the handshake, respond right away, otherwise
 			// we'll send the DHT port later
-			if (m_sent_handshake)
+			if (m_sent_bitfield)
 				write_dht_port();
 		}
 	}


### PR DESCRIPTION
from a peer that did not advertise support for it, before sending the bitfield