### PR TITLE
Fix error messages related to opening files

### DIFF
--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -607,3 +607,4 @@ cflags
 cxxflags
 linkflags
 lto
+SetEndOfFile

--- a/include/libtorrent/error_code.hpp
+++ b/include/libtorrent/error_code.hpp
@@ -544,6 +544,8 @@ namespace errors {
 		// hidden
 		storage_error(): file_idx(-1), operation(operation_t::unknown) {}
 		explicit storage_error(error_code e): ec(e), file_idx(-1), operation(operation_t::unknown) {}
+		storage_error(error_code e, operation_t const op)
+			: ec(e), file_idx(-1), operation(op) {}
 
 		// explicitly converts to true if this object represents an error, and
 		// false if it does not.

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -166,7 +166,7 @@ namespace aux {
 		boost::optional<aux::file_view> open_file(settings_interface const&, file_index_t
 			, aux::open_mode_t, storage_error&) const;
 		boost::optional<aux::file_view> open_file_impl(settings_interface const&
-			, file_index_t, aux::open_mode_t, error_code&) const;
+			, file_index_t, aux::open_mode_t, storage_error&) const;
 
 		bool use_partfile(file_index_t index) const;
 		void use_partfile(file_index_t index, bool b);

--- a/include/libtorrent/operations.hpp
+++ b/include/libtorrent/operations.hpp
@@ -182,6 +182,12 @@ namespace libtorrent {
 
 		// an async wait operation on a timer
 		timer,
+
+		// call to mmap() (or windows counterpart)
+		file_mmap,
+
+		// call to ftruncate() (or SetEndOfFile() on windows)
+		file_truncate,
 	};
 
 	// maps an operation id (from peer_error_alert and peer_disconnected_alert)

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1080,6 +1080,8 @@ namespace {
 			case o::enum_route: return -1;
 			case o::file_seek: return -1;
 			case o::timer: return -1;
+			case o::file_mmap: return -1;
+			case o::file_truncate: return -1;
 		}
 		return -1;
 	}
