### PR TITLE
disable use of SetFileValidData() by default (windows).

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+	* disable use of SetFileValidData() by default (windows). A new setting
+	  allows enabling it
+
 2.0 release
 
 	* dropped depenency on iconv

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -586,3 +586,4 @@ libgnutls
 0x200000
 golang
 img
+SetFileValidData

--- a/include/libtorrent/aux_/open_mode.hpp
+++ b/include/libtorrent/aux_/open_mode.hpp
@@ -52,6 +52,7 @@ namespace aux {
 		constexpr open_mode_t hidden = 5_bit;
 		constexpr open_mode_t sparse = 6_bit;
 		constexpr open_mode_t executable = 7_bit;
+		constexpr open_mode_t allow_set_file_valid_data = 8_bit;
 	}
 } // aux
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -940,6 +940,14 @@ namespace aux {
 			// HTTPS trackers to fail.
 			validate_https_trackers,
 
+			// when set to true, enables the attempt to use SetFileValidData()
+			// to pre-allocate disk space. This system call will only work when
+			// running with Administrator privileges on Windows, and so this
+			// setting is only relevant in that scenario. Using
+			// SetFileValidData() poses a security risk, as it may reveal
+			// previously deleted information from the disk.
+			enable_set_file_valid_data,
+
 			max_bool_setting_internal
 		};
 

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -215,7 +215,9 @@ file_handle::file_handle(string_view name, std::int64_t const size
 		::DeviceIoControl(m_fd, FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, &temp, nullptr);
 	}
 
-	if ((mode & open_mode::truncate) && !(mode & aux::open_mode::sparse))
+	if ((mode & open_mode::truncate)
+		&& !(mode & aux::open_mode::sparse)
+		&& (mode & aux::open_mode::allow_set_file_valid_data))
 	{
 		LARGE_INTEGER sz;
 		sz.QuadPart = size;

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -802,6 +802,13 @@ namespace libtorrent {
 			mode |= (m_file_created[file] == false) ? aux::open_mode::truncate : aux::open_mode::read_only;
 		}
 
+#ifdef _WIN32
+		if (sett.get_bool(settings_pack::enable_set_file_valid_data))
+		{
+			mode |= aux::open_mode::allow_set_file_valid_data;
+		}
+#endif
+
 		boost::optional<aux::file_view> h = open_file_impl(sett, file, mode, ec.ec);
 		if ((mode & aux::open_mode::write)
 			&& ec.ec == boost::system::errc::no_such_file_or_directory)

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -217,6 +217,7 @@ namespace libtorrent {
 		SET(dht_read_only, false, nullptr),
 		SET(piece_extent_affinity, false, nullptr),
 		SET(validate_https_trackers, false, &session_impl::update_validate_https),
+		SET(enable_set_file_valid_data, false, nullptr),
 	}});
 
 	CONSTEXPR_SETTINGS


### PR DESCRIPTION
A new setting allows enabling it.