### PR TITLE
[5/?] Add pre-commit hooks for python code style, and clean up setup.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,11 @@ repos:
             tools/set_version.py|
             tools/update_copyright.py
           )$
+- repo: https://github.com/myint/autoflake
+  rev: v1.4
+  hooks:
+    - id: autoflake
+      args: [--in-place, --remove-unused-variables, --remove-all-unused-imports, --remove-duplicate-keys]
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,43 @@ repos:
     -   id: check-xml
     -   id: debug-statements
     -   id: check-symlinks
+    -   id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.7.0
   hooks:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
+- repo: https://github.com/PyCQA/isort
+  rev: 5.7.0
+  hooks:
+    - id: isort
+      exclude: |
+          (?x)^(
+            # Enable these later, avoid bloating this PR
+            bindings/python/client.py|
+            bindings/python/dummy_data.py|
+            bindings/python/make_torrent.py|
+            bindings/python/simple_client.py|
+            bindings/python/test.py|
+            docs/gen_reference_doc.py|
+            examples/run_benchmarks.py|
+            fuzzers/tools/generate_initial_corpus.py|
+            fuzzers/tools/unify_corpus_names.py|
+            test/socks.py|
+            test/web_server.py|
+            test/websocket_server.py|
+            tools/clean.py|
+            tools/copyright.py|
+            tools/dht_flood.py|
+            tools/parse_dht_log.py|
+            tools/parse_dht_rtt.py|
+            tools/parse_dht_stats.py|
+            tools/parse_session_stats.py|
+            tools/parse_utp_log.py|
+            tools/run_benchmark.py|
+            tools/set_version.py|
+            tools/update_copyright.py
+          )$
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,51 @@ repos:
   hooks:
     - id: autoflake
       args: [--in-place, --remove-unused-variables, --remove-all-unused-imports, --remove-duplicate-keys]
+- repo: https://github.com/python/black
+  rev: 20.8b1
+  hooks:
+    - id: black
+      # Avoiding PR bloat
+      exclude: |
+          (?x)^(
+               bindings/c/tools/gen_alert_header.py|
+               bindings/c/tools/gen_header.py|
+               bindings/python/client.py|
+               bindings/python/dummy_data.py|
+               bindings/python/make_torrent.py|
+               bindings/python/simple_client.py|
+               bindings/python/test.py|
+               docs/filter-rst.py|
+               docs/gen_reference_doc.py|
+               docs/gen_settings_doc.py|
+               docs/gen_stats_doc.py|
+               docs/gen_todo.py|
+               docs/join_rst.py|
+               examples/run_benchmarks.py|
+               fuzzers/tools/generate_initial_corpus.py|
+               fuzzers/tools/unify_corpus_names.py|
+               test/http_proxy.py|
+               test/socks.py|
+               test/web_server.py|
+               test/websocket_server.py|
+               tools/benchmark_checking.py|
+               tools/clean.py|
+               tools/copyright.py|
+               tools/dht_flood.py|
+               tools/gen_convenience_header.py|
+               tools/gen_fwd.py|
+               tools/parse_dht_log.py|
+               tools/parse_dht_rtt.py|
+               tools/parse_dht_stats.py|
+               tools/parse_lookup_log.py|
+               tools/parse_peer_log.py|
+               tools/parse_sample.py|
+               tools/parse_session_stats.py|
+               tools/parse_utp_log.py|
+               tools/run_benchmark.py|
+               tools/set_version.py|
+               tools/update_copyright.py
+          )$
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:
@@ -76,7 +121,27 @@ repos:
             # Enable these later, avoid bloating this PR
             bindings/c/tools/gen_alert_header.py|
             bindings/c/tools/gen_header.py|
+            bindings/python/client.py|
+            bindings/python/test.py|
+            docs/gen_todo.py|
+            docs/gen_reference_doc.py|
+            docs/gen_settings_doc.py|
+            docs/gen_stats_doc.py|
+            examples/run_benchmarks.py|
             fuzzers/tools/generate_initial_corpus.py|
+            test/socks.py|
             test/websocket_server.py|
