### PR TITLE
separate directory class from file.hpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,6 +582,7 @@ HEADERS = \
   aux_/deprecated.hpp               \
   aux_/deque.hpp                    \
   aux_/dev_random.hpp               \
+  aux_/directory.hpp                \
   aux_/disable_deprecation_warnings_push.hpp \
   aux_/disable_warnings_pop.hpp     \
   aux_/disable_warnings_push.hpp    \
@@ -594,6 +595,7 @@ HEADERS = \
   aux_/escape_string.hpp            \
   aux_/export.hpp                   \
   aux_/ffs.hpp                      \
+  aux_/file_pointer.hpp             \
   aux_/file_progress.hpp            \
   aux_/file_view_pool.hpp           \
   aux_/generate_peer_id.hpp         \

--- a/include/libtorrent/aux_/directory.hpp
+++ b/include/libtorrent/aux_/directory.hpp
@@ -31,21 +31,11 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#ifndef TORRENT_FILE_HPP_INCLUDED
-#define TORRENT_FILE_HPP_INCLUDED
+#ifndef TORRENT_DIRECTORY_HPP_INCLUDED
+#define TORRENT_DIRECTORY_HPP_INCLUDED
 
-#include <memory>
 #include <string>
-#include <functional>
-
-#include "libtorrent/config.hpp"
-#include "libtorrent/string_view.hpp"
-#include "libtorrent/span.hpp"
-#include "libtorrent/aux_/storage_utils.hpp"
-#include "libtorrent/aux_/open_mode.hpp"
-#include "libtorrent/flags.hpp"
-
-#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include "libtorrent/error_code.hpp"
 
 #ifdef TORRENT_WINDOWS
 // windows part
@@ -54,65 +44,36 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/types.h>
 #else
 // posix part
-#define _FILE_OFFSET_BITS 64
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600
-#endif
-
-#include <unistd.h>
-#include <sys/uio.h>
-#include <fcntl.h>
-#include <sys/types.h>
 #include <dirent.h> // for DIR
 
-#undef _FILE_OFFSET_BITS
-
 #endif
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
-#include "libtorrent/error_code.hpp"
-#include "libtorrent/assert.hpp"
-#include "libtorrent/time.hpp"
-
 namespace libtorrent {
+namespace aux {
 
+struct TORRENT_EXTRA_EXPORT directory
+{
+	directory(std::string const& path, error_code& ec);
+	~directory();
+
+	directory(directory const&) = delete;
+	directory& operator=(directory const&) = delete;
+
+	void next(error_code& ec);
+	std::string file() const;
+	bool done() const { return m_done; }
+private:
 #ifdef TORRENT_WINDOWS
-	using handle_type = HANDLE;
+	HANDLE m_handle;
+	WIN32_FIND_DATAW m_fd;
 #else
-	using handle_type = int;
+	DIR* m_handle;
+	std::string m_name;
 #endif
+	bool m_done;
+};
 
-	struct TORRENT_EXTRA_EXPORT file
-	{
-		file();
-		file(std::string const& p, aux::open_mode_t m, error_code& ec);
-		file(file&&) noexcept;
-		file& operator=(file&&);
-		~file();
 
-		file(file const&) = delete;
-		file& operator=(file const&) = delete;
-
-		bool open(std::string const& p, aux::open_mode_t m, error_code& ec);
-		void close();
-		bool set_size(std::int64_t size, error_code& ec);
-
-		std::int64_t writev(std::int64_t file_offset, span<iovec_t const> bufs
-			, error_code& ec, aux::open_mode_t flags = {});
-		std::int64_t readv(std::int64_t file_offset, span<iovec_t const> bufs
-			, error_code& ec, aux::open_mode_t flags = {});
-
-		std::int64_t get_size(error_code& ec) const;
-
-	private:
-		handle_type m_file_handle;
-	};
 }
-
-#endif // TORRENT_FILE_HPP_INCLUDED
+}
+#endif

