### PR TITLE
Piece picker changes with priority based selector

### DIFF
--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -151,6 +151,9 @@ namespace libtorrent {
 		// small)
 		static constexpr picker_options_t piece_extent_affinity = 7_bit;
 
+		// pick pieces in priority descending order
+		static constexpr picker_options_t priority_order = 8_bit;
+		
 		struct downloading_piece
 		{
 			downloading_piece()

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -872,6 +872,10 @@ namespace aux {
 			// happen at the application level.
 			allow_idna,
 
+			// when enabled, pieces are picked, based on their priority value. 
+			// Same priorities will follow sequential order.
+			piece_priority_order,
+
 			max_bool_setting_internal
 		};
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -921,7 +921,11 @@ namespace libtorrent {
 			ret |= piece_picker::time_critical_mode;
 		}
 
-		if (t->is_sequential_download())
+		if (m_settings.get_bool(settings_pack::piece_priority_order))
+		{
+			ret |= piece_picker::priority_order;
+		}
+		else if (t->is_sequential_download())
 		{
 			ret |= piece_picker::sequential;
 		}

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -213,6 +213,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		SET(validate_https_trackers, true, &session_impl::update_validate_https),
 		SET(ssrf_mitigation, true, nullptr),
 		SET(allow_idna, false, nullptr),
+		SET(piece_priority_order, false, nullptr),
 	}});
 
 	aux::array<int_setting_entry_t, settings_pack::num_int_settings> const int_settings


### PR DESCRIPTION
PR does these changes:
- New setting in `settings_pack` that enables priority-based piece selection.
- New `piece_picker::priority_order` bit to transfer configuration to `piece_picker`.

In `peer_connection::picker_options()`:
- `piece_picker::priority_order` placed above `piece_picker::sequential`, because basically priority_order is the same, but first sorted with priority.

In `piece_picker::pick_pieces`:
- `if (options & time_critical_mode)` check is moved above, to make sure time critical pieces are picked before any other selector mode.
- Other conditions starting with `if`, instead of `else if`, because all time critical pieces can be already requested, usually it is not much of them.
- `for (auto i = m_pieces.begin(); i != m_pieces.end() && piece_priority(*i) == top_priority; ++i)` - this was leaving the loop if first piece is not `top_priority`, no?
- Added new functionality to iterate pieces with specific priorities. Not sure it there is a better (faster) way of that, to keep the order.

What do you think?

Related to #5891 