### PR TITLE
Modify Jamfile

### DIFF
--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -20,6 +20,14 @@ feature libtorrent-link : shared static : composite propagated ;
 feature libtorrent-python-pic : off on : composite propagated link-incompatible ;
 feature.compose <libtorrent-python-pic>on : <cflags>-fPIC ;
 
+# when invoking the install_module target, this feature can be specified to
+# install the python module to a specific directory
+feature python-install-path : : free path ;
+
+# when not specifying a custom install path, this controls whether to install
+# the python module in the system directory or user-specifc directory
+feature python-install-scope : user system : ;
+
 # this is just to force boost build to pick the desired python target when using LIBTORRENT_PYTHON_INTERPRETER
 feature libtorrent-python : on ;
 
@@ -236,8 +244,8 @@ my-python-extension libtorrent
 rule python-install-dir-custom ( properties * )
 {
     local python_path = [ os.environ PYTHON_LIB_PATH ] ;
-    
-    if ! [ on $(<) return $(python_path) ] 
+
+    if ! [ on $(<) return $(python_path) ]
     {
         Echo ;
         Echo "Warning: The PYTHON_LIB_PATH cannot be empty when used with install_module_custom" ;
@@ -255,8 +263,8 @@ rule python-install-dir-local ( properties * )
     local pythons_versions = [ feature.values python ] ;
     local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
     local python_v = $(split_python_versions[1]) ;
-    local python_path = [ SHELL "python$(python_v) -c \"import site; print(site.USER_SITE, end = '')\"" ] ;
-    
+    local python_path = [ SHELL "python$(python_v) -c \"import sys; import site; sys.stdout.write(site.USER_SITE)\"" ] ;
+
 	return <location>$(python_path) ;
 }
 
@@ -266,30 +274,30 @@ rule python-install-dir-system ( properties * )
     local pythons_versions = [ feature.values python ] ;
     local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
     local python_v = $(split_python_versions[1]) ;
-    
+
     if [ on $(<) return $(python_path_set) ]
     {
-        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1], end = '')\"" ] ; 
+        python_path = [ SHELL "python$(python_v) -c \"import sys; sys.stdout.write(sys.path[1])\"" ] ;
     }
     else
     {
-        python_path = [ SHELL "python$(python_v) -c \"import sysconfig; print(sysconfig.get_config_var('DESTSHARED'), end = '')\"" ] ;
+        python_path = [ SHELL "python$(python_v) -c \"import sys; import sysconfig; sys.stdout.write(sysconfig.get_config_var('DESTSHARED'))\"" ] ;
     }
 	return <location>$(python_path) ;
 }
-   
+
 install install_module_custom
 	: libtorrent
 	: <conditional>@python-install-dir-custom
 	<install-type>PYTHON_EXTENSION
 	;
-    
+
 install install_module_local
 	: libtorrent
 	: <conditional>@python-install-dir-local
 	<install-type>PYTHON_EXTENSION
 	;
-    
+
 install install_module_system
 	: libtorrent
 	: <conditional>@python-install-dir-system

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -243,6 +243,8 @@ rule python-install-dir-custom ( properties * )
         Echo "Warning: The PYTHON_LIB_PATH cannot be empty when used with install_module_custom" ;
         Echo ;
         Echo "Make sure you set this variable: export PYTHON_LIB_PATH=\"/path/to/install\"" ;
+        Echo ;
+        Echo "If you use a relative path like 'path/to/lib' this path will become 'bindings/python/path/to/lib'" ;
         Exit ;
     }
 	return <location>$(python_path) ;
@@ -253,7 +255,7 @@ rule python-install-dir-local ( properties * )
     local pythons_versions = [ feature.values python ] ;
     local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
     local python_v = $(split_python_versions[1]) ;
-    local python_path = [ SHELL "python$(python_v) -m site --user-site | tr -d '\n'" ] ;
+    local python_path = [ SHELL "python$(python_v) -c \"import site; print(site.USER_SITE, end = '')\"" ] ;
     
 	return <location>$(python_path) ;
 }
@@ -267,18 +269,18 @@ rule python-install-dir-system ( properties * )
     
     if [ on $(<) return $(python_path_set) ]
     {
-        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1])\" | tr -d '\n'" ] ;
+        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1], end = '')\"" ] ;   
     }
     else
     {
         if $(python_v) = 2
         {
-            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[5])\" | tr -d '\n'" ] ;
+            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[5], end = '')\"" ] ;
         }
         
         if $(python_v) = 3
         {
-            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[3])\" | tr -d '\n'" ] ;
+            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[3], end = '')\"" ] ;
         } 
     }
 	return <location>$(python_path) ;

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -25,7 +25,7 @@ feature.compose <libtorrent-python-pic>on : <cflags>-fPIC ;
 feature python-install-path : : free path ;
 
 # when not specifying a custom install path, this controls whether to install
-# the python module in the system directory or user-specifc directory
+# the python module in the system directory or user-specific directory
 feature python-install-scope : user system : ;
 
 # this is just to force boost build to pick the desired python target when using LIBTORRENT_PYTHON_INTERPRETER
