### PR TITLE
shortcuts to ask a torrent_info for v1 and v2 metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* add v1() and v2() functions to torrent_info
+	* fix piece_layers() to work for single-piece files
 	* fix python binding regression in session constructor flags
 	* fix unaligned piece requests in mmap_storage
 	* improve client_data_t ergonomics

--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -232,6 +232,12 @@ namespace libtorrent {
 		// This is optional.
 		void set_creator(char const* str);
 
+		// sets the "creation time" field. Defaults to the system clock at the
+		// time of construction of the create_torrent object. The timestamp is
+		// specified in seconds, posix time. If the creation date is set to 0,
+		// the "creation date" field will be omitted from the generated torrent.
+		void set_creation_date(std::time_t timestamp);
+
 		// This sets the SHA-1 hash for the specified piece (``index``). You are required
 		// to set the hash for every piece in the torrent before generating it. If you have
 		// the files on disk, you can use the high level convenience function to do this.

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -373,6 +373,12 @@ TORRENT_VERSION_NAMESPACE_3
 		sha1_hash info_hash() const noexcept;
 		info_hash_t const& info_hashes() const { return m_info_hash; }
 
+		// returns whether this torrent has v1 and/or v2 metadata, respectively.
+		// Hybrid torrents have both. These are shortcuts for
+		// info_hashes().has_v1() and info_hashes().has_v2() calls.
+		bool v1() const;
+		bool v2() const;
+
 #if TORRENT_ABI_VERSION == 1
 		// deprecated in 1.0. Use the variants that take an index instead
 		// internal_file_entry is no longer exposed in the API
@@ -520,8 +526,8 @@ TORRENT_VERSION_NAMESPACE_3
 		const std::string& name() const { return m_files.name(); }
 
 		// ``creation_date()`` returns the creation date of the torrent as time_t
-		// (`posix time`_). If there's no time stamp in the torrent file, the
-		// optional object will be uninitialized.
+		// (`posix time`_). If there's no time stamp in the torrent file, 0 is
+		// returned.
 		// .. _`posix time`: http://www.opengroup.org/onlinepubs/009695399/functions/time.html
 		std::time_t creation_date() const
 		{ return m_creation_date; }
@@ -592,6 +598,10 @@ TORRENT_VERSION_NAMESPACE_3
 		// return the bytes of the piece layer hashes for the specified file. If
 		// the file doesn't have a piece layer, an empty span is returned.
 		// The span size is divisible by 32, the size of a SHA-256 hash.
+		// If the size of the file is smaller than or equal to the piece size,
+		// the files "root hash" is the hash of the file and is not saved
+		// separately in the "piece layers" field, but this function still
+		// returns the root hash of the file in that case.
 		span<char const> piece_layer(file_index_t) const;
 
 		// clears the piece layers from the torrent_info. This is done by the

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -641,7 +641,8 @@ namespace {
 		if (!m_comment.empty())
 			dict["comment"] = m_comment;
 
-		dict["creation date"] = m_creation_date;
+		if (m_creation_date != 0)
+			dict["creation date"] = m_creation_date;
 
 		if (!m_created_by.empty())
 			dict["created by"] = m_created_by;
@@ -968,5 +969,10 @@ namespace {
 	{
 		if (str == nullptr) m_created_by.clear();
 		else m_created_by = str;
+	}
+
+	void create_torrent::set_creation_date(std::time_t timestamp)
+	{
+		m_creation_date = timestamp;
 	}
 }

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1465,7 +1465,8 @@ namespace {
 			}
 
 			auto const hashes = piece_layer->second;
-			if ((hashes.size() % sha256_hash::size()) != 0) {
+			if ((hashes.size() % sha256_hash::size()) != 0)
+			{
 				ec = errors::torrent_invalid_piece_layer;
 				return false;
 			}
@@ -1481,6 +1482,14 @@ namespace {
 	{
 		TORRENT_ASSERT_PRECOND(f >= file_index_t(0));
 		if (f >= m_piece_layers.end_index()) return {};
+		if (m_files.pad_file_at(f)) return {};
+
+		if (m_files.file_size(f) <= piece_length())
+		{
+			auto const root_ptr = m_files.root_ptr(f);
+			if (root_ptr == nullptr) return {};
+			return {root_ptr, lt::sha256_hash::size()};
+		}
 		return m_piece_layers[f];
 	}
 
@@ -1852,6 +1861,9 @@ namespace {
 	{
 		return m_info_hash.get_best();
 	}
+
+	bool torrent_info::v1() const { return m_piece_hashes != 0; }
+	bool torrent_info::v2() const { return !m_piece_layers.empty(); }
 
 TORRENT_VERSION_NAMESPACE_3_END
 

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -47,6 +47,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstring>
 #include <iostream>
 #include <fstream>
+#include <string>
+
+using namespace std::literals::string_literals;
 
 constexpr lt::file_index_t operator""_file (unsigned long long int const v)
 { return lt::file_index_t{static_cast<int>(v)}; }
@@ -422,4 +425,103 @@ TORRENT_TEST(implicit_v1_only)
 	TEST_EQUAL(info.files().pad_file_at(1_file), true);
 	TEST_EQUAL(info.files().file_name(2_file), "B");
 	TEST_EQUAL(info.name(), "test");
+}
+
+namespace {
+
+template <typename Fun>
+lt::torrent_info test_field(Fun f)
+{
+	lt::file_storage fs;
+	fs.add_file("A", 0x4000);
+	lt::create_torrent t(fs, 0x4000);
+	for (lt::piece_index_t i : fs.piece_range())
+		t.set_hash(i, lt::sha1_hash::max());
+
+	f(t);
+
+	std::vector<char> buffer;
+	lt::bencode(std::back_inserter(buffer), t.generate());
+	return lt::torrent_info(buffer, lt::from_span);
+}
+}
+
+TORRENT_TEST(no_creation_date)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_creation_date(0);
+	});
+	TEST_EQUAL(info.creation_date(), 0);
+}
+
+TORRENT_TEST(creation_date)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_creation_date(1337);
+	});
+	TEST_EQUAL(info.creation_date(), 1337);
+}
+
+TORRENT_TEST(comment)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_comment("foobar");
+	});
+	TEST_EQUAL(info.comment(), "foobar");
+}
+
+TORRENT_TEST(creator)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_creator("foobar");
+	});
+	TEST_EQUAL(info.creator(), "foobar");
+}
+
+TORRENT_TEST(dht_nodes)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.add_node({"foobar"s, 1337});
+	});
+	using nodes = std::vector<std::pair<std::string, int>>;
+	TEST_CHECK((info.nodes() == nodes{{"foobar", 1337}}));
+}
+
+TORRENT_TEST(ssl_cert)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_root_cert("foobar");
+	});
+	TEST_EQUAL(info.ssl_cert(), "foobar");
+}
+
+TORRENT_TEST(priv)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_priv(true);
+	});
+	TEST_CHECK(info.priv());
+}
+
+TORRENT_TEST(piece_layer)
+{
+	lt::file_storage fs;
+	fs.add_file("test/large", 0x8000);
+	fs.add_file("test/small-1", 0x4000);
+	fs.add_file("test/small-2", 0x3fff);
+	lt::create_torrent t(fs, 0x4000);
+
+	using p = lt::piece_index_t::diff_type;
+	t.set_hash2(lt::file_index_t(0), p(0), lt::sha256_hash::max());
+	t.set_hash2(lt::file_index_t(0), p(1), lt::sha256_hash::max());
+	t.set_hash2(lt::file_index_t(1), p(0), lt::sha256_hash::max());
+	t.set_hash2(lt::file_index_t(2), p(0), lt::sha256_hash::max());
+
+	std::vector<char> buffer;
+	lt::bencode(std::back_inserter(buffer), t.generate());
+	lt::torrent_info info(buffer, lt::from_span);
+
+	TEST_CHECK(info.piece_layer(lt::file_index_t(0)).size() == lt::sha256_hash::size() * 2);
+	TEST_CHECK(info.piece_layer(lt::file_index_t(1)).size() == lt::sha256_hash::size());
+	TEST_CHECK(info.piece_layer(lt::file_index_t(2)).size() == lt::sha256_hash::size());
 }

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -64,7 +64,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 
+#include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/variant/get.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 using namespace std::placeholders;
 using namespace lt;

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -282,6 +282,8 @@ static test_torrent_t const test_torrents[] =
 			TEST_EQUAL(ti->info_hashes().has_v1(), true);
 			TEST_EQUAL(ti->info_hashes().has_v2(), true);
 			TEST_EQUAL(aux::to_hex(ti->info_hashes().v2), "597b180c1a170a585dfc5e85d834d69013ceda174b8f357d5bb1a0ca509faf0a"_sv);
