### PR TITLE
fix building python bindings with CMake

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -78,6 +78,10 @@ python_add_module(python-libtorrent
 	src/error_code.cpp
 )
 
+if (MSVC)
+	target_compile_options(python-libtorrent PRIVATE /bigobj)
+endif()
+
 set_target_properties(python-libtorrent
 	PROPERTIES
 		OUTPUT_NAME libtorrent


### PR DESCRIPTION
Main library already used /bigobj

---

Follow-up to https://github.com/arvidn/libtorrent/pull/5197, should be merged before proceeding with https://github.com/arvidn/libtorrent/pull/4574.

@arvidn Should I submit the same PR for other branches, or will you merge this into them yourself?