@@ -241,68 +241,44 @@ my-python-extension libtorrent
 	<suppress-import-lib>false
 	;
 
-rule python-install-dir-custom ( properties * )
+rule python-install-dir ( properties * )
 {
-    local python_path = [ os.environ PYTHON_LIB_PATH ] ;
+	local python_custom_path = [ feature.get-values python-install-path : $(properties) ] ;
+	if ( $(python_custom_path)  != "" )
+	{
+		# if the user has provided an install location, use that one
+		return <location>$(python_custom_path) ;
+	}
 
-    if ! [ on $(<) return $(python_path) ]
-    {
-        Echo ;
-        Echo "Warning: The PYTHON_LIB_PATH cannot be empty when used with install_module_custom" ;
-        Echo ;
-        Echo "Make sure you set this variable: export PYTHON_LIB_PATH=\"/path/to/install\"" ;
-        Echo ;
-        Echo "If you use a relative path like 'path/to/lib' this path will become 'bindings/python/path/to/lib'" ;
-        Exit ;
-    }
-	return <location>$(python_path) ;
-}
-
-rule python-install-dir-local ( properties * )
-{
-    local pythons_versions = [ feature.values python ] ;
-    local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
-    local python_v = $(split_python_versions[1]) ;
-    local python_path = [ SHELL "python$(python_v) -c \"import sys; import site; sys.stdout.write(site.USER_SITE)\"" ] ;
-
-	return <location>$(python_path) ;
-}
-
-rule python-install-dir-system ( properties * )
-{
-    local python_path_set = [ os.environ PYTHONPATH ] ;
+    local pythonpath_set = [ os.environ PYTHONPATH ] ;
     local pythons_versions = [ feature.values python ] ;
     local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
     local python_v = $(split_python_versions[1]) ;
 
-    if [ on $(<) return $(python_path_set) ]
+	if <python-install-scope>system in $(properties)
     {
-        python_path = [ SHELL "python$(python_v) -c \"import sys; sys.stdout.write(sys.path[1])\"" ] ;
+        if [ on $(<) return $(pythonpath_set) ]
+        {
+            python_system_path = [ SHELL "python$(python_v) -c \"import sys; sys.stdout.write(sys.path[1])\"" ] ;
+        }
+        else
+        {
+            python_system_path = [ SHELL "python$(python_v) -c \"import sys; import sysconfig; sys.stdout.write(sysconfig.get_config_var('DESTSHARED'))\"" ] ;
+        }
+        return <location>$(python_system_path) ;
     }
-    else
-    {
-        python_path = [ SHELL "python$(python_v) -c \"import sys; import sysconfig; sys.stdout.write(sysconfig.get_config_var('DESTSHARED'))\"" ] ;
-    }
-	return <location>$(python_path) ;
+    
+    local python_user_path = [ SHELL "python$(python_v) -c \"import sys; import site; sys.stdout.write(site.USER_SITE)\"" ] ;
+    return <location>$(python_user_path) ;
 }
 
-install install_module_custom
+install install_module
 	: libtorrent
-	: <conditional>@python-install-dir-custom
+	: <conditional>@python-install-dir
 	<install-type>PYTHON_EXTENSION
 	;
 
-install install_module_local
-	: libtorrent
-	: <conditional>@python-install-dir-local
-	<install-type>PYTHON_EXTENSION
-	;
-
-install install_module_system
-	: libtorrent
-	: <conditional>@python-install-dir-system
-	<install-type>PYTHON_EXTENSION
-	;
+explicit install_module ;
 
 install stage_module
 	: libtorrent

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -253,7 +253,7 @@ rule python-install-dir-local ( properties * )
     local pythons_versions = [ feature.values python ] ;
     local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
     local python_v = $(split_python_versions[1]) ;
-    local python_path = [ SHELL "python$(python_v) -m site --user-site" ] ;
+    local python_path = [ SHELL "python$(python_v) -m site --user-site | tr -d '\n'" ] ;
     
 	return <location>$(python_path) ;
 }
@@ -267,18 +267,18 @@ rule python-install-dir-system ( properties * )
     
     if [ on $(<) return $(python_path_set) ]
     {
-        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1])\"" ] ;
+        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1])\" | tr -d '\n'" ] ;
     }
     else
     {
         if $(python_v) = 2
         {
-            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[6])\"" ] ;
+            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[5])\" | tr -d '\n'" ] ;
         }
         
         if $(python_v) = 3
         {
-            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[4])\"" ] ;
+            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[3])\" | tr -d '\n'" ] ;
         } 
     }
 	return <location>$(python_path) ;

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -269,19 +269,11 @@ rule python-install-dir-system ( properties * )
     
     if [ on $(<) return $(python_path_set) ]
     {
-        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1], end = '')\"" ] ;   
+        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1], end = '')\"" ] ; 
     }
     else
     {
-        if $(python_v) = 2
-        {
-            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[5], end = '')\"" ] ;
-        }
-        
-        if $(python_v) = 3
-        {
-            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[3], end = '')\"" ] ;
-        } 
+        python_path = [ SHELL "python$(python_v) -c \"import sysconfig; print(sysconfig.get_config_var('DESTSHARED'), end = '')\"" ] ;
     }
 	return <location>$(python_path) ;
 }

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -5,6 +5,7 @@ import project ;
 import targets ;
 import "class" : new ;
 import modules ;
