### PR TITLE
Alloca improvement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix to avoid large stack allocations
+
 1.2.9 released
 
 	* add macro TORRENT_CXX11_ABI for clients building with C++14 against

--- a/include/libtorrent/aux_/alloca.hpp
+++ b/include/libtorrent/aux_/alloca.hpp
@@ -77,36 +77,26 @@ struct alloca_destructor
 #if defined TORRENT_WINDOWS || defined TORRENT_MINGW
 
 #include <malloc.h>
-#define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::ptrdiff_t>(n); \
-	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(_alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
-	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); \
-	::libtorrent::aux::uninitialized_default_construct(v.begin(), v.end()); \
-	} \
-	::libtorrent::aux::alloca_destructor<t> v##_destructor{v}
+#define TORRENT_ALLOCA_FUN _alloca
 
 #elif defined TORRENT_BSD
 
 #include <stdlib.h>
-#define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
-	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::ptrdiff_t>(n); \
-	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
-	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); \
-	::libtorrent::aux::uninitialized_default_construct(v.begin(), v.end()); \
-	} \
-	::libtorrent::aux::alloca_destructor<t> v##_destructor{v}
+#define TORRENT_ALLOCA_FUN alloca
 
 #else
 
 #include <alloca.h>
+#define TORRENT_ALLOCA_FUN alloca
+
+#endif
+
 #define TORRENT_ALLOCA(v, t, n) ::libtorrent::span<t> v; { \
 	auto TORRENT_ALLOCA_size = ::libtorrent::aux::numeric_cast<std::ptrdiff_t>(n); \
-	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(alloca(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
+	auto* TORRENT_ALLOCA_tmp = static_cast<t*>(TORRENT_ALLOCA_FUN(sizeof(t) * static_cast<std::size_t>(TORRENT_ALLOCA_size))); \
 	v = ::libtorrent::span<t>(TORRENT_ALLOCA_tmp, TORRENT_ALLOCA_size); \
 	::libtorrent::aux::uninitialized_default_construct(v.begin(), v.end()); \
 	} \
 	::libtorrent::aux::alloca_destructor<t> v##_destructor{v}
-
-#endif
 
 #endif // TORRENT_ALLOCA_HPP_INCLUDED

--- a/test/test_alloca.cpp
+++ b/test/test_alloca.cpp
@@ -71,3 +71,12 @@ TORRENT_TEST(alloca_destruct)
 	TEST_EQUAL(destructed, 3);
 }
 
+TORRENT_TEST(alloca_large)
+{
+	// this is something like 256 kiB of allocation
+	// it should be made on the heap and always succeed
+	TORRENT_ALLOCA(vec, A, 65536);
+	for (auto const& a : vec)
+		TEST_EQUAL(a.val, 1337);
+}
+


### PR DESCRIPTION
attempted allocations larger than 4kiB are made on the heap, instead of the stack