-            tools/benchmark_checking.py
+            test/web_server.py|
+            tools/benchmark_checking.py|
+            tools/dht_flood.py|
+            tools/gen_fwd.py|
+            tools/parse_dht_stats.py|
+            tools/parse_dht_log.py|
+            tools/parse_lookup_log.py|
+            tools/parse_peer_log.py|
+            tools/parse_session_stats.py|
+            tools/parse_utp_log.py|
+            tools/run_benchmark.py|
+            tools/set_version.py|
+            tools/update_copyright.py
         )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,48 @@ repos:
                tools/set_version.py|
                tools/update_copyright.py
           )$
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.800
+  hooks:
+    - id: mypy
+      # Avoiding PR bloat
+      exclude: |
+          (?x)^(
+              bindings/c/tools/gen_alert_header.py|
+              bindings/c/tools/gen_header.py|
+              bindings/python/client.py|
+              bindings/python/dummy_data.py|
+              bindings/python/make_torrent.py|
+              bindings/python/test.py|
+              docs/filter-rst.py|
+              docs/gen_reference_doc.py|
+              docs/gen_settings_doc.py|
+              docs/gen_stats_doc.py|
+              docs/gen_todo.py|
+              examples/run_benchmarks.py|
+              fuzzers/tools/generate_initial_corpus.py|
+              setup.py|
+              test/http_proxy.py|
+              test/socks.py|
+              test/web_server.py|
+              test/websocket_server.py|
+              tools/benchmark_checking.py|
+              tools/clean.py|
+              tools/copyright.py|
+              tools/dht_flood.py|
+              tools/gen_convenience_header.py|
+              tools/gen_fwd.py|
+              tools/parse_dht_log.py|
+              tools/parse_dht_stats.py|
+              tools/parse_lookup_log.py|
+              tools/parse_peer_log.py|
+              tools/parse_sample.py|
+              tools/parse_session_stats.py|
+              tools/parse_utp_log.py|
+              tools/run_benchmark.py|
+              tools/set_version.py|
+              tools/update_copyright.py
+          )$
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -2,7 +2,9 @@
 
 import contextlib
 from distutils import log
+import distutils.cmd
 import distutils.debug
+import distutils.errors
 import distutils.sysconfig
 import os
 import pathlib
@@ -12,13 +14,19 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+from typing import cast
+from typing import IO
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Set
 import warnings
 
 import setuptools
-import setuptools.command.build_ext as _build_ext_lib
+import setuptools.command.build_ext as build_ext_lib
 
 
-def b2_bool(value):
+def b2_bool(value: bool) -> str:
     if value:
         return "on"
     return "off"
@@ -40,30 +48,35 @@ def b2_bool(value):
 
 
 class B2Distribution(setuptools.Distribution):
-    def reinitialize_command(self, command, reinit_subcommands=0):
+    def reinitialize_command(
+        self, command: str, reinit_subcommands: int = 0
+    ) -> distutils.cmd.Command:
         if command == "build_ext":
