### PR TITLE
fix error handling for pool allocation failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ set(libtorrent_aux_include_files
 	numeric_cast
 	openssl
 	path
+	pool
 	portmap
 	proxy_settings
 	range

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix error handling for pool allocation failure
 
 1.2.11 released
 

--- a/include/libtorrent/Makefile.am
+++ b/include/libtorrent/Makefile.am
@@ -218,6 +218,7 @@ nobase_include_HEADERS = \
   aux_/instantiate_connection.hpp   \
   aux_/range.hpp                    \
   aux_/windows.hpp                  \
+  aux_/pool.hpp                     \
   \
   extensions/smart_ban.hpp          \
   extensions/ut_metadata.hpp        \

--- a/include/libtorrent/aux_/pool.hpp
+++ b/include/libtorrent/aux_/pool.hpp
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2010-2018, Arvid Norberg
+Copyright (c) 2020, Arvid Norberg
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -30,43 +30,31 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#ifndef TORRENT_DISK_JOB_POOL
-#define TORRENT_DISK_JOB_POOL
+#ifndef TORRENT_POOL_HPP
+#define TORRENT_POOL_HPP
 
-#include "libtorrent/config.hpp"
-#include "libtorrent/disk_io_job.hpp" // for job_action_t
-#include "libtorrent/aux_/pool.hpp"
-#include <mutex>
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/pool/pool.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 namespace libtorrent {
+namespace aux {
 
-	struct disk_io_job;
+struct allocator_new_delete
+{
+	using size_type = std::size_t;
+	using difference_type = std::ptrdiff_t;
 
-	struct TORRENT_EXTRA_EXPORT disk_job_pool
-	{
-		disk_job_pool();
-		~disk_job_pool();
+	// TODO: ensure the alignment is good here
+	static char* malloc(size_type const bytes)
+	{ return new char[bytes]; }
+	static void free(char* const block)
+	{ delete [] block; }
+};
 
-		disk_io_job* allocate_job(job_action_t type);
-		void free_job(disk_io_job* j);
-		void free_jobs(disk_io_job** j, int num);
+using pool = boost::pool<allocator_new_delete>;
 
-		int jobs_in_use() const { return m_jobs_in_use; }
-		int read_jobs_in_use() const { return m_read_jobs; }
-		int write_jobs_in_use() const { return m_write_jobs; }
-
-	private:
-
-		// total number of in-use jobs
-		int m_jobs_in_use;
-		// total number of in-use read jobs
-		int m_read_jobs;
-		// total number of in-use write jobs
-		int m_write_jobs;
-
-		std::mutex m_job_mutex;
-		aux::pool m_job_pool;
-	};
+}
 }
 
-#endif // TORRENT_DISK_JOB_POOL
+#endif

--- a/include/libtorrent/kademlia/rpc_manager.hpp
+++ b/include/libtorrent/kademlia/rpc_manager.hpp
@@ -36,15 +36,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 #include <cstdint>
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-#include <boost/pool/pool.hpp>
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #include <libtorrent/socket.hpp>
 #include <libtorrent/time.hpp>
 #include <libtorrent/kademlia/node_id.hpp>
 #include <libtorrent/kademlia/observer.hpp>
 #include <libtorrent/aux_/listen_socket_handle.hpp>
+#include <libtorrent/aux_/pool.hpp>
 
 namespace libtorrent { class entry; }
 
@@ -120,7 +117,7 @@ private:
 	void* allocate_observer();
 	void free_observer(void* ptr);
 
-	mutable boost::pool<> m_pool_allocator;
+	mutable lt::aux::pool m_pool_allocator;
 
 	std::unordered_multimap<std::uint16_t, observer_ptr> m_transactions;
 

--- a/include/libtorrent/torrent_peer_allocator.hpp
+++ b/include/libtorrent/torrent_peer_allocator.hpp
@@ -35,12 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/torrent_peer.hpp"
-
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-
-#include <boost/pool/pool.hpp>
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#include "libtorrent/aux_/pool.hpp"
 
 namespace libtorrent {
 
@@ -83,10 +78,10 @@ namespace libtorrent {
 		// to have tens of thousands of peers, and a pool
 		// saves significant overhead
 
-		boost::pool<> m_ipv4_peer_pool{sizeof(libtorrent::ipv4_peer), 500};
-		boost::pool<> m_ipv6_peer_pool{sizeof(libtorrent::ipv6_peer), 500};
+		aux::pool m_ipv4_peer_pool{sizeof(libtorrent::ipv4_peer), 500};
+		aux::pool m_ipv6_peer_pool{sizeof(libtorrent::ipv6_peer), 500};
 #if TORRENT_USE_I2P
-		boost::pool<> m_i2p_peer_pool{sizeof(libtorrent::i2p_peer), 500};
+		aux::pool m_i2p_peer_pool{sizeof(libtorrent::i2p_peer), 500};
 #endif
 
 		// the total number of bytes allocated (cumulative)

--- a/src/disk_job_pool.cpp
+++ b/src/disk_job_pool.cpp
@@ -53,7 +53,6 @@ namespace libtorrent {
 		std::unique_lock<std::mutex> l(m_job_mutex);
 		disk_io_job* ptr = static_cast<disk_io_job*>(m_job_pool.malloc());
 		m_job_pool.set_next_size(100);
-		if (ptr == nullptr) return nullptr;
 		++m_jobs_in_use;
 		if (type == job_action_t::read) ++m_read_jobs;
 		else if (type == job_action_t::write) ++m_write_jobs;


### PR DESCRIPTION
Use regular new, that throws on failure, rather than the nothrow version