### PR TITLE
Add a cibuildwheel workflow

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,142 @@
+name: cibuildwheel
+
+# Note: We use a dynamic matrix to build different sets of wheels under
+# different conditions. On workflow_dispatch, we build the full suite of
+# wheels. This takes hours, so on pull_request, we just build a representative
+# sample.
+
+# The full list of cibuildwheel's build targets can be found here:
+# https://github.com/pypa/cibuildwheel/blob/v2.2.0a1/cibuildwheel/resources/build-platforms.toml
+
+# Notes on build targets we (don't) support:
+# - pypy: libtorrent doesn't build with pypy as of writing
+# - macos_arm64: can be cross-compiled from x86_64, but not run, so can't be
+#   tested. Build output indicates it isn't building correctly
+# - macos_universal2: b2 / setup.py doesn't have a straightforward way to build
+#   this as of writing
+# - abi3: Not supported by boost-python (or pybind11) or cibuildwheel as of
+#   writing
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Write 'PUBLISH' to publish to pypi. BEWARE! ARTIFACTS ARE IMMUTABLE AND CANNOT BE REPLACED ONCE PUBLISHED!
+      publish_test:
+        description: Write 'PUBLISH_TEST' to publish to test-pypi. BEWARE! ARTIFACTS ARE IMMUTABLE AND CANNOT BE REPLACED ONCE PUBLISHED!
+
+  pull_request:
+    paths:
+      - .github/workflows/cibuildwheel.yml
+      - tools/cibuildwheel/**
+      - pyproject.toml
+
+jobs:
+  configure_matrix:
+    runs-on: ubuntu-latest
+    env:
+      # github actions syntax doesn't allow us to have yaml structures as
+      # an input to a job. These environment variables are literal json strings
+      MATRIX_PULL_REQUEST: |
+        {
+          "include": [
+            {"os": "ubuntu-20.04", "CIBW_BUILD": "cp37-manylinux_*", "CIBW_ARCHS": "x86_64"},
+            {"os": "ubuntu-20.04", "CIBW_BUILD": "cp37-musllinux_*", "CIBW_ARCHS": "x86_64"},
+            {"os": "macos-10.15", "CIBW_BUILD": "cp37-*", "CIBW_ARCHS": "x86_64"},
+            {"os": "windows-2019", "CIBW_BUILD": "cp37-*", "CIBW_ARCHS": "AMD64"}
+          ]
+        }
+      MATRIX_WORKFLOW_DISPATCH: |
+        {
+          "include": [
+            {"os": "ubuntu-20.04", "CIBW_BUILD": "cp*-manylinux_*", "CIBW_ARCHS": "x86_64"},
+            {"os": "ubuntu-20.04", "CIBW_BUILD": "cp*-manylinux_*", "CIBW_ARCHS": "aarch64"},
+            {"os": "ubuntu-20.04", "CIBW_BUILD": "cp*-musllinux_*", "CIBW_ARCHS": "x86_64"},
+            {"os": "ubuntu-20.04", "CIBW_BUILD": "cp*-musllinux_*", "CIBW_ARCHS": "aarch64"},
+            {"os": "macos-10.15", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "x86_64"},
+            {"os": "windows-2019", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "x86"},
+            {"os": "windows-2019", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "AMD64"}
+          ]
+        }
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+    - id: set-matrix
+      run: |
+        if [ $GITHUB_EVENT_NAME == "pull_request" ]; then
+          echo ::set-output name=matrix::$(echo $MATRIX_PULL_REQUEST | jq -c)
+        else
+          echo ::set-output name=matrix::$(echo $MATRIX_WORKFLOW_DISPATCH | jq -c)
+        fi
+
+  build_wheels:
+    needs: configure_matrix
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.configure_matrix.outputs.matrix) }}
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
+      CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: actions/cache@v2
+      id: cache-wheel
+      with:
+        path: wheelhouse
+        key: wheel-${{ matrix.CIBW_BUILD }}-${{ matrix.CIBW_ARCHS }}-${{ github.sha }}
+
+    - uses: docker/setup-qemu-action@v1
+      if: steps.cache-wheel.outputs.cache-hit != 'true' && runner.os == 'Linux'
+
+    - uses: pypa/cibuildwheel@v2.2.2
+      if: steps.cache-wheel.outputs.cache-hit != 'true'
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+        name: wheels
+
+  upload_pypi:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    if: needs.build_wheels.result == 'success' && github.event.inputs.publish == 'PUBLISH'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: wheels
+        path: wheelhouse
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: wheelhouse
+        skip_existing: true
+
+  upload_pypi_test:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    if: needs.build_wheels.result == 'success' && github.event.inputs.publish_test == 'PUBLISH_TEST'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: wheels
+        path: wheelhouse
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        packages_dir: wheelhouse
+        skip_existing: true
+        repository_url: https://test.pypi.org/legacy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
     -   id: debug-statements
     -   id: check-symlinks
     -   id: check-toml
+- repo: https://github.com/pappasam/toml-sort
+  rev: v0.19.0
+  hooks:
+  - id: toml-sort
+    args: [--all, --in-place]
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.7.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,88 @@
+[project]
+requires-python = ">=3.7"
+
+[tool.cibuildwheel]
+skip = "pp*"
+
+[tool.cibuildwheel.macos]
+before-all = [
+    "./tools/cibuildwheel/setup_boost.sh $BOOST_VERSION $BOOST_ROOT",
+    "brew install openssl",
+]
+test-command = [
+    "cd {project}/bindings/python",
+    "python test.py",
+]
+
+[tool.cibuildwheel.macos.environment]
+BOOST_BUILD_PATH = "/tmp/boost/tools/build"
+BOOST_ROOT = "/tmp/boost"
+BOOST_VERSION = "1.76.0"
+MACOSX_DEPLOYMENT_TARGET = "10.9"  # required for full C++11 support
+PATH = "/tmp/boost:$PATH"
+
+[[tool.cibuildwheel.overrides]]
+before-all = [
+    "./tools/cibuildwheel/setup_boost.sh $BOOST_VERSION $BOOST_ROOT",
+    "yum install -y glibc-static",  # needed for libutil.a and libdl.a
+    "./tools/cibuildwheel/setup_ccache_on_manylinux.sh",
+    "./tools/cibuildwheel/setup_openssl.sh",
+]
+before-test = "ccache -s"
+select = "*-manylinux_*"
+test-command = [
+    "cd {project}/bindings/python",
+    "python test.py",
+]
+
+[tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
+BOOST_BUILD_PATH = "/tmp/boost/tools/build"
+BOOST_ROOT = "/tmp/boost"
+BOOST_VERSION = "1.76.0"
+PATH = "/usr/local/ccache/bin:/tmp/boost:$PATH"
+
+[[tool.cibuildwheel.overrides]]
+before-all = [
+    "./tools/cibuildwheel/setup_boost.sh $BOOST_VERSION $BOOST_ROOT",
+    "apk add ccache openssl-dev openssl-libs-static",
+    "./tools/cibuildwheel/setup_openssl.sh",
+]
+before-test = "ccache -s"
+select = "*-musllinux_*"
+test-command = [
+    "cd {project}/bindings/python",
+    "python test.py",
+]
+
+[tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
+BOOST_BUILD_PATH = "/tmp/boost/tools/build"
+BOOST_ROOT = "/tmp/boost"
+BOOST_VERSION = "1.76.0"
+PATH = "/usr/lib/ccache/bin:/tmp/boost:$PATH"
+
+[[tool.cibuildwheel.overrides]]
+before-all = [
+    "bash -c './tools/cibuildwheel/setup_boost.sh $BOOST_VERSION $BOOST_ROOT'",
+    "bash -c 'choco install --no-progress --x86 openssl'",  # choco only allows EITHER 32 OR 64-bit version of a package
+]
+select = "*-win32"
+
+[[tool.cibuildwheel.overrides]]
+before-all = [
+    "bash -c './tools/cibuildwheel/setup_boost.sh $BOOST_VERSION $BOOST_ROOT'",
+    "bash -c 'choco install --no-progress openssl'",        # choco only allows EITHER 32 OR 64-bit version of a package
+]
+select = "*-win_amd64"
+
+[tool.cibuildwheel.windows]
+test-command = '''bash -c "cd '{project}/bindings/python' && python test.py"'''
+
+[tool.cibuildwheel.windows.environment]
+BOOST_BUILD_PATH = 'c:/boost/tools/build'
+BOOST_ROOT = 'c:/boost'
+BOOST_VERSION = "1.76.0"
+PATH = 'c:/boost;$PATH'
+
 [tool.isort]
 profile = "google"
 single_line_exclusions = []

--- a/tools/cibuildwheel/manylinux/build-openssl.sh
+++ b/tools/cibuildwheel/manylinux/build-openssl.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Top-level build script called from Dockerfile
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+source $MY_DIR/build_utils.sh
+
+# Install a more recent openssl
+check_var ${OPENSSL_ROOT}
+check_var ${OPENSSL_HASH}
+check_var ${OPENSSL_DOWNLOAD_URL}
+
+OPENSSL_VERSION=${OPENSSL_ROOT#*-}
+OPENSSL_MIN_VERSION=1.1.1
+
+INSTALLED=$(openssl version | head -1 | awk '{ print $2 }')
+SMALLEST=$(echo -e "${INSTALLED}\n${OPENSSL_MIN_VERSION}" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -1)
+if [ "${SMALLEST}" == "${OPENSSL_MIN_VERSION}" ]; then
+	echo "skipping installation of openssl ${OPENSSL_VERSION}, system provides openssl ${INSTALLED} which is newer than openssl ${OPENSSL_MIN_VERSION}"
+	exit 0
+fi
+
+if which yum; then
+	yum erase -y openssl-devel
+else
+	apt-get remove -y libssl-dev
+fi
+
+fetch_source ${OPENSSL_ROOT}.tar.gz ${OPENSSL_DOWNLOAD_URL}
+check_sha256sum ${OPENSSL_ROOT}.tar.gz ${OPENSSL_HASH}
+tar -xzf ${OPENSSL_ROOT}.tar.gz
+pushd ${OPENSSL_ROOT}
+./config no-shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS} -fPIC" CXXFLAGS="${MANYLINUX_CXXFLAGS} -fPIC" LDFLAGS="${MANYLINUX_LDFLAGS} -fPIC" > /dev/null
+make > /dev/null
+make install_sw > /dev/null
+popd
+rm -rf ${OPENSSL_ROOT} ${OPENSSL_ROOT}.tar.gz
+
+
+/usr/local/ssl/bin/openssl version

--- a/tools/cibuildwheel/manylinux/build_utils.sh
+++ b/tools/cibuildwheel/manylinux/build_utils.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Helper utilities for build
+
+
+# use all flags used by ubuntu 20.04 for hardening builds, dpkg-buildflags --export
+# other flags mentioned in https://wiki.ubuntu.com/ToolChain/CompilerFlags can't be
+# used because the distros used here are too old
+MANYLINUX_CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
+MANYLINUX_CFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+MANYLINUX_LDFLAGS="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
+
+
+function check_var {
+    if [ -z "$1" ]; then
+        echo "required variable not defined"
+        exit 1
+    fi
+}
+
+
+function fetch_source {
+    # This is called both inside and outside the build context (e.g. in Travis) to prefetch
+    # source tarballs, where curl exists (and works)
+    local file=$1
+    check_var ${file}
+    local url=$2
+    check_var ${url}
+    if [ -f ${file} ]; then
+        echo "${file} exists, skipping fetch"
+    else
+        curl -fsSL -o ${file} ${url}/${file}
+    fi
+}
+
+
+function check_sha256sum {
+    local fname=$1
+    check_var ${fname}
+    local sha256=$2
+    check_var ${sha256}
+
+    echo "${sha256}  ${fname}" > ${fname}.sha256
+    sha256sum -c ${fname}.sha256
+    rm -f ${fname}.sha256
+}
+
+
+function do_standard_install {
+    ./configure "$@" CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" "CXXFLAGS=${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}" > /dev/null
+    make > /dev/null
+    make install > /dev/null
+}
+
+function strip_ {
+	# Strip what we can -- and ignore errors, because this just attempts to strip
+	# *everything*, including non-ELF files:
+	find $1 -type f -print0 | xargs -0 -n1 strip --strip-unneeded 2>/dev/null || true
+}
+
+function clean_pyc {
+	find $1 -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
+}

--- a/tools/cibuildwheel/manylinux/openssl-version.sh
+++ b/tools/cibuildwheel/manylinux/openssl-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export OPENSSL_ROOT=openssl-1.1.1l
+export OPENSSL_HASH=0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
+export OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source

--- a/tools/cibuildwheel/setup_boost.sh
+++ b/tools/cibuildwheel/setup_boost.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script is meant to be called by cibuildwheel. It should run on github
+# actions Linux, Mac and Windows.
+
+set -ex
+
+VERSION="$1"
+BOOST_ROOT="$2"
+
+VUNDER="${VERSION//./_}"
+
+TEMP_ARCHIVE="$(mktemp)"
+
+mkdir -p "$BOOST_ROOT"
+
+curl -L -o "$TEMP_ARCHIVE" "https://boostorg.jfrog.io/artifactory/main/release/${VERSION}/source/boost_${VUNDER}.tar.gz"
+
+tar -z -x -C "$BOOST_ROOT" -f "$TEMP_ARCHIVE" --strip-components 1
+rm "$TEMP_ARCHIVE"
+
+cd "$BOOST_ROOT"
+
+./bootstrap.sh
+
+cat ./project-config.jam
+
+./b2 headers

--- a/tools/cibuildwheel/setup_ccache_on_manylinux.sh
+++ b/tools/cibuildwheel/setup_ccache_on_manylinux.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -xe
+
+if [ $(uname -m) != x86_64 -a $(uname -m) != aarch64 ]
+then
+	echo "ccache isn't known to exist on $(uname -m). skipping ccache setup"
+	exit 0
+fi
+
+yum install -y epel-release  # overlay containing ccache
+yum install -y ccache
+
+# The symlinks in /usr/lib64/ccache are auto-managed by rpm postinstall
+# scripts. They are only created if appropriate packages are installed. However
+# this management only knows about the standard gcc* packages, not the
+# devtoolset packages, so they don't get created correctly on manylinux. We try
+# to create them ourselves.
+mkdir -p /usr/local/ccache/bin
+for path in /opt/rh/devtoolset-*/root/usr/bin/*cc /opt/rh/devtoolset-*/root/usr/bin/*cc-[0-9]* /opt/rh/devtoolset-*/root/usr/bin/*++ /opt/rh/devtoolset-*/root/usr/bin/*++-[0-9]* /opt/rh/devtoolset-*/root/usr/bin/*cpp /opt/rh/devtoolset-*/root/usr/bin/*cpp-[0-9]*
+do
+	ln -s /usr/bin/ccache "/usr/local/ccache/bin/$(basename "$path")"
+done

--- a/tools/cibuildwheel/setup_openssl.sh
+++ b/tools/cibuildwheel/setup_openssl.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -xe
+
+TOOLS=$(dirname "$(readlink -f "$0")")
+
+. "$TOOLS/manylinux/openssl-version.sh"
+manylinux-entrypoint "$TOOLS/manylinux/build-openssl.sh"
+
+# If the build script finds a new enough openssl on the system, it will skip building.
+
+if [ -d /usr/local/ssl ]
+then
+	ln -s /usr/local/ssl/include/openssl /usr/local/include
+	ln -s /usr/local/ssl/lib/libcrypto.a /usr/local/lib
+	ln -s /usr/local/ssl/lib/libssl.a /usr/local/lib
+fi


### PR DESCRIPTION
This adds a `cibuildwheel` workflow.

## Features
 * Builds and tests wheels in 28 flavors
 * Can be run manually, with an option to upload to pypi
 * ~~Will run automatically when a release is published, **unconditionally** uploads to pypi~~
 * If a PR touches cibuildwheel infrastructure (`cibuildwheel.yml` or `tools/cibuildwheel/**`), we will test by building a *representative sample* of wheels (the full suite of wheels takes hours)
 * Caches build artifacts, so re-runs are fast

## Changes
* ~~The python project name is changed from `python-libtorrent` to just `libtorrent`. Closer to common practice in python, plus the name was available on pypi~~
* ~~Other changes to `setup.py`, following the principle that `--config-mode=distutils` should create a wheel-suitable build by default~~

## Tests
I patched this (and other dependent build system changes) on the `v1.2.14` and `v2.0.4` tags. I uploaded the wheels to test-pypi:
* https://test.pypi.org/project/libtorrent/2.0.4.post3/
* https://test.pypi.org/project/libtorrent/1.2.14.post3/

## Release procedures and notes

* @arvidn should create a pypi API token restricted to the "libtorrent" project, and add it as a github actions secret (`PYPI_API_TOKEN`)
* EDIT: also create an API token on test-pypi restricted to the separate "libtorrent" project there, and add it as a github actions secret `TEST_PYPI_API_TOKEN`
* I already registered the project on pypi (EDIT: and test-pypi), and invited @arvidn as an owner

Proposed release procedure:
* before you create a release, manually run the `cibuildwheel` workflow without publishing to pypi, to make sure everything builds
* If everything builds, run the workflow again and publish to pypi. ~~Or just create the release, and the workflow will publish automatically.~~

## Release procedure caveats
**NOTE**: pypi uploads are **immutable**, and **filenames cannot be reused even after files are deleted**. Publish with care!!

* I already uploaded some files for libtorrent 2.0.4, then deleted them, not realizing those filenames can never be used again
  * If desired, this could be remedied by publishing a 2.0.4.1 release
* It's good practice to upload to https://test.pypi.org/ before uploading the "production" index at https://pypi.org/
* ~~But "libtorrent" at test-pypi is held by someone else, I believe by github user @mayli~~ 
* ~~I have contacted @mayli by email to transfer ownership of the test-pypi project~~ EDIT: mayli transferred ownership of the project, thanks!

## Build Flavors
* `cp37-cp37m-macosx_10_9_x86_64`
* `cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64`
* `cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64`
* `cp37-cp37m-musllinux_1_1_aarch64`
* `cp37-cp37m-musllinux_1_1_x86_64`
* `cp37-cp37m-win32`
* `cp37-cp37m-win_amd64`
* `cp38-cp38-macosx_10_9_x86_64`
* `cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64`
* `cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64`
* `cp38-cp38-musllinux_1_1_aarch64`
* `cp38-cp38-musllinux_1_1_x86_64`
* `cp38-cp38-win32`
* `cp38-cp38-win_amd64`
* `cp39-cp39-macosx_10_9_x86_64`
* `cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64`
* `cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64`
* `cp39-cp39-musllinux_1_1_aarch64`
* `cp39-cp39-musllinux_1_1_x86_64`
* `cp39-cp39-win32`
* `cp39-cp39-win_amd64`
* `cp310-cp310-macosx_10_9_x86_64`
* `cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64`
* `cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64`
* `cp310-cp310-musllinux_1_1_aarch64`
* `cp310-cp310-musllinux_1_1_x86_64`
* `cp310-cp310-win32`
* `cp310-cp310-win_amd64`

## Missing flavors
### Flavors we'd like to build but can't
* macos arm64
  * the x86 macos runners *can* cross-compile, but I can't seem to make it work. We are invoking `b2 architecture=arm address-model=64` which should be right, but there are still link errors about mixing `x86_64` objects.
  * macos on x86_64 cannot run or emulate arm64 code, so these builds can't be tested until there are m1 mac runners 
* macos `universal2`
  * `b2 architecture=combined address-model=64` does not build this (should pick `-arch x86_64 -arch arm64`), even in boost 1.77.0. I tried `cxxflags="-arch x86_64 -arch arm64"`, but the compiler says these flags are unused.
  * as above, these can't be tested until there are m1 mac runners. apparently mac on m1 *can* emulate x86_64, so universal binaries *can* be tested on a single runner, just not the runners we have
* ~~`musllinux`~~
  * ~~this is new, and `cibuildwheel` doesn't support it yet~~ EDIT: the latest cibuildwheel supports this!
* pypy
  * the python bindings don't build with this. I'll investigate

### Other flavors
The build times already take hours, and the artifacts are large due to static linking, and pypi has finite hosting space. We should add flavors as requested, rather than building everything.

[Python 3.6 will reach end of life in 2021-12](https://www.python.org/dev/peps/pep-0494/), so I've preemptively removed it from the list to shorten build times. [numpy has already done this in their most recent release](https://pypi.org/project/numpy/#files)

## Future optimizations

The builds currently take hours on `aarch64` and other emulated architectures. It would be nice to reduce this.

### `abi3`
The biggest win would be to use `abi3` which would let us produce one build per platform rather than building for every python version. However
  * [boost-python doesn't support `abi3`](https://github.com/boostorg/python/issues/221)
  * [pybind11 (the main boost-python alternative) doesn't support `abi3`](https://github.com/pybind/pybind11/issues/1755)
  * [cibuildwheel is janky to use with `abi3`](https://github.com/pypa/cibuildwheel/issues/78)

### Prebuild dependencies

* openssl and boost-python (in all python versions) are built from source every time. We could cache them somewhere. On linux, using `actions/cache` is difficult  because the builds run in docker. The right approach is probably to build a custom docker image with prebuilt dependencies. This would especially cut down build times for `aarch64` and other emulated architectures.

### macos `ccache`

We build artifacts for a given platform sequentially in a single job, which lets us use `ccache`. On the Linux builds this works well today.

On mac, `ccache` reports 0% hit rates between builds for some reason. The only thing that changes is the python version. We should investigate this.

### windows `ccache` equivalent

On Windows, there is no build caching. It would be nice to have. However the Windows builds already complete in ~40 minutes, so this is a smaller gain compared to others.