### PR TITLE
add missing update_storage_node_ids

### DIFF
--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -128,6 +128,8 @@ namespace libtorrent { namespace dht {
 			, std::bind(&dht_tracker::get_node, this, _1, _2)
 			, m_storage));
 
+		update_storage_node_ids();
+
 #ifndef TORRENT_DISABLE_LOGGING
 		if (m_log->should_log(dht_logger::tracker))
 		{
@@ -151,6 +153,8 @@ namespace libtorrent { namespace dht {
 	void dht_tracker::delete_socket(aux::listen_socket_handle const& s)
 	{
 		m_nodes.erase(s);
+
+		update_storage_node_ids();
 	}
 
 	void dht_tracker::start(find_data::nodes_callback const& f)


### PR DESCRIPTION
to keep the DHT storage up to date when the m_nodes list is updated.

@aldenml would you mind taking a look at this? I think this was an oversight. I ended up encountering an assert where `m_nodes` had 1 entry in it but the storage object (`dht_default_storage`) had an empty list of `m_node_ids`