### PR TITLE
restore peer_connection::is_seed

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -266,7 +266,7 @@ namespace libtorrent {
 		bool m_upload_mode:1;
 
 		// this is set to false as long as the connections
-		// of this torrent hasn't been initialized. If we
+		// of this torrent haven't been initialized. If we
 		// have metadata from the start, connections are
 		// initialized immediately, if we didn't have metadata,
 		// they are initialized right after files_checked().

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2012,6 +2012,7 @@ namespace libtorrent {
 				, static_cast<void*>(m_peer_info));
 #endif
 
+			TORRENT_ASSERT(t->ready_for_connections());
 			TORRENT_ASSERT(m_have_piece.all_set());
 			TORRENT_ASSERT(m_have_piece.count() == m_have_piece.size());
 			TORRENT_ASSERT(m_have_piece.size() == t->torrent_file().num_pieces());
@@ -3319,7 +3320,6 @@ namespace libtorrent {
 #endif
 
 		t->set_seed(m_peer_info, true);
-		TORRENT_ASSERT(is_seed());
 		m_upload_only = true;
 		m_bitfield_received = true;
 
@@ -6634,10 +6634,6 @@ namespace libtorrent {
 	bool peer_connection::is_seed() const
 	{
 		TORRENT_ASSERT(is_single_thread());
-
-		// if the peer told us it has all pieces, it doesn't matter whether we
-		// have the metadata or not, this peer is a seed.
-		if (m_have_all) return true;
 
 		// if m_num_pieces == 0, we probably don't have the
 		// metadata yet.

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8124,7 +8124,6 @@ bool is_downloading_state(int const st)
 				if (p.peer_info_struct()->seed)
 				{
 					++seeds;
-					TORRENT_ASSERT(!p.m_bitfield_received || p.is_seed());
 				}
 				else
 				{


### PR DESCRIPTION
to not take m_have_all into account. It caused some regression in edge cases