### PR TITLE
Fix possible overflow when setting connection limit

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -668,7 +668,7 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 		// 80% of the available file descriptors should go to connections
 		m_settings.set_int(settings_pack::connections_limit, std::min(
 			m_settings.get_int(settings_pack::connections_limit)
-			, std::max(5, (max_files - 20) * 8 / 10)));
+			, std::max(5, ((max_files - 20) / 10) * 8)));
 		// 20% goes towards regular files (see disk_io_thread)
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log())


### PR DESCRIPTION
For large values of `max_files` the expression `(max_files - 20) * 8 / 10` overflows and becomes negative, when this happens `connections_limit` is set to 5, which is very low. It is common for `max_open_files()` to return `INT_MAX` so overflow handling is needed. An easy fix is to change it so that the division happens first, `((max_files - 20) / 10) * 8`. That's what this PR does.

Ref: https://github.com/qbittorrent/qBittorrent/issues/13747#issuecomment-761716512