### PR TITLE
minor cleanups to URL seed

### DIFF
--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -79,6 +79,10 @@ namespace libtorrent {
 
 	void http_seed_connection::on_connected()
 	{
+		peer_id pid;
+		aux::random_bytes(pid);
+		set_pid(pid);
+
 		// this is always a seed
 		incoming_have_all();
 		web_connection_base::on_connected();
@@ -328,13 +332,9 @@ namespace libtorrent {
 
 				std::string const& server_version = m_parser.header("server");
 				if (!server_version.empty())
-				{
-					m_server_string = "URL seed @ ";
-					m_server_string += m_host;
-					m_server_string += " (";
-					m_server_string += server_version;
-					m_server_string += ")";
-				}
+					m_server_string = server_version;
+				else
+					m_server_string = m_host;
 
 				m_response_left = atol(m_parser.header("content-length").c_str());
 				if (m_response_left == -1)

--- a/src/web_connection_base.cpp
+++ b/src/web_connection_base.cpp
@@ -91,8 +91,7 @@ namespace libtorrent {
 		if (!m_basic_auth.empty())
 			m_basic_auth = base64encode(m_basic_auth);
 
-		m_server_string = "URL seed @ ";
-		m_server_string += m_host;
+		m_server_string = m_host;
 	}
 
 	int web_connection_base::timeout() const

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -140,6 +140,10 @@ std::string escape_file_path(file_storage const& storage, file_index_t index)
 
 void web_peer_connection::on_connected()
 {
+	peer_id pid;
+	aux::random_bytes(pid);
+	set_pid(pid);
+
 	if (m_web->have_files.empty())
 	{
 		incoming_have_all();
@@ -514,17 +518,10 @@ namespace {
 
 	std::string get_peer_name(http_parser const& p, std::string const& host)
 	{
-		std::string ret = "URL seed @ ";
-		ret += host;
-
 		std::string const& server_version = p.header("server");
 		if (!server_version.empty())
-		{
-			ret += " (";
-			ret += server_version;
-			ret += ")";
-		}
-		return ret;
+			return server_version;
+		return host;
 	}
 
 	std::tuple<std::int64_t, std::int64_t> get_range(


### PR DESCRIPTION
just use the server string as client name, always generate a unique peer id