### PR TITLE
increase the default setting for max_allowed_in_request_queue

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* increase default max_allowed_in_request_queue
 	* fix loading non-ascii filenames on windows with torrent_info constructor (2.0 regression)
 	* add std::hash<> specialization for info_hash_t
 	* fix integer overflow in hash_picker and properly restrict max file sizes in torrents

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -232,7 +232,7 @@ namespace libtorrent {
 		SET(piece_timeout, 20, nullptr),
 		SET(request_timeout, 60, nullptr),
 		SET(request_queue_time, 3, nullptr),
-		SET(max_allowed_in_request_queue, 500, nullptr),
+		SET(max_allowed_in_request_queue, 2000, nullptr),
 		SET(max_out_request_queue, 500, nullptr),
 		SET(whole_pieces_threshold, 20, nullptr),
 		SET(peer_timeout, 120, nullptr),


### PR DESCRIPTION
from 500 to 2000. The entries in this queue are relatively small, and allowing too few may negatively impact high-throughput peers