### PR TITLE
Default setup.py to do static linking on all platforms

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -363,11 +363,6 @@ class LibtorrentBuildExt(BuildExtBase):
     def _configure_b2_with_distutils(self):
         if os.name == "nt":
             self._maybe_add_arg("--abbreviate-paths")
-            self._maybe_add_arg("boost-link=static")
-        else:
-            self._maybe_add_arg("boost-link=shared")
-
-        self._maybe_add_arg("libtorrent-link=static")
 
         if distutils.debug.DEBUG:
             self._maybe_add_arg("--debug-configuration")
@@ -376,6 +371,8 @@ class LibtorrentBuildExt(BuildExtBase):
 
         # Default feature configuration
         self._maybe_add_arg("deprecated-functions=on")
+        self._maybe_add_arg("boost-link=static")
+        self._maybe_add_arg("libtorrent-link=static")
 
         variant = "debug" if self.debug else "release"
         self._maybe_add_arg(f"variant={variant}")


### PR DESCRIPTION
As we discussed before, `setup.py` should default to do static linking.

It won't do this with `setup.py build_ext --config-mode=b2`.

This is based on #5969.