### PR TITLE
move merkle trees into the torrent object, where they belong. Expose …

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -401,6 +401,9 @@ namespace libtorrent {
 		// it will initialize the storage and the piece-picker
 		void init();
 
+		void load_merkle_trees(aux::vector<std::vector<sha256_hash>, file_index_t> t
+			, aux::vector<std::vector<bool>, file_index_t> mask);
+
 		// find the peer that introduced us to the given endpoint. This is
 		// used when trying to holepunch. We need the introducer so that we
 		// can send a rendezvous connect message
@@ -1058,6 +1061,8 @@ namespace libtorrent {
 
 		std::shared_ptr<const torrent_info> get_torrent_copy();
 
+		std::vector<std::vector<sha256_hash>> get_piece_layers() const;
+
 		std::vector<announce_entry> trackers() const;
 
 		// this sets all the "enabled" states on all trackers, giving them
@@ -1115,6 +1120,8 @@ namespace libtorrent {
 		{ return m_torrent_file->is_valid(); }
 		bool are_files_checked() const
 		{ return m_files_checked; }
+
+		void initialize_merkle_trees();
 
 		// parses the info section from the given
 		// bencoded tree and moves the torrent
@@ -1374,6 +1381,9 @@ namespace libtorrent {
 		// separate class (to use as memeber here instead)
 		std::vector<piece_index_t> m_predictive_pieces;
 #endif
+
+		// v2 merkle tree for each file
+		aux::vector<aux::merkle_tree, file_index_t> m_merkle_trees;
 
 		// the performance counters of this session
 		counters& m_stats_counters;
@@ -1650,6 +1660,10 @@ namespace libtorrent {
 		// flapping. If the state changes back during this period, we cancel the
 		// quarantine
 		bool m_pending_active_change:1;
+
+		// this is set to true if all piece layers were successfully loaded and
+		// validated. Only for v2 torrents
+		bool m_v2_piece_layers_validated:1;
 
 // ----
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -848,8 +848,18 @@ namespace aux {
 		// If the torrent doesn't have metadata, the pointer will not be
 		// initialized (i.e. a nullptr). The torrent may be in a state
 		// without metadata only if it was started without a .torrent file, e.g.
-		// by being added by magnet link
+		// by being added by magnet link.
+		// Note that the torrent_info object returned here may be a different
+		// instance than the one added to the session, with different attributes
+		// like piece layers, dht nodes and trackers. A torrent_info object does
+		// not round-trip cleanly when added to a session.
 		std::shared_ptr<const torrent_info> torrent_file() const;
+
+		// returns the piece layers for all files in the torrent. If this is a
+		// v1 torrent (and doesn't have any piece layers) it returns an empty
+		// vector. This is a blocking call that will synchronize with the
+		// libtorrent network thread.
+		std::vector<std::vector<sha256_hash>> piece_layers() const;
 
 #if TORRENT_ABI_VERSION == 1
 

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -493,7 +493,6 @@ namespace {
 
 		if (make_v2)
 		{
-			auto const& file_trees = ti.internal_merkle_trees();
 			m_fileroots.resize(m_files.num_files());
 			m_file_piece_hash.resize(m_files.num_files());
 			for (auto const i : m_files.file_range())
@@ -502,17 +501,17 @@ namespace {
 				if (m_files.pad_file_at(i)) continue;
 
 				auto const file_size = m_files.file_size(i);
-				if (file_size < m_files.piece_length())
+				if (file_size <= m_files.piece_length())
 				{
 					set_hash2(i, piece_index_t::diff_type{0}, m_files.root(i));
 					continue;
 				}
 
-				aux::vector<sha256_hash> pieces = file_trees[i].get_piece_layer();
+				span<char const> pieces = ti.piece_layer(i);
 
 				piece_index_t::diff_type p{0};
-				for (auto const& ph : pieces)
-					set_hash2(i, p++, ph);
+				for (int h = 0; h < int(pieces.size()); h += int(sha256_hash::size()))
+					set_hash2(i, p++, sha256_hash(pieces.data() + h));
 			}
 		}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -222,6 +222,7 @@ bool is_downloading_state(int const st)
 		, m_magnet_link(false)
 		, m_apply_ip_filter(p.flags & torrent_flags::apply_ip_filter)
 		, m_pending_active_change(false)
+		, m_v2_piece_layers_validated(false)
 		, m_connect_boost_counter(static_cast<std::uint8_t>(settings().get_int(settings_pack::torrent_connect_boost)))
 		, m_incomplete(0xffffff)
 		, m_announce_to_dht(!(p.flags & torrent_flags::paused))
@@ -263,6 +264,9 @@ bool is_downloading_state(int const st)
 
 		if (!m_torrent_file)
 			m_torrent_file = (p.ti ? p.ti : std::make_shared<torrent_info>(m_info_hash));
+
+		if (m_torrent_file->is_valid())
+			initialize_merkle_trees();
 
 		// --- WEB SEEDS ---
 
@@ -385,7 +389,7 @@ bool is_downloading_state(int const st)
 		if (m_torrent_file->is_valid() && m_torrent_file->info_hashes().has_v2())
 		{
 			if (!p.merkle_trees.empty())
-				m_torrent_file->internal_load_merkle_trees(
+				load_merkle_trees(
 					std::move(p.merkle_trees), std::move(p.merkle_tree_mask));
 
 			// we really don't want to store extra copies of the trees
@@ -406,6 +410,30 @@ bool is_downloading_state(int const st)
 
 		// TODO: 3 we could probably get away with just saving a few fields here
 		m_add_torrent_params = std::make_unique<add_torrent_params>(std::move(p));
+	}
+
+	void torrent::load_merkle_trees(
+		aux::vector<std::vector<sha256_hash>, file_index_t> trees_import
+		, aux::vector<std::vector<bool>, file_index_t> mask)
+	{
+		auto const& fs = m_torrent_file->orig_files();
+
+		for (file_index_t i{0}; i < fs.end_file(); ++i)
+		{
+			if (fs.pad_file_at(i) || fs.file_size(i) == 0)
+				continue;
+
+			if (i >= trees_import.end_index()) break;
+			if (i < mask.end_index() && !mask[i].empty())
+			{
+				mask[i].resize(m_merkle_trees[i].size(), false);
+				m_merkle_trees[i].load_sparse_tree(trees_import[i], mask[i]);
+			}
+			else
+			{
+				m_merkle_trees[i].load_tree(trees_import[i]);
+			}
+		}
 	}
 
 	void torrent::inc_stats_counter(int c, int value)
@@ -1190,8 +1218,11 @@ bool is_downloading_state(int const st)
 		//INVARIANT_CHECK;
 
 		m_hash_picker.reset(new hash_picker(m_torrent_file->orig_files()
-			, m_torrent_file->internal_merkle_trees(), std::move(verified)
-			, m_torrent_file->v2_piece_hashes_verified()
+			, m_merkle_trees, std::move(verified)
+			// if we have all the piece layers and the piece size is the same as
+			// the block size, we have all the hashes we need already. This
+			// means "have all hashes".
+			, m_v2_piece_layers_validated
 				&& m_torrent_file->piece_length() == default_block_size));
 	}
 
@@ -6522,7 +6553,7 @@ namespace {
 		if (!m_torrent_file->is_valid()) return {};
 		TORRENT_ASSERT(validate_hash_request(req, m_torrent_file->files()));
 
-		auto const& f = m_torrent_file->internal_merkle_trees()[req.file];
+		auto const& f = m_merkle_trees[req.file];
 
 		return f.get_hashes(req.base, req.index, req.count, req.proof_layers);
 	}
@@ -6598,6 +6629,14 @@ namespace {
 	{
 		if (!m_torrent_file->is_valid()) return {};
 		return m_torrent_file;
+	}
+
+	std::vector<std::vector<sha256_hash>> torrent::get_piece_layers() const
+	{
+		std::vector<std::vector<sha256_hash>> ret;
+		for (auto const& tree : m_merkle_trees)
+			ret.emplace_back(tree.get_piece_layer());
+		return ret;
 	}
 
 	void torrent::enable_all_trackers()
@@ -6840,8 +6879,8 @@ namespace {
 		if (m_torrent_file->info_hashes().has_v2())
 		{
 			ret.merkle_trees.clear();
-			ret.merkle_trees.reserve(m_torrent_file->internal_merkle_trees().size());
-			for (auto const& t : m_torrent_file->internal_merkle_trees())
+			ret.merkle_trees.reserve(m_merkle_trees.size());
+			for (auto const& t : m_merkle_trees)
 			{
 				// use stuctured binding in C++17
 				aux::vector<bool> mask;
@@ -7229,6 +7268,44 @@ namespace {
 		return peerinfo->connection != nullptr;
 	}
 
+	void torrent::initialize_merkle_trees()
+	{
+		if (!info_hash().has_v2()) return;
+
+		bool valid = m_torrent_file->v2_piece_hashes_verified();
+
+		file_storage const& fs = m_torrent_file->orig_files();
+		m_merkle_trees.reserve(fs.num_files());
+		for (file_index_t i : fs.file_range())
+		{
+			if (fs.pad_file_at(i) || fs.file_size(i) == 0)
+			{
+				m_merkle_trees.emplace_back();
+				continue;
+			}
+			m_merkle_trees.emplace_back(fs.file_num_blocks(i)
+				, fs.piece_length() / default_block_size, fs.root_ptr(i));
+			auto const piece_layer = m_torrent_file->piece_layer(i);
+			if (piece_layer.empty())
+			{
+				valid = false;
+				continue;
+			}
+
+			if (!m_merkle_trees[i].load_piece_layer(piece_layer))
+			{
+				set_error(errors::torrent_invalid_piece_layer
+					, torrent_status::error_file_metadata);
+				valid = false;
+				m_merkle_trees[i] = aux::merkle_tree();
+			}
+		}
+
+		m_v2_piece_layers_validated = valid;
+
+		m_torrent_file->free_piece_layers();
+	}
+
 	bool torrent::set_metadata(span<char const> metadata_buf)
 	{
 		TORRENT_ASSERT(is_single_thread());
@@ -7313,6 +7390,8 @@ namespace {
 		m_info_hash = m_torrent_file->info_hashes();
 
 		m_ses.update_torrent_info_hash(shared_from_this(), old_ih);
+
+		initialize_merkle_trees();
 
 		update_gauge();
 		update_want_tick();

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -719,6 +719,12 @@ namespace libtorrent {
 			std::shared_ptr<const torrent_info>(), &torrent::get_torrent_copy);
 	}
 
+	std::vector<std::vector<sha256_hash>> torrent_handle::piece_layers() const
+	{
+		return sync_call_ret<std::vector<std::vector<sha256_hash>>>({}
+			, &torrent::get_piece_layers);
+	}
+
 #if TORRENT_ABI_VERSION == 1
 	// this function should either be removed, or return
 	// reference counted handle to the torrent_info which

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -1081,6 +1081,14 @@ TORRENT_TEST(merkle_trees)
 	p.ti = generate_torrent();
 	p.save_path = ".";
 
+	std::vector<std::vector<char>> piece_layers;
+
+	for (file_index_t const i : p.ti->files().file_range())
+	{
+		auto const pspan = p.ti->piece_layer(i);
+		piece_layers.emplace_back(pspan.begin(), pspan.end());
+	}
+
 	lt::session ses(settings());
 	auto h = ses.add_torrent(p);
 
@@ -1095,15 +1103,18 @@ TORRENT_TEST(merkle_trees)
 
 	TEST_EQUAL(a->params.merkle_trees.size(), 3);
 	TEST_EQUAL(a->params.merkle_tree_mask.size(), 3);
-	TEST_EQUAL(p.ti->internal_merkle_trees().size(), 3);
+
+	auto const pl = h.piece_layers();
+	TEST_CHECK(pl.size() == piece_layers.size());
+
 	for (file_index_t const i : p.ti->files().file_range())
 	{
-		// use stuctured binding in C++17
-		std::vector<bool> mask;
-		std::vector<sha256_hash> sparse_tree;
-		std::tie(sparse_tree, mask) = p.ti->internal_merkle_trees()[i].build_sparse_vector();
-		TEST_CHECK(a->params.merkle_trees[i] == sparse_tree);
-		TEST_CHECK(a->params.merkle_tree_mask[i] == mask);
+		auto const& one_layer = pl[std::size_t(int(i))];
+		TEST_CHECK(one_layer.size() == piece_layers[std::size_t(int(i))].size() / lt::sha256_hash::size());
+		for (int piece = 0; piece < int(one_layer.size()); ++piece)
+			TEST_CHECK(one_layer[std::size_t(piece)] == lt::sha256_hash(piece_layers[std::size_t(int(i))].data() + piece * lt::sha256_hash::size()));
+		auto const& m = a->params.merkle_tree_mask[i];
+		TEST_CHECK(std::count(m.begin(), m.end(), true) == int(a->params.merkle_trees[i].size()));
 	}
 }
 


### PR DESCRIPTION
…them via torrent_info and torrent_handle