### PR TITLE
fix issue in setup.py

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -231,7 +231,7 @@ class LibtorrentBuildExt(BuildExtBase):
             with open('compile_flags') as f:
                 opts = f.read()
                 if '-std=c++' in opts:
-                    self.cxxflags = '-std=c++' + opts.split('-std=c++')[-1].split()[0]
+                    self.cxxflags = ['-std=c++' + opts.split('-std=c++')[-1].split()[0]]
         except:
             pass
 


### PR DESCRIPTION
where a -std=c++ option found in compile_flags was handled incorrectly and split into individual characters