### PR TITLE
fix incorrect mapping of error code to error string

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -384,8 +384,10 @@ TORRENT_VERSION_NAMESPACE_2
 		error_code const error;
 	};
 
-	// This alert is generated when a limit is reached that might have a negative impact on
-	// upload or download rate performance.
+	// This alert is generated when a limit is reached that might have
+	// a negative impact on upload or download rate performance.
+	// NOTE: any additions to this enum should have a corresponding entry
+	//   added to the `warning_str` map in alert.cpp
 	struct TORRENT_EXPORT performance_alert final : torrent_alert
 	{
 		enum performance_warning_t


### PR DESCRIPTION
This fixes a slightly maddening issue where the enum of error codes didn't line up with the human readable error strings.

The map overhead is only incurred when converting to a human-readable string, so I assume it is acceptable.

It might not be apparent from the diff, but check out the location of the bittyrant message in the enum vs. the string list.