### PR TITLE
use a different error code than host-unreachable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* use a different error code than host-unreachable, when skipping tracker announces
+
 1.2.10 released
 
 	* fix regression in python binding for move_storage()

--- a/include/libtorrent/error_code.hpp
+++ b/include/libtorrent/error_code.hpp
@@ -428,6 +428,9 @@ namespace libtorrent {
 			invalid_tracker_transaction_id,
 			// invalid action field in UDP tracker response
 			invalid_tracker_action,
+			// skipped announce (because it's assumed to be unreachable over the
+			// given source network interface)
+			announce_skipped,
 
 #if TORRENT_ABI_VERSION == 1
 			// expected string in bencoded string

--- a/src/error_code.cpp
+++ b/src/error_code.cpp
@@ -245,8 +245,7 @@ namespace libtorrent {
 			"udp tracker response packet has invalid size",
 			"invalid transaction id in udp tracker response",
 			"invalid action field in udp tracker response",
-#if TORRENT_ABI_VERSION == 1
-			"",
+			"skipping tracker announce (unreachable)",
 			"",
 			"",
 			"",
@@ -257,6 +256,7 @@ namespace libtorrent {
 			"",
 			"",
 
+#if TORRENT_ABI_VERSION == 1
 // bdecode errors
 			"expected string in bencoded string",
 			"expected colon in bencoded string",
@@ -269,7 +269,8 @@ namespace libtorrent {
 			"",
 			"",
 #else
-			"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+			"", "", "", "", "",
+			"", "", "", "", "",
 #endif
 			"random number generator failed",
 		};

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -282,7 +282,7 @@ namespace libtorrent {
 
 		if (endpoints.empty())
 		{
-			fail(error_code(boost::system::errc::host_unreachable, system_category()));
+			fail(lt::errors::announce_skipped);
 			return;
 		}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -11126,7 +11126,8 @@ bool is_downloading_state(int const st)
 #endif
 					// don't try to announce from this endpoint again
 					if (ec == boost::system::errc::address_family_not_supported
-						|| ec == boost::system::errc::host_unreachable)
+						|| ec == boost::system::errc::host_unreachable
+						|| ec == lt::errors::announce_skipped)
 					{
 						aep->enabled = false;
 #ifndef TORRENT_DISABLE_LOGGING

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -217,7 +217,7 @@ namespace libtorrent {
 
 		if (m_endpoints.empty())
 		{
-			fail(error_code(boost::system::errc::host_unreachable, generic_category()));
+			fail(lt::errors::announce_skipped);
 			return;
 		}
 


### PR DESCRIPTION
when skipping tracker announces