### PR TITLE
session constructor flags in python binding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix python binding regression in session constructor flags
 	* fix unaligned piece requests in mmap_storage
 	* improve client_data_t ergonomics
 	* fix issue with concurrent access to part files


### PR DESCRIPTION
the session constructor taking a settings_pack directly was deprecated, but this is still the only way to construct a session via the python bindings. session_params does not have a python binding (yet). When updating the python binding, there was an incorrect assumption that the session would be constructed via an implicitly created session_params object (which would happen if deprecated functions was disabled). However, when the session is constructed with the deprecated settings_pack, the flags actually matter for adding default plugins. The python binding could be improved in this regard, ideally to better match the C++ API by having a session_params object