### PR TITLE
Bump minimum required boost version in master to 1.75.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,13 +4,18 @@ freebsd_instance:
 task:
   install_script: |
     IGNORE_OSVERSION=yes pkg update
-    pkg install -U -y git boost_build boost-libs unzip wget openssl cmake ninja
+    pkg install -U -y git unzip wget openssl cmake ninja
     echo "using clang ;" > ~/user-config.jam
+  boost_script: |
+      git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+      cd boost
+      ./bootstrap.sh
+      ./b2 headers
   submodules_script: |
     git submodule update --init --recursive
   build_cmake_script: |
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=OFF -G Ninja .
-    cmake --build . --parallel 2
+    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dpython-bindings=OFF -DBOOST_ROOT="$(pwd)/boost" -G Ninja -B cmake-build-dir
+    cmake --build cmake-build-dir
     ./test/test_primitives
   tests_script: |
     cd test

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -37,7 +37,10 @@ jobs:
     - name: dependencies (linux)
       if: runner.os == 'Linux'
       run: |
-        sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
+        git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+        cd boost
+        ./bootstrap.sh
+        ./b2 headers
 
     - name: install boost (windows)
       if: runner.os == 'Windows'
@@ -68,5 +71,8 @@ jobs:
     - name: build
       if: runner.os != 'Windows'
       run: |
+        export BOOST_ROOT="$(pwd)/boost"
+        export PATH="$BOOST_ROOT:$PATH"
+        export BOOST_BUILD_PATH"$BOOST_ROOT/tools/build"
         cd bindings/c
         b2

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -43,7 +43,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: cmd
       run: |
-        git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+        git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
         cd boost
         bootstrap.bat
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,8 +41,11 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
           echo "using gcc ;" >>~/user-config.jam
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
 
       - name: install gcrypt
         if: ${{ contains(matrix.config, 'crypto=gcrypt') }}
@@ -50,15 +53,21 @@ jobs:
 
       - name: build library
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           b2 ${{ matrix.config }} cxxstd=17
 
       - name: build examples
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           cd examples
           b2 ${{ matrix.config }}
 
       - name: build tools
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           cd tools
           b2 ${{ matrix.config }} warnings-as-errors=on
 
@@ -87,11 +96,16 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
           echo "using clang : 9 : clang++-9 ;" >>~/user-config.jam
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
 
       - name: build fuzzers
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           cd fuzzers
           b2 clang cxxstd=17 warnings-as-errors=on
 
@@ -114,11 +128,16 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
           echo "using gcc ;" >>~/user-config.jam
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
 
       - name: compile header files individually
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           b2 check-headers cxxstd=17 warnings-as-errors=on
 
 
@@ -143,11 +162,16 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev
           echo "using clang_tidy : : clang-tidy \"-checks=-clang-analyzer-core.*,-clang-analyzer-unix.*\" : <cxxflags>-I/usr/local/clang-7.0.0/include/c++/v1 <cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++ ;" >> ~/user-config.jam;
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
 
       - name: analyze
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           b2 -a clang_tidy
 
 
@@ -189,13 +213,18 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
-          pip install websockets
-          echo "using gcc ;" >>~/user-config.jam
           echo "using clang : 10 : clang++-10 ;" >>~/user-config.jam
+          echo "using gcc ;" >>~/user-config.jam
+          pip install websockets
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
 
       - name: build and run tests
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           cd test
           b2 ${{ matrix.config }} -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
 
@@ -226,11 +255,16 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
           echo "using gcc ;" >>~/user-config.jam
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
 
       - name: build and run simulations
         run: |
+          export BOOST_ROOT="$(pwd)/boost"
+          export PATH="$BOOST_ROOT:$PATH"
           cd simulation
           b2 debug-iterators=on invariant-checks=full asserts=on picker-debugging=on
 
@@ -256,10 +290,13 @@ jobs:
 
       - name: install dependencies
         run: |
