### PR TITLE
widen contract for file_storage::symlink

### DIFF
--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -665,14 +665,22 @@ namespace {
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < end_file());
 		internal_file_entry const& fe = m_files[index];
-		TORRENT_ASSERT(fe.symlink_index < int(m_symlinks.size()));
-
-		auto const& link = m_symlinks[fe.symlink_index];
-
 		// TODO: 3 this is a hack to retain ABI compatibility with 1.2.1
 		// in next major release, make this return by value
 		static std::string storage[4];
 		static std::atomic<size_t> counter{0};
+
+		if (fe.symlink_index == internal_file_entry::not_a_symlink)
+		{
+			std::string& ret = storage[(counter++) % 4];
+			ret.clear();
+			return ret;
+		}
+
+		TORRENT_ASSERT(fe.symlink_index < int(m_symlinks.size()));
+
+		auto const& link = m_symlinks[fe.symlink_index];
+
 		std::string& ret = storage[(counter++) % 4];
 		ret.reserve(m_name.size() + link.size() + 1);
 		ret.assign(m_name);

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -775,6 +775,21 @@ TORRENT_TEST(query_symlinks)
 	TEST_CHECK(ret3 != ret4);
 }
 
+TORRENT_TEST(query_symlinks2)
+{
+	file_storage fs;
+	fs.set_piece_length(1024);
+	fs.add_file("test/0", 10);
+	fs.add_file("test/1", 10);
+	fs.add_file("test/2", 10);
+	fs.add_file("test/3", 10);
+
+	TEST_CHECK(fs.symlink(file_index_t{0}).empty());
+	TEST_CHECK(fs.symlink(file_index_t{1}).empty());
+	TEST_CHECK(fs.symlink(file_index_t{2}).empty());
+	TEST_CHECK(fs.symlink(file_index_t{3}).empty());
+}
+
 // TODO: test file attributes
 // TODO: test symlinks
 // TODO: test reorder_file (make sure internal_file_entry::swap() is used)


### PR DESCRIPTION
to return an empty string for non-symlinks