### PR TITLE
prefer __builtin_popcountl() over portable C implementation of popcnt

### DIFF
--- a/src/bitfield.cpp
+++ b/src/bitfield.cpp
@@ -109,6 +109,9 @@ namespace libtorrent {
 
 		for (int i = 1; i < words + 1; ++i)
 		{
+#if defined __GNUC__ || defined __clang__
+			ret += __builtin_popcountl(m_buf[i]);
+#else
 			std::uint32_t const v = m_buf[i];
 			// from:
 			// http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
@@ -122,6 +125,7 @@ namespace libtorrent {
 			c = ((c >> S[4]) + c) & B[4];
 			ret += c;
 			TORRENT_ASSERT(ret <= size());
+#endif
 		}
 
 		TORRENT_ASSERT(ret <= size());


### PR DESCRIPTION
This enables the ARM64 SIMD instruction on Apple M1