-          sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev
+          echo "using gcc ;" >>~/user-config.jam
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
+          cd boost
+          ./bootstrap.sh
+          ./b2 headers
           sudo apt install python-docutils python-pygments python-pil gsfonts inkscape icoutils graphviz hunspell imagemagick python3-setuptools
           python3 -m pip install aafigure
-          echo "using gcc ;" >>~/user-config.jam
 
       - name: build tarball
         run: AAFIGURE=~/.local/bin/aafigure RST2HTML=rst2html make dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,7 +86,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: cmd
       run: |
-        git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+        git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
         cd boost
         bootstrap.bat
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: install boost
         run: |
-          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
           cd boost
           bootstrap.bat
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: install boost
         run: |
-          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
           cd boost
           bootstrap.bat
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: install boost
         run: |
-          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.75.0 https://github.com/boostorg/boost.git
           cd boost
           bootstrap.bat
 
@@ -172,4 +172,3 @@ jobs:
           set PATH=%BOOST_ROOT%;%PATH%
           cd tools
           b2 ${{ matrix.config }} warnings=all warnings-as-errors=on
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "deps/libdatachannel"]
 	path = deps/libdatachannel
 	url = https://github.com/paullouisageneau/libdatachannel.git
-[submodule "deps/json"]
-	path = deps/json
-	url = https://github.com/vinniefalco/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,12 +807,8 @@ if (webtorrent)
 endif()
 
 # Boost
-find_public_dependency(Boost REQUIRED)
+find_public_dependency(Boost 1.75.0 REQUIRED)
 target_include_directories(torrent-rasterbar PUBLIC ${Boost_INCLUDE_DIRS})
-if (Boost_MAJOR_VERSION LESS_EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
-	find_package(Boost REQUIRED COMPONENTS system)
-	target_link_libraries(torrent-rasterbar PUBLIC ${Boost_SYSTEM_LIBRARY})
-endif()
 
 if (exceptions)
 	if (MSVC)

--- a/Jamfile
+++ b/Jamfile
@@ -168,22 +168,14 @@ rule linking ( properties * )
 		result += <local-visibility>global ;
 	}
 
-	local BOOST_VERSION_TAG = [ modules.peek boostcpp : BOOST_VERSION_TAG ] ;
 	local json ;
-	if $(BOOST_VERSION_TAG) >= 1_75
+	if $(BOOST_ROOT)
 	{
-		if $(BOOST_ROOT)
-		{
-			json = /boost/json//boost_json ;
-		}
-		else
-		{
-			json = system_boost_json ;
-		}
+		json = /boost/json//boost_json ;
 	}
 	else
 	{
-		json = shipped_boost_json ;
+		json = system_boost_json ;
 	}
 
 	if <boost-link>static in $(properties)
@@ -956,32 +948,8 @@ lib torrent
 # return libdir and includedir
 rule install-paths ( properties * )
 {
-	import version ;
-
-	# package.paths was introduced in boost-1.70 (2018.02)
-	# however, boost build's versioning scheme changed in boost-1.71 to version
-	# 4.0
-	local boost-build-version = [ SPLIT_BY_CHARACTERS [ version.boost-build ] : "-" ] ;
-	if [ version.version-less [ SPLIT_BY_CHARACTERS $(boost-build-version[1]) : "." ] : 2018 03 ]
-	{
-		import option ;
-		import property ;
-		local prefix = [ option.get prefix : [ property.select <install-default-prefix> : $(properties) ] ] ;
-		prefix = $(prefix:G=) ;
-		# Or some likely defaults if neither is given.
-		if ! $(prefix)
-		{
-			if [ modules.peek : NT ] { prefix = C:\\$(package-name) ; }
-			else if [ modules.peek : UNIX ] { prefix = /usr/local ; }
-		}
-
-		return $(prefix)/lib $(prefix)/include ;
-	}
-	else
-	{
-		local p = [ package.paths libtorrent : $(properties) ] ;
-		return [ $(p).libdir ] [ $(p).includedir ] ;
-	}
+	local p = [ package.paths libtorrent : $(properties) ] ;
+	return [ $(p).libdir ] [ $(p).includedir ] ;
 }
 
 rule generate-pkg-config ( properties * )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - if not defined ssl_include ( set ssl_include=c:\ )
   - if not defined ssl_root_dir ( set ssl_root_dir=c:\ )
   - cd %ROOT_DIRECTORY%
