### PR TITLE
fix need_save_resume_data() for renaming files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 1.2.13 released
 
+	* fix need_save_resume_data() for renaming files, share-mode, upload-mode,
+	  disable- pex, lsd, and dht.
 	* fix incoming TCP connections when using tracker-only proxy
 	* fix issue with paths starting with ./
 	* fix integer overflow when setting a high DHT upload rate limit

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -770,6 +770,9 @@ bool is_downloading_state(int const st)
 		{
 			inc_stats_counter(counters::non_filter_torrents);
 		}
+
+		set_need_save_resume();
+
 		m_apply_ip_filter = b;
 		ip_filter_updated();
 		state_updated();
@@ -1028,11 +1031,23 @@ bool is_downloading_state(int const st)
 		if (mask & torrent_flags::stop_when_ready)
 			stop_when_ready(bool(flags & torrent_flags::stop_when_ready));
 		if (mask & torrent_flags::disable_dht)
-			m_enable_dht = !bool(flags & torrent_flags::disable_dht);
+		{
+			bool const new_value = !bool(flags & torrent_flags::disable_dht);
+			if (m_enable_dht != new_value) set_need_save_resume();
+			m_enable_dht = new_value;
+		}
 		if (mask & torrent_flags::disable_lsd)
-			m_enable_lsd = !bool(flags & torrent_flags::disable_lsd);
+		{
+			bool const new_value = !bool(flags & torrent_flags::disable_lsd);
+			if (m_enable_lsd != new_value) set_need_save_resume();
+			m_enable_lsd = new_value;
+		}
 		if (mask & torrent_flags::disable_pex)
-			m_enable_pex = !bool(flags & torrent_flags::disable_pex);
+		{
+			bool const new_value = !bool(flags & torrent_flags::disable_pex);
+			if (m_enable_pex != new_value) set_need_save_resume();
+			m_enable_pex = new_value;
+		}
 	}
 
 #ifndef TORRENT_DISABLE_SHARE_MODE
@@ -1041,6 +1056,7 @@ bool is_downloading_state(int const st)
 		if (s == m_share_mode) return;
 
 		m_share_mode = s;
+		set_need_save_resume();
 #ifndef TORRENT_DISABLE_LOGGING
 		debug_log("*** set-share-mode: %d", s);
 #endif
@@ -1065,6 +1081,7 @@ bool is_downloading_state(int const st)
 		debug_log("*** set-upload-mode: %d", b);
 #endif
 
+		set_need_save_resume();
 		update_gauge();
 		state_updated();
 		send_upload_only();
@@ -4649,6 +4666,8 @@ bool is_downloading_state(int const st)
 				alerts().emplace_alert<file_renamed_alert>(get_handle()
 					, filename, file_idx);
 			m_torrent_file->rename_file(file_idx, filename);
+
+			set_need_save_resume();
 		}
 	}
 	catch (...) { handle_exception(); }


### PR DESCRIPTION
share-mode, upload-mode, disable- pex, lsd, and dht.