### PR TITLE
WebTorrent: Fix assert "p->connection == &c"

### DIFF
--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -1007,6 +1007,9 @@ namespace libtorrent::aux {
 			if (!p->is_rtc_addr)
 				return nullptr; // prefer the non-rtc peer
 
+			if (p->connection)
+				return nullptr; // the peer is already connected
+
 			// update and return it
 			p->port = remote.port();
 			return p;


### PR DESCRIPTION
This PR fixes an issue with `peer_list::add_rtc_peer()` which would override an already connected peer if `allow_multiple_connections_per_ip` is unset.

It fixes the assert fail `p->connection == &c` at `src/peer_list.cpp:1176` (see https://github.com/arvidn/libtorrent/issues/5100#issuecomment-761764251).
