### PR TITLE
Fix GitHub Actions workflows running on Ubuntu

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2.3.3
 
+      - name: update package lists
+        run: |
+          sudo apt update
+
       - name: install dependencies
         run: |
           sudo apt install python-docutils python-pygments python-pil gsfonts inkscape icoutils graphviz hunspell imagemagick

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,10 @@ jobs:
         with:
            submodules: recursive
 
+      - name: update package lists
+        run: |
+          sudo apt update
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -57,6 +61,10 @@ jobs:
         with:
            submodules: recursive
 
+      - name: update package lists
+        run: |
+          sudo apt update
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -79,6 +87,10 @@ jobs:
         with:
            submodules: recursive
 
+      - name: update package lists
+        run: |
+          sudo apt update
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -99,6 +111,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
            submodules: recursive
+
+      - name: update package lists
+        run: |
+          sudo apt update
 
       - name: install clang-tidy
         run: sudo apt install clang-tidy
@@ -129,6 +145,10 @@ jobs:
         with:
            submodules: recursive
 
+      - name: update package lists
+        run: |
+          sudo apt update
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -155,6 +175,10 @@ jobs:
         with:
            submodules: recursive
 
+      - name: update package lists
+        run: |
+          sudo apt update
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -176,6 +200,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
            submodules: recursive
+
+      - name: update package lists
+        run: |
+          sudo apt update
 
       - name: install boost
         run: |
@@ -206,6 +234,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
            submodules: recursive
+
+      - name: update package lists
+        run: |
+          sudo apt update
 
       - name: install boost
         run: |


### PR DESCRIPTION
Always update package lists before attempting to install any packages.

This prevents update failures due to attempted downloads of packages that no longer exist.