### PR TITLE
Fix redundant and failed bytes overflow check

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1466,7 +1466,7 @@ namespace libtorrent {
 
 		// the number of bytes that has been
 		// downloaded that failed the hash-test
-		std::int32_t m_total_failed_bytes = 0;
+		std::int64_t m_total_failed_bytes = 0;
 		std::int64_t m_total_redundant_bytes = 0;
 
 		// the sequence number for this torrent, this is a

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -11108,10 +11108,10 @@ bool is_downloading_state(int const st)
 		TORRENT_ASSERT(static_cast<int>(reason) >= 0);
 		TORRENT_ASSERT(static_cast<int>(reason) < static_cast<int>(waste_reason::max));
 
-		if (m_total_redundant_bytes <= std::numeric_limits<std::int32_t>::max() - b)
+		if (m_total_redundant_bytes <= std::numeric_limits<std::int64_t>::max() - b)
 			m_total_redundant_bytes += b;
 		else
-			m_total_redundant_bytes = std::numeric_limits<std::int32_t>::max();
+			m_total_redundant_bytes = std::numeric_limits<std::int64_t>::max();
 
 		// the stats counters are 64 bits, so we don't check for overflow there
 		m_stats_counters.inc_stats_counter(counters::recv_redundant_bytes, b);
@@ -11122,10 +11122,10 @@ bool is_downloading_state(int const st)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(b > 0);
-		if (m_total_failed_bytes <= std::numeric_limits<std::int32_t>::max() - b)
+		if (m_total_failed_bytes <= std::numeric_limits<std::int64_t>::max() - b)
 			m_total_failed_bytes += b;
 		else
-			m_total_failed_bytes = std::numeric_limits<std::int32_t>::max();
+			m_total_failed_bytes = std::numeric_limits<std::int64_t>::max();
 
 		// the stats counters are 64 bits, so we don't check for overflow there
 		m_stats_counters.inc_stats_counter(counters::recv_failed_bytes, b);


### PR DESCRIPTION
The current overflow check caps `m_total_redundant_bytes` to 2 GiB, while this value can exceed 2 GiB while `strict_end_game_mode` is set to `false` on large torrents, resulting in an incorrect `downloaded` value. 
Since this value is very unlikely to reach int64 max, I don't think there's a need to perform an overflow check in `inc_stats_counter()`.