### PR TITLE
Pin linux workflows to ubuntu-latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
 
    docs:
       name: Docs
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
       - name: checkout

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,7 +9,7 @@ jobs:
 
    build:
       name: build
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       continue-on-error: true
 
       strategy:
@@ -48,7 +48,7 @@ jobs:
 
    fuzzers:
       name: Fuzzers
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       continue-on-error: true
 
       steps:
@@ -71,7 +71,7 @@ jobs:
 
    check_headers:
       name: check headers
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
       - name: checkout
@@ -92,7 +92,7 @@ jobs:
 
    clang_tidy:
       name: clang-tidy
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
       - name: checkout
@@ -116,7 +116,7 @@ jobs:
 
    test:
       name: Tests
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       continue-on-error: true
 
       strategy:
@@ -147,7 +147,7 @@ jobs:
 
    sim:
       name: Simulations
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
       - name: checkout
@@ -169,7 +169,7 @@ jobs:
 
    python:
       name: Python bindings
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
       - name: checkout
@@ -199,7 +199,7 @@ jobs:
 
    dist:
       name: build dist
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
       - name: checkout


### PR DESCRIPTION
CIs are failing because something appears to be broken with the `ubuntu-20.04` action runner.

There's #5749, but per [actions/virtual-environments](https://github.com/actions/virtual-environments), I see that:
```
The Ubuntu 20.04 virtual environment is currently provided as a preview only.
The "ubuntu-latest" YAML workflow label still uses the Ubuntu 18.04 virtual environment.
```

If we intended to pin a version, maybe `ubuntu-20.04` is unstable now. Perhaps `ubuntu-18.04` is better, or maybe `ubuntu-latest` is a nice way to express that things should build on latest stable ubuntu.

Anyway, this PR is really to check if reverting to 18.04 fixes the current problems, so I can work on my other PR without the CI going crazy.