### PR TITLE
Changed library name to lowercase to build properly with mingw on linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,7 +594,7 @@ target_link_libraries(torrent-rasterbar
 if (WIN32)
 	target_link_libraries(torrent-rasterbar
 		PRIVATE
-			wsock32 ws2_32 Iphlpapi
+			wsock32 ws2_32 iphlpapi
 			debug dbghelp crypt32
 	)
 


### PR DESCRIPTION
When building on Linux - `iphlpapi` library cannot be found, because of case-sensitive file naming on Linux.
Compilation with Mingw now works fine, but I have not tested on Windows, if it works fine as well.

