### PR TITLE
[4/?] Add setup.py build_ext --config-mode

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,18 +11,51 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # on linux and mac, the boost libraries are fixed to a python version.
+      # since we install boost from repos on those systems, we must use the
+      # matching python versions
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2019 ]
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.8
+          - os: macos-latest
+            python-version: 3.9
+          - os: windows-2019
+            python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
 
+    # Note:
+    #  - on mac and linux images, 'python' is python2 and 'python3' is
+    #    python3
+    #  - on windows, neither 'python' nor 'python3' is in PATH by default
+    #  - setup-python sets up PATH so 'python' and 'python3' point to the
+    #    requested version on mac and linux, but on windows it only sets up
+    #    'python'.
+    - uses: actions/setup-python@v2
+      with:
+         python-version: ${{ matrix.python-version }}
+
+    # given the above, link 'python3' -> 'python' on windows so we have a
+    # consistent command. per
+    # https://github.com/actions/setup-python/issues/123
+    - name: link python3 (windows)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: mklink "%pythonLocation%\python3.exe" "%pythonLocation%\python.exe"
+
+    - name: install tox
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade tox
+
     - name: dependencies (MacOS)
       if: runner.os == 'macOS'
       run: |
-        brew install boost-build boost boost-python3 python@3.9
+        brew install boost-build boost boost-python3
 
     - name: update package lists (linux)
       if: runner.os == 'Linux'
@@ -33,7 +66,7 @@ jobs:
     - name: dependencies (linux)
       if: runner.os == 'Linux'
       run: |
-        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev python3 python3-setuptools
+        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev
 
     # there appears to be a bug in boost-build where referring to a
     # dependency that's on a different drive fails, deep in boost-build
@@ -42,40 +75,16 @@ jobs:
       if: runner.os == 'Windows'
       shell: cmd
       run: |
+        echo on
         echo using msvc ; >%HOMEDRIVE%%HOMEPATH%\user-config.jam
         mklink /J boost %BOOST_ROOT_1_72_0%
         cd boost
         b2 headers
+        cd ..
+        echo BOOST_ROOT=%CD%\boost>>%GITHUB_ENV%
+        echo BOOST_BUILD_PATH=%CD%\boost\tools\build>>%GITHUB_ENV%
+        echo %CD%\boost>>%GITHUB_PATH%
 
-    - name: build/install (windows)
-      if: runner.os == 'Windows'
-      shell: cmd
+    - name: build/test with tox
       run: |
-        set BOOST_ROOT=%CD%\boost
-        set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
-        set PATH=%BOOST_ROOT%;%PATH%
-
-        cd bindings\python
-        python setup.py build_ext install --user --prefix=
-
-    - name: tests (windows)
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        cd bindings\python
-        python test.py
-
-    - name: build/install
-      if: runner.os != 'Windows'
-      run: |
-        cd bindings/python
-        # Homebrew's python "framework" sets a prefix via distutils config.
-        # --prefix conflicts with --user, so null out prefix so we have one
-        # command that works everywhere
-        python3 setup.py build_ext --b2-args="libtorrent-link=static" install --user --prefix=
-
-    - name: tests
-      if: runner.os != 'Windows'
-      run: |
-        cd bindings/python
-        python3 test.py
+        tox -e py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,11 @@ repos:
             tools/set_version.py|
             tools/update_copyright.py
           )$
+- repo: https://github.com/myint/autoflake
+  rev: v1.4
+  hooks:
+    - id: autoflake
+      args: [--in-place, --remove-unused-variables, --remove-all-unused-imports, --remove-duplicate-keys]
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,43 @@ repos:
     -   id: check-xml
     -   id: debug-statements
     -   id: check-symlinks
+    -   id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.7.0
   hooks:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
