### PR TITLE
Tweak Peer Turnover prioritisation...

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7429,10 +7429,6 @@ bool is_downloading_state(int const st)
 		if (lhs->on_parole() != rhs->on_parole())
 			return lhs->on_parole();
 
-		// prefer to disconnect peers that chokes us
-		if (lhs->is_choked() != rhs->is_choked())
-			return lhs->is_choked();
-
 		// prefer to disconnect peers that send data at a lower rate over those waiting to download
 		// the assumption is that a connection waiting to start downloading has the same potential 
 		// to be faster than the current slowest downloading connection than a new connection that 
@@ -7471,6 +7467,11 @@ bool is_downloading_state(int const st)
 			if (lhs_transferred != rhs_transferred)
 				return lhs_transferred < rhs_transferred;
 		}
+
+		// prefer to disconnect peers that chokes us
+		// this code dropped with agreement from @arvidn
+		// if (lhs->is_choked() != rhs->is_choked())
+		//	return lhs->is_choked();
 
 		// if none of the above preferences apply then ...
 		// prefer to disconnect peers that have been silent longest


### PR DESCRIPTION
... to prefer peers still waiting to download over the slowest actually downloading.

This is a partial solution to the issue discussed in #4989.

Peer Turnover only applies when most connection slots are in use, and the primary purpose is to free up the least beneficial connection slots in the hope that LibTorrent can find a faster download peer.

Previously a connection which has been made but which has not yet started downloading is preferred for disconnect over the slowest downloading connection.

The primary aim of this change is to prioritise connections that are waiting to start downloading over the slowest actually downloading on  the assumption that a connection that has already been made but is waiting to start downloading has the same chance of being faster than any new connection - and we should not lose the time already spent waiting by disconnecting and making a new connection that then waits. 

This is perhaps a bit simplistic, because it leaves LibTorrent open to keeping (potentially malicious) connections open that are (perhaps deliberately) never going to start downloading. To avoid this we will limit the above change to connections which have been waiting less than Peer_Turnover_Maximum_Wait and retain the current preference of disconnecting the waiting connection if it has been waiting longer than this, For this commit Peer_Turnover_Maximum_Wait is a hardcoded constant but this can be changed to a configurable setting in a future commit.