### PR TITLE
removed queue size limiter for time critical mode.

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -916,11 +916,6 @@ namespace libtorrent {
 		TORRENT_ASSERT(t);
 		if (!t) return {};
 
-		if (t->num_time_critical_pieces() > 0)
-		{
-			ret |= piece_picker::time_critical_mode;
-		}
-
 		if (t->is_sequential_download())
 		{
 			ret |= piece_picker::sequential;

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -2001,11 +2001,6 @@ namespace {
 			{
 				pc.inc_stats_counter(counters::piece_picker_partial_loops);
 
-				// in time critical mode, only pick high priority pieces
-				if ((options & time_critical_mode)
-					&& piece_priority(dp.index) != top_priority)
-					continue;
-
 				if (!is_piece_free(dp.index, pieces)) continue;
 
 				TORRENT_ASSERT(m_piece_map[dp.index].download_queue()
@@ -2055,11 +2050,6 @@ namespace {
 		{
 			for (piece_index_t i : suggested_pieces)
 			{
-				// in time critical mode, only pick high priority pieces
-				if ((options & time_critical_mode)
-					&& piece_priority(i) != top_priority)
-					continue;
-
 				pc.inc_stats_counter(counters::piece_picker_suggest_loops);
 				if (!is_piece_free(i, pieces)) continue;
 
@@ -2094,44 +2084,40 @@ namespace {
 				if (num_blocks <= 0) return ret;
 			}
 
-			// in time critical mode, only pick high priority pieces
-			if (!(options & time_critical_mode))
+			if (options & reverse)
 			{
-				if (options & reverse)
+				for (piece_index_t i = prev(m_reverse_cursor); i >= m_cursor; --i)
 				{
-					for (piece_index_t i = prev(m_reverse_cursor); i >= m_cursor; --i)
-					{
-						if (!is_piece_free(i, pieces)) continue;
-						// we've already added high priority pieces
-						if (piece_priority(i) == top_priority) continue;
+					if (!is_piece_free(i, pieces)) continue;
+					// we've already added high priority pieces
+					if (piece_priority(i) == top_priority) continue;
 
-						ret |= picker_log_alert::reverse_sequential;
+					ret |= picker_log_alert::reverse_sequential;
 
-						num_blocks = add_blocks(i, pieces
-							, interesting_blocks, backup_blocks
-							, backup_blocks2, num_blocks
-							, prefer_contiguous_blocks, peer, suggested_pieces
-							, options);
-						if (num_blocks <= 0) return ret;
-					}
+					num_blocks = add_blocks(i, pieces
+						, interesting_blocks, backup_blocks
+						, backup_blocks2, num_blocks
+						, prefer_contiguous_blocks, peer, suggested_pieces
+						, options);
+					if (num_blocks <= 0) return ret;
 				}
-				else
+			}
+			else
+			{
+				for (piece_index_t i = m_cursor; i < m_reverse_cursor; ++i)
 				{
-					for (piece_index_t i = m_cursor; i < m_reverse_cursor; ++i)
-					{
-						if (!is_piece_free(i, pieces)) continue;
-						// we've already added high priority pieces
-						if (piece_priority(i) == top_priority) continue;
+					if (!is_piece_free(i, pieces)) continue;
+					// we've already added high priority pieces
+					if (piece_priority(i) == top_priority) continue;
 
-						ret |= picker_log_alert::sequential_pieces;
+					ret |= picker_log_alert::sequential_pieces;
 
-						num_blocks = add_blocks(i, pieces
-							, interesting_blocks, backup_blocks
-							, backup_blocks2, num_blocks
-							, prefer_contiguous_blocks, peer, suggested_pieces
-							, options);
-						if (num_blocks <= 0) return ret;
-					}
+					num_blocks = add_blocks(i, pieces
+						, interesting_blocks, backup_blocks
+						, backup_blocks2, num_blocks
+						, prefer_contiguous_blocks, peer, suggested_pieces
+						, options);
+					if (num_blocks <= 0) return ret;
 				}
 			}
 		}
@@ -2144,7 +2130,7 @@ namespace {
 			// pieces. This is why reverse mode is disabled when we're in
 			// time-critical mode, because all high priority pieces are at the
 			// front of the list
-			if ((options & reverse) && !(options & time_critical_mode))
+			if (options & reverse)
 			{
 				for (int i = int(m_priority_boundaries.size()) - 1; i >= 0; --i)
 				{
@@ -2208,14 +2194,6 @@ namespace {
 				{
 					pc.inc_stats_counter(counters::piece_picker_rare_loops);
 
-					// in time critical mode, only pick high priority pieces
-					// it's safe to break here because in this mode we
-					// pick pieces in priority order. Once we hit a lower priority
-					// piece, we won't encounter any more high priority ones
-					if ((options & time_critical_mode)
-						&& piece_priority(i) != top_priority)
-						break;
-
 					if (!is_piece_free(i, pieces)) continue;
 
 					ret |= picker_log_alert::rarest_first;
@@ -2227,25 +2205,6 @@ namespace {
 						, options);
 					if (num_blocks <= 0) return ret;
 				}
-			}
-		}
-		else if (options & time_critical_mode)
-		{
-			// if we're in time-critical mode, we are only allowed to pick
-			// high priority pieces.
-			for (auto i = m_pieces.begin();
-				i != m_pieces.end() && piece_priority(*i) == top_priority; ++i)
-			{
-				if (!is_piece_free(*i, pieces)) continue;
-
-				ret |= picker_log_alert::time_critical;
-
-				num_blocks = add_blocks(*i, pieces
-					, interesting_blocks, backup_blocks
-					, backup_blocks2, num_blocks
-					, prefer_contiguous_blocks, peer, suggested_pieces
-					, options);
-				if (num_blocks <= 0) return ret;
 			}
 		}
 		else
@@ -2373,10 +2332,6 @@ get_out:
 		{
 			downloading_piece const& dp = *i;
 
-			if ((options & time_critical_mode)
-				&& piece_priority(dp.index) != top_priority)
-				continue;
-
 			// we either don't have this piece, or we've already requested from it
 			if (!pieces[dp.index]) continue;
 
@@ -2415,10 +2370,6 @@ get_out:
 			if (!pieces[dp.index]) continue;
 			// don't pick pieces with priority 0
 			TORRENT_ASSERT(piece_priority(dp.index) > dont_download);
-
-			if ((options & time_critical_mode)
-				&& piece_priority(dp.index) != top_priority)
-				continue;
 
 			partials[c++] = &dp;
 		}
@@ -2468,10 +2419,6 @@ get_out:
 			if (!pieces[i.index]) continue;
 			if (piece_priority(i.index) == dont_download) continue;
 			if (i.locked) continue;
-
-			if ((options & time_critical_mode)
-				&& piece_priority(i.index) != top_priority)
-				continue;
 
 			int idx = -1;
 			for (auto const& info : blocks_for_piece(i))

--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -83,8 +83,7 @@ namespace libtorrent {
 
 		// in time critical mode, only have 1 outstanding request at a time
 		// via normal requests
-		int const desired_queue_size = time_critical_mode
-			? 1 : c.desired_queue_size();
+		int const desired_queue_size = c.desired_queue_size();
 
 		int num_requests = desired_queue_size
 			- int(c.download_queue().size())
@@ -206,8 +205,7 @@ namespace libtorrent {
 		bool const dont_pick_busy_blocks
 			= ((ses.settings().get_bool(settings_pack::strict_end_game_mode)
 				&& p.get_download_queue_size() < p.num_want_left())
-				|| dq.size() + rq.size() > 0)
-				&& !time_critical_mode;
+				|| dq.size() + rq.size() > 0);
 
 		// this is filled with an interesting piece
 		// that some other peer is currently downloading
@@ -216,13 +214,6 @@ namespace libtorrent {
 		for (piece_block const& pb : interesting_pieces)
 		{
 			if (prefer_contiguous_blocks == 0 && num_requests <= 0) break;
-
-			if (time_critical_mode && p.piece_priority(pb.piece_index) != top_priority)
-			{
-				// assume the subsequent pieces are not prio 7 and
-				// be done
-				break;
-			}
 
 			int num_block_requests = p.num_peers(pb);
 			if (num_block_requests > 0)


### PR DESCRIPTION
Does think make sense? 

When we have time critical pieces - other pieces are skipped inside `request_blocks` and queue is also limited.

Related to #5891 