+- repo: https://github.com/PyCQA/isort
+  rev: 5.7.0
+  hooks:
+    - id: isort
+      exclude: |
+          (?x)^(
+            # Enable these later, avoid bloating this PR
+            bindings/python/client.py|
+            bindings/python/dummy_data.py|
+            bindings/python/make_torrent.py|
+            bindings/python/simple_client.py|
+            bindings/python/test.py|
+            docs/gen_reference_doc.py|
+            examples/run_benchmarks.py|
+            fuzzers/tools/generate_initial_corpus.py|
+            fuzzers/tools/unify_corpus_names.py|
+            test/socks.py|
+            test/web_server.py|
+            test/websocket_server.py|
+            tools/clean.py|
+            tools/copyright.py|
+            tools/dht_flood.py|
+            tools/parse_dht_log.py|
+            tools/parse_dht_rtt.py|
+            tools/parse_dht_stats.py|
+            tools/parse_session_stats.py|
+            tools/parse_utp_log.py|
+            tools/run_benchmark.py|
+            tools/set_version.py|
+            tools/update_copyright.py
+          )$
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,51 @@ repos:
   hooks:
     - id: autoflake
       args: [--in-place, --remove-unused-variables, --remove-all-unused-imports, --remove-duplicate-keys]
+- repo: https://github.com/python/black
+  rev: 20.8b1
+  hooks:
+    - id: black
+      # Avoiding PR bloat
+      exclude: |
+          (?x)^(
+               bindings/c/tools/gen_alert_header.py|
+               bindings/c/tools/gen_header.py|
+               bindings/python/client.py|
+               bindings/python/dummy_data.py|
+               bindings/python/make_torrent.py|
+               bindings/python/simple_client.py|
+               bindings/python/test.py|
+               docs/filter-rst.py|
+               docs/gen_reference_doc.py|
+               docs/gen_settings_doc.py|
+               docs/gen_stats_doc.py|
+               docs/gen_todo.py|
+               docs/join_rst.py|
+               examples/run_benchmarks.py|
+               fuzzers/tools/generate_initial_corpus.py|
+               fuzzers/tools/unify_corpus_names.py|
+               test/http_proxy.py|
+               test/socks.py|
+               test/web_server.py|
+               test/websocket_server.py|
+               tools/benchmark_checking.py|
+               tools/clean.py|
+               tools/copyright.py|
+               tools/dht_flood.py|
+               tools/gen_convenience_header.py|
+               tools/gen_fwd.py|
+               tools/parse_dht_log.py|
+               tools/parse_dht_rtt.py|
+               tools/parse_dht_stats.py|
+               tools/parse_lookup_log.py|
+               tools/parse_peer_log.py|
+               tools/parse_sample.py|
+               tools/parse_session_stats.py|
+               tools/parse_utp_log.py|
+               tools/run_benchmark.py|
+               tools/set_version.py|
+               tools/update_copyright.py
+          )$
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:
@@ -76,7 +121,27 @@ repos:
             # Enable these later, avoid bloating this PR
             bindings/c/tools/gen_alert_header.py|
             bindings/c/tools/gen_header.py|
+            bindings/python/client.py|
+            bindings/python/test.py|
+            docs/gen_todo.py|
+            docs/gen_reference_doc.py|
+            docs/gen_settings_doc.py|
+            docs/gen_stats_doc.py|
+            examples/run_benchmarks.py|
             fuzzers/tools/generate_initial_corpus.py|
+            test/socks.py|
             test/websocket_server.py|
