### PR TITLE
fix homebrew search paths for M1 Macs

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -29,10 +29,12 @@ else
 {
 	local boost-lib-search-path =
 		<search>/usr/local/opt/boost/lib
+		<search>/opt/homebrew/lib
 		;
 
 	local boost-include-path =
 		<include>/usr/local/opt/boost/include
+		<include>/opt/homebrew/include
 	;
 
 	# the names are decorated in MacPorts.
@@ -360,7 +362,8 @@ rule openssl-lib-path ( properties * )
 	{
 		# on macOS, default to pick up openssl from the homebrew installation
 		# brew install openssl
-		OPENSSL_LIB = /usr/local/opt/openssl/lib ;
+		# homebrew on M1 Macs install to /opt/homebrew
+		OPENSSL_LIB = /opt/homebrew/opt/openssl/lib /usr/local/opt/openssl/lib ;
 	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_LIB) = ""
 	{
@@ -386,7 +389,8 @@ rule openssl-include-path ( properties * )
 	{
 		# on macOS, default to pick up openssl from the homebrew installation
 		# brew install openssl
-		OPENSSL_INCLUDE = /usr/local/opt/openssl/include ;
+		# homebrew on M1 Macs install to /opt/homebrew
+		OPENSSL_INCLUDE = /opt/homebrew/opt/openssl/include /usr/local/opt/openssl/include ;
 	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_INCLUDE) = ""
 	{


### PR DESCRIPTION
/opt/homebrew instead of /usr/local