### PR TITLE
Restrict some github actions by path

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,11 @@ name: Android
 on:
    push:
       branches: [ RC_2_0 master ]
+      paths-ignore:
+         - bindings/python/**
    pull_request:
+      paths-ignore:
+         - bindings/python/**
 
 env:
   NDK_VERSION: "r21d"

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -3,7 +3,11 @@ name: C bindings
 on:
    push:
       branches: [ RC_1_2 RC_2_0 master ]
+      paths-ignore:
+         - bindings/python/**
    pull_request:
+      paths-ignore:
+         - bindings/python/**
 
 jobs:
   test:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,11 @@ name: MacOS
 on:
    push:
       branches: [ RC_1_2 RC_2_0 master ]
+      paths-ignore:
+         - bindings/python/**
    pull_request:
+      paths-ignore:
+         - bindings/python/**
 
 jobs:
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,29 @@ name: Python bindings
 on:
    push:
       branches: [ RC_1_2 RC_2_0 master ]
+      paths:
+      - src/**
+      - include/**
+      - deps/**
+      - Jamfile
+      - Jamroot.jam
+      - bindings/python/**
+      - setup.py
+      - setup.cfg
+      - tox.ini
+      - pyproject.toml
    pull_request:
+      paths:
+      - src/**
+      - include/**
+      - deps/**
+      - Jamfile
+      - Jamroot.jam
+      - bindings/python/**
+      - setup.py
+      - setup.cfg
+      - tox.ini
+      - pyproject.toml
 
 jobs:
   test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,11 @@ name: Windows
 on:
    push:
       branches: [ RC_1_2 RC_2_0 master ]
+      paths-ignore:
+         - bindings/python/**
    pull_request:
+      paths-ignore:
+         - bindings/python/**
 
 defaults:
    run:


### PR DESCRIPTION
This turns on path-based restrictions for some github actions.

This adds a risk of missing some builds/tests if we don't get the paths right, but the upside is hopefully faster development speed.

If you think this is a good idea, I think we should also refactor `{linux|macos|windows}.yml` such that e.g. the build jobs are all in one workflow file, the simulation jobs in another, and the "dist" job in another.