### PR TITLE
[8/?] Add type stubs to the python bindings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,10 @@ repos:
                tools/set_version.py|
                tools/update_copyright.py
           )$
+      # black doesn't run on *.pyi files by default, for reasons
+    - id: black
+      name: black (pyi)
+      types: [pyi]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.800
   hooks:

--- a/bindings/python/install_data/libtorrent/__init__.pyi
+++ b/bindings/python/install_data/libtorrent/__init__.pyi
@@ -1,0 +1,1976 @@
+import datetime
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Iterable
+from typing import Iterator
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import overload
+from typing import Tuple
+from typing import Union
+
+from typing_extensions import TypedDict
+
+# I created this file by starting with stubgen and modifying its output.
+
+# I recommend that maintainers occasionally re-run stubgen, and compare it to
+# this file. This diff will be too verbose to use for small changes, but it's the
+# only way to ensure coverage.
+
+# To help with the above process, please keep everything in sorted order, to
+# match stubgen's output.
+
+# Typing notes:
+# - This project has a very particular approach to typed enum values. Pay
+#   special attention to which are typed, and which are just ints.
+# - Some attributes like add_torrent_params.save_path ought to be read as one
+#   type (str) and set as another (Union[str, bytes]), but mypy doesn't support
+#   this.
+# - We use strict primitive types (Dict and List) for function args, because
+#   boost strictly requires these, and will not understand duck-typed
+#   abstractions like Mapping or Sequence.
+# - I chose to make the "names" and "values" enum class attributes typed as
+#   Mapping, specifically to block modification. I coludn't think of a case
+#   where these would need to be used in a Dict context.
+# - Boost mangles function signatures to all look like (*args, **kwargs) in
+#   python. This allows for "anonymous" positional args which python doesn't
+#   normally support. We want the type stubs to match the *usage* of a function,
+#   not this mangled version, so for anonymous positional args, we use a name
+#   like "_name" (these names might fairly all be "_", but python doesn't allow
+#   duplicates). PEP 570 provides positional-only argument syntax but mypy
+#   doesn't support it as of writing.
+
+_PathLike = Union[str, bytes]
+_Entry = Union[bytes, int, List, Dict[bytes, Any], Tuple[int, ...]]
+
+create_smart_ban_plugin: str
+create_ut_metadata_plugin: str
+create_ut_pex_plugin: str
+version: str
+version_major: int
+version_minor: int
+__version__: str
+@overload
+def add_files(fs: file_storage, path: _PathLike, flags: int = ...) -> None: ...
+@overload
+def add_files(
+    fs: file_storage,
+    path: _PathLike,
+    predicate: Callable[[str], Any],
+    flags: int = ...,
+) -> None: ...
+def add_magnet_uri(
+    _session: session, _uri: str, _limits: Dict[str, Any]
+) -> torrent_handle: ...
+def bdecode(_bencoded: bytes) -> _Entry: ...
+def bdecode_category() -> error_category: ...
+def bencode(_bdecoded: _Entry) -> bytes: ...
+def client_fingerprint(_pid: sha1_hash) -> Optional[fingerprint]: ...
+
+# We could have this return Mapping, but this would interfere with using it as
+# input elsewhere where Dict is strictly expected
+def default_settings() -> Dict[str, Any]: ...
+def find_metric_idx(_metric_name: str) -> int: ...
+def generate_fingerprint(
+    _prefix: Union[str, bytes], _major: int, _minor: int, _rev: int, _tag: int
+) -> str: ...
+def generic_category() -> error_category: ...
+def get_bdecode_category() -> error_category: ...
+def get_http_category() -> error_category: ...
+def get_i2p_category() -> error_category: ...
+def get_libtorrent_category() -> error_category: ...
+def get_socks_category() -> error_category: ...
+def get_upnp_category() -> error_category: ...
+def high_performance_seed() -> Dict[str, Any]: ...
+def http_category() -> error_category: ...
+def i2p_category() -> error_category: ...
+def identify_client(_pid: sha1_hash) -> str: ...
+def libtorrent_category() -> error_category: ...
+@overload
+def make_magnet_uri(_handle: torrent_handle) -> str: ...
+@overload
+def make_magnet_uri(_ti: torrent_info) -> str: ...
+def min_memory_usage() -> Dict[str, Any]: ...
+def operation_name(_op: operation_t) -> str: ...
+def parse_magnet_uri(_uri: str) -> add_torrent_params: ...
+
+# Note that we include every param supported by add_torrent() here, though
+# this type is only created by parse_magnet_uri_dict() which doesn't populate
+# everything. This is to support users modifying its output before passing to
+# add_torrent().
+class _AddTorrentParamsDict(TypedDict, total=False):
+    ti: torrent_info
+    trackers: List[str]
+    dht_nodes: List[Tuple[str, int]]
+    info_hashes: bytes
+    info_hash: bytes
+    name: str
+    save_path: str
+    storage_mode: storage_mode_t
+    url: str
+    flags: int
+    resume_data: bytes
+    http_seeds: List[str]
+    banned_peers: List[Tuple[str, int]]
+    peers: List[Tuple[str, int]]
+    trackerid: str
+    renamed_files: Dict[int, str]
+    file_priorities: List[int]
+
+def parse_magnet_uri_dict(_uri: str) -> _AddTorrentParamsDict: ...
+@overload
+def read_resume_data(_bencoded: bytes) -> add_torrent_params: ...
+@overload
+def read_resume_data(
+    _bencoded: bytes, _limits: Dict[str, Any]
+) -> add_torrent_params: ...
+@overload
+def read_session_params(buffer: bytes, flags: int = ...) -> session_params: ...
+@overload
+def read_session_params(dict: Dict[bytes, Any], flags: int = ...) -> session_params: ...
+def session_stats_metrics() -> List[stats_metric]: ...
+@overload
+def set_piece_hashes(
+    _ct: create_torrent, _path: _PathLike, _callback: Callable[[int], Any]
+) -> None: ...
+@overload
+def set_piece_hashes(_ct: create_torrent, _path: _PathLike) -> None: ...
+def socks_category() -> error_category: ...
+def system_category() -> error_category: ...
+def upnp_category() -> error_category: ...
+def write_resume_data(_atp: add_torrent_params) -> Dict[bytes, Any]: ...
+def write_resume_data_buf(_atp: add_torrent_params) -> bytes: ...
+def write_session_params(
+    entry: session_params, flags: int = ...
+) -> Dict[bytes, Any]: ...
+
+class add_piece_flags_t:
+    overwrite_existing: int
+
+class add_torrent_alert(torrent_alert):
+    error: error_code
+    params: add_torrent_params
+
+class add_torrent_params:
+    active_time: int
+    added_time: int
+    banned_peers: List[Tuple[str, int]]
+    completed_time: int
+    dht_nodes: List[Tuple[str, int]]
+    download_limit: int
+    file_priorities: List[int]
+    finished_time: int
+    flags: int
+    have_pieces: List[bool]
+    http_seeds: List[str]
+    info_hash: sha1_hash
+    info_hashes: info_hash_t
+    last_download: int
+    last_seen_complete: int
+    last_upload: int
+    max_connections: int
+    max_uploads: int
+    merkle_tree: List[sha1_hash]
+    name: str
+    num_complete: int
+    num_downloaded: int
+    num_incomplete: int
+    peers: List[Tuple[str, int]]
+    piece_priorities: List[int]
+    renamed_files: Dict[int, str]
+    resume_data: List[str]
+    save_path: str
+    seeding_time: int
+    storage_mode: storage_mode_t
+    ti: Optional[torrent_info]
+    total_downloaded: int
+    total_uploaded: int
+    tracker_tiers: List[int]
+    trackerid: str
+    trackers: List[str]
+    unfinished_pieces: Dict[int, List[bool]]
+    upload_limit: int
+    url: str
+    url_seeds: List[str]
+    verified_pieces: List[bool]
+    version: int
+
+class add_torrent_params_flags_t:
+    default_flags: int
+    flag_apply_ip_filter: int
+    flag_auto_managed: int
+    flag_duplicate_is_error: int
+    flag_merge_resume_http_seeds: int
+    flag_merge_resume_trackers: int
+    flag_override_resume_data: int
+    flag_override_trackers: int
+    flag_override_web_seeds: int
+    flag_paused: int
+    flag_pinned: int
+    flag_seed_mode: int
+    flag_sequential_download: int
+    flag_share_mode: int
+    flag_stop_when_ready: int
+    flag_super_seeding: int
+    flag_update_subscribe: int
+    flag_upload_mode: int
+    flag_use_resume_save_path: int
+
+class alert:
+    class category_t:
+        all_categories: int
+        block_progress_notification: int
+        connect_notification: int
+        debug_notification: int
+        dht_log_notification: int
+        dht_notification: int
+        dht_operation_notification: int
+        error_notification: int
+        file_progress_notification: int
+        incoming_request_notification: int
+        ip_block_notification: int
+        peer_log_notification: int
+        peer_notification: int
+        performance_warning: int
+        picker_log_notification: int
+        piece_progress_notification: int
+        port_mapping_log_notification: int
+        port_mapping_notification: int
+        progress_notification: int
+        session_log_notification: int
+        stats_notification: int
+        status_notification: int
+        storage_notification: int
+        torrent_log_notification: int
+        tracker_notification: int
+        upload_notification: int
+    def category(self) -> int: ...
+    def message(self) -> str: ...
+    def what(self) -> str: ...
+
+class alert_category:
+    all: int
+    block_progress: int
+    connect: int
+    dht: int
+    dht_log: int
+    dht_operation: int
+    error: int
+    file_progress: int
+    incoming_request: int
+    ip_block: int
+    peer: int
+    peer_log: int
+    performance_warning: int
+    picker_log: int
+    piece_progress: int
+    port_mapping: int
+    port_mapping_log: int
+    session_log: int
+    stats: int
+    status: int
+    storage: int
+    torrent_log: int
+    tracker: int
+    upload: int
+
+class alerts_dropped_alert(alert):
+    dropped_alerts: List[bool]
+
+class announce_entry:
+    def __init__(self, url: str) -> None: ...
+    def can_announce(self, _is_seed: bool) -> bool: ...
+    def is_working(self) -> bool: ...
+    def min_announce_in(self) -> int: ...
+    def next_announce_in(self) -> int: ...
+    def reset(self) -> None: ...
+    def trim(self) -> None: ...
+    complete_sent: bool
+    fail_limit: int
+    fails: int
+    last_error: error_code
+    message: str
+    min_announce: Optional[datetime.datetime]
+    next_announce: Optional[datetime.datetime]
+    scrape_complete: int
+    scrape_downloaded: int
+    scrape_incomplete: int
+    send_stats: bool
+    source: int
+    start_sent: bool
+    tier: int
+    trackerid: str
+    updating: bool
+    url: str
+    verified: bool
+
+class anonymous_mode_alert(torrent_alert):
+    kind: int
+    str: str
+
+class bandwidth_mixed_algo_t(int):
+    names: Mapping[str, bandwidth_mixed_algo_t]
+    peer_proportional: bandwidth_mixed_algo_t
+    prefer_tcp: bandwidth_mixed_algo_t
+    values: Mapping[int, bandwidth_mixed_algo_t]
+
+class block_downloading_alert(peer_alert):
+    block_index: int
+    peer_speedmsg: str
+    piece_index: int
+
+class block_finished_alert(peer_alert):
+    block_index: int
+    piece_index: int
+
+class block_timeout_alert(peer_alert):
+    block_index: int
+    piece_index: int
+
+class block_uploaded_alert(peer_alert):
+    block_index: int
+    piece_index: int
+
+class cache_flushed_alert(torrent_alert):
+    pass
+
+class choking_algorithm_t(int):
+    auto_expand_choker: choking_algorithm_t
+    bittyrant_choker: choking_algorithm_t
+    fixed_slots_choker: choking_algorithm_t
+    names: Mapping[str, choking_algorithm_t]
+    rate_based_choker: choking_algorithm_t
+    values: Mapping[int, choking_algorithm_t]
+
+class create_torrent:
+    canonical_files: int
+    merkle: int
+    modification_time: int
+    optimize_alignment: int
+    symlinks: int
+    v1_only: int
+    v2_only: int
+    @overload
+    def __init__(
+        self, storage: file_storage, piece_size: int = ..., flags: int = ...
+    ) -> None: ...
+    @overload
+    def __init__(self, _fs: file_storage) -> None: ...
+    @overload
+    def __init__(self, ti: torrent_info) -> None: ...
+    def add_collection(self, _collection: str) -> None: ...
+    def add_http_seed(self, _url: str) -> None: ...
+    def add_node(self, _ip: str, _port: int) -> None: ...
+    def add_similar_torrent(self, _info_hash: sha1_hash) -> None: ...
+    def add_tracker(self, announce_url: str, tier: int = ...) -> None: ...
+    def add_url_seed(self, _url: str) -> None: ...
+    def files(self) -> file_storage: ...
+    def generate(self) -> Dict[bytes, Any]: ...
+    def num_pieces(self) -> int: ...
+    def piece_length(self) -> int: ...
+    def piece_size(self, _index: int) -> int: ...
+    def priv(self) -> bool: ...
+    def set_comment(self, _comment: str) -> None: ...
+    def set_creator(self, _creator: str) -> None: ...
+    def set_file_hash(self, _index: int, _hash: bytes) -> None: ...
+    def set_hash(self, _index: int, _hash: bytes) -> None: ...
+    def set_priv(self, _priv: bool) -> None: ...
+    # TODO: is this right?
+    def set_root_cert(self, pem: str) -> None: ...
+
+class create_torrent_flags_t:
+    merkle: int
+    modification_time: int
+    optimize: int
+    optimize_alignment: int
+    symlinks: int
+    v2_only: int
+
+class deadline_flags_t:
+    alert_when_available: int
+
+class deprecated_move_flags_t(int):
+    always_replace_files: deprecated_move_flags_t
+    dont_replace: deprecated_move_flags_t
+    fail_if_exist: deprecated_move_flags_t
+    names: Mapping[str, deprecated_move_flags_t]
+    values: Mapping[int, deprecated_move_flags_t]
+
+class dht_announce_alert(alert):
+    info_hash: sha1_hash
+    ip: str
+    port: int
+
+class dht_bootstrap_alert(alert):
+    pass
+
+class dht_get_peers_alert(alert):
+    info_hash: sha1_hash
+
+class dht_get_peers_reply_alert(alert):
+    def num_peers(self) -> int: ...
+    def peers(self) -> List[Tuple[str, int]]: ...
+    info_hash: sha1_hash
+
+class dht_immutable_item_alert(alert):
+    item: _Entry
+    target: sha1_hash
+
+class _DhtNodeDict(TypedDict):
+    nid: sha1_hash
+    endpoint: Tuple[str, int]
+
+class dht_live_nodes_alert(alert):
+    node_id: sha1_hash
+    nodes: List[_DhtNodeDict]
+    num_nodes: int
+
+class dht_log_alert(alert):
+    def log_message(self) -> str: ...
+    module: int
+
+class dht_lookup:
+    branch_factor: int
+    outstanding_requests: int
+    response: int
+    timeouts: int
+    type: Optional[str]
+
+class dht_mutable_item_alert(alert):
+    authoritative: bool
+    item: _Entry
+    key: bytes
+    salt: bytes
+    seq: int
+    signature: bytes
+
+class dht_outgoing_get_peers_alert(alert):
+    endpoint: Tuple[str, int]
+    info_hash: sha1_hash
+    ip: Tuple[str, int]
+    obfuscated_info_hash: sha1_hash
+
+class dht_pkt_alert(alert):
+    pkt_buf: bytes
+
+class dht_put_alert(alert):
+    num_success: int
+    public_key: bytes
+    salt: bytes
+    seq: int
+    signature: bytes
+    target: sha1_hash
+
+class dht_reply_alert(tracker_alert):
+    num_peers: int
+
+class dht_sample_infohashes_alert(alert):
+    endpoint: Tuple[str, int]
+    interval: datetime.timedelta
+    nodes: List[_DhtNodeDict]
+    num_infohashes: int
+    num_nodes: int
+    num_samples: int
+    samples: List[sha1_hash]
+
+class dht_settings:
+    aggressive_lookups: bool
+    block_ratelimit: int
+    block_timeout: int
+    enforce_node_id: bool
+    extended_routing_table: bool
+    ignore_dark_internet: bool
+    item_lifetime: int
+    max_dht_items: int
+    max_fail_count: int
+    max_peers_reply: int
+    max_torrent_search_reply: int
+    max_torrents: int
+    privacy_lookups: bool
+    read_only: bool
+    restrict_routing_ips: bool
+    restrict_search_ips: bool
+    search_branching: int
+
+class dht_state:
+    nids: List[Tuple[str, sha1_hash]]
+    nodes: List[Tuple[str, int]]
+    nodes6: List[Tuple[str, int]]
+
+class _DhtStatsActiveRequest(TypedDict):
+    type: Optional[str]
+    outstanding_requests: int
+    timeouts: int
+    responses: int
+    branch_factor: int
+    nodes_left: int
+    last_sent: int
+    first_timeout: int
+
+class _DhtStatsRoute(TypedDict):
+    num_nodes: int
+    num_replacements: int
+
+class dht_stats_alert(alert):
+    active_requests: List[_DhtStatsActiveRequest]
+    routing_table: List[_DhtStatsRoute]
+
+class enc_level(int):
+    both: enc_level
+    names: Mapping[str, enc_level]
+    pe_both: enc_level
+    pe_plaintext: enc_level
+    pe_rc4: enc_level
+    plaintext: enc_level
+    rc4: enc_level
+    values: Mapping[int, enc_level]
+
+class enc_policy(int):
+    disabled: enc_policy
+    enabled: enc_policy
+    forced: enc_policy
+    names: Mapping[str, enc_policy]
+    pe_disabled: enc_policy
+    pe_enabled: enc_policy
+    pe_forced: enc_policy
+    values: Mapping[int, enc_policy]
+
+class error_category:
+    def message(self, _value: int) -> str: ...
+    def name(self) -> str: ...
+
+class error_code:
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(self, _value: int, _cat: error_category) -> None: ...
+    def assign(self, _value: int, _cat: error_category) -> None: ...
+    def category(self) -> error_category: ...
+    def clear(self) -> None: ...
+    def message(self) -> str: ...
+    def value(self) -> int: ...
+
+class event_t(int):
+    completed: event_t
+    names: Mapping[str, event_t]
+    none: event_t
+    paused: event_t
+    started: event_t
+    stopped: event_t
+    values: Mapping[int, event_t]
+
+class external_ip_alert(alert):
+    external_address: str
+
+class fastresume_rejected_alert(torrent_alert):
+    def file_path(self) -> str: ...
+    error: error_code
+    msg: str
+    op: operation_t
+    operation: str
+
+class file_completed_alert(torrent_alert):
+    index: int
+
+class file_entry:
+    executable_attribute: bool
+    filehash: sha1_hash
+    hidden_attribute: bool
+    mtime: int
+    offset: int
+    pad_file: bool
+    path: str
+    size: int
+    symlink_attribute: bool
+    symlink_path: str
+
+class file_error_alert(torrent_alert):
+    def filename(self) -> str: ...
+    error: error_code
+    file: str
+    msg: str
+
+class file_flags_t:
+    flag_executable: int
+    flag_hidden: int
+    flag_pad_file: int
+    flag_symlink: int
+
+class file_open_mode:
+    locked: int
+    no_atime: int
+    random_access: int
+    read_only: int
+    read_write: int
+    rw_mask: int
+    sparse: int
+    write_only: int
+
+class file_prio_alert(torrent_alert):
+    pass
+
+class file_progress_flags_t:
+    piece_granularity: int
+
+class file_rename_failed_alert(torrent_alert):
+    error: error_code
+    index: int
+
+class file_renamed_alert(torrent_alert):
+    def new_name(self) -> str: ...
+    def old_name(self) -> str: ...
+    index: int
+    name: str
+
+class file_slice:
+    file_index: int
+    offset: int
+    size: int
+
+class file_storage:
+    flag_executable: int
+    flag_hidden: int
+    flag_pad_file: int
+    flag_symlink: int
+    @overload
+    def add_file(self, entry: file_entry) -> None: ...
+    @overload
+    def add_file(
+        self,
+        path: str,
+        size: int,
+        flags: int = ...,
+        mtime: int = ...,
+        linkpath: str = ...,
+    ) -> None: ...
+    def at(self, _index: int) -> file_entry: ...
+    def file_flags(self, _index: int) -> int: ...
+    def file_name(self, _index: int) -> str: ...
+    def file_offset(self, _index: int) -> int: ...
+    def file_path(self, idx: int, save_path: str = ...) -> str: ...
+    def file_size(self, _index: int) -> int: ...
+    def hash(self, _index: int) -> sha1_hash: ...
+    def is_valid(self) -> bool: ...
+    def name(self) -> str: ...
+    def num_files(self) -> int: ...
+    def num_pieces(self) -> int: ...
+    def piece_length(self) -> int: ...
+    def piece_size(self, _index: int) -> int: ...
+    def rename_file(self, _index: int, _path: str) -> None: ...
+    def set_name(self, _path: str) -> None: ...
+    def set_num_pieces(self, _num: int) -> None: ...
+    def set_piece_length(self, _len: int) -> None: ...
+    def size_on_disk(self) -> int: ...
+    def symlink(self, _index: int) -> str: ...
+    def total_size(self) -> int: ...
+    def __iter__(self) -> Iterator[file_entry]: ...
+    def __len__(self) -> int: ...
+
+class fingerprint:
+    def __init__(
+        self, _prefix: str, _maj: int, _min: int, _rev: int, _tag: int
+    ) -> None: ...
+    major_version: int
+    minor_version: int
+    revision_version: int
+    tag_version: int
+
+class hash_failed_alert(torrent_alert):
+    piece_index: int
+
+class i2p_alert(alert):
+    error: error_code
+
+class incoming_connection_alert(alert):
+    endpoint: Tuple[str, int]
+    ip: Tuple[str, int]
+    socket_type: socket_type_t
+
+class info_hash_t:
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(self, sha1_hash: sha1_hash) -> None: ...
+    def get(self, _v: protocol_version) -> sha1_hash: ...
+    def get_best(self) -> sha1_hash: ...
+    def has(self, _v: protocol_version) -> bool: ...
+    def has_v1(self) -> bool: ...
+    def has_v2(self) -> bool: ...
+    def __eq__(self, other: Any) -> bool: ...
+    def __lt__(self, other: Any) -> bool: ...
+    def __ne__(self, other: Any) -> bool: ...
+    v1: sha1_hash
+    # v2: sha256_hash
+
+class invalid_request_alert(peer_alert):
+    request: peer_request
+
+class io_buffer_mode_t(int):
+    disable_os_cache: int
+    disable_os_cache_for_aligned_files: int
+    enable_os_cache: int
+    names: Mapping[str, io_buffer_mode_t]
+    values: Mapping[int, io_buffer_mode_t]
+
+class ip_filter:
+    def access(self, _ip: str) -> int: ...
+    def add_rule(self, _start: str, _stop: str, _flag: int) -> None: ...
+    def export_filter(self) -> Tuple[List[Tuple[str, str]], List[Tuple[str, str]]]: ...
+
+class kind(int):
+    names: Mapping[str, kind]
+    tracker_no_anonymous: kind
+    values: Mapping[int, kind]
+
+class listen_failed_alert(alert):
+    def listen_interface(self) -> str: ...
+    address: str
+    endpoint: Tuple[str, int]
+    error: error_code
+    op: operation_t
+    operation: int
+    port: int
+    sock_type: listen_failed_alert_socket_type_t
+    socket_type: socket_type_t
+
+class listen_failed_alert_socket_type_t(int):
+    i2p: listen_failed_alert_socket_type_t
+    names: Mapping[str, listen_failed_alert_socket_type_t]
+    socks5: listen_failed_alert_socket_type_t
+    tcp: listen_failed_alert_socket_type_t
+    tcp_ssl: listen_failed_alert_socket_type_t
+    udp: listen_failed_alert_socket_type_t
+    utp_ssl: listen_failed_alert_socket_type_t
+    values: Mapping[int, listen_failed_alert_socket_type_t]
+
+class listen_on_flags_t(int):
+    listen_no_system_port: listen_on_flags_t
+    listen_reuse_address: listen_on_flags_t
+    names: Mapping[str, listen_on_flags_t]
+    values: Mapping[int, listen_on_flags_t]
+
+class listen_succeded_alert_socket_type_t(int):
+    i2p: listen_succeded_alert_socket_type_t
+    names: Mapping[str, listen_succeded_alert_socket_type_t]
+    socks5: listen_succeded_alert_socket_type_t
+    tcp: listen_succeded_alert_socket_type_t
+    tcp_ssl: listen_succeded_alert_socket_type_t
+    udp: listen_succeded_alert_socket_type_t
+    utp_ssl: listen_succeded_alert_socket_type_t
+    values: Mapping[int, listen_succeded_alert_socket_type_t]
+
+class listen_succeeded_alert(alert):
+    address: str
+    endpoint: Tuple[str, int]
+    port: int
+    sock_type: listen_succeded_alert_socket_type_t
+    socket_type: socket_type_t
+
+class log_alert(alert):
+    def log_message(self) -> str: ...
+    def msg(self) -> str: ...
+
+class lsd_error_alert(alert):
+    error: error_code
+
+class metadata_failed_alert(torrent_alert):
+    error: error_code
+
+class metadata_received_alert(torrent_alert):
+    pass
+
+class metric_type_t(int):
+    counter: metric_type_t
+    gauge: metric_type_t
+    names: Mapping[str, metric_type_t]
+    values: Mapping[int, metric_type_t]
+
+class move_flags_t(int):
+    always_replace_files: move_flags_t
+    dont_replace: move_flags_t
+    fail_if_exist: move_flags_t
+    names: Mapping[str, move_flags_t]
+    values: Mapping[int, move_flags_t]
+
+class open_file_state:
+    file_index: int
+    # last_use: broken
+    open_mode: file_open_mode
+
+class operation_t(int):
+    alloc_cache_piece: operation_t
+    alloc_recvbuf: operation_t
+    alloc_sndbuf: operation_t
+    available: operation_t
+    bittorrent: operation_t
+    check_resume: operation_t
+    connect: operation_t
+    encryption: operation_t
+    enum_if: operation_t
+    exception: operation_t
+    file: Any = ...
+    file_copy: operation_t
+    file_fallocate: operation_t
+    file_hard_link: operation_t
+    file_open: operation_t
+    file_read: operation_t
+    file_remove: operation_t
+    file_rename: operation_t
+    file_stat: operation_t
+    file_write: operation_t
+    get_interface: operation_t
+    getname: operation_t
+    getpeername: operation_t
+    handshake: operation_t
+    hostname_lookup: operation_t
+    iocontrol: operation_t
+    mkdir: operation_t
+    names: Mapping[str, operation_t]
+    parse_address: operation_t
+    partfile_move: operation_t
+    partfile_read: operation_t
+    partfile_write: operation_t
+    sock_accept: operation_t
+    sock_bind: operation_t
+    sock_bind_to_device: operation_t
+    sock_listen: operation_t
+    sock_open: operation_t
+    sock_option: operation_t
+    sock_read: operation_t
+    sock_write: operation_t
+    ssl_handshake: operation_t
+    symlink: operation_t
+    unknown: operation_t
+    values: Mapping[int, operation_t]
+
+class options_t:
+    delete_files: int
+
+class pause_flags_t:
+    graceful_pause: int
+
+class pe_settings:
+    allowed_enc_level: int
+    in_enc_policy: int
+    out_enc_policy: int
+    prefer_rc4: bool
+
+class peer_alert(torrent_alert):
+    endpoint: Tuple[str, int]
+    ip: Tuple[str, int]
+    pid: sha1_hash
+
+class peer_ban_alert(peer_alert):
+    pass
+
+class peer_blocked_alert(peer_alert):
+    reason: reason_t
+
+class peer_class_type_filter:
+    i2p_socket: peer_class_type_filter_socket_type_t
+    ssl_tcp_socket: peer_class_type_filter_socket_type_t
+    ssl_utp_socket: peer_class_type_filter_socket_type_t
+    tcp_socket: peer_class_type_filter_socket_type_t
+    utp_socket: peer_class_type_filter_socket_type_t
+    def add(self, _type: peer_class_type_filter_socket_type_t, _class: int) -> None: ...
+    def allow(
+        self, _type: peer_class_type_filter_socket_type_t, _class: int
+    ) -> None: ...
+    def apply(
+        self, _type: peer_class_type_filter_socket_type_t, _class: int
+    ) -> int: ...
+    def disallow(
+        self, _type: peer_class_type_filter_socket_type_t, _class: int
+    ) -> None: ...
+    def remove(
+        self, _type: peer_class_type_filter_socket_type_t, _class: int
+    ) -> None: ...
+
+class peer_class_type_filter_socket_type_t(int):
+    i2p_socket: peer_class_type_filter_socket_type_t
+    names: Mapping[str, peer_class_type_filter_socket_type_t]
+    ssl_tcp_socket: peer_class_type_filter_socket_type_t
+    ssl_utp_socket: peer_class_type_filter_socket_type_t
+    tcp_socket: peer_class_type_filter_socket_type_t
+    utp_socket: peer_class_type_filter_socket_type_t
+    values: Mapping[int, peer_class_type_filter_socket_type_t]
+
+class peer_connect_alert(peer_alert):
+    pass
+
+class peer_disconnected_alert(peer_alert):
+    error: error_code
+    msg: str
+    op: operation_t
+    # reason: close_reason_t
+    socket_type: socket_type_t
+
+class peer_error_alert(peer_alert):
+    error: error_code
+    op: operation_t
+
+peer_id = sha1_hash
+
+class peer_info:
+    bw_disk: int
+    bw_global: int
+    bw_idle: int
+    bw_limit: int
+    bw_network: int
+    bw_torrent: int
+    choked: int
+    connecting: int
+    dht: int
+    endgame_mode: int
+    handshake: int
+    holepunched: int
+    http_seed: int
+    interesting: int
+    local_connection: int
+    lsd: int
+    on_parole: int
+    optimistic_unchoke: int
+    outgoing_connection: int
+    pex: int
+    plaintext_encrypted: int
+    queued: int
+    rc4_encrypted: int
+    remote_choked: int
+    remote_interested: int
+    resume_data: int
+    seed: int
+    snubbed: int
+    standard_bittorrent: int
+    supports_extensions: int
+    tracker: int
+    upload_only: int
+    web_seed: int
+    client: bytes
+    # connection_type: TODO
+    down_speed: int
+    download_limit: int
+    download_queue_length: int
+    download_queue_time: int
+    download_rate_peak: int
+    downloading_block_index: int
+    downloading_piece_index: int
+    downloading_progress: int
+    downloading_total: int
+    estimated_reciprocation_rate: int
+    failcount: int
+    flags: int
+    ip: Tuple[str, int]
+    last_active: int
+    last_request: int
+    load_balancing: int
+    local_endpoint: Tuple[str, int]
+    num_hashfails: int
+    num_pieces: int
+    payload_down_speed: int
+    payload_up_speed: int
+    pending_disk_bytes: int
+    pid: sha1_hash
+    pieces: List[bool]
+    progress: float
+    progress_ppm: int
+    queue_bytes: int
+    read_state: int
+    receive_buffer_size: int
+    recevie_quota: int
+    remote_dl_rate: int
+    request_timeout: int
+    rtt: int
+    send_buffer_size: int
+    send_quota: int
+    source: int
+    total_download: int
+    total_upload: int
+    up_speed: int
+    upload_limit: int
+    upload_queue_length: int
+    upload_rate_peak: int
+    used_receive_buffer: int
+    used_send_buffer: int
+    write_state: int
+
+class peer_log_alert(peer_alert):
+    def log_message(self) -> str: ...
+    def msg(self) -> str: ...
+
+class peer_request:
+    def __eq__(self, other: Any) -> bool: ...
+    length: int
+    piece: int
+    start: int
+
+class peer_snubbed_alert(peer_alert):
+    pass
+
+class peer_unsnubbed_alert(peer_alert):
+    pass
+
+class performance_alert(torrent_alert):
+    warning_code: performance_warning_t
+
+class performance_warning_t(int):
+    bittyrant_with_no_uplimit: performance_warning_t
+    download_limit_too_low: performance_warning_t
+    names: Mapping[str, performance_warning_t]
+    outstanding_disk_buffer_limit_reached: performance_warning_t
+    outstanding_request_limit_reached: performance_warning_t
+    send_buffer_watermark_too_low: performance_warning_t
+    too_few_file_descriptors: performance_warning_t
+    too_few_outgoing_ports: performance_warning_t
+    too_high_disk_queue_limit: performance_warning_t
+    too_many_optimistic_unchoke_slots: performance_warning_t
+    upload_limit_too_low: performance_warning_t
+    values: Mapping[int, performance_warning_t]
+
+class picker_log_alert(peer_alert):
+    def blocks(self) -> List[int]: ...
+    picker_flags: int
+
+class piece_finished_alert(torrent_alert):
+    piece_index: int
+
+class portmap_alert(alert):
+    external_port: int
+    map_protocol: portmap_protocol
+    map_transport: portmap_transport
+    map_type: int
+    mapping: int
+    type: int
+
+class portmap_error_alert(alert):
+    error: error_code
+    map_transport: portmap_transport
+    map_type: int
+    mapping: int
+    msg: str
+    type: int
+
+class portmap_log_alert(alert):
+    map_transport: portmap_transport
+    map_type: int
+    msg: str
+    type: int
+
+class portmap_protocol(int):
+    names: Mapping[str, portmap_protocol]
+    none: portmap_protocol
+    tcp: portmap_protocol
+    udp: portmap_protocol
+    values: Mapping[int, portmap_protocol]
+
+class portmap_transport(int):
+    names: Mapping[str, portmap_transport]
+    natpmp: portmap_transport
+    upnp: portmap_transport
+    values: Mapping[int, portmap_transport]
+
+class protocol_type:
+    tcp: portmap_protocol
+    udp: portmap_protocol
+
+class protocol_version(int):
+    V1: protocol_version
+    V2: protocol_version
+    names: Mapping[str, protocol_version]
+    values: Mapping[int, protocol_version]
+
+class proxy_type_t(int):
+    http: proxy_type_t
+    http_pw: proxy_type_t
+    i2p_proxy: proxy_type_t
+    names: Mapping[str, proxy_type_t]
+    none: proxy_type_t
+    class proxy_settings:
+        hostname: str
+        port: int
+        password: str
+        username: str
+        type: proxy_type_t
+        proxy_peer_connections: bool
+        proxy_hostnames: bool
+    proxy_type: proxy_type_t
+    socks4: proxy_type_t
+    socks5: proxy_type_t
+    socks5_pw: proxy_type_t
+    values: Mapping[int, proxy_type_t]
+
+class read_piece_alert(torrent_alert):
+    buffer: bytes
+    ec: error_code
+    error: error_code
+    piece: int
+    size: int
+
+class reannounce_flags_t:
+    ignore_min_interval: int
+
+class reason_t(int):
+    i2p_mixed: reason_t
+    invalid_local_interface: reason_t
+    ip_filter: reason_t
+    names: Mapping[str, reason_t]
+    port_filter: reason_t
+    privileged_ports: reason_t
+    tcp_disabled: reason_t
+    utp_disabled: reason_t
+    values: Mapping[int, reason_t]
+
+class request_dropped_alert(peer_alert):
+    block_index: int
+    piece_index: int
+
+class save_resume_data_alert(torrent_alert):
+    params: add_torrent_params
+    resume_data: bytes
+
+class save_resume_data_failed_alert(torrent_alert):
+    error: error_code
+    msg: str
+
+class save_resume_flags_t:
+    flush_disk_cache: int
+    only_if_modified: int
+    save_info_dict: int
+
+class save_state_flags_t:
+    save_as_map: int
+    save_dht_proxy: int
+    save_dht_settings: int
+    save_dht_state: int
+    save_encryption_settings: int
+    save_i2p_proxy: int
+    save_peer_proxy: int
+    save_proxy: int
+    save_settings: int
+    save_tracker_proxy: int
+    save_web_proxy: int
+
+class scrape_failed_alert(tracker_alert):
+    def error_message(self) -> str: ...
+    error: error_code
+    msg: str
+
+class scrape_reply_alert(tracker_alert):
+    complete: int
+    incomplete: int
+
+class seed_choking_algorithm_t(int):
+    anti_leech: seed_choking_algorithm_t
+    fastest_upload: seed_choking_algorithm_t
+    names: Mapping[str, seed_choking_algorithm_t]
+    round_robin: seed_choking_algorithm_t
+    values: Mapping[int, seed_choking_algorithm_t]
+
+class _PeerClassInfo(TypedDict):
+    ignore_unchoke_slots: bool
+    connection_limit_factor: int
+    label: str
+    upload_limit: int
+    download_limit: int
+    upload_priority: int
+    download_priority: int
+
+class session:
+    delete_files: int
+    delete_partfile: int
+    global_peer_class_id: int
+    local_peer_class_id: int
+    reopen_map_ports: int
+    tcp: portmap_protocol
+    tcp_peer_class_id: int
+    udp: portmap_protocol
+    @overload
+    def __init__(
+        self, fingerprint: fingerprint = ..., flags: int = ..., alert_mask: int = ...
+    ) -> None: ...
+    @overload
+    def __init__(self, settings: Dict[str, Any], flags: int = ...) -> None: ...
+    def add_dht_node(self, _endpoint: Tuple[str, int]) -> None: ...
+    def add_dht_router(self, router: str, port: int) -> None: ...
+    def add_extension(self, _extension: Any) -> None: ...
+    def add_port_mapping(
+        self, _proto: portmap_protocol, _int: int, _ext: int
+    ) -> int: ...
+    @overload
+    def add_torrent(
+        self,
+        _ti: torrent_info,
+        _save: _PathLike,
+        resume_data: Optional[_Entry] = ...,
+        storage_mode: storage_mode_t = ...,
+        paused: bool = ...,
+    ) -> torrent_handle: ...
+    @overload
+    def add_torrent(self, _atp: add_torrent_params) -> torrent_handle: ...
+    @overload
+    def add_torrent(
+        self, _bdecoded: Union[Dict[str, Any], _AddTorrentParamsDict]
+    ) -> torrent_handle: ...
+    def apply_settings(self, _settings: Dict[str, Any]) -> None: ...
+    @overload
+    def async_add_torrent(self, _atp: add_torrent_params) -> None: ...
+    @overload
+    def async_add_torrent(self, _bdecoded: Dict[str, Any]) -> None: ...
+    def create_peer_class(self, _name: str) -> int: ...
+    def delete_peer_class(self, _class: int) -> None: ...
+    def delete_port_mapping(self, _mapping: int) -> None: ...
+    def dht_announce(self, _info_hash: sha1_hash, _port: int, _flags: int) -> None: ...
+    def dht_get_immutable_item(self, _target: sha1_hash) -> None: ...
+    def dht_get_mutable_item(self, _key: bytes, _salt: bytes) -> None: ...
+    def dht_get_peers(self, _info_hash: sha1_hash) -> None: ...
+    def dht_live_nodes(self, _info_hash: sha1_hash) -> None: ...
+    def dht_proxy(self) -> proxy_type_t.proxy_settings: ...
+    def dht_put_immutable_item(self, _entry: _Entry) -> sha1_hash: ...
+    def dht_put_mutable_item(
+        self, _private: bytes, _public: bytes, _data: bytes, _salt: bytes
+    ) -> None: ...
+    def dht_sample_infohashes(
+        self, _endpoint: Tuple[str, int], _target: sha1_hash
+    ) -> None: ...
+    def dht_state(self) -> Dict[bytes, Any]: ...
+    def download_rate_limit(self) -> int: ...
+    def find_torrent(self, _info_hash: sha1_hash) -> torrent_handle: ...
+    def get_dht_settings(self) -> dht_settings: ...
+    def get_ip_filter(self) -> ip_filter: ...
+    def get_pe_settings(self) -> pe_settings: ...
+    def get_peer_class(self, _class: int) -> _PeerClassInfo: ...
+    def get_settings(self) -> Dict[str, Any]: ...
+    def get_torrent_status(
+        self, pred: Callable[[torrent_status], bool], flags: int = ...
+    ) -> List[torrent_status]: ...
+    def get_torrents(self) -> List[torrent_handle]: ...
+    def i2p_proxy(self) -> proxy_type_t.proxy_settings: ...
+    def id(self) -> sha1_hash: ...
+    def is_dht_running(self) -> bool: ...
+    def is_listening(self) -> bool: ...
+    def is_paused(self) -> bool: ...
+    def listen_on(
+        self, min: int, max: int, interface: Optional[str] = ..., flags: int = ...
+    ) -> None: ...
+    def listen_port(self) -> int: ...
+    def load_state(self, entry: _Entry, flags: int = ...) -> None: ...
+    def local_download_rate_limit(self) -> int: ...
+    def local_upload_rate_limit(self) -> int: ...
+    def max_connections(self) -> int: ...
+    def num_connections(self) -> int: ...
+    def outgoing_ports(self, _min: int, _max: int) -> None: ...
+    def pause(self) -> None: ...
+    def peer_proxy(self) -> proxy_type_t.proxy_settings: ...
+    def pop_alerts(self) -> List[alert]: ...
+    def post_dht_stats(self) -> None: ...
+    def post_session_stats(self) -> None: ...
+    def post_torrent_updates(self, flags: int = ...) -> None: ...
+    def proxy(self) -> proxy_type_t.proxy_settings: ...
+    def refresh_torrent_status(
+        self, torrents: List[torrent_status], flags: int = ...
+    ) -> List[torrent_status]: ...
+    def remove_torrent(self, _handle: torrent_handle, option: int = ...) -> None: ...
+    def reopen_network_sockets(self, _options: int) -> None: ...
+    def resume(self) -> None: ...
+    def save_state(self, flags: int = ...) -> Dict[bytes, Any]: ...
+    def set_alert_fd(self, _fd: int) -> None: ...
+    def set_alert_mask(self, _mask: int) -> None: ...
+    def set_alert_notify(self, _callback: Callable[[], Any]) -> None: ...
+    def set_alert_queue_size_limit(self, _limit: int) -> int: ...
+    def set_dht_proxy(self, _settings: proxy_type_t.proxy_settings) -> None: ...
+    def set_dht_settings(self, _settings: dht_settings) -> None: ...
+    def set_download_rate_limit(self, _rate: int) -> None: ...
+    def set_i2p_proxy(self, _settings: proxy_type_t.proxy_settings) -> None: ...
+    def set_ip_filter(self, _filter: ip_filter) -> None: ...
+    def set_local_download_rate_limit(self, _rate: int) -> None: ...
+    def set_local_upload_rate_limit(self, _rate: int) -> None: ...
+    def set_max_connections(self, _num: int) -> None: ...
+    def set_max_half_open_connections(self, _num: int) -> None: ...
+    def set_max_uploads(self, _num: int) -> None: ...
+    def set_pe_settings(self, _settings: pe_settings) -> None: ...
+    def set_peer_class(
+        self, _class: int, _info: Union[Dict[str, Any], _PeerClassInfo]
+    ) -> None: ...
+    def set_peer_class_filter(self, _filter: ip_filter) -> None: ...
+    def set_peer_class_type_filter(self, _pctf: peer_class_type_filter) -> None: ...
+    def set_peer_id(self, _pid: sha1_hash) -> None: ...
+    def set_peer_proxy(self, _settings: proxy_type_t.proxy_settings) -> None: ...
+    def set_proxy(self, _settings: proxy_type_t.proxy_settings) -> None: ...
+    def set_tracker_proxy(self, _settings: proxy_type_t.proxy_settings) -> None: ...
+    def set_upload_rate_limit(self, _rate: int) -> None: ...
+    def set_web_seed_proxy(self, _settings: proxy_type_t.proxy_settings) -> None: ...
+    def start_dht(self) -> None: ...
+    def start_lsd(self) -> None: ...
+    def start_natpmp(self) -> None: ...
+    def start_upnp(self) -> None: ...
+    def status(self) -> session_status: ...
+    def stop_dht(self) -> None: ...
+    def stop_lsd(self) -> None: ...
+    def stop_natpmp(self) -> None: ...
+    def stop_upnp(self) -> None: ...
+    def tracker_proxy(self) -> proxy_type_t.proxy_settings: ...
+    def upload_rate_limit(self) -> int: ...
+    def wait_for_alert(self, _ms: int) -> Optional[alert]: ...
+    def web_seed_proxy(self) -> proxy_type_t.proxy_settings: ...
+
+class session_flags_t:
+    add_default_plugins: int
+    paused: int
+    start_default_features: int
+
+class session_params:
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(self, _settings: Dict[str, Any]) -> None: ...
+    dht_state: dht_state
+    ext_state: Dict[str, bytes]
+    ip_filter: ip_filter
+    settings: Dict[str, Any]
+
+class session_stats_alert(alert):
+    values: Dict[str, int]
+
+class session_stats_header_alert(alert):
+    pass
+
+class _UtpStatsDict(TypedDict):
+    num_idle: int
+    num_syn_sent: int
+    num_connected: int
+    num_fin_sent: int
+    num_close_wait: int
+
+class session_status:
+    active_requests: List[dht_lookup]
+    allowed_upload_slots: int
+    dht_download_rate: int
+    dht_global_nodes: int
+    dht_node_cache: int
+    dht_nodes: int
+    dht_torrents: int
+    dht_total_allocations: int
+    dht_upload_rate: int
+    down_bandwidth_bytes_queue: int
+    down_bandwidth_queue: int
+    download_rate: int
+    has_incoming_connections: bool
+    ip_overhead_download_rate: int
+    ip_overhead_upload_rate: int
+    num_peers: int
+    num_unchoked: int
+    optimistic_unchoke_counter: int
+    payload_download_rate: int
+    payload_upload_rate: int
+    total_dht_download: int
+    total_dht_upload: int
+    total_download: int
+    total_failed_bytes: int
+    total_ip_overhead_download: int
+    total_ip_overhead_upload: int
+    total_payload_download: int
+    total_payload_upload: int
+    total_redundant_bytes: int
+    total_tracker_download: int
+    total_tracker_upload: int
+    total_upload: int
+    tracker_download_rate: int
+    tracker_upload_rate: int
+    unchoke_counter: int
+    up_bandwidth_bytes_queue: int
+    up_bandwidth_queue: int
+    upload_rate: int
+    utp_stats: _UtpStatsDict
+
+class sha1_hash:
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(self, _digest: bytes) -> None: ...
+    def clear(self) -> None: ...
+    def is_all_zeros(self) -> bool: ...
+    def to_bytes(self) -> bytes: ...
+    def to_string(self) -> bytes: ...
+    def __eq__(self, other: Any) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __lt__(self, other: Any) -> bool: ...
+    def __ne__(self, other: Any) -> bool: ...
+
+class socket_type_t(int):
+    http: socket_type_t
+    http_ssl: socket_type_t
+    i2p: socket_type_t
+    names: Mapping[str, socket_type_t]
+    socks5: socket_type_t
+    socks5_ssl: socket_type_t
+    tcp: socket_type_t
+    tcp_ssl: socket_type_t
+    udp: socket_type_t
+    utp: socket_type_t
+    utp_ssl: socket_type_t
+    values: Mapping[int, socket_type_t]
+
+class socks5_alert(alert):
+    error: error_code
+    ip: Tuple[str, int]
+    op: operation_t
+
+class state_changed_alert(torrent_alert):
+    prev_state: torrent_status.states
+    state: torrent_status.states
+
+class state_update_alert(alert):
+    status: List[torrent_status]
+
+class stats_alert(torrent_alert):
+    interval: int
+    transferred: List[int]
+
+class stats_channel(int):
+    download_dht_protocol: stats_channel
+    download_ip_protocol: stats_channel
+    download_payload: stats_channel
+    download_protocol: stats_channel
+    download_tracker_protocol: stats_channel
+    names: Mapping[str, stats_channel]
+    upload_dht_protocol: stats_channel
+    upload_ip_protocol: stats_channel
+    upload_payload: stats_channel
+    upload_protocol: stats_channel
+    upload_tracker_protocol: stats_channel
+    values: Mapping[int, stats_channel]
+
+class stats_metric:
+    name: str
+    type: metric_type_t
+    value_index: int
+
+class status_flags_t:
+    query_accurate_download_counters: int
+    query_distributed_copies: int
+    query_last_seen_complete: int
+    query_pieces: int
+    query_verified_pieces: int
+
+class storage_mode_t(int):
+    names: Mapping[str, storage_mode_t]
+    storage_mode_allocate: storage_mode_t
+    storage_mode_sparse: storage_mode_t
+    values: Mapping[int, storage_mode_t]
+
+class storage_moved_alert(torrent_alert):
+    def old_path(self) -> str: ...
+    def storage_path(self) -> str: ...
+    path: str
+
+class storage_moved_failed_alert(torrent_alert):
+    def file_path(self) -> str: ...
+    error: error_code
+    op: operation_t
+    operation: str
+
+class suggest_mode_t(int):
+    names: Mapping[str, suggest_mode_t]
+    no_piece_suggestions: suggest_mode_t
+    suggest_read_cache: suggest_mode_t
+    values: Mapping[int, suggest_mode_t]
+
+class torrent_added_alert(torrent_alert):
+    pass
+
+class torrent_alert(alert):
+    handle: torrent_handle
+    torrent_name: str
+
+class torrent_checked_alert(torrent_alert):
+    pass
+
+class torrent_delete_failed_alert(torrent_alert):
+    error: error_code
+    info_hash: sha1_hash
+    info_hashes: info_hash_t
+    msg: str
+
+class torrent_deleted_alert(torrent_alert):
+    info_hash: sha1_hash
+    info_hashes: info_hash_t
+
+class torrent_error_alert(torrent_alert):
+    error: error_code
+
+class torrent_finished_alert(torrent_alert):
+    pass
+
+class torrent_flags:
+    apply_ip_filter: int
+    auto_managed: int
+    default_flags: int
+    disable_dht: int
+    disable_lsd: int
+    disable_pex: int
+    duplicate_is_error: int
+    no_verify_files: int
+    override_trackers: int
+    override_web_seeds: int
+    paused: int
+    seed_mode: int
+    sequential_download: int
+    share_mode: int
+    stop_when_ready: int
+    super_seeding: int
+    update_subscribe: int
+    upload_mode: int
+
+class _BlockInfoDict(TypedDict):
+    state: int
+    num_peers: int
+    bytes_progress: int
+    block_size: int
+    peer: Tuple[str, int]
+
+class _PartialPieceInfoDict(TypedDict):
+    piece_index: int
+    blocks_in_piece: int
+    blocks: List[_BlockInfoDict]
+
+class _ErrorCodeDict(TypedDict):
+    value: int
+    category: str
+
+class _AnnounceInfohashDict(TypedDict):
+    message: str
+    last_error: _ErrorCodeDict
+    next_announce: Optional[datetime.datetime]
+    min_announce: Optional[datetime.datetime]
+    scrape_incomplete: int
+    scrape_complete: int
+    scrape_downloaded: int
+    fails: int
+    updating: bool
+    start_sent: bool
+    complete_sent: bool
+
+class _AnnounceEndpointDict(TypedDict):
+    local_address: Tuple[str, int]
+    info_hashes: List[_AnnounceInfohashDict]
+    message: str
+    last_error: _ErrorCodeDict
+    next_announce: Optional[datetime.datetime]
+    min_announce: Optional[datetime.datetime]
+    scrape_incomplete: int
+    scrape_complete: int
+    scrape_downloaded: int
+    fails: int
+    updating: bool
+    start_sent: bool
+    complete_sent: bool
+
+class _AnnounceEntryDict(TypedDict):
+    url: str
+    trackerid: str
+    tier: int
+    fail_limit: int
+    source: int
+    verified: bool
+    message: str
+    last_error: _ErrorCodeDict
+    next_announce: Optional[datetime.datetime]
+    min_announce: Optional[datetime.datetime]
+    scrape_incomplete: int
+    scrape_complete: int
+    scrape_downloaded: int
+    fails: int
+    updating: bool
+    start_sent: bool
+    complete_sent: bool
+    endpoints: List[_AnnounceEndpointDict]
+    send_stats: bool
+
+class torrent_handle:
+    alert_when_available: int
+    flush_disk_cache: int
+    graceful_pause: int
+    ignore_min_interval: int
+    only_if_modified: int
+    overwrite_existing: int
+    piece_granularity: int
+    query_accurate_download_counters: int
+    query_distributed_copies: int
+    query_last_seen_complete: int
+    query_pieces: int
+    query_verified_pieces: int
+    save_info_dict: int
+    def add_http_seed(self, _url: str) -> None: ...
+    def add_piece(self, _index: int, _data: bytes, _flags: int) -> None: ...
+    def add_tracker(self, _announce: Dict[str, Any]) -> None: ...
+    def add_url_seed(self, _url: str) -> None: ...
+    def apply_ip_filter(self, _enabled: bool) -> None: ...
+    def auto_managed(self, _enabled: bool) -> None: ...
+    def clear_error(self) -> None: ...
+    def clear_piece_deadlines(self) -> None: ...
+    def connect_peer(
+        self, _endpoint: Tuple[str, int], source: int = ..., flags: int = ...
+    ) -> None: ...
+    def download_limit(self) -> int: ...
+    def file_priorities(self) -> List[int]: ...
+    @overload
+    def file_priority(self, _prio: int) -> int: ...
+    @overload
+    def file_priority(self, _index: int, _prio: int) -> None: ...
+    def file_progress(self, flags: int = ...) -> List[int]: ...
+    def file_status(self) -> List[open_file_state]: ...
+    def flags(self) -> int: ...
+    def flush_cache(self) -> None: ...
+    def force_dht_announce(self) -> None: ...
+    def force_reannounce(
+        self, seconds: int = ..., tracker_idx: int = ..., flags: int = ...
+    ) -> None: ...
+    def force_recheck(self) -> None: ...
+    def get_download_queue(self) -> List[_PartialPieceInfoDict]: ...
+    def get_file_priorities(self) -> List[int]: ...
+    def get_peer_info(self) -> List[peer_info]: ...
+    def get_piece_priorities(self) -> List[int]: ...
+    def get_torrent_info(self) -> torrent_info: ...
+    def has_metadata(self) -> bool: ...
+    def have_piece(self, _index: int) -> bool: ...
+    def http_seeds(self) -> List[str]: ...
+    def info_hash(self) -> sha1_hash: ...
+    def info_hashes(self) -> info_hash_t: ...
+    def is_auto_managed(self) -> bool: ...
+    def is_finished(self) -> bool: ...
+    def is_paused(self) -> bool: ...
+    def is_seed(self) -> bool: ...
+    def is_valid(self) -> bool: ...
+    def max_connections(self) -> int: ...
+    def max_uploads(self) -> int: ...
+    def move_storage(self, path: _PathLike, flags: int = ...) -> None: ...
+    def name(self) -> str: ...
+    def need_save_resume_data(self) -> bool: ...
+    def pause(self, flags: int = ...) -> None: ...
+    def piece_availability(self) -> List[int]: ...
+    def piece_priorities(self) -> List[int]: ...
+    @overload
+    def piece_priority(self, _index: int) -> int: ...
+    @overload
+    def piece_priority(self, _index: int, _prio: int) -> None: ...
+    def prioritize_files(self, _priorities: List[int]) -> None: ...
+    @overload
+    def prioritize_pieces(self, _priorities: List[Tuple[int, int]]) -> None: ...
+    @overload
+    def prioritize_pieces(self, __priorities: List[int]) -> None: ...
+    def queue_position(self) -> int: ...
+    def queue_position_bottom(self) -> None: ...
+    def queue_position_down(self) -> None: ...
+    def queue_position_top(self) -> None: ...
+    def queue_position_up(self) -> None: ...
+    def read_piece(self, _index: int) -> None: ...
+    def remove_http_seed(self, _url: str) -> None: ...
+    def remove_url_seed(self, _url: str) -> None: ...
+    def rename_file(self, _index: int, _path: str) -> None: ...
+    def replace_trackers(
+        self, _entries: Iterable[Union[announce_entry, Dict[str, Any]]]
+    ) -> None: ...
+    def reset_piece_deadline(self, _index: int) -> None: ...
+    def resume(self) -> None: ...
+    def save_path(self) -> str: ...
+    def save_resume_data(self, flags: int = ...) -> None: ...
+    def scrape_tracker(self, index: int = ...) -> None: ...
+    def set_download_limit(self, _limit: int) -> None: ...
+    @overload
+    def set_flags(self, _flags: int) -> None: ...
+    @overload
+    def set_flags(self, _flags: int, _mask: int) -> None: ...
+    def set_max_connections(self, _num: int) -> None: ...
+    def set_max_uploads(self, _num: int) -> None: ...
+    def set_metadata(self, _metadata: bytes) -> None: ...
+    def set_peer_download_limit(
+        self, _endpoint: Tuple[str, int], _limit: int
+    ) -> None: ...
+    def set_peer_upload_limit(
+        self, _endpoint: Tuple[str, int], _limit: int
+    ) -> None: ...
+    def set_piece_deadline(
+        self, index: int, deadline: int, flags: int = ...
+    ) -> None: ...
+    def set_priority(self, _prio: int) -> None: ...
+    def set_ratio(self, _ratio: float) -> None: ...
+    def set_sequential_download(self, _enabled: bool) -> None: ...
+    def set_share_mode(self, _enabled: bool) -> None: ...
+    def set_ssl_certificate(
+        self,
+        cert: _PathLike,
+        private_key: _PathLike,
+        dh_params: _PathLike,
+        passphrase: str = ...,
+    ) -> None: ...
+    def set_tracker_login(self, _user: str, _pass: str) -> None: ...
+    def set_upload_limit(self, _limit: int) -> None: ...
+    def set_upload_mode(self, _enabled: bool) -> None: ...
+    def status(self, flags: int = ...) -> torrent_status: ...
+    def stop_when_ready(self, _enabled: bool) -> None: ...
+    @overload
+    def super_seeding(self, _enabled: bool) -> None: ...
+    @overload
+    def super_seeding(self) -> bool: ...
+    def torrent_file(self) -> Optional[torrent_info]: ...
+    def trackers(self) -> List[_AnnounceEntryDict]: ...
+    def unset_flags(self, _flags: int) -> None: ...
+    def upload_limit(self) -> int: ...
+    def url_seeds(self) -> List[str]: ...
+    def use_interface(self, _name: str) -> None: ...
+    def write_resume_data(self) -> Dict[bytes, Any]: ...
+    def __eq__(self, other: Any) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __lt__(self, other: Any) -> bool: ...
+    def __ne__(self, other: Any) -> bool: ...
+
+class _WebSeedDict(TypedDict):
+    url: str
+    auth: str
+
+class torrent_info:
+    @overload
+    def __init__(self, _info_hashes: info_hash_t) -> None: ...
+    @overload
+    def __init__(self, _info_hash: sha1_hash) -> None: ...
+    @overload
+    def __init__(self, ti: torrent_info) -> None: ...
+    @overload
+    def __init__(self, _path: str) -> None: ...
+    @overload
+    def __init__(self, _path: str, _limits: Dict[str, Any]) -> None: ...
+    @overload
+    def __init__(self, _bencoded: bytes) -> None: ...
+    @overload
+    def __init__(self, _bencoded: bytes, _limits: Dict[str, Any]) -> None: ...
+    @overload
+    def __init__(self, _bdecoded: Dict[bytes, Any]) -> None: ...
+    @overload
+    def __init__(
+        self, _bdecoded: Dict[bytes, Any], _limits: Dict[str, Any]
+    ) -> None: ...
+    def add_http_seed(
+        self,
+        url: str,
+        extern_auth: str = ...,
+        extra_headers: List[Tuple[str, str]] = ...,
+    ) -> None: ...
+    def add_node(self, _ip: str, _port: int) -> None: ...
+    def add_tracker(
+        self, url: str, tier: int = ..., source: tracker_source = ...
+    ) -> None: ...
+    def add_url_seed(
+        self,
+        url: str,
+        extern_auth: str = ...,
+        extra_headers: List[Tuple[str, str]] = ...,
+    ) -> None: ...
+    def collections(self) -> List[str]: ...
+    def comment(self) -> str: ...
+    def creation_date(self) -> int: ...
+    def creator(self) -> str: ...
+    def file_at(self, _index: int) -> file_entry: ...
+    def files(self) -> file_storage: ...
+    def hash_for_piece(self, _index: int) -> bytes: ...
+    def info_hash(self) -> sha1_hash: ...
+    def info_hashes(self) -> info_hash_t: ...
+    def info_section(self) -> bytes: ...
+    def is_i2p(self) -> bool: ...
+    def is_merkle_torrent(self) -> bool: ...
+    def is_valid(self) -> bool: ...
+    def map_block(self, _piece: int, _offset: int, _size: int) -> List[file_slice]: ...
+    def map_file(self, _file: int, _offset: int, _size: int) -> peer_request: ...
+    def merkle_tree(self) -> List[bytes]: ...
+    def metadata(self) -> bytes: ...
+    def metadata_size(self) -> int: ...
+    def name(self) -> str: ...
+    def nodes(self) -> List[Tuple[str, int]]: ...
+    def num_files(self) -> int: ...
+    def num_pieces(self) -> int: ...
+    def orig_files(self) -> file_storage: ...
+    def piece_length(self) -> int: ...
+    def piece_size(self, _index: int) -> int: ...
+    def priv(self) -> bool: ...
+    def remap_files(self, _fs: file_storage) -> None: ...
+    def rename_file(self, _index: int, _path: str) -> None: ...
+    def set_merkle_tree(self, _tree: List[bytes]) -> None: ...
+    def set_web_seeds(self, _seeds: List[Dict[str, Any]]) -> None: ...
+    def similar_torrents(self) -> List[sha1_hash]: ...
+    def size_on_disk(self) -> int: ...
+    def ssl_cert(self) -> str: ...
+    def total_size(self) -> int: ...
+    def trackers(self) -> Iterator[announce_entry]: ...
+    def web_seeds(self) -> List[_WebSeedDict]: ...
+
+class torrent_log_alert(torrent_alert):
+    def log_message(self) -> str: ...
+    def msg(self) -> str: ...
+
+class torrent_need_cert_alert(torrent_alert):
+    error: error_code
+
+class torrent_paused_alert(torrent_alert):
+    pass
+
+class torrent_removed_alert(torrent_alert):
+    info_hash: sha1_hash
+    info_hashes: info_hash_t
+
+class torrent_resumed_alert(torrent_alert):
+    pass
+
+class torrent_status:
+    allocating: torrent_status.states
+    checking_files: torrent_status.states
+    checking_resume_data: torrent_status.states
+    downloading: torrent_status.states
+    downloading_metadata: torrent_status.states
+    finished: torrent_status.states
+    queued_for_checking: torrent_status.states
+    seeding: torrent_status.states
+    class states(int):
+        allocating: torrent_status.states
+        checking_files: torrent_status.states
+        checking_resume_data: torrent_status.states
+        downloading: torrent_status.states
+        downloading_metadata: torrent_status.states
+        finished: torrent_status.states
+        names: Mapping[str, torrent_status.states]
+        queued_for_checking: torrent_status.states
+        seeding: torrent_status.states
+        values: Mapping[int, torrent_status.states]
+    def __eq__(self, other: Any) -> bool: ...
+    active_duration: datetime.timedelta
+    active_time: int
+    added_time: int
+    all_time_download: int
+    all_time_upload: int
+    announce_interval: datetime.timedelta
+    announcing_to_dht: bool
+    announcing_to_lsd: bool
+    announcing_to_trackers: bool
+    auto_managed: bool
+    block_size: int
+    completed_time: int
+    connect_candidates: int
+    connections_limit: int
+    current_tracker: str
+    distributed_copies: float
+    distributed_fraction: int
+    distributed_full_copies: int
+    down_bandwidth_queue: int
+    download_payload_rate: int
+    download_rate: int
+    errc: error_code
+    error: str
+    error_file: int
+    finished_duration: datetime.timedelta
+    finished_time: int
+    flags: int
+    handle: torrent_handle
+    has_incoming: bool
+    has_metadata: bool
+    info_hash: sha1_hash
+    info_hashes: info_hash_t
+    ip_filter_applies: bool
+    is_finished: bool
+    is_loaded: bool
+    is_seeding: bool
+    last_download: Optional[datetime.datetime]
+    last_scrape: int
+    last_seen_complete: int
+    last_upload: Optional[datetime.datetime]
+    list_peers: int
+    list_seeds: int
+    moving_storage: bool
+    name: str
+    need_save_resume: bool
+    next_announce: datetime.timedelta
+    num_complete: int
+    num_connections: int
+    num_incomplete: int
+    num_peers: int
+    num_pieces: int
+    num_seeds: int
+    num_uploads: int
+    paused: bool
+    pieces: List[bool]
+    priority: int
+    progress: float
+    progress_ppm: int
+    queue_position: int
+    save_path: str
+    seed_mode: bool
+    seed_rank: int
+    seeding_duration: datetime.timedelta
+    seeding_time: int
+    sequential_download: bool
+    share_mode: bool
+    state: torrent_status.states
+    stop_when_ready: bool
+    storage_mode: storage_mode_t
+    super_seeding: bool
+    time_since_download: int
+    time_since_upload: int
+    torrent_file: Optional[torrent_info]
+    total_done: int
+    total_download: int
+    total_failed_bytes: int
+    total_payload_download: int
+    total_payload_upload: int
+    total_redundant_bytes: int
+    total_upload: int
+    total_wanted: int
+    total_wanted_done: int
+    up_bandwidth_queue: int
+    upload_mode: bool
+    upload_payload_rate: int
+    upload_rate: int
+    uploads_limit: int
+    verified_pieces: List[bool]
+
+class tracker_alert(torrent_alert):
+    def tracker_url(self) -> str: ...
+    local_endpoint: Tuple[str, int]
+    url: str
+
+class tracker_announce_alert(tracker_alert):
+    event: event_t
+
+class tracker_error_alert(tracker_alert):
+    def error_message(self) -> str: ...
+    def failure_reason(self) -> str: ...
+    error: error_code
+    msg: str
+    status_code: int
+    times_in_row: int
+
+class tracker_reply_alert(tracker_alert):
+    num_peers: int
+
+class tracker_source(int):
+    names: Mapping[str, tracker_source]
+    source_client: tracker_source
+    source_magnet_link: tracker_source
+    source_tex: tracker_source
+    source_torrent: tracker_source
+    values: Mapping[int, tracker_source]
+
+class tracker_warning_alert(tracker_alert):
+    pass
+
+class udp_error_alert(alert):
+    endpoint: Tuple[str, int]
+    error: error_code
+
+class unwanted_block_alert(peer_alert):
+    block_index: int
+    piece_index: int
+
+class url_seed_alert(torrent_alert):
+    def error_message(self) -> str: ...
+    def server_url(self) -> str: ...
+    error: error_code
+    msg: str
+    url: str

