### PR TITLE
don't announce stopped-event to websocket trackers.

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5845,12 +5845,13 @@ namespace {
 	}
 
 #if TORRENT_USE_RTC
-	void torrent::generate_rtc_offers(int count
-			, std::function<void(error_code const&, std::vector<aux::rtc_offer>)> handler)
+	void torrent::generate_rtc_offers(int const count
+		, std::function<void(error_code const&, std::vector<aux::rtc_offer>)> handler)
 	{
 		// rtc_signaling is created lazily
-		if(!m_rtc_signaling)
+		if (!m_rtc_signaling)
 		{
+			TORRENT_ASSERT(count > 0);
 			m_rtc_signaling = std::make_shared<aux::rtc_signaling>(m_ses.get_context()
 				, this
 				, std::bind(&torrent::on_rtc_stream, this, _1));


### PR DESCRIPTION
This (appears) to solve a shutdown stall where we send stopped-announces after aborting outstanding announces (including the persistent websocket connection). The announec causes the persistent connection to be re-established and sometimes not torn down properly again, to complete the shut down.

Without this patch shutdown can stall, waiting for these async operations:

```
websocket_stream::on_read: (1)
2: void libtorrent::aux::websocket_stream::async_read<boost::beast::basic_flat_buffer<std::allocator<char> >, std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>, std::_Placeholder<2>))(boost::system::error_code, unsigned long)> >(boost::beast::basic_flat_buffer<std::allocator<char> >&, std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>, std::_Placeholder<2>))(boost::system::error_code, unsigned long)>&&)
3: libtorrent::aux::websocket_tracker_connection::do_read()
4: libtorrent::aux::websocket_tracker_connection::on_connect(boost::system::error_code const&)
5: void std::__invoke_impl<void, void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&>(std::__invoke_memfun_deref, void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&)
6: std::__invoke_result<void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&>::type std::__invoke<void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&>(void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&)
7: void std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>))(boost::system::error_code const&)>::__call<void, boost::system::error_code const&, 0ul, 1ul>(std::tuple<boost::system::error_code const&>&&, std::_Index_tuple<0ul, 1ul>)
8: void std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>))(boost::system::error_code const&)>::operator()<boost::system::error_code const&, void>(boost::system::error_code const&)
9: std::_Function_handler<void (boost::system::error_code const&), std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>))(boost::system::error_code const&)> >::_M_invoke(std::_Any_data const&, boost::system::error_code const&)
10: std::function<void (boost::system::error_code const&)>::operator()(boost::system::error_code const&) const

websocket_tracker_connection::on_read: (1)
2: libtorrent::aux::websocket_tracker_connection::do_read()
3: libtorrent::aux::websocket_tracker_connection::on_connect(boost::system::error_code const&)
4: void std::__invoke_impl<void, void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&>(std::__invoke_memfun_deref, void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&)
5: std::__invoke_result<void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&>::type std::__invoke<void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&>(void (libtorrent::aux::websocket_tracker_connection::*&)(boost::system::error_code const&), std::shared_ptr<libtorrent::aux::websocket_tracker_connection>&, boost::system::error_code const&)
6: void std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>))(boost::system::error_code const&)>::__call<void, boost::system::error_code const&, 0ul, 1ul>(std::tuple<boost::system::error_code const&>&&, std::_Index_tuple<0ul, 1ul>)
7: void std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>))(boost::system::error_code const&)>::operator()<boost::system::error_code const&, void>(boost::system::error_code const&)
8: std::_Function_handler<void (boost::system::error_code const&), std::_Bind<void (libtorrent::aux::websocket_tracker_connection::*(std::shared_ptr<libtorrent::aux::websocket_tracker_connection>, std::_Placeholder<1>))(boost::system::error_code const&)> >::_M_invoke(std::_Any_data const&, boost::system::error_code const&)
9: std::function<void (boost::system::error_code const&)>::operator()(boost::system::error_code const&) const
10: void std::__invoke_impl<void, std::function<void (boost::system::error_code const&)>&, boost::system::error_code&>(std::__invoke_other, std::function<void (boost::system::error_code const&)>&, boost::system::error_code&)
```

@paullouisageneau Does this make sense? I fear I may have misunderstood something. Does it make sense to make 0 offers?