-  - set BOOST_ROOT=c:\Libraries\boost_1_71_0
+  - set BOOST_ROOT=c:\Libraries\boost_1_75_0
   - set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
   - echo %BOOST_ROOT%
   - echo %BOOST_BUILD_PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,10 +96,8 @@ build_script:
     cd %BOOST_ROOT% &&
     b2.exe cxxstd=17 release --with-python --with-system --layout=system address-model=64 link=shared stage &&
     cd %ROOT_DIRECTORY% &&
-    mkdir build &&
-    cd build &&
-    cmake -DBOOST_LIBRARYDIR=%BOOST_ROOT%\stage\lib -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dwebtorrent=%webtorrent% -DOPENSSL_ROOT_DIR=%ssl_root_dir% -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 16 2019" -A x64 .. &&
-    cmake --build . --config Release --parallel %NUMBER_OF_PROCESSORS% -- -verbosity:minimal
+    cmake -DBOOST_LIBRARYDIR=%BOOST_ROOT%\stage\lib -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dwebtorrent=%webtorrent% -DOPENSSL_ROOT_DIR=%ssl_root_dir% -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G Ninja -B build &&
+    cmake --build build --config Release
     )
 
 test_script:

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -31,41 +31,20 @@ feature python-install-path : : free path ;
 # the python module in the system directory or user-specifc directory
 feature python-install-scope : user system : ;
 
-# copied from boost 1.63's boost python jamfile
-rule find-py3-version
+# this is just to force boost build to pick the desired python target when using LIBTORRENT_PYTHON_INTERPRETER
+feature libtorrent-python : on ;
+
+if $(LIBTORRENT_PYTHON_INTERPRETER)
 {
-	local BOOST_VERSION_TAG = [ modules.peek boostcpp : BOOST_VERSION_TAG ] ;
-	if $(BOOST_VERSION_TAG) >= 1_67
-	{
-		# starting with boost 1.67.0 boost python no longer define a separate
-		# target for python3 (boost_python3) so then we just use the regular
-		# boost_python target
-		return ;
-	}
-	local versions = [ feature.values python ] ;
-	local py3ver ;
-	for local v in $(versions)
-	{
-		if $(v) >= 3.0
-		{
-			py3ver = $(v) ;
-		}
-	}
-	return $(py3ver) ;
+	echo "using python interpreter at: " $(LIBTORRENT_PYTHON_INTERPRETER) ;
+	using python : : "$(LIBTORRENT_PYTHON_INTERPRETER)" : : : <libtorrent-python>on ;
 }
 
 if $(BOOST_ROOT)
 {
 	use-project /boost : $(BOOST_ROOT) ;
 	alias boost_python : /boost/python//boost_python : : : <include>$(BOOST_ROOT) ;
-	if [ find-py3-version ]
-	{
-		alias boost_python3 : /boost/python//boost_python3 : : : <include>$(BOOST_ROOT) ;
-	}
-	else
-	{
-		alias boost_python3 : boost_python ;
-	}
+	alias boost_python3 : boost_python ;
 }
 else
 {
@@ -175,12 +154,6 @@ rule libtorrent_linking ( properties * )
 		ECHO "WARNING: you probably want to specify libtorrent-link=static rather than link=static" ;
 	}
 
