### PR TITLE
[2/?] Fix setup.py's --project-config bypass

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -411,24 +411,25 @@ class LibtorrentBuildExt(BuildExtBase):
         self._maybe_add_arg(f"python-install-path={target.parent}")
         self._maybe_add_arg("install_module")
 
-        # We use a "project-config.jam" to instantiate a python environment
-        # to exactly match the running one.
-        try:
-            if override_project_config:
-                config = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+        # Two paths depending on whether or not we use a generated
+        # project-config.jam or not.
+        if override_project_config:
+            config = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+            try:
                 write_b2_python_config(config)
                 config.seek(0)
                 log.info("project-config.jam contents:")
                 log.info(config.read())
                 config.close()
                 self._b2_args_split.append(f"--project-config={config.name}")
+                yield
+            finally:
+                # If we errored while writing config, windows may complain about
+                # unlinking a file "in use"
+                config.close()
+                os.unlink(config.name)
+        else:
             yield
-
-        finally:
-            # If we errored while writing config, windows may complain about
-            # unlinking a file "in use"
-            config.close()
-            os.unlink(config.name)
 
 
 setuptools.setup(


### PR DESCRIPTION
This fixes the code for when setup.py's `--project-config` override is *not* used. The `config` variable is undefined in the `finally:` clause.

I'm quite surprised that `flake8` didn't detect this. `mypy` doesn't either, when run locally. They usually catch variable scope problems.