### PR TITLE
extend bigobj fixes to cover intel-win toolset

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -270,7 +270,7 @@ rule building ( properties * )
 		result += <build>no ;
 	}
 
-	if <toolset>msvc in $(properties)
+	if <toolset>msvc in $(properties) || <toolset>intel-win in $(properties)
 	{
 		# allow larger .obj files (with more sections)
 		result += <cflags>/bigobj ;

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -130,6 +130,19 @@ rule libtorrent_linking ( properties * )
 {
 	local result ;
 
+	# allow larger .obj files (with more sections)
+	if <toolset>msvc in $(properties) || <toolset>intel-win in $(properties)
+	{
+		# allow larger .obj files (with more sections)
+		result += <cflags>/bigobj ;
+	}
+
+	if <toolset>gcc in $(properties) && <target-os>windows in $(properties)
+	{
+		# allow larger .obj files (with more sections)
+		result += <cflags>-Wa,-mbig-obj ;
+	}
+
 	if ! <target-os>windows in $(properties)
 		&& <toolset>gcc in $(properties)
 		&& <libtorrent-link>static in $(properties)


### PR DESCRIPTION
as well as python bindings