### PR TITLE
fix enumeration of network routes to support larger routing tables

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix network route enumeration for large routing tables
 	* fixed issue where pop_alerts() could return old, invalid alerts
 	* fix issue when receiving have-all message before the metadata
 	* don't leave lingering part files handles open


### PR DESCRIPTION
 by adapting the buffer size when necessary, rather than sticking to a fixed size buffer when reading from the netlink socket.

@ssiloti would you mind taking a look at this?

The patch is a little bit bigger than it needed to be because I wasn't excited about the way the address family was set on the netlink request messages, so I pulled some of that out of `nl_dump_request()`