--- a/bindings/python/mypy-tox.ini
+++ b/bindings/python/mypy-tox.ini
@@ -1,0 +1,5 @@
+[mypy]
+ignore_missing_imports = True
+
+[mypy-libtorrent]
+ignore_missing_imports = False

--- a/bindings/python/tests/alert_test.py
+++ b/bindings/python/tests/alert_test.py
@@ -346,8 +346,10 @@ class TorrentAlertTest(AlertTest):
         self.atp.flags &= ~lt.torrent_flags.auto_managed
         self.atp.flags &= ~lt.torrent_flags.paused
         self.atp.save_path = self.dir.name
-        self.file_path = os.path.join(self.dir.name, self.atp.ti.files().file_path(0))
-        self.torrent_name = self.atp.ti.name()
+        ti = self.atp.ti
+        assert ti is not None
+        self.file_path = os.path.join(self.dir.name, ti.files().file_path(0))
+        self.torrent_name = ti.name()
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -1354,7 +1356,9 @@ class FileRenamedAlertTest(TorrentAlertTest):
         self.assertEqual(alert.index, 0)
         self.assertEqual(alert.name, "other.txt")
         self.assertEqual(alert.new_name(), "other.txt")
-        self.assertEqual(alert.old_name(), self.atp.ti.files().file_path(0))
+        ti = self.atp.ti
+        assert ti is not None
+        self.assertEqual(alert.old_name(), ti.files().file_path(0))
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
     def test_deprecated(self) -> None:
