### PR TITLE
fix issue with setting file priorities and saving resume data

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,7 +121,7 @@ jobs:
           sudo apt update
 
       - name: install clang-tidy
-        run: sudo apt install clang-tidy
+        run: sudo apt install clang-tidy libc++-dev
 
       - name: install boost
         run: |

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -399,7 +399,8 @@ TORRENT_TEST(is_finished)
 				TEST_EQUAL(is_finished(ses), false);
 				std::vector<download_priority_t> prio(4, dont_download);
 				ses.get_torrents()[0].prioritize_files(prio);
-				TEST_EQUAL(is_finished(ses), true);
+				// applying the priorities is asynchronous. the torrent may not
+				// finish immediately
 			}
 		},
 		[](std::shared_ptr<lt::session> ses[2]) {


### PR DESCRIPTION
The need-save-resume flag should not be set until *after* the new file priorities have been applied. Don't set the need-save-resume flag just by loading the resume data (when applying the file priorities into the piece priorities)