-	local BOOST_VERSION_TAG = [ modules.peek boostcpp : BOOST_VERSION_TAG ] ;
-	if <boost-link>static in $(properties) && $(BOOST_VERSION_TAG) < 1_74 && <target-os>linux in $(properties)
-	{
-		ECHO "WARNING: you cannot link statically against boost-python on linux before version 1.74.0, because it links against pthread statically in that case, which is not allowed" ;
-	}
-
 	local boost_python_lib ;
 
 	for local prop in $(properties)
@@ -198,10 +171,7 @@ rule libtorrent_linking ( properties * )
 		boost_python_lib = boost_python ;
 	}
 
-	# linux must link dynamically against boost python because it pulls
-	# in libpthread, which must be linked dynamically since we're building a .so
-	# (the static build of libpthread is not position independent)
-	if <boost-link>shared in $(properties) || ( <target-os>linux in $(properties) && $(BOOST_VERSION_TAG) < 1_74 )
+	if <boost-link>shared in $(properties)
 	{
 		result += <library>$(boost_python_lib)/<link>shared/<warnings>off ;
 	}
@@ -353,4 +323,3 @@ install stage_dependencies
 
 explicit stage_module ;
 explicit stage_dependencies ;
-

--- a/bindings/python/src/boost_python.hpp
+++ b/bindings/python/src/boost_python.hpp
@@ -11,10 +11,7 @@
 
 #include <boost/bind/placeholders.hpp>
 
-// in boost 1.60, placeholders moved into a namespace, just like std
-#if BOOST_VERSION >= 106000
 using namespace boost::placeholders;
-#endif
 
 #include <boost/python/stl_iterator.hpp>
 #include <boost/get_pointer.hpp>
@@ -40,4 +37,3 @@ inline void python_deprecated(char const* msg)
 }
 
 #endif
-

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -107,8 +107,8 @@ You'll find boost here__.
 __ https://www.boost.org/users/download/#live
 
 Extract the archive to some directory where you want it. For the sake of this
-guide, let's assume you extract the package to ``c:\boost_1_69_0``. You'll
-need at least version 1.66 of the boost library in order to build libtorrent.
+guide, let's assume you extract the package to ``c:\boost_1_75_0``. You'll
+need at least version 1.75 of the boost library in order to build libtorrent.
 
 
 Step 2: Setup BBv2
@@ -118,7 +118,7 @@ If you have installed ``boost-build`` via a package manager, you can skip this
 step. If not, you need to build boost build from the boost source package.
 
 First you need to build ``b2``. You do this by opening a terminal (In windows,
-run ``cmd``). Change directory to ``c:\boost_1_68_0\tools\build``. Then run the
+run ``cmd``). Change directory to ``c:\boost_1_75_0\tools\build``. Then run the
 script called ``bootstrap.bat`` or ``bootstrap.sh`` on a Unix system. This will
 build ``b2`` and place it in a directory ``src/engine/bin.<architecture>``.
 Copy the ``b2.exe`` (or ``b2`` on a Unix system) to a place that's in you
@@ -133,11 +133,11 @@ set the environment variable ``BOOST_BUILD_PATH``. This is the path that tells
 ``b2`` where it can find boost-build, your configuration file and all the
 toolsets (descriptions used by boost-build to know how to use different
 compilers on different platforms). Assuming the boost install path above, set
-it to ``c:\boost_1_68_0\tools\build``.
+it to ``c:\boost_1_75_0\tools\build``.
 
 To set an environment variable in windows, type for example::
 
-  set BOOST_BUILD_PATH=c:\boost_1_68_0\tools\build\v2
+  set BOOST_BUILD_PATH=c:\boost_1_75_0\tools\build\v2
 
 In a terminal window.
 
@@ -180,7 +180,7 @@ Step 3: Building libtorrent
 When building libtorrent, boost is either picked up from system installed
 locations or from a boost source package, if the ``BOOST_ROOT`` environment
 variable is set pointing to one. If you're building boost from source, set
-``BOOST_ROOT`` to your boost directory, e.g. ``c:\boost_1_68_0``.
+``BOOST_ROOT`` to your boost directory, e.g. ``c:\boost_1_75_0``.
 
 Then the only thing left is simply to invoke ``b2``. If you want to specify
 a specific toolset to use (compiler) you can just add that to the command line.