@@ -1570,7 +1574,7 @@ class PeerDisconnectedAlertTest(PeerAlertTest):
 
         alert = wait_for(self.session, lt.peer_disconnected_alert, timeout=15)
 
-        self.assertEqual(alert.reason, 1)
+        self.assertEqual(alert.reason, 1)  # type: ignore
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
     def test_deprecated(self) -> None:

--- a/bindings/python/tests/create_torrent_test.py
+++ b/bindings/python/tests/create_torrent_test.py
@@ -81,11 +81,15 @@ class FileStorageTest(unittest.TestCase):
 
     def test_add_file_bytes(self) -> None:
         fs = lt.file_storage()
-        fs.add_file(os.path.join(b"path", b"file.txt"), 1024)
+        fs.add_file(os.path.join(b"path", b"file.txt"), 1024)  # type: ignore
         self.assertEqual(fs.file_path(0), os.path.join("path", "file.txt"))
 
         fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "file.txt"), 1024, linkpath=b"other.txt")
+        fs.add_file(  # type: ignore
+            os.path.join("path", "file.txt"),
+            1024,
+            linkpath=b"other.txt",
+        )
         self.assertEqual(fs.symlink(0), os.path.join("path", "other.txt"))
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5988")
@@ -93,9 +97,9 @@ class FileStorageTest(unittest.TestCase):
         fs = lt.file_storage()
 
         with self.assertWarns(DeprecationWarning):
