### PR TITLE
CMake: Fix static_runtime compile option on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR) # Configurable policies: <= CMP0094
 
+cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0092 NEW)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
@@ -486,8 +487,12 @@ elseif(MSVC)
 endif()
 
 if(static_runtime)
-	include(ucm_flags)
-	ucm_set_runtime(STATIC)
+	if (MSVC)
+		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+	else()
+		include(ucm_flags)
+		ucm_set_runtime(STATIC)
+	endif()
 	set(Boost_USE_MULTITHREADED ON)
 	set(Boost_USE_STATIC_RUNTIME ON)
 	set(OPENSSL_MSVC_STATIC_RT ON)


### PR DESCRIPTION
Some recent changes broke my static compilation on MSVC and this patch fixed it.