### PR TITLE
AppVeyor: switch the CMake build to Ninja Multi-Config generators for easier build parallelization

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,6 @@ version: "{build}"
 branches:
   only:
     - master
-    - RC_2_0
-    - RC_1_2
-    - RC_1_1
 image: Visual Studio 2019
 clone_depth: 1
 environment:
@@ -93,13 +90,12 @@ build_script:
   # we need to build the boost libraries we use with C++17
   # and stage it for cmake to pick up
   - if defined cmake (
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat" &&
     cd %BOOST_ROOT% &&
     b2.exe cxxstd=17 release --with-python --with-system --layout=system address-model=64 link=shared stage &&
     cd %ROOT_DIRECTORY% &&
-    mkdir build &&
-    cd build &&
-    cmake -DBOOST_LIBRARYDIR=%BOOST_ROOT%\stage\lib -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dwebtorrent=%webtorrent% -DOPENSSL_ROOT_DIR=%ssl_root_dir% -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Visual Studio 16 2019" -A x64 .. &&
-    cmake --build . --config Release --parallel %NUMBER_OF_PROCESSORS% -- -verbosity:minimal
+    cmake -B build -DBOOST_LIBRARYDIR=%BOOST_ROOT%\stage\lib -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dwebtorrent=%webtorrent% -DOPENSSL_ROOT_DIR=%ssl_root_dir% -Dpython-bindings=%python% -Dboost-python-module-name="python" -Dskip-python-runtime-test=true -DPython_ADDITIONAL_VERSIONS="2.7" -G "Ninja Multi-Config" &&
+    cmake --build build --config Release
     )
 
 test_script:


### PR DESCRIPTION
- About `/p:UseMultiToolTask=true`: see https://discourse.cmake.org/t/parallel-does-not-really-enable-parallel-compiles-with-msbuild/964 and https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/ linked at the bottom of that discourse thread.

- Removed the `RC_*` branches, but let me know if they should still be there.

---

PR now targets `master` with only a minor change.