### PR TITLE
WebTorrent: Update libdatachannel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,7 @@ endif()
 
 if (webtorrent)
 	option(NO_WEBSOCKET "Disable WebSocket support in libdatachannel" ON)
+	option(NO_MEDIA "Disable media transport support in libdatachannel" ON)
 	if(GNUTLS_FOUND)
 		option(USE_GNUTLS "Use GnuTLS instead of OpenSSL for libdatachannel" ON)
 	else()


### PR DESCRIPTION
This PR updates libdatachannel to v0.10.4. The modifications mainly affect media transport, but there is still some ICE enhancements and fixes in libjuice that can be useful here.  