-            return self.get_command_obj("build_ext")
-        return super().reinitialize_command(
-            command, reinit_subcommands=reinit_subcommands
+            return cast(distutils.cmd.Command, self.get_command_obj("build_ext"))
+        return cast(
+            distutils.cmd.Command,
+            super().reinitialize_command(
+                command, reinit_subcommands=reinit_subcommands
+            ),
         )
 
 
 # Various setuptools logic expects us to provide Extension instances for each
 # extension in the distro.
 class StubExtension(setuptools.Extension):
-    def __init__(self, name):
+    def __init__(self, name: str):
         # An empty sources list ensures the base build_ext command won't build
         # anything
         super().__init__(name, sources=[])
 
 
-def b2_escape(value):
+def b2_escape(value: str) -> str:
     value = value.replace("\\", "\\\\")
     value = value.replace('"', '\\"')
     return f'"{value}"'
 
 
-def write_b2_python_config(config):
+def write_b2_python_config(config: IO[str]) -> None:
     write = config.write
     # b2 keys python environments by X.Y version, breaking ties by matching
     # a property list, called the "condition" of the environment. To ensure
@@ -109,6 +122,7 @@ def write_b2_python_config(config):
     # Note that sysconfig and distutils.sysconfig disagree here, especially on
     # windows.
     ext_suffix = distutils.sysconfig.get_config_var("EXT_SUFFIX")
+    ext_suffix = str(ext_suffix or "")
 
     # python.jam appends the platform-specific final suffix on its own. I can't
     # find a consistent value from sysconfig or distutils.sysconfig for this.
@@ -120,16 +134,13 @@ def write_b2_python_config(config):
     write(" ;\n")
 
 
-BuildExtBase = _build_ext_lib.build_ext
-
-
-class LibtorrentBuildExt(BuildExtBase):
+class LibtorrentBuildExt(build_ext_lib.build_ext):
 
     CONFIG_MODE_DISTUTILS = "distutils"
     CONFIG_MODE_B2 = "b2"
     CONFIG_MODES = (CONFIG_MODE_DISTUTILS, CONFIG_MODE_B2)
 
-    user_options = BuildExtBase.user_options + [
+    user_options = build_ext_lib.build_ext.user_options + [
         (
             "config-mode=",
             None,
@@ -195,28 +206,28 @@ class LibtorrentBuildExt(BuildExtBase):
         ),
     ]
 
-    boolean_options = BuildExtBase.boolean_options + ["pic", "hash"]
+    boolean_options = build_ext_lib.build_ext.boolean_options + ["pic", "hash"]
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
 
         self.config_mode = self.CONFIG_MODE_DISTUTILS
         self.b2_args = ""
         self.no_autoconf = ""
 
-        self.toolset = None
-        self.libtorrent_link = None
-        self.boost_link = None
-        self.pic = None
-        self.optimization = None
-        self.hash = None
-        self.cxxstd = None
+        self.toolset: Optional[str] = None
+        self.libtorrent_link: Optional[str] = None
+        self.boost_link: Optional[str] = None
+        self.pic: Optional[bool] = None
+        self.optimization: Optional[str] = None
+        self.hash: Optional[bool] = None
+        self.cxxstd: Optional[str] = None
 
-        self._b2_args_split = []
-        self._b2_args_configured = set()
+        self._b2_args_split: List[str] = []
+        self._b2_args_configured: Set[str] = set()
 
-        return super().initialize_options()
+        super().initialize_options()
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         super().finalize_options()
 
         if self.config_mode not in self.CONFIG_MODES:
@@ -274,7 +285,7 @@ class LibtorrentBuildExt(BuildExtBase):
             warnings.warn("--cxxstd is deprecated; use --b2-args=cxxstd=...")
             self._maybe_add_arg(f"cxxstd={self.cxxstd}")
 
-    def _should_add_arg(self, arg):
+    def _should_add_arg(self, arg: str) -> bool:
         m = re.match(r"(-\w).*", arg)
         if m:
             name = m.group(1)
@@ -282,18 +293,18 @@ class LibtorrentBuildExt(BuildExtBase):
             name = arg.split("=", 1)[0]
         return name not in self._b2_args_configured
 
-    def _maybe_add_arg(self, arg):
+    def _maybe_add_arg(self, arg: str) -> bool:
         if self._should_add_arg(arg):
             self._b2_args_split.append(arg)
             return True
         return False
 
-    def run(self):
+    def run(self) -> None:
         # The current jamfile layout just supports one extension
         self._build_extension_with_b2()
-        return super().run()
+        super().run()
 
-    def _build_extension_with_b2(self):
+    def _build_extension_with_b2(self) -> None:
         python_binding_dir = pathlib.Path(__file__).parent.absolute()
         with self._configure_b2():
             command = ["b2"] + self._b2_args_split
@@ -301,7 +312,7 @@ class LibtorrentBuildExt(BuildExtBase):
             subprocess.run(command, cwd=python_binding_dir, check=True)
 
     @contextlib.contextmanager
-    def _configure_b2(self):
+    def _configure_b2(self) -> Iterator[None]:
         if self.config_mode == self.CONFIG_MODE_DISTUTILS:
             # If we're using distutils mode, we'll auto-configure a lot of args
             # and write temporary config.
@@ -310,7 +321,7 @@ class LibtorrentBuildExt(BuildExtBase):
             # If we're using b2 mode, no configuration needed
             yield
 
-    def _configure_b2_with_distutils(self):
+    def _configure_b2_with_distutils(self) -> Iterator[None]:
         if os.name == "nt":
             self._maybe_add_arg("--abbreviate-paths")
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -317,11 +317,6 @@ class LibtorrentBuildExt(BuildExtBase):
     def _configure_b2_with_distutils(self):
         if os.name == "nt":
             self._maybe_add_arg("--abbreviate-paths")
-            self._maybe_add_arg("boost-link=static")
-        else:
-            self._maybe_add_arg("boost-link=shared")
-
-        self._maybe_add_arg("libtorrent-link=static")
 
         if distutils.debug.DEBUG:
             self._maybe_add_arg("--debug-configuration")
@@ -330,6 +325,8 @@ class LibtorrentBuildExt(BuildExtBase):
 
         # Default feature configuration
         self._maybe_add_arg("deprecated-functions=on")
+        self._maybe_add_arg("boost-link=static")
+        self._maybe_add_arg("libtorrent-link=static")
 
         variant = "debug" if self.debug else "release"
         self._maybe_add_arg(f"variant={variant}")

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
+import contextlib
 from distutils import log
 import distutils.debug
 import distutils.sysconfig
 import os
 import pathlib
+import re
+import shlex
+import subprocess
 import sys
 import sysconfig
 import tempfile
-import subprocess
-import contextlib
 import warnings
-import re
-import shlex
 
 import setuptools
 import setuptools.command.build_ext as _build_ext_lib

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -411,24 +411,25 @@ class LibtorrentBuildExt(BuildExtBase):
         self._maybe_add_arg(f"python-install-path={target.parent}")
         self._maybe_add_arg("install_module")
 
-        # We use a "project-config.jam" to instantiate a python environment
-        # to exactly match the running one.
-        try:
-            if override_project_config:
-                config = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+        # Two paths depending on whether or not we use a generated
+        # project-config.jam or not.
+        if override_project_config:
+            config = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+            try:
                 write_b2_python_config(config)
                 config.seek(0)
                 log.info("project-config.jam contents:")
                 log.info(config.read())
                 config.close()
                 self._b2_args_split.append(f"--project-config={config.name}")
+                yield
+            finally:
+                # If we errored while writing config, windows may complain about
+                # unlinking a file "in use"
+                config.close()
+                os.unlink(config.name)
+        else:
             yield
-
-        finally:
-            # If we errored while writing config, windows may complain about
-            # unlinking a file "in use"
-            config.close()
-            os.unlink(config.name)
 
 
 setuptools.setup(

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -167,11 +167,7 @@ class LibtorrentBuildExt(BuildExtBase):
             None,
             "(DEPRECATED; use --b2-args=libtorrent-link=...) ",
         ),
-        (
-            "boost-link=",
-            None,
-            "(DEPRECATED; use --b2-args=boost-link=...) "
-        ),
+        ("boost-link=", None, "(DEPRECATED; use --b2-args=boost-link=...) "),
         ("toolset=", None, "(DEPRECATED; use --b2-args=toolset=...) b2 toolset"),
         (
             "pic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.isort]
+profile = "google"
+single_line_exclusions = []
+src_paths = ["."]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,13 @@
 # https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
 max-line-length = 88
 extend-ignore = E203, W503
+
+[mypy]
+warn_return_any = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unreachable = True
+warn_unused_configs = True
+#disallow_any_unimported = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [flake8]
-max-line-length = 120
+# https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
+max-line-length = 88
+extend-ignore = E203, W503

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@
 import os
 import runpy
 
-os.chdir('bindings/python')
-runpy.run_path('setup.py')
+os.chdir("bindings/python")
+runpy.run_path("setup.py")


### PR DESCRIPTION
This is based on #5970.

This PR:
* introduces some python auto-formatting and type checking
* applies this to `setup.py`
* adds some minor readability fixes to `setup.py`

The pre-commit config excludes all existing python files except `setup.py` to prevent bloating the PR.

The intent is to illustrate what my proposed python auto-formatting would look like for discussion, and later apply it to other files.

I tried to pick this code style as a reasonable selection of practices in the open source python world. The code style is based on [black](https://github.com/psf/black). It's not very configurable, by design. I added some other auto-formatters to improve source code stability.

I also enforce python type annotations with mypy. In my experience, mypy runs very quickly and is quite good at catching python bugs.