### PR TITLE
fix _WIN32_WINNT minimum version checking

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -848,7 +848,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 
 #elif TORRENT_USE_GETADAPTERSADDRESSES
 
-#if _WIN32_WINNT >= 0x0501
+#if _WIN32_WINNT >= 0x0600
 		using GetAdaptersAddresses_t = ULONG (WINAPI *)(ULONG,ULONG,PVOID,PIP_ADAPTER_ADDRESSES,PULONG);
 		// Get GetAdaptersAddresses() pointer
 		auto GetAdaptersAddresses =


### PR DESCRIPTION
- OnLinkPrefixLength is supported from vista(_WIN32_WINNT==0x0600) and above.
- IP_ADAPTER_UNICAST_ADDRESS is IP_ADAPTER_UNICAST_ADDRESS_XP in Windows XP, but it does not have OnLinkPrefixLength.
- Microsoft also recommends checking NTDDI_VERSION >= NTDDI_VISTA, _WIN32_WINNT >= 0x0600, or WINVER >= 0x0600 when using IP_ADAPTER_UNICAST_ADDRESS.
- ref : https://docs.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_adapter_unicast_address_lh