@@ -246,8 +246,8 @@ from a cygwin terminal, you'll have to run it from a ``cmd`` terminal. The same 
 cygwin, if you're building with gcc in cygwin you'll have to run it from a cygwin terminal.
 Also, make sure the paths are correct in the different environments. In cygwin, the paths
 (``BOOST_BUILD_PATH`` and ``BOOST_ROOT``) should be in the typical Unix-format (e.g.
-``/cygdrive/c/boost_1_68_0``). In the windows environment, they should have the typical
-windows format (``c:/boost_1_68_0``).
+``/cygdrive/c/boost_1_75_0``). In the windows environment, they should have the typical
+windows format (``c:/boost_1_75_0``).
 
 .. note::
 	In Jamfiles, spaces are separators. It's typically easiest to avoid spaces

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -309,8 +309,8 @@ libtorrent runs on most major operating systems including:
 * Solaris
 
 It uses Boost.Asio, Boost.Optional, Boost.System, Boost.Multiprecision,
-Boost.Pool, Boost.Python (for bindings), Boost.CRC and various
-other boost libraries. At least version 1.70 of boost is required.
+Boost.Pool, Boost.Python (for bindings), Boost.CRC, Boost.JSON and various
+other boost libraries. At least version 1.75 of boost is required.
 
 Since libtorrent uses Boost.Asio it will take full advantage of high performance
 network APIs on the most popular platforms. I/O completion ports on windows,
@@ -320,4 +320,3 @@ libtorrent requires a C++11 compiler and does not build with the following compi
 
 * GCC older than 5.4
 * Visual Studio older than Visual Studio 15 2017 (aka msvc-14.1)
-

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -112,7 +112,7 @@ with an associated port.
 
 For documentation on these types, please refer to the `asio documentation`_.
 
-.. _`asio documentation`: https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio.html
+.. _`asio documentation`: https://www.boost.org/doc/libs/1_75_0/doc/html/boost_asio.html
 
 exceptions
 ==========
@@ -1261,4 +1261,3 @@ web seed
 	A web server that is acting a seed, providing access to all pieces of all
 	files over HTTP. This is an extension that client software may or may not
 	support.
-

--- a/docs/python_binding.rst
+++ b/docs/python_binding.rst
@@ -260,4 +260,3 @@ A very simple example usage of the module would be something like this:
 	:code: python
 	:tab-width: 2
 	:start-after: from __future__ import print_function
-

--- a/include/libtorrent/aux_/proxy_base.hpp
+++ b/include/libtorrent/aux_/proxy_base.hpp
@@ -101,7 +101,7 @@ struct proxy_base
 		m_sock.async_write_some(buffers, std::move(handler));
 	}
 
-#if BOOST_VERSION >= 106600 && !defined TORRENT_BUILD_SIMULATOR
+#if !defined TORRENT_BUILD_SIMULATOR
 	// Compatiblity with the async_wait method introduced in boost 1.66
 
 	static constexpr auto wait_read = tcp::socket::wait_read;

--- a/include/libtorrent/aux_/ssl.hpp
+++ b/include/libtorrent/aux_/ssl.hpp
@@ -76,11 +76,7 @@ using error_code = boost::system::error_code;
 	using boost::asio::ssl::stream;
 #endif
 using boost::asio::ssl::verify_context;
-#if BOOST_VERSION >= 107300
 using boost::asio::ssl::host_name_verification;
-#else
-using host_name_verification = boost::asio::ssl::rfc2818_verification;
-#endif
 
 using native_context_type = SSL_CTX*;
 using native_stream_type = SSL*;

--- a/include/libtorrent/aux_/ssl_stream.hpp
+++ b/include/libtorrent/aux_/ssl_stream.hpp
@@ -47,10 +47,8 @@ struct ssl_stream
 	using lowest_layer_type = typename Stream::lowest_layer_type;
 	using endpoint_type = typename Stream::endpoint_type;
 	using protocol_type = typename Stream::protocol_type;
