### PR TITLE
fix compilation when using boost >= 1.75 and json

### DIFF
--- a/src/websocket_tracker_connection.cpp
+++ b/src/websocket_tracker_connection.cpp
@@ -27,6 +27,9 @@ see LICENSE file.
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/system/system_error.hpp>
 #include <boost/json.hpp>
+#if BOOST_VERSION >= 107500
+#include <boost/json/src.hpp>
+#endif
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include <algorithm>
@@ -205,7 +208,11 @@ void websocket_tracker_connection::do_send(tracker_request const& req)
 		offers_array.emplace_back(std::move(payload_offer));
 	}
 
+#if BOOST_VERSION >= 107500
+	std::string const data = json::serialize(payload);
+#else
 	json::string const data = json::to_string(payload);
+#endif
 	m_write_data.assign(data.begin(), data.end());
 
 #ifndef TORRENT_DISABLE_LOGGING
@@ -232,7 +239,11 @@ void websocket_tracker_connection::do_send(tracker_answer const& ans)
 	obj["type"] = "answer";
 	obj["sdp"] = ans.answer.sdp;
 
+#if BOOST_VERSION >= 107500
+	std::string const data = json::serialize(payload);
+#else
 	json::string const data = json::to_string(payload);
+#endif
 	m_write_data.assign(data.begin(), data.end());
 
 #ifndef TORRENT_DISABLE_LOGGING


### PR DESCRIPTION
@arvidn this is the minimum I found to fix the issue. The problem is that the new boost (>=1.75) includes Boost.JSON, and it gets precedence over the outdated one included in `deps`