### PR TITLE
Change __GNU__ to __GNUC__

### DIFF
--- a/include/libtorrent/aux_/export.hpp
+++ b/include/libtorrent/aux_/export.hpp
@@ -89,7 +89,7 @@ POSSIBILITY OF SUCH DAMAGE.
 # if defined _MSC_VER || defined __MINGW32__
 #  define BOOST_SYMBOL_EXPORT __declspec(dllexport)
 #  define BOOST_SYMBOL_IMPORT __declspec(dllimport)
-# elif __GNU__ >= 4
+# elif __GNUC__ >= 4
 #  define BOOST_SYMBOL_EXPORT __attribute__((visibility("default")))
 #  define BOOST_SYMBOL_IMPORT __attribute__((visibility("default")))
 # else
@@ -99,7 +99,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #if !defined TORRENT_EXPORT_EXTRA \
-  && ((defined __GNU__ && __GNU__ >= 4) || defined __clang__)
+  && ((defined __GNUC__ && __GNUC__ >= 4) || defined __clang__)
 # define TORRENT_UNEXPORT __attribute__((visibility("hidden")))
 #else
 # define TORRENT_UNEXPORT


### PR DESCRIPTION
I noticed that this macro was misnamed in these places when I was looking for code examples that handle symbol visibility.