### PR TITLE
WebTorrent:  Fix peer list sorting

### DIFF
--- a/include/libtorrent/aux_/peer_list.hpp
+++ b/include/libtorrent/aux_/peer_list.hpp
@@ -97,7 +97,7 @@ namespace libtorrent::aux {
 #endif
 
 #if TORRENT_USE_RTC
-        torrent_peer* add_rtc_peer(string_view peer_id
+        torrent_peer* add_rtc_peer(tcp::endpoint const& remote
             , peer_source_flags_t src, pex_flags_t flags
             , torrent_state* state);
 #endif

--- a/include/libtorrent/aux_/rtc_signaling.hpp
+++ b/include/libtorrent/aux_/rtc_signaling.hpp
@@ -73,7 +73,7 @@ struct rtc_offer
 struct TORRENT_EXTRA_EXPORT rtc_signaling final : std::enable_shared_from_this<rtc_signaling>
 {
 	using offers_handler = std::function<void(error_code const&, std::vector<rtc_offer> const&)>;
-	using rtc_stream_handler = std::function<void(peer_id const &pid, rtc_stream_init)>;
+	using rtc_stream_handler = std::function<void(rtc_stream_init)>;
 
 	explicit rtc_signaling(io_context& ioc, torrent* t, rtc_stream_handler handler);
 	~rtc_signaling();

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -708,7 +708,7 @@ namespace aux {
 			, std::function<void(error_code const&, std::vector<aux::rtc_offer>)> handler) override;
 		void on_rtc_offer(aux::rtc_offer const& offer) override;
 		void on_rtc_answer(aux::rtc_answer const& answer) override;
-		void on_rtc_stream(peer_id const& pid, aux::rtc_stream_init stream_init);
+		void on_rtc_stream(aux::rtc_stream_init stream_init);
 #endif
 		void remove_connection(peer_connection const* p);
 	public:

--- a/include/libtorrent/aux_/torrent_peer.hpp
+++ b/include/libtorrent/aux_/torrent_peer.hpp
@@ -220,13 +220,13 @@ namespace libtorrent::aux {
 #if TORRENT_USE_RTC
 	struct TORRENT_EXTRA_EXPORT rtc_peer : torrent_peer
 	{
-		rtc_peer(string_view pid_, peer_source_flags_t src);
+		rtc_peer(tcp::endpoint const& ep, peer_source_flags_t src);
 		rtc_peer(rtc_peer const&) = delete;
 		rtc_peer& operator=(rtc_peer const&) = delete;
 		rtc_peer(rtc_peer&&) = default;
 		rtc_peer& operator=(rtc_peer&&) & = default;
 
-		aux::string_ptr pid;
+		tcp::endpoint endpoint;
 	};
 #endif
 
@@ -250,7 +250,7 @@ namespace libtorrent::aux {
 			return lhs < rhs->address();
 		}
 
-#if TORRENT_USE_I2P || TORRENT_USE_RTC
+#if TORRENT_USE_I2P
 		bool operator()(torrent_peer const* lhs, string_view rhs) const
 		{
 			return lhs->dest().compare(rhs) < 0;
@@ -264,15 +264,8 @@ namespace libtorrent::aux {
 
 		bool operator()(torrent_peer const* lhs, torrent_peer const* rhs) const
 		{
-#if TORRENT_USE_I2P || TORRENT_USE_RTC
-			if (	true
 #if TORRENT_USE_I2P
-					&& rhs->is_i2p_addr == lhs->is_i2p_addr
-#endif
-#if TORRENT_USE_RTC
-					&& rhs->is_rtc_addr == lhs->is_rtc_addr
-#endif
-			)
+			if (rhs->is_i2p_addr == lhs->is_i2p_addr)
 				return lhs->dest().compare(rhs->dest()) < 0;
 #endif
 			return lhs->address() < rhs->address();

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -774,14 +774,9 @@ namespace libtorrent::aux {
 #if TORRENT_USE_ASSERTS
 		else
 		{
-			if (true
 #if TORRENT_USE_I2P
-			&& !p->is_i2p_addr
+			if(!p->is_i2p_addr)
 #endif
-#if TORRENT_USE_RTC
-			&& !p->is_rtc_addr
-#endif
-			)
 			{
 				std::pair<iterator, iterator> range = find_peers(p->address());
 				TORRENT_ASSERT(std::distance(range.first, range.second) == 1);
@@ -985,7 +980,7 @@ namespace libtorrent::aux {
 #endif // TORRENT_USE_I2P
 
 #if TORRENT_USE_RTC
-	torrent_peer* peer_list::add_rtc_peer(string_view const peer_id
+	torrent_peer* peer_list::add_rtc_peer(tcp::endpoint const& remote
 		, peer_source_flags_t const src, pex_flags_t const flags
 		, torrent_state* state)
 	{
@@ -993,12 +988,12 @@ namespace libtorrent::aux {
 		INVARIANT_CHECK;
 
 		iterator const iter = std::lower_bound(m_peers.begin(), m_peers.end()
-				, peer_id, peer_address_compare());
+				, remote.address(), peer_address_compare());
 
 		torrent_peer* p = m_peer_allocator.allocate_peer_entry(
 				torrent_peer_allocator_interface::rtc_peer_type);
 		if (p == nullptr) return nullptr;
-		p = new (p) rtc_peer(peer_id, src);
+		p = new (p) rtc_peer(remote, src);
 
 		if (!insert_peer(p, iter, flags, state))
 		{

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -893,6 +893,16 @@ namespace libtorrent::aux {
 		, pex_flags_t const flags, tcp::endpoint const& remote)
 	{
 		TORRENT_ASSERT(is_single_thread());
+
+#if TORRENT_USE_RTC
+		if (p->is_rtc_addr)
+		{
+			// This method must not be used for rtc peers
+			TORRENT_ASSERT_FAIL();
+			return;
+		}
+#endif
+
 		bool const was_conn_cand = is_connect_candidate(*p);
 
 		TORRENT_ASSERT(p->in_use);
@@ -989,6 +999,19 @@ namespace libtorrent::aux {
 
 		iterator const iter = std::lower_bound(m_peers.begin(), m_peers.end()
 				, remote.address(), peer_address_compare());
+
+		if (!state->allow_multiple_connections_per_ip
+				&& iter != m_peers.end() && (*iter)->address() == remote.address())
+		{
+			// the peer exists
+			torrent_peer* p = *iter;
+			if (!p->is_rtc_addr)
+				return nullptr; // prefer the non-rtc peer
+
+			// update and return it
+			p->port = remote.port();
+			return p;
+		}
 
 		torrent_peer* p = m_peer_allocator.allocate_peer_entry(
 				torrent_peer_allocator_interface::rtc_peer_type);

--- a/src/rtc_signaling.cpp
+++ b/src/rtc_signaling.cpp
@@ -375,7 +375,7 @@ void rtc_signaling::on_data_channel(error_code const& ec
 	connection conn = std::move(it->second);
 	m_connections.erase(it);
 
-	if (ec || !conn.pid)
+	if (ec)
 	{
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("*** RTC negotiation failed");
@@ -388,7 +388,7 @@ void rtc_signaling::on_data_channel(error_code const& ec
 #endif
 
 	TORRENT_ASSERT(dc);
-	m_rtc_stream_handler(*conn.pid, rtc_stream_init{conn.peer_connection, dc});
+	m_rtc_stream_handler(rtc_stream_init{conn.peer_connection, dc});
 }
 
 rtc_signaling::offer_batch::offer_batch(int count, rtc_signaling::offers_handler handler)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5853,8 +5853,8 @@ namespace {
 
 		need_peer_list();
 		torrent_state st = get_peer_list_state();
-		torrent_peer* peerinfo = m_peer_list->add_rtc_peer(endpoint, peer_source_flags_t{}, {}, &st);
-		create_peer_connection(peerinfo, std::move(s), std::move(endpoint));
+		if(torrent_peer* peerinfo = m_peer_list->add_rtc_peer(endpoint, peer_source_flags_t{}, {}, &st))
+			create_peer_connection(peerinfo, std::move(s), std::move(endpoint));
 	}
 #endif
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5848,8 +5848,14 @@ namespace {
 
 		error_code ec;
 		auto endpoint = s.remote_endpoint(ec);
-		TORRENT_ASSERT(!ec);
-		if(ec) return;
+		if(ec)
+		{
+			// This can happen if the peer immediately disconnects
+#ifndef TORRENT_DISABLE_LOGGING
+			debug_log("failed to get RTC stream remote endpoint: %s", ec.message().c_str());
+#endif
+			return;
+		}
 
 		need_peer_list();
 		torrent_state st = get_peer_list_state();

--- a/src/torrent_peer.cpp
+++ b/src/torrent_peer.cpp
@@ -164,10 +164,7 @@ namespace libtorrent::aux {
 		TORRENT_ASSERT(in_use);
 #if TORRENT_USE_I2P
 		if (is_i2p_addr) return std::string(dest());
-#endif // TORRENT_USE_I2P
-#if TORRENT_USE_RTC
-		if (is_rtc_addr) return std::string(dest());
-#endif // TORRENT_USE_RTC
+#endif
 		return address().to_string();
 	}
 #endif
@@ -232,9 +229,9 @@ namespace libtorrent::aux {
 #endif // TORRENT_USE_I2P
 
 #if TORRENT_USE_RTC
-	rtc_peer::rtc_peer(string_view pid_, peer_source_flags_t src)
+	rtc_peer::rtc_peer(tcp::endpoint const& ep, peer_source_flags_t src)
 		: torrent_peer(0, false, src)
-		, pid(pid_)
+		, endpoint(ep)
 	{
 		is_v6_addr = false;
 #if TORRENT_USE_I2P
@@ -260,18 +257,13 @@ namespace libtorrent::aux {
 
 	ipv6_peer::ipv6_peer(ipv6_peer const&) = default;
 
-#if TORRENT_USE_I2P || TORRENT_USE_RTC
+#if TORRENT_USE_I2P
 	string_view torrent_peer::dest() const
 	{
-#if TORRENT_USE_I2P
 		if (is_i2p_addr)
 			return *static_cast<i2p_peer const*>(this)->destination;
-#endif
-#if TORRENT_USE_RTC
-		if (is_rtc_addr)
-			return *static_cast<rtc_peer const*>(this)->pid;
-#endif
-		return "";
+		else
+			return "";
 	}
 #endif
 
@@ -286,7 +278,7 @@ namespace libtorrent::aux {
 		else
 #endif
 #if TORRENT_USE_RTC
-		if (is_rtc_addr) return {};
+		if (is_rtc_addr) return static_cast<rtc_peer const*>(this)->endpoint.address();
 		else
 #endif
 		return static_cast<ipv4_peer const*>(this)->addr;

--- a/test/test_rtc.cpp
+++ b/test/test_rtc.cpp
@@ -110,7 +110,7 @@ void test_offers()
 		success = true;
 	};
 
-	auto handler = [&](peer_id const&, rtc_stream_init) {};
+	auto handler = [&](rtc_stream_init) {};
 
 	sig = std::make_shared<rtc_signaling>(io_context, &tor, handler);
 
@@ -159,7 +159,7 @@ void test_connectivity()
 		sig2->process_offer(offer);
 	};
 
-	auto handler1 = [&](peer_id const&, rtc_stream_init init) {
+	auto handler1 = [&](rtc_stream_init init) {
 		TEST_CHECK(init.peer_connection);
 		TEST_CHECK(init.data_channel);
 		init1 = std::move(init);
@@ -174,7 +174,7 @@ void test_connectivity()
 		}
 	};
 
-	auto handler2 = [&](peer_id const&, rtc_stream_init init) {
+	auto handler2 = [&](rtc_stream_init init) {
 		TEST_CHECK(init.peer_connection);
 		TEST_CHECK(init.data_channel);
 		init2 = std::move(init);
@@ -283,7 +283,7 @@ void test_stream()
 		}
 	};
 
-	auto handler1 = [&](peer_id const&, rtc_stream_init init) {
+	auto handler1 = [&](rtc_stream_init init) {
 		TEST_CHECK(init.peer_connection);
 		TEST_CHECK(init.data_channel);
 
@@ -294,7 +294,7 @@ void test_stream()
 		stream1->async_read_some(read_buffer, read_handler);
 	};
 
-	auto handler2 = [&](peer_id const&, rtc_stream_init init) {
+	auto handler2 = [&](rtc_stream_init init) {
 		TEST_CHECK(init.peer_connection);
 		TEST_CHECK(init.data_channel);
 


### PR DESCRIPTION
This PR addresses a regression introduced by WebTorrent support https://github.com/arvidn/libtorrent/pull/4123: when running with both webRTC and normal peers, the peer list sorting is broken, because it mixes peers sorted by peer id and peers sorted by remote address. This PR resolves the issue by using the remote address for webRTC peers too.

It fixes the duplicate peer issue https://github.com/arvidn/libtorrent/issues/5100