@@ -1875,6 +1877,8 @@ namespace {
 			"enum_route",
 			"file_seek",
 			"timer",
+			"file_mmap",
+			"file_truncate",
 		};
 
 		int const idx = static_cast<int>(op);

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -245,7 +245,11 @@ file_handle::file_handle(string_view name, std::int64_t const size
 	: m_fd(create_file(convert_to_native_path_string(name.to_string()), mode))
 	, m_open_mode(mode)
 {
-	if (m_fd == invalid_handle) throw_ex<system_error>(error_code(GetLastError(), system_category()));
+	if (m_fd == invalid_handle)
+	{
+		throw_ex<storage_error>(error_code(GetLastError(), system_category())
+			, operation_t::file_open);
+	}
 
 	// try to make the file sparse if supported
 	// only set this flag if the file is opened for writing
@@ -262,10 +266,10 @@ file_handle::file_handle(string_view name, std::int64_t const size
 		LARGE_INTEGER sz;
 		sz.QuadPart = size;
 		if (SetFilePointerEx(m_fd, sz, nullptr, FILE_BEGIN) == FALSE)
-			throw_ex<system_error>(error_code(GetLastError(), system_category()));
+			throw_ex<storage_error>(error_code(GetLastError(), system_category()), operation_t::file_seek);
 
 		if (::SetEndOfFile(m_fd) == FALSE)
-			throw_ex<system_error>(error_code(GetLastError(), system_category()));
+			throw_ex<storage_error>(error_code(GetLastError(), system_category()), operation_t::file_truncate);
 
 #ifndef TORRENT_WINRT
 		// Enable privilege required by SetFileValidData()
@@ -330,7 +334,7 @@ file_handle::file_handle(string_view name, std::int64_t const size
 			, file_flags(mode & ~open_mode::no_atime), 0755);
 	}
 #endif
-	if (m_fd < 0) throw_ex<system_error>(error_code(errno, system_category()));
+	if (m_fd < 0) throw_ex<storage_error>(error_code(errno, system_category()), operation_t::file_open);
 
 #ifdef DIRECTIO_ON
 	// for solaris
@@ -340,18 +344,17 @@ file_handle::file_handle(string_view name, std::int64_t const size
 
 	if (mode & open_mode::truncate)
 	{
+		static_assert(sizeof(off_t) >= sizeof(size), "There seems to be a large-file issue in truncate()");
 		if (ftruncate(m_fd, static_cast<off_t>(size)) < 0)
 		{
 			int const err = errno;
 			::close(m_fd);
-			throw_ex<system_error>(error_code(err, system_category()));
+			throw_ex<storage_error>(error_code(err, system_category()), operation_t::file_truncate);
 		}
 
 		if (!(mode & open_mode::sparse))
 		{
 #if TORRENT_HAS_FALLOCATE
-			// if fallocate failed, we have to use posix_fallocate
-			// which can be painfully slow
 			// if you get a compile error here, you might want to
 			// define TORRENT_HAS_FALLOCATE to 0.
 			int const ret = posix_fallocate(m_fd, 0, size);
@@ -360,7 +363,7 @@ file_handle::file_handle(string_view name, std::int64_t const size
 			if (ret != 0 && ret != EINVAL)
 			{
 				::close(m_fd);
-				throw_ex<system_error>(error_code(ret, system_category()));
+				throw_ex<storage_error>(error_code(ret, system_category()), operation_t::file_fallocate);
 			}
 #elif defined F_ALLOCSP64
 			flock64 fl64;
@@ -371,7 +374,7 @@ file_handle::file_handle(string_view name, std::int64_t const size
 			{
 				int const err = errno;
 				::close(m_fd);
-				throw_ex<system_error>(error_code(err, system_category()));
+				throw_ex<storage_error>(error_code(ret, system_category()), operation_t::file_fallocate);
 			}
 #elif defined F_PREALLOCATE
 			fstore_t f = {F_ALLOCATECONTIG, F_PEOFPOSMODE, 0, size, 0};
@@ -386,7 +389,8 @@ file_handle::file_handle(string_view name, std::int64_t const size
 					{
 						int const err = errno;
 						::close(m_fd);
-						throw_ex<system_error>(error_code(err, system_category()));
+						throw_ex<storage_error>(error_code(err, system_category())
+							, operation_t::file_fallocate);
 					}
 					// ok, let's try to allocate non contiguous space then
 					f.fst_flags = F_ALLOCATEALL;
@@ -394,7 +398,8 @@ file_handle::file_handle(string_view name, std::int64_t const size
 					{
 						int const err = errno;
 						::close(m_fd);
-						throw_ex<system_error>(error_code(err, system_category()));
+						throw_ex<storage_error>(error_code(err, system_category())
+							, operation_t::file_fallocate);
 					}
 				}
 			}
@@ -481,12 +486,12 @@ std::int64_t file_handle::get_size() const
 #if TORRENT_HAVE_MMAP
 	struct ::stat fs;
 	if (::fstat(fd(), &fs) != 0)
-		throw_ex<system_error>(error_code(errno, system_category()));
+		throw_ex<storage_error>(error_code(errno, system_category()), operation_t::file_stat);
 	return fs.st_size;
 #else
 	LARGE_INTEGER file_size;
 	if (GetFileSizeEx(fd(), &file_size) == 0)
-		throw_ex<system_error>(error_code(GetLastError(), system_category()));
+		throw_ex<storage_error>(error_code(GetLastError(), system_category()), operation_t::file_stat);
 	return file_size.QuadPart;
 #endif
 }
@@ -563,7 +568,7 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode, std::int64_
 	// still need to create the empty file.
 	if (file_size > 0 && m_mapping == map_failed)
 	{
-		throw_ex<system_error>(error_code(errno, system_category()));
+		throw_ex<storage_error>(error_code(errno, system_category()), operation_t::file_mmap);
 	}
 
 #if TORRENT_USE_MADVISE
@@ -612,7 +617,7 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode
 	// you can't create an mmap of size 0, so we just set it to null. We
 	// still need to create the empty file.
 	if (m_size > 0 && m_mapping == nullptr)
-		throw_ex<system_error>(error_code(GetLastError(), system_category()));
+		throw_ex<storage_error>(error_code(GetLastError(), system_category()), operation_t::file_mmap);
 }
 
 void file_mapping::close()

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -360,12 +360,7 @@ namespace libtorrent {
 					ec.ec.clear();
 					auto f = open_file(sett, file_index, aux::open_mode::write
 						| aux::open_mode::random_access | aux::open_mode::truncate, ec);
-					if (ec)
-					{
-						ec.file(file_index);
-						ec.operation = operation_t::file_fallocate;
-						return;
-					}
+					if (ec) return;
 				}
 			}
 			ec.ec.clear();
@@ -821,7 +816,7 @@ namespace libtorrent {
 		}
 #endif
 
-		boost::optional<aux::file_view> h = open_file_impl(sett, file, mode, ec.ec);
+		boost::optional<aux::file_view> h = open_file_impl(sett, file, mode, ec);
 		if ((mode & aux::open_mode::write)
 			&& ec.ec == boost::system::errc::no_such_file_or_directory)
 		{
@@ -840,7 +835,7 @@ namespace libtorrent {
 				return {};
 			}
 
-			h = open_file_impl(sett, file, mode, ec.ec);
+			h = open_file_impl(sett, file, mode, ec);
 		}
 		if (ec.ec)
 		{
@@ -866,7 +861,7 @@ namespace libtorrent {
 	boost::optional<aux::file_view> mmap_storage::open_file_impl(settings_interface const& sett
 		, file_index_t file
 		, aux::open_mode_t mode
-		, error_code& ec) const
+		, storage_error& ec) const
 	{
 		TORRENT_ASSERT(!files().pad_file_at(file));
 		if (!m_allocate_files) mode |= aux::open_mode::sparse;
@@ -896,9 +891,10 @@ namespace libtorrent {
 #endif
 				);
 		}
-		catch (system_error const& ex)
+		catch (storage_error const& se)
 		{
-			ec = ex.code();
+			ec = se;
+			ec.file(file);
 			TORRENT_ASSERT(ec);
 			return {};
 		}

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -515,12 +515,7 @@ namespace aux {
 					// it's not a problem, we won't access empty files ever again
 					ec.ec.clear();
 					file_pointer f = open_file(file_index, aux::open_mode::write, 0, ec);
-					if (ec)
-					{
-						ec.file(file_index);
-						ec.operation = operation_t::file_fallocate;
-						return;
-					}
+					if (ec) return;
 				}
 			}
 			ec.ec.clear();


### PR DESCRIPTION
specifically truncate and allocate failures (which currently are incorrectly attributed to open file)