### PR TITLE
improving case where uTP and TCP peers are disabled

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1425,25 +1425,49 @@ namespace {
 		return ret;
 	}
 
+namespace {
+	template <typename Pack>
+	int get_setting_impl(Pack const& p, int name, int*)
+	{ return p.get_int(name); }
+
+	template <typename Pack>
+	bool get_setting_impl(Pack const& p, int name, bool*)
+	{ return p.get_bool(name); }
+
+	template <typename Pack>
+	std::string get_setting_impl(Pack const& p, int name, std::string*)
+	{ return p.get_str(name); }
+
+	template <typename Type, typename Pack>
+	Type get_setting(Pack const& p, int name)
+	{
+		return get_setting_impl(p, name, static_cast<Type*>(nullptr));
+	}
+
+	template <typename Type>
+	bool setting_changed(settings_pack const& pack, aux::session_settings const& sett, int name)
+	{
+		return pack.has_val(name)
+			&& get_setting<Type>(pack, name) != get_setting<Type>(sett, name);
+	}
+}
+
 	void session_impl::apply_settings_pack_impl(settings_pack const& pack)
 	{
-		bool const reopen_listen_port =
+		bool const reopen_listen_port
+			= setting_changed<std::string>(pack, m_settings, settings_pack::listen_interfaces)
+			|| setting_changed<int>(pack, m_settings, settings_pack::proxy_type)
+			|| setting_changed<bool>(pack, m_settings, settings_pack::proxy_peer_connections)
 #if TORRENT_ABI_VERSION == 1
-			(pack.has_val(settings_pack::ssl_listen)
-				&& pack.get_int(settings_pack::ssl_listen)
-					!= m_settings.get_int(settings_pack::ssl_listen))
-			||
+			|| setting_changed<int>(pack, m_settings, settings_pack::ssl_listen)
 #endif
-			(pack.has_val(settings_pack::listen_interfaces)
-				&& pack.get_str(settings_pack::listen_interfaces)
-					!= m_settings.get_str(settings_pack::listen_interfaces))
-			|| (pack.has_val(settings_pack::proxy_type)
-				&& pack.get_int(settings_pack::proxy_type)
-					!= m_settings.get_int(settings_pack::proxy_type))
-			|| (pack.has_val(settings_pack::proxy_peer_connections)
-				&& pack.get_bool(settings_pack::proxy_peer_connections)
-					!= m_settings.get_bool(settings_pack::proxy_peer_connections))
 			;
+
+		bool const update_want_peers
+			= setting_changed<bool>(pack, m_settings, settings_pack::seeding_outgoing_connections)
+			|| setting_changed<bool>(pack, m_settings, settings_pack::enable_outgoing_tcp)
+			|| setting_changed<bool>(pack, m_settings, settings_pack::enable_outgoing_utp)
+		;
 
 #ifndef TORRENT_DISABLE_LOGGING
 		session_log("applying settings pack, reopen_listen_port=%s"
@@ -1459,10 +1483,15 @@ namespace {
 			// since the apply_pack will do it
 			update_listen_interfaces();
 		}
-
-		if (reopen_listen_port)
+		else
 		{
 			reopen_listen_sockets();
+		}
+
+		if (update_want_peers)
+		{
+			for (auto const& t : m_torrents)
+				t->update_want_peers();
 		}
 	}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7672,6 +7672,10 @@ namespace {
 				|| m_state == torrent_status::finished))
 			return false;
 
+		if (!settings().get_bool(settings_pack::enable_outgoing_tcp)
+			&& !settings().get_bool(settings_pack::enable_outgoing_utp))
+			return false;
+
 		return true;
 	}
 


### PR DESCRIPTION
mark all torrents as not wanting peer connections when both TCP and uTP connections are disabled. Also fix issue when changing the seeding_outgoing_connections setting. This is essentially an optimization to avoid looping over all torrents all the time asking them to try to connect to a peer, when they will all fail to do so because both TCP and uTP outgoing connections are disabled.

Additionally, I noticed that `torrent::want_peers()` depends on another session-wide setting, `seeding_outgoing_connections`. When this setting is changed, torrents are not given an opportunity to change their want-peers state. This is fixed as well.