### PR TITLE
[6/?] Rework python include/library detection. Use tox for running tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,18 +11,43 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # on linux and mac, the boost libraries are fixed to a python version.
+      # since we install boost from repos on those systems, we must use the
+      # matching python versions
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2019 ]
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.8
+          - os: macos-latest
+            python-version: 3.9
+          - os: windows-2019
+            python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
 
+    # Note:
+    #  - on mac and linux images, 'python' is python2 and 'python3' is
+    #    python3
+    #  - on windows, neither 'python' nor 'python3' is in PATH by default
+    #  - setup-python sets up PATH so 'python' and 'python3' point to the
+    #    requested version on mac and linux, but on windows it only sets up
+    #    'python'.
+    - uses: actions/setup-python@v2
+      with:
+         python-version: ${{ matrix.python-version }}
+
+    - name: install tox
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade tox
+
     - name: dependencies (MacOS)
       if: runner.os == 'macOS'
       run: |
-        brew install boost-build boost boost-python3 python@3.9
+        brew install boost-build boost boost-python3
 
     - name: update package lists (linux)
       if: runner.os == 'Linux'
@@ -33,7 +58,7 @@ jobs:
     - name: dependencies (linux)
       if: runner.os == 'Linux'
       run: |
-        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev python3 python3-setuptools
+        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev
 
     # there appears to be a bug in boost-build where referring to a
     # dependency that's on a different drive fails, deep in boost-build
@@ -42,40 +67,16 @@ jobs:
       if: runner.os == 'Windows'
       shell: cmd
       run: |
+        echo on
         echo using msvc ; >%HOMEDRIVE%%HOMEPATH%\user-config.jam
         mklink /J boost %BOOST_ROOT_1_72_0%
         cd boost
         b2 headers
+        cd ..
+        echo BOOST_ROOT=%CD%\boost>>%GITHUB_ENV%
+        echo BOOST_BUILD_PATH=%CD%\boost\tools\build>>%GITHUB_ENV%
+        echo %CD%\boost>>%GITHUB_PATH%
 
-    - name: build/install (windows)
-      if: runner.os == 'Windows'
-      shell: cmd
+    - name: build/test with tox
       run: |
-        set BOOST_ROOT=%CD%\boost
-        set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
-        set PATH=%BOOST_ROOT%;%PATH%
-
-        cd bindings\python
-        python setup.py build_ext install --user --prefix=
-
-    - name: tests (windows)
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        cd bindings\python
-        python test.py
-
-    - name: build/install
-      if: runner.os != 'Windows'
-      run: |
-        cd bindings/python
-        # Homebrew's python "framework" sets a prefix via distutils config.
-        # --prefix conflicts with --user, so null out prefix so we have one
-        # command that works everywhere
-        python3 setup.py build_ext --b2-args="libtorrent-link=static" install --user --prefix=
-
-    - name: tests
-      if: runner.os != 'Windows'
-      run: |
-        cd bindings/python
-        python3 test.py
+        tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py36,py37,py38,py39
+
+[testenv]
+# Passing all environment variables is not the best thing for isolation, but
+# seems to be expected for building native code. In particular, I can't easily
+# read boost's msvc.jam to figure out what to pass to configure msvc-14.2 on
+# windows. If we discover problems with this, consider restricting passenv with
+# platform-specific testenvs.
+passenv = *
+# tox's "real" support for installing bdists instead of sdists is to use pep517.
+# workaround from https://github.com/tox-dev/tox/issues/185
+changedir = bindings/python
+skip_install = true
+commands =
+    {envpython} setup.py bdist_wheel
+    {envpython} -m pip install --upgrade --force-reinstall --ignore-installed --find-links=dist python-libtorrent
+    {envpython} test.py


### PR DESCRIPTION
[tox](https://tox.readthedocs.io/en/latest/) is designed to run tests against a python project. It's widely used in the python world. It does:
* packaging the project
* installing the project in a virtual environment
* invoking a set of tests

This allows you to just run `tox` in an environment, and the right thing will happen to run tests against the project. This should simplify CI config, as well as simplify the process of running tests locally.

This patch ended up making some changes to the way we manage b2's python configuration.

It's based on #5902.