### PR TITLE
remove old work-around

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -95,10 +95,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/session_settings.hpp"
 #endif
 
-#if TORRENT_COMPLETE_TYPES_REQUIRED
-#include "libtorrent/peer_connection.hpp"
-#endif
-
 #include <algorithm>
 #include <vector>
 #include <set>
@@ -120,6 +116,7 @@ TORRENT_VERSION_NAMESPACE_3_END
 	struct lsd;
 	struct alert;
 	struct torrent_handle;
+	struct peer_connection;
 
 namespace dht {
 

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -97,10 +97,6 @@ POSSIBILITY OF SUCH DAMAGE.
     #include "libtorrent/aux_/rtc_stream.hpp"
 #endif
 
-#if TORRENT_COMPLETE_TYPES_REQUIRED
-#include "libtorrent/peer_connection.hpp"
-#endif
-
 // define as 0 to disable. 1 enables debug output of the pieces and requested
 // blocks. 2 also enables trace output of the time critical piece picking
 // logic

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -62,17 +62,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wformat-extra-args"
 #endif
 
-#if defined __GNUC__
-
-#ifdef _GLIBCXX_CONCEPT_CHECKS
-#define TORRENT_COMPLETE_TYPES_REQUIRED 1
-#endif
-
 // ======= SUNPRO =========
 
-#elif defined __SUNPRO_CC
-
-#define TORRENT_COMPLETE_TYPES_REQUIRED 1
+#if defined __SUNPRO_CC
 
 // ======= MSVC =========
 
@@ -414,10 +406,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef TORRENT_USE_MADVISE
 #define TORRENT_USE_MADVISE 0
-#endif
-
-#ifndef TORRENT_COMPLETE_TYPES_REQUIRED
-#define TORRENT_COMPLETE_TYPES_REQUIRED 0
 #endif
 
 #ifndef TORRENT_USE_FDATASYNC

--- a/include/libtorrent/entry.hpp
+++ b/include/libtorrent/entry.hpp
@@ -281,15 +281,8 @@ namespace libtorrent {
 	private:
 
 		aux::aligned_union<1
-#if TORRENT_COMPLETE_TYPES_REQUIRED
-			// for implementations that require complete types, use char and hope
-			// for the best
-			, std::list<char>
-			, std::map<std::string, char>
-#else
 			, list_type
 			, dictionary_type
-#endif
 			, preformatted_type
 			, string_type
 			, integer_type


### PR DESCRIPTION
for standard libraries that required complete types in containers1