### PR TITLE
fix the complete() function, turning a path into an absolute path, to…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix issue with paths starting with ./
 	* fix integer overflow when setting a high DHT upload rate limit
 	* improve Path MTU discovery logic in uTP
 	* fix overflow issue when rlimit_nofile is set to infinity

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -946,7 +946,8 @@ namespace {
 	std::string complete(string_view f)
 	{
 		if (is_complete(f)) return f.to_string();
-		if (f == ".") return current_working_directory();
+		auto parts = lsplit_path(f);
+		if (parts.first == ".") f = parts.second;
 		return combine_path(current_working_directory(), f);
 	}
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -267,6 +267,12 @@ TORRENT_TEST(paths)
 #endif
 
 	TEST_EQUAL(complete("."), current_working_directory());
+
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(complete(".\\foobar"), current_working_directory() + "\\foobar");
+#else
+	TEST_EQUAL(complete("./foobar"), current_working_directory() + "/foobar");
+#endif
 }
 
 TORRENT_TEST(filename)


### PR DESCRIPTION
… correctly strip the ./ prefix of a relative path