### PR TITLE
Better integration of setup.py to invoke b2

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,44 @@
+name: Python bindings
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: dependencies (macos)
+      if: runner.os == 'macOS'
+      run: |
+        brew install boost-build boost boost-python3 python@3.9
+
+    - name: update package lists
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+
+    - name: dependencies (linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev python3 python3-setuptools
+
+    - name: build/install
+      run: |
+        cd bindings/python
+        # Homebrew's python "framework" sets a prefix via distutils config.
+        # --prefix conflicts with --user, so null out prefix so we have one
+        # command that works everywhere
+        python3 setup.py build_ext -j3 --libtorrent-link=static install --user --prefix=
+
+    - name: tests
+      run: |
+        cd bindings/python
+        python3 test.py

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -10,7 +10,6 @@ use-project /torrent : ../.. ;
 
 BOOST_ROOT = [ modules.peek : BOOST_ROOT ] ;
 # this is used to make bjam use the same version of python which is executing setup.py
-LIBTORRENT_PYTHON_INTERPRETER = [ modules.peek : LIBTORRENT_PYTHON_INTERPRETER ] ;
 
 feature lt-visibility : default hidden : composite propagated ;
 feature.compose <lt-visibility>hidden : <cflags>-fvisibility=hidden <cxxflags>-fvisibility-inlines-hidden ;
@@ -26,15 +25,6 @@ feature python-install-path : : free path ;
 # when not specifying a custom install path, this controls whether to install
 # the python module in the system directory or user-specifc directory
 feature python-install-scope : user system : ;
-
-# this is just to force boost build to pick the desired python target when using LIBTORRENT_PYTHON_INTERPRETER
-feature libtorrent-python : on ;
-
-if $(LIBTORRENT_PYTHON_INTERPRETER)
-{
-	echo "using python interpreter at: " $(LIBTORRENT_PYTHON_INTERPRETER) ;
-	using python : : "$(LIBTORRENT_PYTHON_INTERPRETER)" : : : <libtorrent-python>on ;
-}
 
 # copied from boost 1.63's boost python jamfile
 rule find-py3-version

--- a/tools/set_version.py
+++ b/tools/set_version.py
@@ -48,9 +48,9 @@ def substitute_file(name):
         elif 'VERSION=' in line and name.endswith('build_dist.sh'):
             line = 'VERSION=%d.%d.%d\n' % (version[0], version[1], version[2])
         elif 'version=' in line and name.endswith('setup.py'):
-            line = "    version='%d.%d.%d',\n" % (version[0], version[1], version[2])
+            line = "    version=\"%d.%d.%d\",\n" % (version[0], version[1], version[2])
         elif "version = '" in line and name.endswith('setup.py'):
-            line = "    version='%d.%d.%d',\n" % (version[0], version[1], version[2])
+            line = "    version=\"%d.%d.%d\",\n" % (version[0], version[1], version[2])
         elif '"-LT' in line and name.endswith('settings_pack.cpp'):
             line = re.sub('"-LT[0-9A-Za-z]{4}-"', '"-LT%c%c%c%c-"' % v(version), line)
 


### PR DESCRIPTION
Hi,

I rewrote `setup.py` in the python bindings to be better-integrated with the b2 build system.

My use case is that I want to more easily build [wheels](https://realpython.com/python-wheels/) of libtorrent. Specifically, I want to use [tox](https://tox.readthedocs.io/en/latest/) and [pre-commit](https://pre-commit.com) in my libtorrent-based python project. These (and other tools) set up isolated environments and try to install dependencies, and since libtorrent isn't published on pypi, the easiest way to make these tools work is run a local pypi instance which provides access to libtorrent.

It was possible to make wheels before, but this integration fix makes it much easier. I now can build wheels with custom b2 compilation, like so:
```shell
$ python setup.py build_ext -j9 --debug --libtorrent-link=static bdist_wheel
```

I deleted all the existing build infrastructure from `setup.py` as I don't believe it was very useful: the `--bjam` mode didn't seem to actually integrate with distutils. It just invoked b2 from the global level, but didn't allow for passing options. The non-`--bjam` mode seemed very limited and wasn't referenced at all in [the build docs](http://libtorrent.org/python_binding.html).

I can't find any reference that `setup.py` is actually used by anyone today; debian and alpine's build scripts just invoke autotools and don't use `setup.py`. This is appropriate for them, but setuptools is a better choice for packaging in the distro-agnostic python world.