### PR TITLE
one more fix for android 32 bit issues with fseeko

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -178,8 +178,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_HAS_FALLOCATE 0
 #define TORRENT_HAS_FADVISE 0
 #endif // API < 21
-#if __ANDROID_API__ < 24
+
+// android 32 bits has real problems with fseeko
+#if (__ANDROID_API__ < 24) || defined __arm__ || defined __i386__
 #define TORRENT_HAS_FSEEKO 0
+#endif
+
+#if __ANDROID_API__ < 24
 #define TORRENT_HAS_FTELLO 0
 #endif // API < 24
 


### PR DESCRIPTION
It happens that even with API level >= 24, Android 32 bits is having real issues with `fseeko`. The problem and resolution were tested on android emulators and at least one real device.