+import os ;
 
 use-project /torrent : ../.. ;
 
@@ -232,15 +233,72 @@ my-python-extension libtorrent
 	<suppress-import-lib>false
 	;
 
-rule python-install-dir ( properties * )
+rule python-install-dir-custom ( properties * )
 {
-	local python_path = [ SHELL "python -c \"import sys; print(sys.path[4])\"" ] ;
+    local python_path = [ os.environ PYTHON_LIB_PATH ] ;
+    
+    if ! [ on $(<) return $(python_path) ] 
+    {
+        Echo ;
+        Echo "Warning: The PYTHON_LIB_PATH cannot be empty when used with install_module_custom" ;
+        Echo ;
+        Echo "Make sure you set this variable: export PYTHON_LIB_PATH=\"/path/to/install\"" ;
+        Exit ;
+    }
 	return <location>$(python_path) ;
 }
 
-install install_module
+rule python-install-dir-local ( properties * )
+{
+    local pythons_versions = [ feature.values python ] ;
+    local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
+    local python_v = $(split_python_versions[1]) ;
+    local python_path = [ SHELL "python$(python_v) -m site --user-site" ] ;
+    
+	return <location>$(python_path) ;
+}
+
+rule python-install-dir-system ( properties * )
+{
+    local python_path_set = [ os.environ PYTHONPATH ] ;
+    local pythons_versions = [ feature.values python ] ;
+    local split_python_versions = [ SPLIT_BY_CHARACTERS $(pythons_versions) : "." ] ;
+    local python_v = $(split_python_versions[1]) ;
+    
+    if [ on $(<) return $(python_path_set) ]
+    {
+        python_path = [ SHELL "python$(python_v) -c \"import sys; print(sys.path[1])\"" ] ;
+    }
+    else
+    {
+        if $(python_v) = 2
+        {
+            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[6])\"" ] ;
+        }
+        
+        if $(python_v) = 3
+        {
+            python_path = [ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path[4])\"" ] ;
+        } 
+    }
+	return <location>$(python_path) ;
+}
+   
+install install_module_custom
 	: libtorrent
-	: <conditional>@python-install-dir
+	: <conditional>@python-install-dir-custom
+	<install-type>PYTHON_EXTENSION
+	;
+    
+install install_module_local
+	: libtorrent
+	: <conditional>@python-install-dir-local
+	<install-type>PYTHON_EXTENSION
+	;
+    
+install install_module_system
+	: libtorrent
+	: <conditional>@python-install-dir-system
 	<install-type>PYTHON_EXTENSION
 	;
 
@@ -261,4 +319,3 @@ install stage_dependencies
 
 explicit stage_module ;
 explicit stage_dependencies ;
-

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -232,6 +232,18 @@ my-python-extension libtorrent
 	<suppress-import-lib>false
 	;
 
+rule python-install-dir ( properties * )
+{
+	local python_path = [ SHELL "python -c \"import sys; print(sys.path[4])\"" ] ;
+	return <location>$(python_path) ;
+}
+
+install install_module
+	: libtorrent
+	: <conditional>@python-install-dir
+	<install-type>PYTHON_EXTENSION
+	;
+
 install stage_module
 	: libtorrent
 	: <location>.

--- a/docs/python_binding.rst
+++ b/docs/python_binding.rst
@@ -96,6 +96,16 @@ For example, to build a self-contained python module::
 
 	b2 -j30 libtorrent-link=static boost-link=static stage_module
 
+installing python module
+========================
+
+To install the python module, build it with the following command::
+
+	b2 install_module
+
+The install path will be determined by the output from
+``python -c "import sys; print(sys.path[4])"``.
+
 using libtorrent in python
 ==========================
 


### PR DESCRIPTION
Add 3 new installation options with some logic to determine the version of python to use and where to install the libtorrent libraries.

## install_module_custom

This allows the installation of the libtorrent.so library to a specified location by exporting the custom `PYTHON_LIB_PATH` variable. If the variable is null and this flag is used a warning is printed and the jamfile exits.

## install_module_local

This will check for the major version for python used and use this command to get the `.local` lib path relative to the user's home directory for that version of python.

**Note:** `python_v` is the automatically detected major version of python.

```
[ SHELL "python$(python_v) -m site --user-site" ]
```

## install_module_system

This will check for the major version for python used and use this command to get the system lib path for global installation for that version of python.

**Note:** `python_v` is the automatically detected major version of python

`env -i` is used to ignore the env settings so we always get the same result we need.

```
[ SHELL "env -i python$(python_v) -c \"import sys; print(sys.path)\"" ] ;
```

If the variable `PYTHONPATH` is exported this will override the checks and this path will be used and `env -i` is not used