### PR TITLE
Simplify file

### DIFF
--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -88,10 +88,6 @@ namespace libtorrent {
 	using handle_type = int;
 #endif
 
-#ifdef TORRENT_WINDOWS
-	bool is_sparse(HANDLE file);
-#endif
-
 	struct TORRENT_EXTRA_EXPORT directory
 	{
 		directory(std::string const& path, error_code& ec);

--- a/include/libtorrent/file.hpp
+++ b/include/libtorrent/file.hpp
@@ -126,11 +126,8 @@ namespace libtorrent {
 		file& operator=(file const&) = delete;
 
 		bool open(std::string const& p, aux::open_mode_t m, error_code& ec);
-		bool is_open() const;
 		void close();
 		bool set_size(std::int64_t size, error_code& ec);
-
-		aux::open_mode_t open_mode() const { return m_open_mode; }
 
 		std::int64_t writev(std::int64_t file_offset, span<iovec_t const> bufs
 			, error_code& ec, aux::open_mode_t flags = {});
@@ -139,13 +136,8 @@ namespace libtorrent {
 
 		std::int64_t get_size(error_code& ec) const;
 
-		handle_type native_handle() const { return m_file_handle; }
-
 	private:
-
 		handle_type m_file_handle;
-
-		aux::open_mode_t m_open_mode{};
 	};
 }
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -86,7 +86,6 @@ struct iovec
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
-#include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/file.hpp"
 #include "libtorrent/aux_/path.hpp" // for convert_to_native_path_string
 #include "libtorrent/string_util.hpp"
@@ -103,11 +102,6 @@ struct iovec
 #ifdef TORRENT_WINDOWS
 // windows part
 
-#ifndef PtrToPtr64
-#define PtrToPtr64(x) (x)
-#endif
-
-#include "libtorrent/utf8.hpp"
 #include "libtorrent/aux_/win_util.hpp"
 
 #ifndef WIN32_LEAN_AND_MEAN
@@ -134,11 +128,6 @@ struct iovec
 #define ftruncate ftruncate64
 #endif
 
-#elif defined __APPLE__ && defined __MACH__ && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
-// mac specifics
-
-#include <copyfile.h>
-
 #endif
 
 // make sure the _FILE_OFFSET_BITS define worked
@@ -159,29 +148,29 @@ static_assert(sizeof(lseek(0, 0, 0)) >= 8, "64 bit file operations are required"
 namespace libtorrent {
 
 #ifdef TORRENT_WINDOWS
-	namespace {
-		std::int64_t read(HANDLE fd, void* data, std::size_t len)
+namespace {
+	std::int64_t read(HANDLE fd, void* data, std::size_t len)
+	{
+		DWORD bytes_read = 0;
+		if (ReadFile(fd, data, DWORD(len), &bytes_read, nullptr) == FALSE)
 		{
-			DWORD bytes_read = 0;
-			if (ReadFile(fd, data, DWORD(len), &bytes_read, nullptr) == FALSE)
-			{
-				return -1;
-			}
-
-			return bytes_read;
+			return -1;
 		}
 
-		std::int64_t write(HANDLE fd, void const* data, std::size_t len)
-		{
-			DWORD bytes_written = 0;
-			if (WriteFile(fd, data, DWORD(len), &bytes_written, nullptr) == FALSE)
-			{
-				return -1;
-			}
-
-			return bytes_written;
-		}
+		return bytes_read;
 	}
+
+	std::int64_t write(HANDLE fd, void const* data, std::size_t len)
+	{
+		DWORD bytes_written = 0;
+		if (WriteFile(fd, data, DWORD(len), &bytes_written, nullptr) == FALSE)
+		{
+			return -1;
+		}
+
+		return bytes_written;
+	}
+}
 #endif
 
 	directory::directory(std::string const& path, error_code& ec)
@@ -269,16 +258,10 @@ namespace libtorrent {
 #endif
 	}
 
-#ifdef TORRENT_WINDOWS
-	void acquire_manage_volume_privs();
-#endif
-
-	file::file() : m_file_handle(INVALID_HANDLE_VALUE)
-	{}
+	file::file() : m_file_handle(INVALID_HANDLE_VALUE) {}
 
 	file::file(file&& f) noexcept
 		: m_file_handle(f.m_file_handle)
-		, m_open_mode(f.m_open_mode)
 	{
 		f.m_file_handle = INVALID_HANDLE_VALUE;
 	}
@@ -287,7 +270,6 @@ namespace libtorrent {
 	{
 		file tmp(std::move(*this)); // close at end of scope
 		m_file_handle = f.m_file_handle;
-		m_open_mode = f.m_open_mode;
 		f.m_file_handle = INVALID_HANDLE_VALUE;
 		return *this;
 	}
@@ -311,43 +293,12 @@ namespace libtorrent {
 		native_path_string file_path = convert_to_native_path_string(path);
 
 #ifdef TORRENT_WINDOWS
-
-		struct win_open_mode_t
-		{
-			DWORD rw_mode;
-			DWORD create_mode;
-		};
-
-		static std::array<win_open_mode_t, 2> const mode_array{
-		{
-			// read_only
-			{GENERIC_READ, OPEN_EXISTING},
-			// read_write
-			{GENERIC_WRITE | GENERIC_READ, OPEN_ALWAYS},
-		}};
-
-		win_open_mode_t const& m = mode_array[(mode & aux::open_mode::write) ? 1 : 0];
-		DWORD const a = (mode & aux::open_mode::hidden) ? FILE_ATTRIBUTE_HIDDEN : 0;
-
-		// one might think it's a good idea to pass in FILE_FLAG_RANDOM_ACCESS. It
-		// turns out that it isn't. That flag will break your operating system:
-		// http://support.microsoft.com/kb/2549369
-
-		DWORD const flags = ((mode & aux::open_mode::random_access) ? 0 : FILE_FLAG_SEQUENTIAL_SCAN)
-			| a
-			| ((mode & aux::open_mode::no_cache) ? FILE_FLAG_WRITE_THROUGH : 0);
-
-		if (!(mode & aux::open_mode::sparse))
-		{
-			// Enable privilege required by SetFileValidData()
-			// https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-setfilevaliddata
-			static std::once_flag flag;
-			std::call_once(flag, acquire_manage_volume_privs);
-		}
-
-		handle_type handle = CreateFileW(file_path.c_str(), m.rw_mode
+		handle_type handle = CreateFileW(file_path.c_str()
+			, (mode & aux::open_mode::write) ? GENERIC_WRITE | GENERIC_READ : GENERIC_READ
 			, FILE_SHARE_READ | FILE_SHARE_WRITE
-			, nullptr, m.create_mode, flags, nullptr);
+			, nullptr
+			, (mode & aux::open_mode::write) ? OPEN_ALWAYS : OPEN_EXISTING
+			, 0, nullptr);
 
 		if (handle == INVALID_HANDLE_VALUE)
 		{
@@ -357,59 +308,18 @@ namespace libtorrent {
 		}
 
 		m_file_handle = handle;
-
-		// try to make the file sparse if supported
-		// only set this flag if the file is opened for writing
-		if ((mode & aux::open_mode::sparse)
-			&& (mode & aux::open_mode::write))
-		{
-			DWORD temp;
-			::DeviceIoControl(native_handle(), FSCTL_SET_SPARSE, nullptr, 0
-				, nullptr, 0, &temp, nullptr);
-		}
 #else // TORRENT_WINDOWS
 
-		// rely on default umask to filter x and w permissions
-		// for group and others
-		int permissions = S_IRUSR | S_IWUSR
-			| S_IRGRP | S_IWGRP
-			| S_IROTH | S_IWOTH;
-
-		if (mode & aux::open_mode::executable)
-			permissions |= S_IXGRP | S_IXOTH | S_IXUSR;
-#ifdef O_BINARY
-		static const int mode_array[] = {O_RDONLY | O_BINARY, O_RDWR | O_CREAT | O_BINARY};
-#else
-		static const int mode_array[] = {O_RDONLY, O_RDWR | O_CREAT};
-#endif
-
-		int open_mode = 0
-#ifdef O_NOATIME
-			| ((mode & aux::open_mode::no_atime) ? O_NOATIME : 0)
-#endif
-#ifdef O_SYNC
-			| ((mode & aux::open_mode::no_cache) ? O_SYNC : 0)
-#endif
-			;
-
 		handle_type handle = ::open(file_path.c_str()
-			, mode_array[(mode & aux::open_mode::write) ? 1 : 0] | open_mode
-			, permissions);
-
-#ifdef O_NOATIME
-		// O_NOATIME is not allowed for files we don't own
-		// so, if we get EPERM when we try to open with it
-		// try again without O_NOATIME
-		if (handle == -1 && (mode & aux::open_mode::no_atime) && errno == EPERM)
-		{
-			mode &= ~aux::open_mode::no_atime;
-			open_mode &= ~O_NOATIME;
-			handle = ::open(file_path.c_str()
-				, mode_array[(mode & aux::open_mode::write) ? 1 : 0] | open_mode
-				, permissions);
-		}
+			, ((mode & aux::open_mode::write) ? O_RDWR | O_CREAT : O_RDONLY)
+#ifdef O_BINARY
+			| O_BINARY
 #endif
-		if (handle == -1)
+			, S_IRUSR | S_IWUSR
+			| S_IRGRP | S_IWGRP
+			| S_IROTH | S_IWOTH);
+
+		if (handle == INVALID_HANDLE_VALUE)
 		{
 			ec.assign(errno, system_category());
 			TORRENT_ASSERT(ec);
@@ -417,51 +327,10 @@ namespace libtorrent {
 		}
 
 		m_file_handle = handle;
-
-#ifdef DIRECTIO_ON
-		// for solaris
-		if (mode & aux::open_mode::no_cache)
-		{
-			int yes = 1;
-			directio(native_handle(), DIRECTIO_ON);
-		}
 #endif
 
-#ifdef F_NOCACHE
-		// for BSD/Mac
-		if (mode & aux::open_mode::no_cache)
-		{
-			int yes = 1;
-			::fcntl(native_handle(), F_NOCACHE, &yes);
-
-#ifdef F_NODIRECT
-			// it's OK to temporarily cache written pages
-			::fcntl(native_handle(), F_NODIRECT, &yes);
-#endif
-		}
-#endif
-
-#ifdef POSIX_FADV_RANDOM
-		if (mode & aux::open_mode::random_access)
-		{
-			// disable read-ahead
-			// NOTE: in android this function was introduced in API 21,
-			// but the constant POSIX_FADV_RANDOM is there for lower
-			// API levels, just don't add :: to allow a macro workaround
-			posix_fadvise(native_handle(), 0, 0, POSIX_FADV_RANDOM);
-		}
-#endif
-
-#endif
-		m_open_mode = mode;
-
-		TORRENT_ASSERT(is_open());
+		TORRENT_ASSERT(m_file_handle != INVALID_HANDLE_VALUE);
 		return true;
-	}
-
-	bool file::is_open() const
-	{
-		return m_file_handle != INVALID_HANDLE_VALUE;
 	}
 
 #ifdef TORRENT_WINDOWS
@@ -506,43 +375,19 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 
 	void file::close()
 	{
-		if (!is_open()) return;
+		if (m_file_handle == INVALID_HANDLE_VALUE) return;
 
 #ifdef TORRENT_WINDOWS
-
-		// if this file is open for writing, has the sparse
-		// flag set, but there are no sparse regions, unset
-		// the flag
-		if ((m_open_mode & aux::open_mode::write)
-			&& (m_open_mode & aux::open_mode::sparse)
-			&& !is_sparse(native_handle()))
-		{
-			// according to MSDN, clearing the sparse flag of a file only
-			// works on windows vista and later
-#ifdef TORRENT_MINGW
-			typedef struct _FILE_SET_SPARSE_BUFFER {
-				BOOLEAN SetSparse;
-			} FILE_SET_SPARSE_BUFFER;
-#endif
-			DWORD temp;
-			FILE_SET_SPARSE_BUFFER b;
-			b.SetSparse = FALSE;
-			::DeviceIoControl(native_handle(), FSCTL_SET_SPARSE, &b, sizeof(b)
-				, nullptr, 0, &temp, nullptr);
-		}
-
-		CloseHandle(native_handle());
+		CloseHandle(m_file_handle);
 #else
 		if (m_file_handle != INVALID_HANDLE_VALUE)
 			::close(m_file_handle);
 #endif
 
 		m_file_handle = INVALID_HANDLE_VALUE;
-
-		m_open_mode = {};
 	}
 
-	namespace {
+namespace {
 
 	template <class Fun>
 	std::int64_t iov(Fun f, handle_type fd, std::int64_t file_offset
@@ -586,7 +431,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 		return ret;
 	}
 
-	} // anonymous namespace
+} // anonymous namespace
 
 	// this has to be thread safe and atomic. i.e. on posix systems it has to be
 	// turned into a series of pread() calls
@@ -603,9 +448,9 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 			return -1;
 		}
 		TORRENT_ASSERT(!bufs.empty());
-		TORRENT_ASSERT(is_open());
+		TORRENT_ASSERT(m_file_handle != INVALID_HANDLE_VALUE);
 
-		return iov(&read, native_handle(), file_offset, bufs, ec);
+		return iov(&read, m_file_handle, file_offset, bufs, ec);
 	}
 
 	// This has to be thread safe, i.e. atomic.
@@ -623,209 +468,41 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 #endif
 			return -1;
 		}
-		TORRENT_ASSERT(m_open_mode & aux::open_mode::write);
 		TORRENT_ASSERT(!bufs.empty());
-		TORRENT_ASSERT(is_open());
+		TORRENT_ASSERT(m_file_handle != INVALID_HANDLE_VALUE);
 
 		ec.clear();
 
-		std::int64_t ret = iov(&write, native_handle(), file_offset, bufs, ec);
+		std::int64_t ret = iov(&write, m_file_handle, file_offset, bufs, ec);
 
-#if TORRENT_USE_FDATASYNC \
-	&& !defined F_NOCACHE && \
-	!defined DIRECTIO_ON
-		if (m_open_mode & aux::open_mode::no_cache)
-		{
-			if (::fdatasync(native_handle()) != 0
-				&& errno != EINVAL
-				&& errno != ENOSYS)
-			{
-				ec.assign(errno, system_category());
-			}
-		}
-#endif
 		return ret;
 	}
 
-#ifdef TORRENT_WINDOWS
-	void acquire_manage_volume_privs()
-	{
-		using OpenProcessToken_t = BOOL (WINAPI*)(HANDLE, DWORD, PHANDLE);
-
-		using LookupPrivilegeValue_t = BOOL (WINAPI*)(LPCSTR, LPCSTR, PLUID);
-
-		using AdjustTokenPrivileges_t = BOOL (WINAPI*)(
-			HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES, PDWORD);
-
-		auto OpenProcessToken =
-			aux::get_library_procedure<aux::advapi32, OpenProcessToken_t>("OpenProcessToken");
-		auto LookupPrivilegeValue =
-			aux::get_library_procedure<aux::advapi32, LookupPrivilegeValue_t>("LookupPrivilegeValueA");
-		auto AdjustTokenPrivileges =
-			aux::get_library_procedure<aux::advapi32, AdjustTokenPrivileges_t>("AdjustTokenPrivileges");
-
-		if (OpenProcessToken == nullptr
-			|| LookupPrivilegeValue == nullptr
-			|| AdjustTokenPrivileges == nullptr)
-		{
-			return;
-		}
-
-
-		HANDLE token;
-		if (!OpenProcessToken(GetCurrentProcess()
-			, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &token))
-			return;
-
-		BOOST_SCOPE_EXIT_ALL(&token) {
-			CloseHandle(token);
-		};
-
-		TOKEN_PRIVILEGES privs{};
-		if (!LookupPrivilegeValue(nullptr, "SeManageVolumePrivilege"
-			, &privs.Privileges[0].Luid))
-		{
-			return;
-		}
-
-		privs.PrivilegeCount = 1;
-		privs.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-
-		AdjustTokenPrivileges(token, FALSE, &privs, 0, nullptr, nullptr);
-	}
-
-	void set_file_valid_data(HANDLE f, std::int64_t size)
-	{
-		using SetFileValidData_t = BOOL (WINAPI*)(HANDLE, LONGLONG);
-		auto SetFileValidData =
-			aux::get_library_procedure<aux::kernel32, SetFileValidData_t>("SetFileValidData");
-
-		if (SetFileValidData)
-		{
-			// we don't necessarily expect to have enough
-			// privilege to do this, so ignore errors.
-			SetFileValidData(f, size);
-		}
-	}
-#endif
-
 	bool file::set_size(std::int64_t s, error_code& ec)
 	{
-		TORRENT_ASSERT(is_open());
+		TORRENT_ASSERT(m_file_handle != INVALID_HANDLE_VALUE);
 		TORRENT_ASSERT(s >= 0);
 
 #ifdef TORRENT_WINDOWS
 
 		LARGE_INTEGER offs;
-		LARGE_INTEGER cur_size;
-		if (GetFileSizeEx(native_handle(), &cur_size) == FALSE)
+		offs.QuadPart = s;
+		if (SetFilePointerEx(m_file_handle, offs, &offs, FILE_BEGIN) == FALSE)
 		{
 			ec.assign(GetLastError(), system_category());
 			return false;
 		}
-		offs.QuadPart = s;
-		// only set the file size if it's not already at
-		// the right size. We don't want to update the
-		// modification time if we don't have to
-		if (cur_size.QuadPart != s)
+		if (::SetEndOfFile(m_file_handle) == FALSE)
 		{
-			if (SetFilePointerEx(native_handle(), offs, &offs, FILE_BEGIN) == FALSE)
-			{
-				ec.assign(GetLastError(), system_category());
-				return false;
-			}
-			if (::SetEndOfFile(native_handle()) == FALSE)
-			{
-				ec.assign(GetLastError(), system_category());
-				return false;
-			}
-			if (!(m_open_mode & aux::open_mode::sparse))
-			{
-				// if the user has permissions, avoid filling
-				// the file with zeroes, but just fill it with
-				// garbage instead
-				set_file_valid_data(m_file_handle, s);
-			}
+			ec.assign(GetLastError(), system_category());
+			return false;
 		}
+
 #else // NON-WINDOWS
-		struct stat st{};
-		if (::fstat(native_handle(), &st) != 0)
+		if (::ftruncate(m_file_handle, s) < 0)
 		{
 			ec.assign(errno, system_category());
 			return false;
-		}
-
-		// only truncate the file if it doesn't already
-		// have the right size. We don't want to update
-		if (st.st_size != s && ::ftruncate(native_handle(), s) < 0)
-		{
-			ec.assign(errno, system_category());
-			return false;
-		}
-
-		// if we're not in sparse mode, allocate the storage
-		// but only if the number of allocated blocks for the file
-		// is less than the file size. Otherwise we would just
-		// update the modification time of the file for no good
-		// reason.
-		if (!(m_open_mode & aux::open_mode::sparse)
-			&& std::int64_t(st.st_blocks) < (s + st.st_blksize - 1) / st.st_blksize)
-		{
-			// How do we know that the file is already allocated?
-			// if we always try to allocate the space, we'll update
-			// the modification time without actually changing the file
-			// but if we don't do anything if the file size is
-#ifdef F_PREALLOCATE
-			fstore_t f = {F_ALLOCATECONTIG, F_PEOFPOSMODE, 0, s, 0};
-			if (fcntl(native_handle(), F_PREALLOCATE, &f) < 0)
-			{
-				// MacOS returns EINVAL if the file already has the space
-				// pre-allocated. In which case we can just move on.
-				if (errno != EINVAL)
-				{
-					if (errno != ENOSPC)
-					{
-						ec.assign(errno, system_category());
-						return false;
-					}
-					// ok, let's try to allocate non contiguous space then
-					f.fst_flags = F_ALLOCATEALL;
-					if (fcntl(native_handle(), F_PREALLOCATE, &f) < 0)
-					{
-						ec.assign(errno, system_category());
-						return false;
-					}
-				}
-			}
-#endif // F_PREALLOCATE
-
-#ifdef F_ALLOCSP64
-			flock64 fl64;
-			fl64.l_whence = SEEK_SET;
-			fl64.l_start = 0;
-			fl64.l_len = s;
-			if (fcntl(native_handle(), F_ALLOCSP64, &fl64) < 0)
-			{
-				ec.assign(errno, system_category());
-				return false;
-			}
-
-#endif // F_ALLOCSP64
-
-#if TORRENT_HAS_FALLOCATE
-			// if fallocate failed, we have to use posix_fallocate
-			// which can be painfully slow
-			// if you get a compile error here, you might want to
-			// define TORRENT_HAS_FALLOCATE to 0.
-			int const ret = posix_fallocate(native_handle(), 0, s);
-			// posix_allocate fails with EINVAL in case the underlying
-			// filesystem does not support this operation
-			if (ret != 0 && ret != EINVAL && ret != ENOTSUP)
-			{
-				ec.assign(ret, system_category());
-				return false;
-			}
-#endif // TORRENT_HAS_FALLOCATE
 		}
 #endif // TORRENT_WINDOWS
 		return true;
@@ -835,7 +512,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 	{
 #ifdef TORRENT_WINDOWS
 		LARGE_INTEGER file_size;
-		if (!GetFileSizeEx(native_handle(), &file_size))
+		if (!GetFileSizeEx(m_file_handle, &file_size))
 		{
 			ec.assign(GetLastError(), system_category());
 			return -1;
@@ -843,7 +520,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 		return file_size.QuadPart;
 #else
 		struct stat fs = {};
-		if (::fstat(native_handle(), &fs) != 0)
+		if (::fstat(m_file_handle, &fs) != 0)
 		{
 			ec.assign(errno, system_category());
 			return -1;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -333,46 +333,6 @@ namespace {
 		return true;
 	}
 
-#ifdef TORRENT_WINDOWS
-	// returns true if the given file has any regions that are
-	// sparse, i.e. not allocated.
-	bool is_sparse(HANDLE file)
-	{
-		LARGE_INTEGER file_size;
-		if (!GetFileSizeEx(file, &file_size))
-			return false;
-
-#ifndef FSCTL_QUERY_ALLOCATED_RANGES
-typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
-	LARGE_INTEGER FileOffset;
-	LARGE_INTEGER Length;
-} FILE_ALLOCATED_RANGE_BUFFER;
-#define FSCTL_QUERY_ALLOCATED_RANGES ((0x9 << 16) | (1 << 14) | (51 << 2) | 3)
-#endif
-		FILE_ALLOCATED_RANGE_BUFFER in;
-		in.FileOffset.QuadPart = 0;
-		in.Length.QuadPart = file_size.QuadPart;
-
-		FILE_ALLOCATED_RANGE_BUFFER out[2];
-
-		DWORD returned_bytes = 0;
-		BOOL ret = DeviceIoControl(file, FSCTL_QUERY_ALLOCATED_RANGES, static_cast<void*>(&in), sizeof(in)
-			, out, sizeof(out), &returned_bytes, nullptr);
-
-		if (ret == FALSE)
-		{
-			return true;
-		}
-
-		// if we have more than one range in the file, we're sparse
-		if (returned_bytes != sizeof(FILE_ALLOCATED_RANGE_BUFFER)) {
-			return true;
-		}
-
-		return (in.Length.QuadPart != out[0].Length.QuadPart);
-	}
-#endif
-
 	void file::close()
 	{
 		if (m_file_handle == INVALID_HANDLE_VALUE) return;

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -39,7 +39,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/throw.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/error_code.hpp"
-#include "libtorrent/file.hpp" // for is_sparse
+
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/scope_exit.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+
 #include <cstdint>
 
 #if TORRENT_HAVE_MMAP
@@ -65,6 +69,47 @@ namespace {
 		return (mode & open_mode::write)
 			? file_size : std::min(std::int64_t(fh.get_size()), file_size);
 	}
+
+#ifdef TORRENT_WINDOWS
+	// returns true if the given file has any regions that are
+	// sparse, i.e. not allocated.
+	bool is_sparse(HANDLE file)
+	{
+		LARGE_INTEGER file_size;
+		if (!GetFileSizeEx(file, &file_size))
+			return false;
+
+#ifndef FSCTL_QUERY_ALLOCATED_RANGES
+typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
+	LARGE_INTEGER FileOffset;
+	LARGE_INTEGER Length;
+} FILE_ALLOCATED_RANGE_BUFFER;
+#define FSCTL_QUERY_ALLOCATED_RANGES ((0x9 << 16) | (1 << 14) | (51 << 2) | 3)
+#endif
+		FILE_ALLOCATED_RANGE_BUFFER in;
+		in.FileOffset.QuadPart = 0;
+		in.Length.QuadPart = file_size.QuadPart;
+
+		FILE_ALLOCATED_RANGE_BUFFER out[2];
+
+		DWORD returned_bytes = 0;
+		BOOL ret = DeviceIoControl(file, FSCTL_QUERY_ALLOCATED_RANGES, static_cast<void*>(&in), sizeof(in)
+			, out, sizeof(out), &returned_bytes, nullptr);
+
+		if (ret == FALSE)
+		{
+			return true;
+		}
+
+		// if we have more than one range in the file, we're sparse
+		if (returned_bytes != sizeof(FILE_ALLOCATED_RANGE_BUFFER)) {
+			return true;
+		}
+
+		return (in.Length.QuadPart != out[0].Length.QuadPart);
+	}
+
+#endif
 } // anonymous
 
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE


### PR DESCRIPTION
the `file` class is only used in the part file, torrent_info (when loading from file) and in tests. It no longer needs these bells an whistles, and I would like to move it into a test utility class, and have the part file use the same file abstraction as its storage, and `torrent_info` should just use something simpler.