### PR TITLE
Update soversion and set it correctly in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,12 @@ project(libtorrent
 	DESCRIPTION "Bittorrent library"
 	VERSION ${VER_MAJOR}.${VER_MINOR}.${VER_TINY}
 )
-set (SOVERSION "10")
+set (LIBVERSION_MAJOR 11)
+set (LIBVERSION_MINOR 0)
+set (LIBVERSION_PATCH 0)
+
+set (LIBVERSION ${LIBVERSION_MAJOR}.${LIBVERSION_MINOR}.${LIBVERSION_PATCH})
+set (SOVERSION ${LIBVERSION_MAJOR})
 
 include(GNUInstallDirs)
 include(GeneratePkgConfig)
@@ -515,7 +520,7 @@ set_target_properties(torrent-rasterbar
 	PROPERTIES
 		CXX_VISIBILITY_PRESET "hidden"
 		VISIBILITY_INLINES_HIDDEN "true"
-		VERSION ${PROJECT_VERSION}
+		VERSION ${LIBVERSION}
 		SOVERSION ${SOVERSION}
 )
 

--- a/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
+++ b/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
@@ -49,4 +49,4 @@ set(_interface_compile_options "${_TARGET_INTERFACE_COMPILE_OPTIONS}")
 string(REPLACE ";" " " _interface_compile_options "${_interface_compile_options}")
 
 configure_file("@_pkg_config_file_template_filename@" "@_generate_target_dir@/@_package_name@.pc" @ONLY)
-file(INSTALL "@_generate_target_dir@/@_package_name@.pc" DESTINATION "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/pkgconfig")
+file(INSTALL "@_generate_target_dir@/@_package_name@.pc" DESTINATION "@CMAKE_INSTALL_FULL_LIBDIR@/pkgconfig")

--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ dnl  increment AGE, Otherwise AGE is reset to 0. If CURRENT has changed,
 dnl  REVISION is set to 0, otherwise REVISION is incremented.
 dnl ---------------------------------------------------------------------------
 
-m4_define([VERSION_INFO_CURRENT],[10])
+m4_define([VERSION_INFO_CURRENT],[11])
 m4_define([VERSION_INFO_REVISION],[0])
 m4_define([VERSION_INFO_AGE],[0])
 INTERFACE_VERSION_INFO=VERSION_INFO_CURRENT:VERSION_INFO_REVISION:VERSION_INFO_AGE


### PR DESCRIPTION
I wouldn't want to speak out of turn, but judging from the changelog for 2.0 there are breaking API changes, so a soversion bump is warranted.

This also solves https://github.com/arvidn/libtorrent/issues/4927