### PR TITLE
Use boost::system in header-only form when compiling with boost >= 1.69

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,9 +719,12 @@ else()
 endif()
 
 # Boost
-find_public_dependency(Boost REQUIRED COMPONENTS system)
+find_public_dependency(Boost REQUIRED)
 target_include_directories(torrent-rasterbar PUBLIC ${Boost_INCLUDE_DIRS})
-target_link_libraries(torrent-rasterbar PUBLIC ${Boost_SYSTEM_LIBRARY})
+if (Boost_VERSION VERSION_LESS 106900)  # CMP0093 OLD behavior
+	find_package(Boost REQUIRED COMPONENTS system)
+	target_link_libraries(torrent-rasterbar PUBLIC ${Boost_SYSTEM_LIBRARY})
+endif()
 
 if (exceptions)
 	if (MSVC)


### PR DESCRIPTION
https://www.boost.org/doc/libs/1_72_0/libs/system/doc/html/system.html#changes_in_boost_1_69