### PR TITLE
make client_test use fixed_slots_choker

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -1226,7 +1226,6 @@ examples:
 #endif
 
 	auto& settings = params.settings;
-	settings.set_int(settings_pack::choking_algorithm, settings_pack::rate_based_choker);
 
 	settings.set_str(settings_pack::user_agent, "client_test/" LIBTORRENT_VERSION);
 	settings.set_int(settings_pack::alert_mask

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4347,7 +4347,12 @@ namespace {
 		int const allowed_upload_slots = unchoke_sort(peers
 			, unchoke_interval, m_settings);
 
-		if (m_settings.get_int(settings_pack::choking_algorithm) != settings_pack::fixed_slots_choker)
+		if (m_settings.get_int(settings_pack::choking_algorithm) == settings_pack::fixed_slots_choker)
+		{
+			int const upload_slots = get_int_setting(settings_pack::unchoke_slots_limit);
+			m_stats_counters.set_value(counters::num_unchoke_slots, upload_slots);
+		}
+		else
 		{
 			m_stats_counters.set_value(counters::num_unchoke_slots
 				, allowed_upload_slots);


### PR DESCRIPTION
Fix issue in allowed unchoke slots for fixed-slot choker when switching choking algorithm back and forth