-            fs.add_file(os.path.join(b"path", b"file.txt"), 1024)
+            fs.add_file(os.path.join(b"path", b"file.txt"), 1024)  # type: ignore
         with self.assertWarns(DeprecationWarning):
-            fs.add_file(
+            fs.add_file(  # type: ignore
                 os.path.join("path", "file.txt"),
                 1024,
                 linkpath=os.path.join(b"path", b"other.txt"),
@@ -260,7 +264,7 @@ class FileStorageTest(unittest.TestCase):
         fs.set_name("other")
         self.assertEqual(fs.file_path(0), os.path.join("other", "test.txt"))
 
-        fs.set_name(b"bytes")
+        fs.set_name(b"bytes")  # type: ignore
         self.assertEqual(fs.file_path(0), os.path.join("bytes", "test.txt"))
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5988")
@@ -268,7 +272,7 @@ class FileStorageTest(unittest.TestCase):
         fs = lt.file_storage()
         fs.add_file(os.path.join("path", "test.txt"), 1024)
         with self.assertWarns(DeprecationWarning):
-            fs.set_name(b"bytes")
+            fs.set_name(b"bytes")  # type: ignore
 
     def test_rename_file(self) -> None:
         fs = lt.file_storage()
@@ -276,7 +280,7 @@ class FileStorageTest(unittest.TestCase):
         fs.rename_file(0, os.path.join("path", "other.txt"))
         self.assertEqual(fs.file_path(0), os.path.join("path", "other.txt"))
 
-        fs.rename_file(0, os.path.join(b"path", b"bytes.txt"))
+        fs.rename_file(0, os.path.join(b"path", b"bytes.txt"))  # type: ignore
         self.assertEqual(fs.file_path(0), os.path.join("path", "bytes.txt"))
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5988")
@@ -284,7 +288,7 @@ class FileStorageTest(unittest.TestCase):
         fs = lt.file_storage()
         fs.add_file(os.path.join("path", "test.txt"), 1024)
         with self.assertWarns(DeprecationWarning):
-            fs.rename_file(0, os.path.join(b"path", b"bytes.txt"))
+            fs.rename_file(0, os.path.join(b"path", b"bytes.txt"))  # type: ignore
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5989")
     def test_rename_file_invalid(self) -> None:
@@ -520,7 +524,7 @@ class CreateTorrentTest(unittest.TestCase):
         fs.add_file("test.txt", 1024)
         ct = lt.create_torrent(fs)
         ct.set_hash(0, lib.get_random_bytes(20))
-        ct.set_root_cert(b"test")
+        ct.set_root_cert(b"test")  # type: ignore
         entry = ct.generate()
         self.assertEqual(entry[b"info"][b"ssl-cert"], b"test")
 
@@ -531,10 +535,10 @@ class CreateTorrentTest(unittest.TestCase):
         ct = lt.create_torrent(fs)
         ct.set_hash(0, lib.get_random_bytes(20))
         # ct.add_collection("ascii-str")
-        ct.add_collection(b"ascii-bytes")
+        ct.add_collection(b"ascii-bytes")  # type: ignore
         # ct.add_collection("non-ascii-str-\u1234")
-        ct.add_collection("non-ascii-bytes-\u1234".encode())
-        ct.add_collection(b"bad-\xff")
+        ct.add_collection("non-ascii-bytes-\u1234".encode())  # type: ignore
+        ct.add_collection(b"bad-\xff")  # type: ignore
         entry = ct.generate()
         self.assertEqual(
             entry[b"info"][b"collections"],
@@ -554,10 +558,10 @@ class CreateTorrentTest(unittest.TestCase):
         ct = lt.create_torrent(fs)
         ct.set_hash(0, lib.get_random_bytes(20))
         ct.add_collection("ascii-str")
-        ct.add_collection(b"ascii-bytes")
+        ct.add_collection(b"ascii-bytes")  # type: ignore
         ct.add_collection("non-ascii-str-\u1234")
-        ct.add_collection("non-ascii-bytes-\u1234".encode())
-        ct.add_collection(b"bad-\xff")
+        ct.add_collection("non-ascii-bytes-\u1234".encode())  # type: ignore
+        ct.add_collection(b"bad-\xff")  # type: ignore
         entry = ct.generate()
         self.assertEqual(
             entry[b"info"][b"collections"],

--- a/bindings/python/tests/fingerprint_test.py
+++ b/bindings/python/tests/fingerprint_test.py
@@ -8,25 +8,34 @@ class GenerateFingerprintTest(unittest.TestCase):
     def test_generate(self) -> None:
         # full version
         self.assertEqual(
-            lt.generate_fingerprint_bytes(b"ABCD", 1, 2, 3, 4), b"-AB1234-"
+            lt.generate_fingerprint_bytes(b"ABCD", 1, 2, 3, 4),  # type: ignore
+            b"-AB1234-",
         )
 
         # short name
         self.assertEqual(
-            lt.generate_fingerprint_bytes(b"A", 1, 2, 3, 4), b"-A\x001234-"
+            lt.generate_fingerprint_bytes(b"A", 1, 2, 3, 4),  # type: ignore
+            b"-A\x001234-",
         )
 
         # major.minor
-        self.assertEqual(lt.generate_fingerprint_bytes(b"ABCD", 1, 2), b"-AB1200-")
+        self.assertEqual(
+            lt.generate_fingerprint_bytes(b"ABCD", 1, 2),  # type: ignore
+            b"-AB1200-",
+        )
 
         # high versions
         self.assertEqual(
-            lt.generate_fingerprint_bytes(b"ABCD", 1000, 2000, 3000, 4000), b"unknown"
+            lt.generate_fingerprint_bytes(  # type: ignore
+                b"ABCD", 1000, 2000, 3000, 4000
+            ),
+            b"unknown",
         )
 
         # version < 0
         self.assertEqual(
-            lt.generate_fingerprint_bytes(b"ABCD", -1, -1, -1, -1), b"-AB0000-"
+            lt.generate_fingerprint_bytes(b"ABCD", -1, -1, -1, -1),  # type: ignore
+            b"-AB0000-",
         )
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5988")

--- a/bindings/python/tests/lib.py
+++ b/bindings/python/tests/lib.py
@@ -85,8 +85,10 @@ def cleanup_with_windows_fix(
     for _ in loop_until_timeout(timeout, msg="PermissionError clear"):
         try:
             unlink_all_files(tempdir.name)
-        except PermissionError as exc:
-            if sys.platform == "win32" and exc.winerror == 5:
+        except PermissionError:
+            if sys.platform == "win32":
+                # current release of mypy doesn't know about winerror
+                # if exc.winerror == 5:
                 continue
             raise
         break

--- a/bindings/python/tests/magnet_uri_test.py
+++ b/bindings/python/tests/magnet_uri_test.py
@@ -186,7 +186,10 @@ class ParseMagnetTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as path:
             params["save_path"] = path
             handle = session.add_torrent(params)
-            self.assertEqual(str(handle.info_hashes().v2), self.info_hash_sha256)
+            self.assertEqual(
+                str(handle.info_hashes().v2),  # type: ignore
+                self.info_hash_sha256,
+            )
             self.assertEqual(handle.name(), "test.txt")
             self.assertEqual(
                 [t["url"] for t in handle.trackers()], ["http://example.com/tr"]

--- a/bindings/python/tests/session_test.py
+++ b/bindings/python/tests/session_test.py
@@ -378,23 +378,23 @@ class AddTorrentParamsTest(unittest.TestCase):
         atp = lt.add_torrent_params()
 
         with self.assertWarns(DeprecationWarning):
-            atp.name = b"test.txt"
+            atp.name = b"test.txt"  # type: ignore
 
     def test_name_assign_bytes(self) -> None:
         atp = lt.add_torrent_params()
 
-        atp.name = b"test.txt"
+        atp.name = b"test.txt"  # type: ignore
         self.assertEqual(atp.name, "test.txt")
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5988")
     def test_trackerid_assign_bytes_deprecated(self) -> None:
         atp = lt.add_torrent_params()
         with self.assertWarns(DeprecationWarning):
-            atp.trackerid = b"trackerid"
+            atp.trackerid = b"trackerid"  # type: ignore
 
     def test_trackerid_assign_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.trackerid = b"trackerid"
+        atp.trackerid = b"trackerid"  # type: ignore
         self.assertEqual(atp.trackerid, "trackerid")
 
     def test_save_path_ascii_str(self) -> None:
@@ -405,7 +405,7 @@ class AddTorrentParamsTest(unittest.TestCase):
 
     def test_save_path_ascii_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.save_path = b"test"
+        atp.save_path = b"test"  # type: ignore
         self.assertEqual(atp.save_path, "test")
         self.assertEqual(lt.write_resume_data(atp)[b"save_path"], b"test")
 
@@ -417,7 +417,7 @@ class AddTorrentParamsTest(unittest.TestCase):
 
     def test_save_path_non_ascii_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.save_path = os.fsencode("\u1234")
+        atp.save_path = os.fsencode("\u1234")  # type: ignore
         self.assertEqual(atp.save_path, "\u1234")
         self.assertEqual(lt.write_resume_data(atp)[b"save_path"], os.fsencode("\u1234"))
 
@@ -433,7 +433,7 @@ class AddTorrentParamsTest(unittest.TestCase):
     @lib.uses_surrogate_paths()
     def test_save_path_surrogate_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.save_path = os.fsencode("\udcff")
+        atp.save_path = os.fsencode("\udcff")  # type: ignore
         self.assertEqual(atp.save_path, "\udcff")
         self.assertEqual(lt.write_resume_data(atp)[b"save_path"], os.fsencode("\udcff"))
 
@@ -449,7 +449,7 @@ class AddTorrentParamsTest(unittest.TestCase):
     @lib.uses_non_unicode_paths()
     def test_save_path_non_unicode_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.save_path = b"\xff"
+        atp.save_path = b"\xff"  # type: ignore
         self.assertEqual(atp.save_path, os.fsdecode(b"\xff"))
         self.assertEqual(lt.write_resume_data(atp)[b"save_path"], b"\xff")
 
@@ -533,7 +533,7 @@ class AddTorrentParamsTest(unittest.TestCase):
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
     def test_renamed_files_ascii_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.renamed_files = {0: b"test.txt"}
+        atp.renamed_files = {0: b"test.txt"}  # type: ignore
         self.assertEqual(atp.renamed_files, {0: "test.txt"})
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
@@ -545,7 +545,7 @@ class AddTorrentParamsTest(unittest.TestCase):
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
     def test_renamed_files_non_ascii_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.renamed_files = {0: os.fsencode("\u1234.txt")}
+        atp.renamed_files = {0: os.fsencode("\u1234.txt")}  # type: ignore
         self.assertEqual(atp.renamed_files, {0: "\u1234.txt"})
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5984")
@@ -559,7 +559,7 @@ class AddTorrentParamsTest(unittest.TestCase):
     @lib.uses_surrogate_paths()
     def test_renamed_files_surrogate_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.renamed_files = {0: os.fsencode("\udcff.txt")}
+        atp.renamed_files = {0: os.fsencode("\udcff.txt")}  # type: ignore
         self.assertEqual(atp.renamed_files, {0: "\udcff.txt"})
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5984")
@@ -573,7 +573,7 @@ class AddTorrentParamsTest(unittest.TestCase):
     @lib.uses_non_unicode_paths()
     def test_renamed_files_non_unicode_bytes(self) -> None:
         atp = lt.add_torrent_params()
-        atp.renamed_files = {0: b"\xff.txt"}
+        atp.renamed_files = {0: b"\xff.txt"}  # type: ignore
         self.assertEqual(atp.renamed_files, {0: os.fsdecode("\xff.txt")})
 
 
@@ -782,13 +782,13 @@ class ResumeDataTest(unittest.TestCase):
         atp = lt.add_torrent_params()
         buf = lt.write_resume_data_buf(atp)
         with self.assertRaises(RuntimeError):
-            lt.read_resume_data(buf, {b"max_decode_depth": 1})
+            lt.read_resume_data(buf, {"max_decode_depth": 1})
 
     def test_limit_decode_tokens(self) -> None:
         atp = lt.add_torrent_params()
         buf = lt.write_resume_data_buf(atp)
         with self.assertRaises(RuntimeError):
-            lt.read_resume_data(buf, {b"max_decode_tokens": 1})
+            lt.read_resume_data(buf, {"max_decode_tokens": 1})
 
     def test_limit_pieces(self) -> None:
         atp = lt.add_torrent_params()
@@ -804,7 +804,7 @@ class ResumeDataTest(unittest.TestCase):
         )
         buf = lt.write_resume_data_buf(atp)
         with self.assertRaises(RuntimeError):
-            lt.read_resume_data(buf, {b"max_pieces": 1})
+            lt.read_resume_data(buf, {"max_pieces": 1})
 
 
 class ConstructorTest(unittest.TestCase):
@@ -943,7 +943,7 @@ class DhtTest(unittest.TestCase):
     def test_announce(self) -> None:
         sha1 = lt.sha1_hash(b"a" * 20)
 
-        self.session.dht_announce(sha1)
+        self.session.dht_announce(sha1)  # type: ignore
         self.session.dht_announce(sha1, 0, 0)
         # self.session.dht_announce(sha1, 0, lt.announce_flags.??)
 
@@ -957,9 +957,14 @@ class DhtTest(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.session.set_dht_settings(dht_settings)
         with self.assertWarns(DeprecationWarning):
-            self.session.dht_get_mutable_item("a" * 32, "salt")
+            self.session.dht_get_mutable_item("a" * 32, "salt")  # type: ignore
         with self.assertWarns(DeprecationWarning):
-            self.session.dht_put_mutable_item("a" * 64, "b" * 32, "data", "salt")
+            self.session.dht_put_mutable_item(
+                "a" * 64,  # type: ignore
+                "b" * 32,  # type: ignore
+                "data",  # type: ignore
+                "salt",  # type: ignore
+            )
 
     def test_dht_lookup(self) -> None:
         lookup = lt.dht_lookup()
@@ -995,17 +1000,21 @@ class AlertHandlingTest(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32", "windows doesn't support pipes")
     def test_set_alert_fd_pipe(self) -> None:
+        # Redundant sys.platform checks are to help mypy
         r, w = os.pipe()
         # Should always be non-blocking, or we'll block the event loop
-        os.set_blocking(w, False)
+        if sys.platform != "win32":
+            os.set_blocking(w, False)
 
         self.session.set_alert_fd(w)
 
         # Pipe should initially be empty
-        os.set_blocking(r, False)
+        if sys.platform != "win32":
+            os.set_blocking(r, False)
         with self.assertRaises(BlockingIOError):
             os.read(r, 1024)
-        os.set_blocking(r, True)
+        if sys.platform != "win32":
+            os.set_blocking(r, True)
 
         # Force an alert to fire
         self.session.post_torrent_updates()
@@ -1110,7 +1119,10 @@ class AddTorrentTest(unittest.TestCase):
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5989")
     def test_old_style_with_wrong_args(self) -> None:
         with self.assertRaises(TypeError):
-            self.session.add_torrent(self.torrent.torrent_info(), resume_data=None)
+            self.session.add_torrent(  # type: ignore
+                self.torrent.torrent_info(),
+                resume_data=None,
+            )
 
     def test_old_style(self) -> None:
         ti = self.torrent.torrent_info()
@@ -1204,7 +1216,9 @@ class AddTorrentTest(unittest.TestCase):
         self.assertIn(status.list_peers, (1, 2))
         self.assertEqual(handle.flags(), lt.torrent_flags.sequential_download)
         # TODO: can we test trackerid?
-        self.assertEqual(handle.torrent_file().files().file_path(0), "renamed.txt")
+        torrent_file = handle.torrent_file()
+        assert torrent_file is not None
+        self.assertEqual(torrent_file.files().file_path(0), "renamed.txt")
         self.assertEqual(handle.get_file_priorities(), [2])
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/6145")
@@ -1214,7 +1228,7 @@ class AddTorrentTest(unittest.TestCase):
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/6145")
     def test_no_torrent_info_old(self) -> None:
         atp = lt.add_torrent_params()
-        atp.info_hash = lt.info_hash_t(lt.sha1_hash(b"a" * 20))
+        atp.info_hash = lt.sha1_hash(b"a" * 20)
         atp.save_path = self.dir.name
         self.session.add_torrent(atp)
 
@@ -1241,7 +1255,7 @@ class AddTorrentTest(unittest.TestCase):
         self.session.pop_alerts()
         handle.save_resume_data()
         alert = self.session.wait_for_alert(10000)
-        self.assertIsInstance(alert, lt.save_resume_data_alert)
+        assert isinstance(alert, lt.save_resume_data_alert)
         atp_dict = lt.write_resume_data(alert.params)
         self.assertEqual(atp_dict[b"info-hash2"], b"a" * 32)
 
@@ -1582,9 +1596,9 @@ class TorrentStatusTest(unittest.TestCase):
         self.assertEqual(len(status_list), 0)
 
         with self.assertRaises(TypeError):
-            self.session.get_torrent_status(None)
+            self.session.get_torrent_status(None)  # type: ignore
         with self.assertRaises(TypeError):
-            self.session.get_torrent_status(lambda: True)
+            self.session.get_torrent_status(lambda: True)  # type: ignore
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/6008")
     def test_refresh_torrent_status(self) -> None:

--- a/bindings/python/tests/sha1_hash_test.py
+++ b/bindings/python/tests/sha1_hash_test.py
@@ -19,10 +19,10 @@ class Sha1HashTest(unittest.TestCase):
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
     def test_init_str_deprecated(self) -> None:
         with self.assertWarns(DeprecationWarning):
-            lt.sha1_hash("a" * 20)
+            lt.sha1_hash("a" * 20)  # type: ignore
 
     def test_init_str(self) -> None:
-        sha1 = lt.sha1_hash("a" * 20)
+        sha1 = lt.sha1_hash("a" * 20)  # type: ignore
         self.assertEqual(sha1.to_bytes(), b"a" * 20)
 
     def test_equal(self) -> None:

--- a/bindings/python/tests/torrent_info_test.py
+++ b/bindings/python/tests/torrent_info_test.py
@@ -74,7 +74,7 @@ class InfoHashTest(unittest.TestCase):
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5986")
     def test_sha256(self) -> None:
-        sha256 = lt.sha256_hash(lib.get_random_bytes(32))
+        sha256 = lt.sha256_hash(lib.get_random_bytes(32))  # type: ignore
 
         ih = lt.info_hash_t(sha256)
         self.assertEqual(ih.get(lt.protocol_version.V1), lt.sha1_hash())
@@ -85,7 +85,7 @@ class InfoHashTest(unittest.TestCase):
         self.assertFalse(ih.has_v1())
         self.assertTrue(ih.has_v2())
         self.assertEqual(ih.v1, lt.sha1_hash())
-        self.assertEqual(ih.v2, sha256)
+        self.assertEqual(ih.v2, sha256)  # type: ignore
 
         self.assertEqual(ih, lt.info_hash_t(sha256))
         self.assertEqual(hash(ih), hash(lt.info_hash_t(sha256)))
@@ -94,9 +94,9 @@ class InfoHashTest(unittest.TestCase):
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5986")
     def test_dual(self) -> None:
         sha1 = lt.sha1_hash(lib.get_random_bytes(20))
-        sha256 = lt.sha256_hash(lib.get_random_bytes(32))
+        sha256 = lt.sha256_hash(lib.get_random_bytes(32))  # type: ignore
 
-        ih = lt.info_hash_t(sha1, sha256)
+        ih = lt.info_hash_t(sha1, sha256)  # type: ignore
         self.assertEqual(ih.get(lt.protocol_version.V1), sha1)
         self.assertEqual(ih.get(lt.protocol_version.V2), sha256)
         self.assertEqual(ih.get_best(), sha256)
@@ -107,8 +107,8 @@ class InfoHashTest(unittest.TestCase):
         self.assertEqual(ih.v1, sha1)
         self.assertEqual(ih.v2, sha256)
 
-        self.assertEqual(ih, lt.info_hash_t(sha1, sha256))
-        self.assertEqual(hash(ih), hash(lt.info_hash_t(sha1, sha256)))
+        self.assertEqual(ih, lt.info_hash_t(sha1, sha256))  # type: ignore
+        self.assertEqual(hash(ih), hash(lt.info_hash_t(sha1, sha256)))  # type: ignore
         self.assertNotEqual(ih, lt.info_hash_t())
 
 
@@ -181,7 +181,7 @@ class ConstructorTest(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             lt.torrent_info(
                 {
-                    "info": {
+                    "info": {  # type: ignore
                         "name": "test.txt",
                         "length": 1024,
                         "piece length": 16384,
@@ -193,7 +193,7 @@ class ConstructorTest(unittest.TestCase):
     def test_dict_with_str_keys(self) -> None:
         ti = lt.torrent_info(
             {
-                "info": {
+                "info": {  # type: ignore
                     "name": "test.txt",
                     "length": 1024,
                     "piece length": 16384,
@@ -255,7 +255,7 @@ class ConstructorWithLimitsTest(unittest.TestCase):
                         b"pieces": b"aaaaaaaaaaaaaaaaaaaa",
                     },
                 },
-                {b"max_decode_depth": 1},
+                {"max_decode_depth": 1},
             )
 
     def test_load_max_pieces_limit(self) -> None:
@@ -269,7 +269,7 @@ class ConstructorWithLimitsTest(unittest.TestCase):
                         b"pieces": b"aaaaaaaaaaaaaaaaaaaa",
                     }
                 },
-                {b"max_pieces": 1},
+                {"max_pieces": 1},
             )
 
     def test_load_max_buffer_size_limit(self) -> None:
@@ -283,7 +283,7 @@ class ConstructorWithLimitsTest(unittest.TestCase):
                         b"pieces": b"aaaaaaaaaaaaaaaaaaaa",
                     }
                 },
-                {b"max_buffer_size": 1},
+                {"max_buffer_size": 1},
             )
 
 
@@ -295,7 +295,9 @@ class FieldTest(unittest.TestCase):
         self.ti.add_tracker("http://example0.com", 0, lt.tracker_source.source_client)
         with self.assertRaises(TypeError):
             self.ti.add_tracker(
-                b"http://example1.com", 1, int(lt.tracker_source.source_torrent)
+                b"http://example1.com",  # type: ignore
+                1,
+                int(lt.tracker_source.source_torrent),  # type: ignore
             )
 
         self.assertEqual([t.url for t in self.ti.trackers()], ["http://example0.com"])
@@ -542,7 +544,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(self.ti.files().file_path(0), "ascii-str.txt")
 
         # ascii bytes
-        self.ti.rename_file(0, b"ascii-bytes.txt")
+        self.ti.rename_file(0, b"ascii-bytes.txt")  # type: ignore
         self.assertEqual(self.ti.files().file_path(0), "ascii-bytes.txt")
 
         # non-ascii str
@@ -550,11 +552,11 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(self.ti.files().file_path(0), "\u1234-str.txt")
 
         # non-ascii bytes
-        self.ti.rename_file(0, "\u1234-bytes.txt".encode())
+        self.ti.rename_file(0, "\u1234-bytes.txt".encode())  # type: ignore
         self.assertEqual(self.ti.files().file_path(0), "\u1234-bytes.txt")
 
         # non-unicode
-        self.ti.rename_file(0, b"\xff.txt")
+        self.ti.rename_file(0, b"\xff.txt")  # type: ignore
         with self.assertRaises(ValueError):
             self.ti.files().file_path(0)
 

--- a/bindings/python/tests/torrent_status_test.py
+++ b/bindings/python/tests/torrent_status_test.py
@@ -30,6 +30,7 @@ class TorrentStatusTest(unittest.TestCase):
         self.assertEqual(self.status.handle, self.handle)
 
         self.assertIsInstance(self.status.torrent_file, lt.torrent_info)
+        assert self.status.torrent_file is not None
         self.assertEqual(
             self.status.torrent_file.info_section(),
             self.torrent.torrent_info().info_section(),

--- a/bindings/python/tests/utility_test.py
+++ b/bindings/python/tests/utility_test.py
@@ -31,19 +31,19 @@ class BencodeTest(unittest.TestCase):
     def test_deprecations(self) -> None:
         # top-level str
         with self.assertWarns(DeprecationWarning):
-            lt.bencode("abc")
+            lt.bencode("abc")  # type: ignore
 
     def test_nonstandard_types(self) -> None:
         # top-level str
-        self.assertEqual(lt.bencode("abc"), b"3:abc")
+        self.assertEqual(lt.bencode("abc"), b"3:abc")  # type: ignore
 
         # top-level float
         with self.assertWarns(DeprecationWarning):
-            self.assertEqual(lt.bencode(1.0), b"0:")
+            self.assertEqual(lt.bencode(1.0), b"0:")  # type: ignore
 
         # top-level other object
         with self.assertWarns(DeprecationWarning):
-            self.assertEqual(lt.bencode(self), b"0:")
+            self.assertEqual(lt.bencode(self), b"0:")  # type: ignore
 
 
 class IdentifyClientTest(unittest.TestCase):

--- a/bindings/python/tests/version_test.py
+++ b/bindings/python/tests/version_test.py
@@ -9,7 +9,7 @@ class VersionTest(unittest.TestCase):
 
     @unittest.skip("need to implement this")
     def test_version_tuple(self) -> None:
-        self.assertIsInstance(lt.__version_info__, tuple)
+        self.assertIsInstance(lt.__version_info__, tuple)  # type: ignore
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
     def test_deprecated(self) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,4 @@ warn_unused_configs = True
 #disallow_any_unimported = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+mypy_path = bindings/python/install_data

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ changedir = bindings/python
 skip_install = true
 deps =
     pytest
+    mypy
 # Build the wheel to match our environment's python, and install it to the
 # environment.
 # Invocation notes:
@@ -33,9 +34,15 @@ deps =
 #   - As of writing, it only saves about 7 seconds on my machine
 # - Note that multithreading with pytest-parallel doesn't work correctly
 #   because assertWarns isn't threadsafe
+# Invocation notes for mypy:
+# - We run this in tox to test the *packaging* of the type stubs. mypy should
+#   be able to find them in the installed environment.
+# - To ensure mypy *only* looks for the packaged type stubs and not the files
+#   in the python directory, only run mypy on the tests dir.
 
 commands =
     {envpython} setup.py bdist_wheel
     {envpython} -m pip install --upgrade --force-reinstall --ignore-installed --find-links=dist python-libtorrent
     {envpython} -m pip install -r test-requirements.txt
     {envpython} -X dev -m pytest --log-level=DEBUG --log-cli-level=DEBUG
+    {envpython} -m mypy --config-file mypy-tox.ini tests


### PR DESCRIPTION
This adds type stubs to the python bindings. The type stubs are packaged with the python extension, so a user can just install `python-libtorrent` to type-check their code.

If the type stubs have errors, the remedy is for users to apply workarounds in their code (typically `# type: ignore` or `cast(...)`), and wait for a new version of libtorrent. Even the standard library's type stubs have errors and gaps, so this is a relatively common practice. When new code is released, mypy has a feature to warn on unused `# type: ignore` or `cast(...)`, so unused workarounds don't accumulate forever.

There currently isn't a way to "test" type stubs, or to measure coverage. But since we are type-checking the python bindings tests, those tests also now exercise the type stubs.

This adds a maintenance burden that the type stubs must be kept in sync with the python bindings. Type stubs can be generated from an extension with `stubgen`, but apparently its output from a boost.python project is very poor. I expect the best maintenance process for the type stubs is to ensure very good coverage of the python bindings *tests*; and type-checking the tests will uncover gaps in the type stubs.

## Packaging

mypy only recognizes type stubs *included in a python package*, not *adjacent to a module*.

This means I had to change `libtorrent.so` to `libtorrent/__init__.so`, and include type stub files in `libtorrent/`.

This is only effective for `setup.py`. So building dirctly with `b2` still builds a `libtorrent.so` in the b2 output directory; but `setup.py` (with both `--config-mode=b2` or `--config-mode=distutils`) will produce `libtorrent/__init__.so`, with type stubs alongside.

This change should be transparent for all usage in python. It may change some introspection output in some cases, but I don't think it changes anything that counts as a stable interface.

## On deprecating functions

Reading the type stubs, you can see various places where two functions do exactly the same thing but one is deprecated (e.g. `msg` vs `log_message()` on many alerts), just because a type changed on the C++ side.

You've indicated this is so the python bindings match the C++ code closely.

If the main motivation for this is that the C++ docs are the only docs, I ask that you consider my thought that type stubs serve double-duty as documentation. It may be easier for python users to read the type stubs to see available functions, rather than try to apply the C++ docs to python. This would make it easier to maintain a world where the names in python diverge from names in C++.

Personally, I would rather deal with names in python that don't quite match C++, rather than deal with deprecations which have no meaning in python.