+			TEST_CHECK(ti->v2());
+			TEST_CHECK(ti->v1());
 		}
 	},
 	{ "v2_multipiece_file.torrent", [](torrent_info const* ti) {
@@ -302,6 +304,8 @@ static test_torrent_t const test_torrents[] =
 			TEST_EQUAL(ti->info_hashes().has_v1(), false);
 			TEST_EQUAL(ti->info_hashes().has_v2(), true);
 			TEST_EQUAL(aux::to_hex(ti->info_hashes().v2), "95e04d0c4bad94ab206efa884666fd89777dbe4f7bd9945af1829037a85c6192"_sv);
+			TEST_CHECK(ti->v2());
+			TEST_CHECK(!ti->v1());
 		}
 	},
 	{ "v2_invalid_filename.torrent", [](torrent_info const* ti) {
@@ -966,6 +970,8 @@ TORRENT_TEST(parse_torrents)
 		piece_picker pp(blocks_per_piece, blocks_in_last_piece, ti->num_pieces());
 
 		TEST_CHECK(ti->piece_length() < std::numeric_limits<int>::max() / 2);
+		TEST_EQUAL(ti->v1(), ti->info_hashes().has_v1());
+		TEST_EQUAL(ti->v2(), ti->info_hashes().has_v2());
 
 		if (t.test) t.test(ti.get());
 


### PR DESCRIPTION
allow not setting a creation date in create_torrent (but default to current timestamp).
Provide more prominent shortcuts to ask a torrent_info about whether it has v1 and v2 metadata