### PR TITLE
WebTorrent: Prevent protocol encryption over WebRTC

### DIFF
--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -200,6 +200,12 @@ namespace {
 		if (is_ssl(get_socket()))
 			out_policy = settings_pack::pe_disabled;
 #endif
+#if TORRENT_USE_RTC
+		// never try an encrypted connection over WebRTC (which is already encrypted)
+		if (torrent_peer *pi = peer_info_struct())
+			if (pi->is_rtc_addr)
+				out_policy = settings_pack::pe_disabled;
+#endif
 #ifndef TORRENT_DISABLE_LOGGING
 		static char const* policy_name[] = {"forced", "enabled", "disabled"};
 		TORRENT_ASSERT(out_policy < sizeof(policy_name)/sizeof(policy_name[0]));


### PR DESCRIPTION
This PR fixes the assert `m_recv_buffer.packet_size() == dh_key_len` from `aux::bt_peer_connection::on_receive_impl`  in https://github.com/arvidn/libtorrent/issues/5100

WebTorrent connections are always made over DTLS and therefore should never use protocol encryption.