### PR TITLE
info_hash related fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,8 @@ PYTHON_FILES= \
   src/session.cpp           \
   src/session_settings.cpp  \
   src/sha1_hash.cpp         \
+  src/sha256_hash.cpp       \
+  src/info_hash.cpp         \
   src/string.cpp            \
   src/torrent_handle.cpp    \
   src/torrent_info.cpp      \

--- a/bindings/python/Jamfile
+++ b/bindings/python/Jamfile
@@ -250,6 +250,8 @@ my-python-extension libtorrent
 	: # sources
 	src/module.cpp
 	src/sha1_hash.cpp
+	src/sha256_hash.cpp
+	src/info_hash.cpp
 	src/converters.cpp
 	src/create_torrent.cpp
 	src/fingerprint.cpp

--- a/bindings/python/src/info_hash.cpp
+++ b/bindings/python/src/info_hash.cpp
@@ -1,0 +1,41 @@
+// Copyright Arvid Norberg 2020. Use, modification and distribution is
+// subject to the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "boost_python.hpp"
+#include <libtorrent/info_hash.hpp>
+
+namespace {
+
+using namespace lt;
+
+long get_hash(info_hash_t const& ih)
+{
+    return std::hash<info_hash_t>{}(ih);
+}
+
+}
+
+void bind_info_hash()
+{
+    using namespace boost::python;
+    using namespace lt;
+
+    class_<info_hash_t>("info_hash_t")
+        .def(init<sha1_hash const&>(arg("sha1_hash")))
+        .def(init<sha256_hash const&>(arg("sha256_hash")))
+        .def(init<sha1_hash const&, sha256_hash const&>((arg("sha1_hash"), arg("sha256_hash"))))
+        .def("__hash__", get_hash)
+        .def("has_v1", &info_hash_t::has_v1)
+        .def("has_v2", &info_hash_t::has_v2)
+        .def("has", &info_hash_t::has)
+        .def("get", &info_hash_t::get)
+        .def("get_best", &info_hash_t::get_best)
+        .add_property("v1", &info_hash_t::v1)
+        .add_property("v2", &info_hash_t::v2)
+        .def(self == self)
+        .def(self != self)
+        .def(self < self)
+        ;
+}
+

--- a/bindings/python/src/module.cpp
+++ b/bindings/python/src/module.cpp
@@ -12,6 +12,8 @@
 void bind_utility();
 void bind_fingerprint();
 void bind_sha1_hash();
+void bind_sha256_hash();
+void bind_info_hash();
 void bind_session();
 void bind_entry();
 void bind_torrent_info();
@@ -40,6 +42,8 @@ BOOST_PYTHON_MODULE(libtorrent)
     bind_utility();
     bind_fingerprint();
     bind_sha1_hash();
+    bind_sha256_hash();
+    bind_info_hash();
     bind_entry();
     bind_torrent_handle();
     bind_session();

--- a/bindings/python/src/sha256_hash.cpp
+++ b/bindings/python/src/sha256_hash.cpp
@@ -12,35 +12,33 @@ namespace {
 
 using namespace lt;
 
-long get_hash(sha1_hash const& s)
+long get_hash(sha256_hash const& s)
 {
-    return std::hash<sha1_hash>{}(s);
+    return std::hash<sha256_hash>{}(s);
 }
 
-bytes sha1_hash_bytes(const sha1_hash& bn) {
+bytes sha256_hash_bytes(const sha256_hash& bn) {
     return bytes(bn.to_string());
 }
 
 }
 
-void bind_sha1_hash()
+void bind_sha256_hash()
 {
     using namespace boost::python;
     using namespace lt;
 
-    class_<sha1_hash>("sha1_hash")
+    class_<sha256_hash>("sha256_hash")
         .def(self == self)
         .def(self != self)
         .def(self < self)
         .def(self_ns::str(self))
         .def(init<std::string>())
-        .def("clear", &sha1_hash::clear)
-        .def("is_all_zeros", &sha1_hash::is_all_zeros)
-        .def("to_string", sha1_hash_bytes)
+        .def("clear", &sha256_hash::clear)
+        .def("is_all_zeros", &sha256_hash::is_all_zeros)
+        .def("to_string", sha256_hash_bytes)
         .def("__hash__", get_hash)
-        .def("to_bytes", sha1_hash_bytes)
+        .def("to_bytes", sha256_hash_bytes)
         ;
-
-    scope().attr("peer_id") = scope().attr("sha1_hash");
 }
 

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -326,6 +326,11 @@ std::shared_ptr<torrent_info> sha1_constructor0(sha1_hash const& ih)
     return std::make_shared<torrent_info>(info_hash_t(ih));
 }
 
+std::shared_ptr<torrent_info> sha256_constructor0(sha256_hash const& ih)
+{
+    return std::make_shared<torrent_info>(info_hash_t(ih));
+}
+
 std::shared_ptr<torrent_info> bencoded_constructor0(dict d)
 {
     entry ent = extract<entry>(d);
@@ -361,22 +366,6 @@ void bind_torrent_info()
         .value("V2", protocol_version::V2)
         ;
 
-    class_<info_hash_t>("info_hash_t")
-        .def(init<sha1_hash const&>(arg("sha1_hash")))
-        .def(init<sha256_hash const&>(arg("sha256_hash")))
-        .def(init<sha1_hash const&, sha256_hash const&>((arg("sha1_hash"), arg("sha256_hash"))))
-        .def("has_v1", &info_hash_t::has_v1)
-        .def("has_v2", &info_hash_t::has_v2)
-        .def("has", &info_hash_t::has)
-        .def("get", &info_hash_t::get)
-        .def("get_best", &info_hash_t::get_best)
-        .add_property("v1", &info_hash_t::v1)
-        .add_property("v2", &info_hash_t::v2)
-        .def(self == self)
-        .def(self != self)
-        .def(self < self)
-        ;
-
     enum_<announce_entry::tracker_source>("tracker_source")
         .value("source_torrent", announce_entry::source_torrent)
         .value("source_client", announce_entry::source_client)
@@ -396,8 +385,8 @@ void bind_torrent_info()
         .def("__init__", make_constructor(&file_constructor1))
         .def(init<torrent_info const&>((arg("ti"))))
 
-        // TODO: add a sha256 constructor as well
         .def("__init__", make_constructor(&sha1_constructor0))
+        .def("__init__", make_constructor(&sha256_constructor0))
 
         .def("add_tracker", (add_tracker1)&torrent_info::add_tracker
             , (arg("url"), arg("tier") = 0


### PR DESCRIPTION
add `sha256_hash` type
add `__hash__` member to `info_hash_t`
add `torrent_info` constructor overload for a `sha256_hash`

@AllSeeingEyeTolledEweSew looks good?