### PR TITLE
fix CMake config file version compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,7 +818,7 @@ string(REPLACE ";" "\n" _find_dependency_calls "${_find_dependency_calls}")
 write_basic_package_version_file(
 	"${CMAKE_CURRENT_BINARY_DIR}/LibtorrentRasterbar/LibtorrentRasterbarConfigVersion.cmake"
 	VERSION ${libtorrent_VERSION}
-	COMPATIBILITY SameMinorVersion
+	COMPATIBILITY AnyNewerVersion
 )
 
 export(EXPORT LibtorrentRasterbarTargets


### PR DESCRIPTION
Make it the application's responsibility to manage their supported
versions.

This can be done with CMake find_package() version ranges, for instance.

---

Context: https://github.com/qbittorrent/qBittorrent/issues/13510#issuecomment-709279090 and the following two comments below it. An application like qBittorrent might want to support two or more versions at the same time that differ in major and minor version. It is difficult to accomplish this with the `SameMinorVersion` restriction in the generated CMake config files.