--- a/include/libtorrent/aux_/file_pointer.hpp
+++ b/include/libtorrent/aux_/file_pointer.hpp
@@ -1,0 +1,57 @@
+/*
+
+Copyright (c) 2020, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_FILE_POINTER_HPP
+#define TORRENT_FILE_POINTER_HPP
+
+#include <cstdio>
+
+namespace libtorrent {
+namespace aux {
+
+struct file_pointer
+{
+	file_pointer(FILE* p) : ptr(p) {}
+	~file_pointer() { if (ptr != nullptr) fclose(ptr); }
+	file_pointer(file_pointer const&) = delete;
+	file_pointer(file_pointer&& f) : ptr(f.ptr) { f.ptr = nullptr; }
+	file_pointer& operator=(file_pointer const&) = delete;
+	file_pointer& operator=(file_pointer&&) = delete;
+	FILE* file() const { return ptr; }
+private:
+	FILE* ptr;
+};
+
+}
+}
+
+#endif

--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -44,7 +44,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <memory>
 
-#include "libtorrent/file.hpp"
 #include "libtorrent/aux_/time.hpp"
 #include "libtorrent/units.hpp"
 #include "libtorrent/storage_defs.hpp"

--- a/include/libtorrent/aux_/posix_storage.hpp
+++ b/include/libtorrent/aux_/posix_storage.hpp
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/storage_utils.hpp" // for iovec_t
 #include "libtorrent/hex.hpp" // to_hex
 #include "libtorrent/aux_/open_mode.hpp" // for aux::open_mode_t
+#include "libtorrent/aux_/file_pointer.hpp"
 #include "libtorrent/part_file.hpp"
 #include <memory>
 #include <string>
@@ -87,7 +88,7 @@ namespace aux {
 
 	private:
 
-		FILE* open_file(file_index_t idx, open_mode_t mode, std::int64_t offset
+		file_pointer open_file(file_index_t idx, open_mode_t mode, std::int64_t offset
 			, storage_error& ec);
 
 		void need_partfile();

--- a/include/libtorrent/part_file.hpp
+++ b/include/libtorrent/part_file.hpp
@@ -48,6 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/units.hpp"
 #include "libtorrent/hasher.hpp"
 #include "libtorrent/aux_/open_mode.hpp"
+#include "libtorrent/aux_/storage_utils.hpp" // for iovec_t
 
 namespace libtorrent {
 

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -45,7 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
 #include "libtorrent/session.hpp" // for default_disk_io_constructor
-#include "libtorrent/file.hpp" // for directory
+#include "libtorrent/aux_/directory.hpp"
 #include "libtorrent/disk_interface.hpp"
 
 #include <sys/types.h>
@@ -120,7 +120,7 @@ namespace {
 
 		if (recurse)
 		{
-			for (directory i(f, ec); !i.done(); i.next(ec))
+			for (aux::directory i(f, ec); !i.done(); i.next(ec))
 			{
 				std::string const leaf = i.file();
 				if (ignore_subdir(leaf)) continue;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/config.hpp"
+#include "libtorrent/aux_/directory.hpp"
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include "libtorrent/span.hpp"
 #include <mutex> // for call_once
@@ -173,6 +174,8 @@ namespace {
 }
 #endif
 
+namespace aux {
+
 	directory::directory(std::string const& path, error_code& ec)
 		: m_done(false)
 	{
@@ -257,6 +260,8 @@ namespace {
 		}
 #endif
 	}
+
+} // namespace aux
 
 	file::file() : m_file_handle(INVALID_HANDLE_VALUE) {}
 

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -69,6 +69,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/path.hpp"
+#include "libtorrent/aux_/storage_utils.hpp" // for iovec_t
 
 #include <functional> // for std::function
 #include <cstdint>

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -72,7 +72,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/path.hpp"
-#include "libtorrent/file.hpp" // for directory
+#include "libtorrent/aux_/directory.hpp"
 #include "libtorrent/string_util.hpp"
 #include <cstring>
 
@@ -412,7 +412,7 @@ namespace {
 		{
 			create_directory(new_path, ec);
 			if (ec) return;
-			for (directory i(old_path, ec); !i.done(); i.next(ec))
+			for (aux::directory i(old_path, ec); !i.done(); i.next(ec))
 			{
 				std::string f = i.file();
 				if (f == ".." || f == ".") continue;
@@ -917,7 +917,7 @@ namespace {
 
 		if (s.mode & file_status::directory)
 		{
-			for (directory i(f, ec); !i.done(); i.next(ec))
+			for (aux::directory i(f, ec); !i.done(); i.next(ec))
 			{
 				if (ec) return;
 				std::string p = i.file();

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -36,7 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/posix_storage.hpp"
 #include "libtorrent/aux_/path.hpp" // for bufs_size
 #include "libtorrent/aux_/open_mode.hpp"
-#include "libtorrent/aux_/scope_end.hpp"
+#include "libtorrent/aux_/file_pointer.hpp"
 #include "libtorrent/torrent_status.hpp"
 #ifdef TORRENT_WINDOWS
 #include "libtorrent/utf8.hpp"
@@ -99,14 +99,13 @@ namespace aux {
 					m_part_file->export_file([this, i, &ec](std::int64_t file_offset, span<char> buf)
 					{
 						// move stuff out of the part file
-						FILE* const f = open_file(i, open_mode::write, file_offset, ec);
+						file_pointer const f = open_file(i, open_mode::write, file_offset, ec);
 						if (ec) return;
-						auto sc = scope_end([f]{ fclose(f); });
 						int const r = static_cast<int>(fwrite(buf.data(), 1
-							, static_cast<std::size_t>(buf.size()), f));
+							, static_cast<std::size_t>(buf.size()), f.file()));
 						if (r != buf.size())
 						{
-							if (ferror(f)) ec.ec.assign(errno, generic_category());
+							if (ferror(f.file())) ec.ec.assign(errno, generic_category());
 							else ec.ec.assign(errors::file_too_short, libtorrent_category());
 							return;
 						}
@@ -179,10 +178,9 @@ namespace aux {
 				return ret;
 			}
 
-			FILE* const f = open_file(file_index, open_mode::read_only
+			file_pointer const f = open_file(file_index, open_mode::read_only
 				, file_offset, ec);
 			if (ec.ec) return -1;
-			auto sc = scope_end([f]{ fclose(f); });
 
 			// set this unconditionally in case the upper layer would like to treat
 			// short reads as errors
@@ -192,10 +190,10 @@ namespace aux {
 			for (auto buf : vec)
 			{
 				int const r = static_cast<int>(fread(buf.data(), 1
-					, static_cast<std::size_t>(buf.size()), f));
+					, static_cast<std::size_t>(buf.size()), f.file()));
 				if (r == 0)
 				{
-					if (ferror(f)) ec.ec.assign(errno, generic_category());
+					if (ferror(f.file())) ec.ec.assign(errno, generic_category());
 					else ec.ec.assign(errors::file_too_short, libtorrent_category());
 					break;
 				}
@@ -256,10 +254,9 @@ namespace aux {
 				return ret;
 			}
 
-			FILE* const f = open_file(file_index, open_mode::write
+			file_pointer const f = open_file(file_index, open_mode::write
 				, file_offset, ec);
 			if (ec.ec) return -1;
-			auto sc = scope_end([f]{ fclose(f); });
 
 			// set this unconditionally in case the upper layer would like to treat
 			// short reads as errors
@@ -269,10 +266,10 @@ namespace aux {
 			for (auto buf : vec)
 			{
 				auto const r = static_cast<int>(fwrite(buf.data(), 1
-					, static_cast<std::size_t>(buf.size()), f));
+					, static_cast<std::size_t>(buf.size()), f.file()));
 				if (r != buf.size())
 				{
-					if (ferror(f)) ec.ec.assign(errno, generic_category());
+					if (ferror(f.file())) ec.ec.assign(errno, generic_category());
 					else ec.ec.assign(errors::file_too_short, libtorrent_category());
 					break;
 				}
@@ -497,21 +494,20 @@ namespace aux {
 					// there's a race here and some other process truncates the file,
 					// it's not a problem, we won't access empty files ever again
 					ec.ec.clear();
-					FILE* f = open_file(file_index, aux::open_mode::write, 0, ec);
+					file_pointer f = open_file(file_index, aux::open_mode::write, 0, ec);
 					if (ec)
 					{
 						ec.file(file_index);
 						ec.operation = operation_t::file_fallocate;
 						return;
 					}
-					fclose(f);
 				}
 			}
 			ec.ec.clear();
 		}
 	}
 
-	FILE* posix_storage::open_file(file_index_t idx, open_mode_t const mode
+	file_pointer posix_storage::open_file(file_index_t idx, open_mode_t const mode
 		, std::int64_t const offset, storage_error& ec)
 	{
 		std::string const fn = files().file_path(idx, m_save_path);
@@ -586,7 +582,6 @@ namespace aux {
 				ec.ec.assign(errno, generic_category());
 				ec.file(idx);
 				ec.operation = operation_t::file_seek;
-				fclose(f);
 				return nullptr;
 			}
 		}

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/hasher.hpp"
 #include "libtorrent/entry.hpp"
 #include "libtorrent/aux_/path.hpp"
-#include "libtorrent/file.hpp"
+#include "libtorrent/aux_/open_mode.hpp"
 #include "libtorrent/utf8.hpp"
 #include "libtorrent/time.hpp"
 #include "libtorrent/random.hpp"
@@ -54,6 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/announce_entry.hpp"
 #include "libtorrent/hex.hpp" // to_hex
 #include "libtorrent/aux_/numeric_cast.hpp"
+#include "libtorrent/aux_/file_pointer.hpp"
 #include "libtorrent/disk_interface.hpp" // for default_block_size
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
@@ -63,6 +64,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 #include <unordered_set>
 #include <cstdint>
+#include <cstdio>
 #include <cinttypes>
 #include <iterator>
 #include <algorithm>
@@ -664,20 +666,47 @@ namespace {
 		, error_code& ec, int const max_buffer_size = 80000000)
 	{
 		ec.clear();
-		file f;
-		if (!f.open(filename, aux::open_mode::read_only, ec)) return -1;
-		std::int64_t const s = f.get_size(ec);
-		if (ec) return -1;
+		aux::file_pointer f(std::fopen(filename.c_str(), "rb"));
+		if (f.file() == nullptr)
+		{
+			ec.assign(errno, generic_category());
+			return -1;
+		}
+
+		if (std::fseek(f.file(), 0, SEEK_END) < 0)
+		{
+			ec.assign(errno, generic_category());
+			return -1;
+		}
+		std::int64_t const s = std::ftell(f.file());
+		if (s < 0)
+		{
+			ec.assign(errno, generic_category());
+			return -1;
+		}
 		if (s > max_buffer_size)
 		{
 			ec = errors::metadata_too_large;
 			return -1;
 		}
+		if (std::fseek(f.file(), 0, SEEK_SET) < 0)
+		{
+			ec.assign(errno, generic_category());
+			return -1;
+		}
 		v.resize(std::size_t(s));
 		if (s == 0) return 0;
-		std::int64_t const read = f.readv(0, {v}, ec);
-		if (read != s) return -3;
-		if (ec) return -3;
+		std::size_t const read = std::fread(v.data(), 1, v.size(), f.file());
+		if (read != std::size_t(s))
+		{
+			if (std::feof(f.file()))
+			{
+				v.resize(read);
+				return 0;
+			}
+			ec.assign(errno, generic_category());
+			return -1;
+		}
 		return 0;
 	}
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "libtorrent/file.hpp"
+#include "libtorrent/aux_/directory.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/string_view.hpp"
@@ -138,7 +139,7 @@ TORRENT_TEST(directory)
 	touch_file(combine_path("file_test_dir", "ghi"), 1000);
 
 	std::set<std::string> files;
-	for (directory i("file_test_dir", ec); !i.done(); i.next(ec))
+	for (aux::directory i("file_test_dir", ec); !i.done(); i.next(ec))
 	{
 		std::string f = i.file();
 		TEST_CHECK(files.count(f) == 0);
@@ -155,7 +156,7 @@ TORRENT_TEST(directory)
 
 	recursive_copy("file_test_dir", "file_test_dir2", ec);
 
-	for (directory i("file_test_dir2", ec); !i.done(); i.next(ec))
+	for (aux::directory i("file_test_dir2", ec); !i.done(); i.next(ec))
 	{
 		std::string f = i.file();
 		TEST_CHECK(files.count(f) == 0);
@@ -651,7 +652,7 @@ TORRENT_TEST(unc_tests)
 
 	std::set<std::string> files;
 
-	for (lt::directory i(long_dir_name, ec); !i.done(); i.next(ec))
+	for (lt::aux::directory i(long_dir_name, ec); !i.done(); i.next(ec))
 	{
 		std::string f = i.file();
 		files.insert(f);


### PR DESCRIPTION
use fopen/fclose/fread in torrent_info, instead of file class. introduce a light abstraction around FILE*