### PR TITLE
CMake: use target_compile_features() to automatically enforce minimum compiler version and C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,49 @@ add_library(torrent-rasterbar
 	${libtorrent_aux_include_files}
 )
 
-select_cxx_standard(torrent-rasterbar 11)
+# C++ 11 support is required
+target_compile_features(torrent-rasterbar
+	PUBLIC
+		cxx_std_11
+		cxx_rvalue_references
+		cxx_reference_qualified_functions
+		cxx_nonstatic_member_init
+		cxx_variadic_templates
+		cxx_generalized_initializers
+		cxx_static_assert
+		cxx_auto_type
+		cxx_trailing_return_types
+		cxx_lambdas
+		cxx_decltype
+		cxx_right_angle_brackets
+		cxx_default_function_template_args
+		cxx_alias_templates
+		cxx_extern_templates
+		cxx_nullptr
+		cxx_strong_enums
+		cxx_enum_forward_declarations
+		cxx_attributes
+		cxx_constexpr
+		cxx_alignas
+		cxx_alignof
+		cxx_delegating_constructors
+		cxx_inheriting_constructors
+		cxx_explicit_conversions
+		cxx_raw_string_literals
+		cxx_user_literals
+		cxx_defaulted_functions
+		cxx_deleted_functions
+		cxx_extended_friend_declarations
+		cxx_sizeof_member
+		cxx_inline_namespaces
+		cxx_unrestricted_unions
+		cxx_local_type_template_args
+		cxx_range_for
+		cxx_final
+		cxx_override
+		cxx_noexcept
+		cxx_defaulted_move_initializers
+)
 
 if (BUILD_SHARED_LIBS)
 	target_compile_definitions(torrent-rasterbar

--- a/cmake/Modules/LibtorrentMacros.cmake
+++ b/cmake/Modules/LibtorrentMacros.cmake
@@ -54,47 +54,6 @@ macro(find_public_dependency _name)
 	endif()
 endmacro()
 
-function(_cxx_standard_to_year _yearVar _std)
-	if (${_std} GREATER 97)
-		math(EXPR _year "1900 + ${_std}")
-	else()
-		math(EXPR _year "2000 + ${_std}")
-	endif()
-	set(${_yearVar} ${_year} PARENT_SCOPE)
-endfunction()
-
-function(select_cxx_standard _target _minimal_supported_version)
-	message(STATUS "Compiler default is C++${CMAKE_CXX_STANDARD_DEFAULT}")
-	# make the CXX_STANDARD property public to ensure it makes it into the pkg-config file
-	get_target_property(_std ${_target} CXX_STANDARD)
-	# ${CMAKE_CXX_STANDARD_DEFAULT} could be 98, which is lower version than C++11. Thus we convert std
-	# version to year value and compare years
-	_cxx_standard_to_year(minimal_supported_version_year ${_minimal_supported_version})
-	# if it is unset, select the default if it is sufficient or the ${_minimal_supported_version}
-	if (NOT ${_std})
-		_cxx_standard_to_year(std_default_year ${CMAKE_CXX_STANDARD_DEFAULT})
-		if (${std_default_year} GREATER_EQUAL ${minimal_supported_version_year})
-			set(_std ${CMAKE_CXX_STANDARD_DEFAULT})
-		else()
-			set(_std ${_minimal_supported_version})
-		endif()
-	else()
-		_cxx_standard_to_year(std_year ${_std})
-		if (${std_year} LESS ${minimal_supported_version_year})
-			message(FATAL_ERROR "The minimal supported C++ standard version is C++${_minimal_supported_version}")
-		endif()
-	endif()
-
-	if (cxx_std_${_std} IN_LIST CMAKE_CXX_COMPILE_FEATURES)
-		# force this standard
-		target_compile_features(${_target} PUBLIC cxx_std_${_std})
-	else()
-		message(FATAL_ERROR "Requested C++ standard version (${_std}) is not supported by the compiler")
-	endif()
-
-	message(STATUS "Building in C++${_std} mode")
-endfunction()
-
 # function for parsing version variables that are set in version.hpp file
 # the version identifiers there are defined as follows:
 # #define LIBTORRENT_VERSION_MAJOR 1


### PR DESCRIPTION
Just a simple:

```cmake
target_compile_features(torrent-rasterbar
    PUBLIC
        cxx_std_11
)
```

provides equivalent functionality to the current mechanism, and would additionally yield the advantages listed in  https://github.com/arvidn/libtorrent/issues/4965#issuecomment-671322398:

> The benefit of using `target_compile_features()` this way is that all the important logic gets taken care of automagically, with the correct behavior in all cases:
>
> -   If the compiler is capable of supporting the minimum required standard, but defaults to an insufficient standard, CMake will append the appropriate `-std` flag to override the default.
> -    If the compiler defaults to a sufficiently recent standard, the compiler default is used.
> -    Even if the compiler default is sufficient, the user can easily override the compiler default (e.g., to select something more recent) by passing `-DCMAKE_CXX_STANDARD=FOO`; this is why this variable should be left alone in the script - so that it can have the correct behavior as a cache variable.

Plus the following point which I previously omitted by mistake:

- The correct minimum `-std` flag is used even if the user mistakenly passes an insufficient value via `-DCMAKE_CXX_STANDARD` at configure-time.

---

Having the other additional features increases resilience in cases where compilers advertise support for a standard, but not _full_ support:

> Experience with qBittorrent shows that only requiring `cxx_std_14`/`cxx_std_11`/etc is not enough to enforce a "true minimum standard", because, for example, some compilers (including some versions of GCC) will pass the `cxx_std_14` test while having incomplete C++14 support. To fix this, one must look at the language support status https://gcc.gnu.org/projects/cxx-status.html, compare with the CMake page, and add the strings corresponding to the appropriate proposal numbers.

This is the reason why this PR is in draft mode - is just using `cxx_std_11` preferable for this project?