### PR TITLE
minor fix to buffer in dht_put

### DIFF
--- a/tools/dht_put.cpp
+++ b/tools/dht_put.cpp
@@ -63,8 +63,8 @@ std::string to_hex(lt::span<char const> key)
 	std::string out;
 	for (auto const b : key)
 	{
-		char buf[20];
-		std::snprintf(buf, sizeof(3), "%02x", static_cast<unsigned char>(b));
+		char buf[3]{};
+		std::snprintf(buf, sizeof(buf), "%02x", static_cast<unsigned char>(b));
 		out += (char*)buf;
 	}
 	return out;


### PR DESCRIPTION
Super minor tweak. Doesn't actually fix any bug, unless when running on a platform where `sizeof(int) == 2`, but it's more optimal and correct now. Found it because of the following complaint:

`Suspicious usage of 'sizeof(K)'; did you mean 'K'? clang-tidy(bugprone-sizeof-expression)`

These were the other instances of the warning in `RC_1_2`, in case you're thinking about adding this check to travis as well:

```cpp
/home/francisco/Documents/libtorrent/src/disk_io_thread.cpp:1051:3: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate [bugprone-sizeof-expression]
                TORRENT_ALLOCA(to_flush, cached_piece_entry*, 200);
                ^
/home/francisco/Documents/libtorrent/include/libtorrent/aux_/alloca.hpp:104:52: note: expanded from macro 'TORRENT_ALLOCA'
        auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
                                                          ^
/home/francisco/Documents/libtorrent/src/peer_connection.cpp:5508:3: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate [bugprone-sizeof-expression]
                TORRENT_ALLOCA(channels, bandwidth_channel*, max_channels);
                ^
/home/francisco/Documents/libtorrent/include/libtorrent/aux_/alloca.hpp:104:52: note: expanded from macro 'TORRENT_ALLOCA'
        auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
                                                          ^
/home/francisco/Documents/libtorrent/src/piece_picker.cpp:1993:4: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate [bugprone-sizeof-expression]
                        TORRENT_ALLOCA(ordered_partials, downloading_piece const*
                        ^
/home/francisco/Documents/libtorrent/include/libtorrent/aux_/alloca.hpp:104:52: note: expanded from macro 'TORRENT_ALLOCA'
        auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
                                                          ^
/home/francisco/Documents/libtorrent/src/piece_picker.cpp:2364:3: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate [bugprone-sizeof-expression]
                TORRENT_ALLOCA(partials, downloading_piece const*, partials_size);
                ^
/home/francisco/Documents/libtorrent/include/libtorrent/aux_/alloca.hpp:104:52: note: expanded from macro 'TORRENT_ALLOCA'
        auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
                                                          ^
```