### PR TITLE
fix concurrent access to part files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix issue with concurrent access to part files
 
 * 2.0.1 released
 


### PR DESCRIPTION
by using pread/overlapped I/O instead of seek+read. This used to work by simply restricting multi-threading when pread wasn't supported