-            tools/benchmark_checking.py
+            test/web_server.py|
+            tools/benchmark_checking.py|
+            tools/dht_flood.py|
+            tools/gen_fwd.py|
+            tools/parse_dht_stats.py|
+            tools/parse_dht_log.py|
+            tools/parse_lookup_log.py|
+            tools/parse_peer_log.py|
+            tools/parse_session_stats.py|
+            tools/parse_utp_log.py|
+            tools/run_benchmark.py|
+            tools/set_version.py|
+            tools/update_copyright.py
         )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,48 @@ repos:
                tools/set_version.py|
                tools/update_copyright.py
           )$
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.800
+  hooks:
+    - id: mypy
+      # Avoiding PR bloat
+      exclude: |
+          (?x)^(
+              bindings/c/tools/gen_alert_header.py|
+              bindings/c/tools/gen_header.py|
+              bindings/python/client.py|
+              bindings/python/dummy_data.py|
+              bindings/python/make_torrent.py|
+              bindings/python/test.py|
+              docs/filter-rst.py|
+              docs/gen_reference_doc.py|
+              docs/gen_settings_doc.py|
+              docs/gen_stats_doc.py|
+              docs/gen_todo.py|
+              examples/run_benchmarks.py|
+              fuzzers/tools/generate_initial_corpus.py|
+              setup.py|
+              test/http_proxy.py|
+              test/socks.py|
+              test/web_server.py|
+              test/websocket_server.py|
+              tools/benchmark_checking.py|
+              tools/clean.py|
+              tools/copyright.py|
+              tools/dht_flood.py|
+              tools/gen_convenience_header.py|
+              tools/gen_fwd.py|
+              tools/parse_dht_log.py|
+              tools/parse_dht_stats.py|
+              tools/parse_lookup_log.py|
+              tools/parse_peer_log.py|
+              tools/parse_sample.py|
+              tools/parse_session_stats.py|
+              tools/parse_utp_log.py|
+              tools/run_benchmark.py|
+              tools/set_version.py|
+              tools/update_copyright.py
+          )$
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.4
   hooks:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -2,7 +2,9 @@
 
 import contextlib
 from distutils import log
+import distutils.cmd
 import distutils.debug
+import distutils.errors
 import distutils.sysconfig
 import os
 import pathlib
@@ -12,13 +14,19 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+from typing import cast
+from typing import IO
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Set
 import warnings
 
 import setuptools
-import setuptools.command.build_ext as _build_ext_lib
+import setuptools.command.build_ext as build_ext_lib
 
 
-def get_msvc_toolset():
+def get_msvc_toolset() -> str:
     # Reference: https://wiki.python.org/moin/WindowsCompilers
     major_minor = sys.version_info[0:2]
     if major_minor in ((2, 6), (2, 7), (3, 0), (3, 1), (3, 2)):
@@ -31,7 +39,7 @@ def get_msvc_toolset():
     return "msvc"
 
 
-def b2_bool(value):
+def b2_bool(value: bool) -> str:
     if value:
         return "on"
     return "off"
@@ -53,30 +61,35 @@ def b2_bool(value):
 
 
 class B2Distribution(setuptools.Distribution):
-    def reinitialize_command(self, command, reinit_subcommands=0):
+    def reinitialize_command(
+        self, command: str, reinit_subcommands: int = 0
+    ) -> distutils.cmd.Command:
         if command == "build_ext":
