### PR TITLE
honor CXXFLAGS & LDFLAGS env variable in python binding

### DIFF
--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -9,6 +9,13 @@ import modules ;
 use-project /torrent : ../.. ;
 
 BOOST_ROOT = [ modules.peek : BOOST_ROOT ] ;
+
+CXXFLAGS = [ modules.peek : CXXFLAGS ] ;
+LDFLAGS = [ modules.peek : LDFLAGS ] ;
+
+ECHO "CXXFLAGS =" $(CXXFLAGS) ;
+ECHO "LDFLAGS =" $(LDFLAGS) ;
+
 # this is used to make bjam use the same version of python which is executing setup.py
 
 feature lt-visibility : default hidden : composite propagated ;
@@ -269,6 +276,8 @@ my-python-extension libtorrent
 	<conditional>@libtorrent_linking
 	<crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto
+	<cxxflags>"$(CXXFLAGS:J= )"
+	<linkflags>"$(LDFLAGS:J= )"
 	# C4268: 'identifier' : 'const' static/global data initialized
 	#		with compiler generated default constructor fills the object with zeros
 	<toolset>msvc:<cflags>/wd4268


### PR DESCRIPTION
This is a stop-gap until build scripts pass in extra build and link arguments on the command line instead