-#if BOOST_VERSION >= 106600
 	using executor_type = typename sock_type::executor_type;
 	executor_type get_executor() { return m_sock->get_executor(); }
-#endif
 
 	ssl::stream_handle_type handle()
 	{

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -433,9 +433,6 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 		issue_write();
 	}
 
-#if BOOST_VERSION >= 106600
-	// Compatiblity with the async_wait method introduced in boost 1.66
-
 	enum wait_type { wait_read, wait_write, wait_error };
 
 	template <class Handler>
@@ -458,7 +455,6 @@ struct TORRENT_EXTRA_EXPORT utp_stream
             break;
 		}
 	}
-#endif
 
 private:
 

--- a/src/websocket_stream.cpp
+++ b/src/websocket_stream.cpp
@@ -233,18 +233,11 @@ void websocket_stream::do_handshake()
 	ADD_OUTSTANDING_ASYNC("websocket_stream::on_handshake");
 	std::visit([&](auto& stream)
 		{
-#if BOOST_VERSION >= 107000
 			stream.set_option(websocket::stream_base::decorator(user_agent_handler));
 			stream.async_handshake(host
 				, m_target
 				, std::bind(&websocket_stream::on_handshake, shared_from_this(), _1));
-#else
-			stream.async_handshake_ex(host
-				, m_target
-				, user_agent_handler
-				, std::bind(&websocket_stream::on_handshake, shared_from_this(), _1));
-#endif
-	}
+		}
 	, m_stream);
 }
 

--- a/src/websocket_tracker_connection.cpp
+++ b/src/websocket_tracker_connection.cpp
@@ -253,8 +253,7 @@ void websocket_tracker_connection::do_read()
 {
 	if (!is_open()) return;
 
-	// Can be replaced by m_read_buffer.clear() with boost 1.70+
-	if (m_read_buffer.size() > 0) m_read_buffer.consume(m_read_buffer.size());
+	if (m_read_buffer.size() > 0) m_read_buffer.clear();
 
 	ADD_OUTSTANDING_ASYNC("websocket_tracker_connection::on_read");
 	m_websocket->async_read(m_read_buffer

--- a/src/websocket_tracker_connection.cpp
+++ b/src/websocket_tracker_connection.cpp
@@ -27,10 +27,7 @@ see LICENSE file.
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/system/system_error.hpp>
-#include <boost/json.hpp>
-#ifdef BOOST_JSON_HEADER_ONLY
 #include <boost/json/src.hpp>
-#endif
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include <algorithm>


### PR DESCRIPTION
Allows for some `#if` cleanups + some cleanups in the build scripts; this is sort of a follow-up to d3216f63aeea558ed54c8bcb2dc9ab112db46577.

Let me know if there is anything wrong with the changes to the Jamfile, I'm not to familiar.

Also, I'm a little unsure about the change from `m_read_buffer.consume(m_read_buffer.size());` to `m_read_buffer.clear();` in `src/websocket_tracker_connection.cpp`.The docs for the former and latter method read, respectively (emphasis mine):

>Remove bytes from beginning of the **readable bytes**.
Removes n bytes from the beginning of the readable bytes.
All buffers sequences previously obtained using
`data` or `prepare` become invalid.
>
>`n`: The number of bytes to remove. If this number is greater than the number of readable bytes, all readable bytes are removed

>Set the size of the **readable and writable bytes** to zero.
This clears the buffer without changing capacity.
Buffer sequences previously obtained using `data` or
`prepare` become invalid.
>
>No-throw guarantee.

I did not study the code in detail, so I don't know if this makes any difference. But from a cursory look, it makes sense and seems to be OK, since in the libtorrent code I only see this buffer being read from, not written to, so the part about "and writable..." in the documentation should have no effect on the current behavior.