### PR TITLE
WebTorrent: Remove leftover compilation flag for g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,10 +790,6 @@ if (webtorrent)
 			-Wno-unused-variable
 			-Wno-format-nonliteral)
 	endif()
-	if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
-		target_compile_options(usrsctp-static PRIVATE
-			-Wno-format-truncation)
-	endif()
 endif()
 
 # Boost


### PR DESCRIPTION
The flag `-Wno-format-truncation` was added to usrsctp-static to prevent compilation warnings. The target does no exist anymore and the flag should be removed to allow compiling WebTorrent support with g++.