### PR TITLE
Update and clarify docs around torrent_handle::is_valid(). Closes #5112

### DIFF
--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -811,12 +811,15 @@ namespace libtorrent {
 		// the swarm. This operation cannot fail. When it completes, you will
 		// receive a torrent_removed_alert.
 		//
+		// remove_torrent() is non-blocking, but will remove the torrent from the
+		// session synchronously. Calling session_handle::add_torrent() immediately
+		// afterward with the same torrent will succeed. Note that this creates a
+		// new handle which is not equal to the removed one.
+		//
 		// The optional second argument ``options`` can be used to delete all the
 		// files downloaded by this torrent. To do so, pass in the value
-		// ``session_handle::delete_files``. The removal of the torrent is asynchronous,
-		// there is no guarantee that adding the same torrent immediately after
-		// it was removed will not throw a system_error exception. Once
-		// the torrent is deleted, a torrent_deleted_alert is posted.
+		// ``session_handle::delete_files``. Once the torrent is deleted, a
+		// torrent_deleted_alert is posted.
 		//
 		// Note that when a queued or downloading torrent is removed, its position
 		// in the download queue is vacated and every subsequent torrent in the
@@ -824,6 +827,18 @@ namespace libtorrent {
 		// large state_update to be posted. When removing all torrents, it is
 		// advised to remove them from the back of the queue, to minimize the
 		// shifting.
+		//
+		// The torrent_handle remains valid for some time after remove_torrent() is
+		// called. It will become invalid only after all libtorrent tasks (such as
+		// I/O tasks) release their references to the torrent. Until this happens,
+		// torrent_handle::is_valid() will return true, and other calls such
+		// as torrent_handle::status() will succeed. Because of this, and because
+		// remove_torrent() is non-blocking, the following sequence usually
+		// succeeds (does not throw system_error):
+		// .. code:: c++
+		//
+		//	session.remove_handle(handle);
+		//	handle.save_resume_data();
 		void remove_torrent(const torrent_handle& h, remove_flags_t options = {});
 
 		// Applies the settings specified by the settings_pack ``s``. This is an

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -545,12 +545,20 @@ namespace aux {
 
 		// Returns true if this handle refers to a valid torrent and false if it
 		// hasn't been initialized or if the torrent it refers to has been
-		// aborted. Note that a handle may become invalid after it has been added
-		// to the session. Usually this is because the storage for the torrent is
-		// somehow invalid or if the filenames are not allowed (and hence cannot
-		// be opened/created) on your filesystem. If such an error occurs, a
-		// file_error_alert is generated and all handles that refers to that
-		// torrent will become invalid.
+		// removed from the session AND destructed.
+		//
+		// To tell if the torrent_handle is in the session, use
+		// torrent_handle::in_session(). This will return true before
+		// session_handle::remove_torrent() is called, and false
+		// afterward.
+		//
+		// Clients should only use is_valid() to determine if the result of
+		// session::find_torrent() was successful.
+		//
+		// Unlike other member functions which return a value, is_valid()
+		// completes immediately, without blocking on a result from the
+		// network thread. Also unlike other functions, it never throws
+		// the system_error exception.
 		bool is_valid() const;
 
 		// will delay the disconnect of peers that we're still downloading
@@ -694,14 +702,17 @@ namespace aux {
 		//	extern int outstanding_resume_data; // global counter of outstanding resume data
 		//	std::vector<torrent_handle> handles = ses.get_torrents();
 		//	ses.pause();
-		//	for (torrent_handle const& h : handles)
+		//	for (torrent_handle const& h : handles) try
 		//	{
-		//		if (!h.is_valid()) continue;
 		//		torrent_status s = h.status();
 		//		if (!s.has_metadata || !s.need_save_resume_data()) continue;
 		//
 		//		h.save_resume_data();
 		//		++outstanding_resume_data;
+		//	}
+		//	catch (lt::system_error const& e)
+		//	{
+		//		// the handle was invalid, ignore this one and move to the next
 		//	}
 		//
 		//	while (outstanding_resume_data > 0)
@@ -1267,6 +1278,13 @@ namespace aux {
 		// i.e. the ``TORRENT_`` macros must match between libtorrent and the
 		// client builds.
 		std::shared_ptr<torrent> native_handle() const;
+
+		// Returns true if the torrent is in the session. It returns true before
+		// session::remove_torrent() is called, and false afterward.
+		//
+		// Note that this is a blocking function, unlike torrent_handle::is_valid()
+		// which returns immediately.
+		bool in_session() const;
 
 	private:
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -863,6 +863,9 @@ namespace libtorrent {
 		return std::size_t(*reinterpret_cast<void* const*>(&th.m_torrent));
 	}
 
+	bool torrent_handle::in_session() const
+	{ return !sync_call_ret<bool>(false, &torrent::is_aborted); }
+
 	static_assert(std::is_nothrow_move_constructible<torrent_handle>::value
 		, "should be nothrow move constructible");
 	static_assert(std::is_nothrow_move_assignable<torrent_handle>::value

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -891,3 +891,16 @@ TORRENT_TEST(redundant_add_piece)
 	h.add_piece(piece_index_t{0}, piece_data.data());
 	std::this_thread::sleep_for(lt::seconds(2));
 }
+
+TORRENT_TEST(test_in_session)
+{
+	lt::session ses(settings());
+	std::shared_ptr<torrent_info> ti = generate_torrent();
+	add_torrent_params p;
+	p.ti = ti;
+	p.save_path = ".";
+	torrent_handle h = ses.add_torrent(p);
+	TEST_CHECK(h.in_session());
+	ses.remove_torrent(h);
+	TEST_CHECK(!h.in_session());
+}


### PR DESCRIPTION
Assuming my understanding in #5112 is right, I'd like to update the documentation around `torrent_handle::is_valid()` and `torrent_removed_alert`. If it's not right, please let me know :)

I wasn't sure if the current practice for things like this is to merge into RC_1_2 or RC_2_0. Let me know and I can fix

Closes: #5112.