-            return self.get_command_obj("build_ext")
-        return super().reinitialize_command(
-            command, reinit_subcommands=reinit_subcommands
+            return cast(distutils.cmd.Command, self.get_command_obj("build_ext"))
+        return cast(
+            distutils.cmd.Command,
+            super().reinitialize_command(
+                command, reinit_subcommands=reinit_subcommands
+            ),
         )
 
 
 # Various setuptools logic expects us to provide Extension instances for each
 # extension in the distro.
 class StubExtension(setuptools.Extension):
-    def __init__(self, name):
+    def __init__(self, name: str):
         # An empty sources list ensures the base build_ext command won't build
         # anything
         super().__init__(name, sources=[])
 
 
-def b2_escape(value):
+def b2_escape(value: str) -> str:
     value = value.replace("\\", "\\\\")
     value = value.replace('"', '\\"')
     return f'"{value}"'
 
 
-def write_b2_python_config(config):
+def write_b2_python_config(config: IO[str]) -> None:
     write = config.write
     # b2 keys python environments by X.Y version, breaking ties by matching
     # a property list, called the "condition" of the environment. To ensure
@@ -122,6 +135,7 @@ def write_b2_python_config(config):
     # Note that sysconfig and distutils.sysconfig disagree here, especially on
     # windows.
     ext_suffix = distutils.sysconfig.get_config_var("EXT_SUFFIX")
+    ext_suffix = str(ext_suffix or "")
 
     # python.jam appends the platform-specific final suffix on its own. I can't
     # find a consistent value from sysconfig or distutils.sysconfig for this.
@@ -133,16 +147,13 @@ def write_b2_python_config(config):
     write(" ;\n")
 
 
-BuildExtBase = _build_ext_lib.build_ext
-
-
-class LibtorrentBuildExt(BuildExtBase):
+class LibtorrentBuildExt(build_ext_lib.build_ext):
 
     CONFIG_MODE_DISTUTILS = "distutils"
     CONFIG_MODE_B2 = "b2"
     CONFIG_MODES = (CONFIG_MODE_DISTUTILS, CONFIG_MODE_B2)
 
-    user_options = BuildExtBase.user_options + [
+    user_options = build_ext_lib.build_ext.user_options + [
         (
             "config-mode=",
             None,
@@ -208,9 +219,9 @@ class LibtorrentBuildExt(BuildExtBase):
         ),
     ]
 
-    boolean_options = BuildExtBase.boolean_options + ["pic", "hash"]
+    boolean_options = build_ext_lib.build_ext.boolean_options + ["pic", "hash"]
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
 
         self.config_mode = self.CONFIG_MODE_DISTUTILS
         self.b2_args = ""
@@ -222,8 +233,8 @@ class LibtorrentBuildExt(BuildExtBase):
         # TODO: this is for backwards compatibility
         # loading these files will be removed in libtorrent-2.0
         try:
-            with open("compile_flags") as f:
-                opts = f.read()
+            with open("compile_flags") as fp:
+                opts = fp.read()
                 if "-std=c++" in opts:
                     self.cxxflags = "-std=c++" + opts.split("-std=c++")[-1].split()[0]
         except OSError:
@@ -232,31 +243,30 @@ class LibtorrentBuildExt(BuildExtBase):
         # TODO: this is for backwards compatibility
         # loading these files will be removed in libtorrent-2.0
         try:
-            with open("link_flags") as f:
-                opts = f.read().split(" ")
-                opts = [x for x in opts if x.startswith("-L")]
-                if len(opts):
-                    self.linkflags = opts
+            with open("link_flags") as fp:
+                opt_list = fp.read().split(" ")
+                opt_list = [x for x in opt_list if x.startswith("-L")]
+                if opt_list:
+                    self.linkflags = opt_list
         except OSError:
             pass
 
+        self.toolset: Optional[str] = None
+        self.libtorrent_link: Optional[str] = None
+        self.boost_link: Optional[str] = None
+        self.pic: Optional[bool] = None
+        self.optimization: Optional[str] = None
+        self.hash: Optional[bool] = None
+        self.cxxstd: Optional[str] = None
         if os.name == "nt":
             self.toolset = get_msvc_toolset()
-        else:
-            self.toolset = None
-        self.libtorrent_link = None
-        self.boost_link = None
-        self.pic = None
-        self.optimization = None
-        self.hash = None
-        self.cxxstd = None
 
-        self._b2_args_split = []
-        self._b2_args_configured = set()
+        self._b2_args_split: List[str] = []
+        self._b2_args_configured: Set[str] = set()
 
-        return super().initialize_options()
+        super().initialize_options()
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         super().finalize_options()
 
         if self.config_mode not in self.CONFIG_MODES:
@@ -314,7 +324,7 @@ class LibtorrentBuildExt(BuildExtBase):
             warnings.warn("--cxxstd is deprecated; use --b2-args=cxxstd=...")
             self._maybe_add_arg(f"cxxstd={self.cxxstd}")
 
-    def _should_add_arg(self, arg):
+    def _should_add_arg(self, arg: str) -> bool:
         m = re.match(r"(-\w).*", arg)
         if m:
             name = m.group(1)
@@ -322,18 +332,18 @@ class LibtorrentBuildExt(BuildExtBase):
             name = arg.split("=", 1)[0]
         return name not in self._b2_args_configured
 
-    def _maybe_add_arg(self, arg):
+    def _maybe_add_arg(self, arg: str) -> bool:
         if self._should_add_arg(arg):
             self._b2_args_split.append(arg)
             return True
         return False
 
-    def run(self):
+    def run(self) -> None:
         # The current jamfile layout just supports one extension
         self._build_extension_with_b2()
-        return super().run()
+        super().run()
 
-    def _build_extension_with_b2(self):
+    def _build_extension_with_b2(self) -> None:
         python_binding_dir = pathlib.Path(__file__).parent.absolute()
         with self._configure_b2():
             if self.linkflags:
@@ -347,7 +357,7 @@ class LibtorrentBuildExt(BuildExtBase):
             subprocess.run(command, cwd=python_binding_dir, check=True)
 
     @contextlib.contextmanager
-    def _configure_b2(self):
+    def _configure_b2(self) -> Iterator[None]:
         if self.config_mode == self.CONFIG_MODE_DISTUTILS:
             # If we're using distutils mode, we'll auto-configure a lot of args
             # and write temporary config.
@@ -356,7 +366,7 @@ class LibtorrentBuildExt(BuildExtBase):
             # If we're using b2 mode, no configuration needed
             yield
 
-    def _configure_b2_with_distutils(self):
+    def _configure_b2_with_distutils(self) -> Iterator[None]:
         if os.name == "nt":
             self._maybe_add_arg("--abbreviate-paths")
             self._maybe_add_arg("boost-link=static")

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -19,6 +19,7 @@ from typing import IO
 from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Set
 import warnings
 
@@ -89,7 +90,9 @@ def b2_escape(value: str) -> str:
     return f'"{value}"'
 
 
-def write_b2_python_config(config: IO[str]) -> None:
+def write_b2_python_config(
+    config: IO[str], include_dirs: Sequence[str], library_dirs: Sequence[str]
+) -> None:
     write = config.write
     # b2 keys python environments by X.Y version, breaking ties by matching
     # a property list, called the "condition" of the environment. To ensure
@@ -104,19 +107,28 @@ def write_b2_python_config(config: IO[str]) -> None:
     write("import feature ;\n")
     write("feature.feature libtorrent-python : on ;\n")
 
-    # python.jam tries to determine correct include and library paths. Per
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=691378 , include
-    # detection is broken, but debian's fix is also broken (invokes a global
-    # pythonX.Y instead of the passed interpreter)
-    paths = sysconfig.get_paths()
-    includes = [paths["include"], paths["platinclude"]]
+    # python.jam's autodetection of library paths and include paths has various
+    # bugs, and has very poor support of non-system python environments,
+    # such as pyenv or virtualenvs. distutils' autodetection is much more
+    # robust, and we trust it more. In case distutils gives empty results,
+    # feed garbage values to boost to block its autodetection.
 
     write("using python")
     write(f" : {sysconfig.get_python_version()}")
     write(f" : {b2_escape(sys.executable)}")
     write(" : ")
-    write(" ".join(b2_escape(path) for path in includes))
-    write(" :")  # libraries
+    if include_dirs:
+        write(" ".join(b2_escape(path) for path in include_dirs))
+    else:
+        write("__BLOCK_AUTODETECTION__")
+    write(" : ")
+    if library_dirs:
+        # Note that python.jam only accepts one library dir! We depend on
+        # passing other library dirs by other means. Not sure if we should
+        # do something smarter here, like pass the first directory that exists.
+        write(b2_escape(library_dirs[0]))
+    else:
+        write("__BLOCK_AUTODETECTION__")
     write(" : <libtorrent-python>on")
 
     # Note that all else being equal, we'd like to exactly control the output
@@ -403,6 +415,12 @@ class LibtorrentBuildExt(build_ext_lib.build_ext):
                 # our project-config.jam
                 self._maybe_add_arg("libtorrent-python=on")
 
+                # python.jam only allows ONE library dir! distutils may autodetect
+                # multiple, and finding the "right" one isn't straightforward. We just
+                # pass them all here and hopefully the right thing happens.
+                for path in self.library_dirs:
+                    self._b2_args_split.append(f"library-path={b2_escape(path)}")
+
         # Our goal is to produce an artifact at this path. If we do this, the
         # distutils build system will skip trying to build it.
         target = pathlib.Path(self.get_ext_fullpath("libtorrent")).absolute()
@@ -422,7 +440,7 @@ class LibtorrentBuildExt(build_ext_lib.build_ext):
         try:
             if override_project_config:
                 config = tempfile.NamedTemporaryFile(mode="w+", delete=False)
-                write_b2_python_config(config)
+                write_b2_python_config(config, self.include_dirs, self.library_dirs)
                 config.seek(0)
                 log.info("project-config.jam contents:")
                 log.info(config.read())

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
+import contextlib
 from distutils import log
 import distutils.debug
 import distutils.sysconfig
 import os
 import pathlib
+import re
+import shlex
+import subprocess
 import sys
 import sysconfig
 import tempfile
-import subprocess
-import contextlib
 import warnings
-import re
-import shlex
 
 import setuptools
 import setuptools.command.build_ext as _build_ext_lib

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -180,11 +180,7 @@ class LibtorrentBuildExt(BuildExtBase):
             None,
             "(DEPRECATED; use --b2-args=libtorrent-link=...) ",
         ),
-        (
-            "boost-link=",
-            None,
-            "(DEPRECATED; use --b2-args=boost-link=...) "
-        ),
+        ("boost-link=", None, "(DEPRECATED; use --b2-args=boost-link=...) "),
         ("toolset=", None, "(DEPRECATED; use --b2-args=toolset=...) b2 toolset"),
         (
             "pic",
@@ -226,19 +222,19 @@ class LibtorrentBuildExt(BuildExtBase):
         # TODO: this is for backwards compatibility
         # loading these files will be removed in libtorrent-2.0
         try:
-            with open('compile_flags') as f:
+            with open("compile_flags") as f:
                 opts = f.read()
-                if '-std=c++' in opts:
-                    self.cxxflags = '-std=c++' + opts.split('-std=c++')[-1].split()[0]
+                if "-std=c++" in opts:
+                    self.cxxflags = "-std=c++" + opts.split("-std=c++")[-1].split()[0]
         except OSError:
             pass
 
         # TODO: this is for backwards compatibility
         # loading these files will be removed in libtorrent-2.0
         try:
-            with open('link_flags') as f:
-                opts = f.read().split(' ')
-                opts = [x for x in opts if x.startswith('-L')]
+            with open("link_flags") as f:
+                opts = f.read().split(" ")
+                opts = [x for x in opts if x.startswith("-L")]
                 if len(opts):
                     self.linkflags = opts
         except OSError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.isort]
+profile = "google"
+single_line_exclusions = []
+src_paths = ["."]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,13 @@
 # https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
 max-line-length = 88
 extend-ignore = E203, W503
+
+[mypy]
+warn_return_any = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unreachable = True
+warn_unused_configs = True
+#disallow_any_unimported = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [flake8]
-max-line-length = 120
+# https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
+max-line-length = 88
+extend-ignore = E203, W503

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@
 import os
 import runpy
 
-os.chdir('bindings/python')
-runpy.run_path('setup.py')
+os.chdir("bindings/python")
+runpy.run_path("setup.py")

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,6 @@ passenv = *
 changedir = bindings/python
 skip_install = true
 commands =
-    {envpython} setup.py build_ext --libtorrent-link=static --boost-link=static bdist_wheel
+    {envpython} setup.py bdist_wheel
     {envpython} -m pip install --upgrade --find-links=dist python-libtorrent
     {envpython} test.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py36,py37,py38,py39
+
+[testenv]
+# Passing all environment variables is not the best thing for isolation, but
+# seems to be expected for building native code. In particular, I can't easily
+# read boost's msvc.jam to figure out what to pass to configure msvc-14.2 on
+# windows. If we discover problems with this, consider restricting passenv with
+# platform-specific testenvs.
+passenv = *
+# tox's "real" support for installing bdists instead of sdists is to use pep517.
+# workaround from https://github.com/tox-dev/tox/issues/185
+changedir = bindings/python
+skip_install = true
+commands =
+    {envpython} setup.py build_ext --libtorrent-link=static --boost-link=static bdist_wheel
+    {envpython} -m pip install --upgrade --find-links=dist python-libtorrent
+    {envpython} test.py


### PR DESCRIPTION
This is an implementation of my suggestion from #5939.

The PR is based on #5905.

This adds `setup.py build_ext --config-mode=[b2|distutils]`. The intent is to have a clear modal deliniation between when users should expect `distutils`-like behavior, when they should expect `b2`-like behavior, and a structured framework for merging the two behaviors.

---

`setup.py bdist_ext --config-mode=b2` is intended for the "just run b2 and package the result" use case, as you mentioned in #5939. It gives full control over the `b2` environment. The usage looks like:

```
python setup.py bdist_ext --config-mode=b2 --b2-args="release address-mode=64 python=3.6 ..."
```

This won't do any auto-configuration. It will just run invoke `b2` with the given command line, and it will expect that the command will output an artifact at the location expected by `distutils`. If it does, it will continue processing the artifact (it can package it with `bdist_wheel`, etc). If the command doesn't produce the expected output, `setup.py` will just fail.

One thing to note is that this doesn't enable cross-compiling wheels. The `bdist_wheel` command will still write wheel metadata appropriate for the running python. Any cross-compiling should probably just use `b2` alone and use the artifact directly.

---

`setup.py bdist_ext --config-mode=distutils` is intended to give the expected behavior of `distutils`. It will build against the running python, doesn't require any special configuration, and by default will produce a build suitable for uploading to pypi.

This mode is close to the current behavior, but to make it pypi-appropriate I've changed it so the default build has `deprecated-functions=on libtorrent-link=static boost-link=static`.

I've also changed the way that `--config-mode=distutils` constructs its `b2` command line, so it can be overridden in a more structured way. It will use the `--b2-args` command line as a starting point, and won't auto-configure any features or arguments that appear in it.

For example, this will add `--hash` to the auto-configured command line:
```
python setup.py bdist_ext --b2-args=--hash
```

This will override the auto-configured default and build without deprecated functions:
```
python setup.py bdist_ext --b2-args=deprecated-functions=off
```

Either of these will block the python auto-configuration:
```
python setup.py bdist_ext --b2-args=--project-config=/path/to/config
python setup.py bdist_ext --b2-args=python=3.6
```

There's a special pattern for "just don't autoconfigure" an argument, because not all arguments have replacements or negatives. For example, we auto-configure `--abbreviate-paths` on windows, but this will negate that:
```
python setup.py bdist_ext --no-autoconf=--abbreviate-paths
```

---

This makes the interaction between automagic and user overrides easier to understand (for `b2` users, anyway), and less limited. I think anyone caught by limitations in `setup.py` will now be able to un-stick themselves.

I've also tried here to draw a brighter line around the scope of the "make b2 behave like distutils" idea. This is a complex project in its own right. I think this PR clarifies where all that complexity should live, both in terms of user expectations and the codebase.