### PR TITLE
allow to set the ca certificate when loading a magnet link

### DIFF
--- a/include/libtorrent/add_torrent_params.hpp
+++ b/include/libtorrent/add_torrent_params.hpp
@@ -365,6 +365,12 @@ TORRENT_VERSION_NAMESPACE_3
 		error_code internal_resume_data_error;
 #endif // TORRENT_ABI_VERSION
 
+		// the root ca certificate to use in case of a magnet link that refers
+        // to an SSL Torrent. It will allow the client to connect to the corresponding swarm
+        // and downloadd the metadata. If it is not the cirrect certificate, the torrent
+        // will stay in downloading metadata state because it cannot be part of the swarm.
+        // This corresponds to the 'ssl-cert' field found on an SSL torrent.
+		std::string ca_certificate;
 	};
 
 TORRENT_VERSION_NAMESPACE_3_END

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -536,6 +536,14 @@ bool is_downloading_state(int const st)
 					? m_peer_list->num_connect_candidates() : -1);
 			}
 #endif
+       
+			if (!p.ca_certificate.empty()) {
+				m_ssl_torrent = true;
+#ifdef TORRENT_SSL_PEERS
+				init_ssl(p.ca_certificate);
+#endif
+			}
+
 		}
 
 #ifndef TORRENT_DISABLE_LOGGING

--- a/test/test_ssl.cpp
+++ b/test/test_ssl.cpp
@@ -16,8 +16,10 @@ see LICENSE file.
 #include "libtorrent/session_status.hpp"
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/hex.hpp" // for to_hex
+#include "libtorrent/magnet_uri.hpp" // for parse_magnet_uri
 #include "libtorrent/time.hpp"
 #include "libtorrent/aux_/ssl.hpp"
+#include "libtorrent/aux_/torrent.hpp"
 
 #include "test.hpp"
 #include "test_utils.hpp"
@@ -606,6 +608,21 @@ TORRENT_TEST(tcp_config5) { test_ssl(5, false); }
 TORRENT_TEST(tcp_config6) { test_ssl(6, false); }
 TORRENT_TEST(tcp_config7) { test_ssl(7, false); }
 TORRENT_TEST(tcp_config8) { test_ssl(8, false); }
+
+TORRENT_TEST(magnet_link_with_ssl) {
+    std::vector<char> ca_cert;
+    error_code ec;
+    load_file(combine_path("..", combine_path("ssl", "root_ca_cert.pem")), ca_cert, ec);
+    
+    add_torrent_params addp = parse_magnet_uri("magnet:?xt=urn:btih:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc%64");
+    addp.save_path = ".";
+    addp.ca_certificate = std::string{ca_cert.begin(), ca_cert.end()};
+
+    session ses;
+    torrent_handle handle = ses.add_torrent(std::move(addp));
+    TEST_CHECK(static_cast<bool>(handle.native_handle()->ssl_ctx()));
+}
+
 #else
 TORRENT_TEST(disabled) {}
 #endif // TORRENT_SSL_PEERS


### PR DESCRIPTION
This means that when you load a magnet link from an SSL torrent,
you can now join the swarm by calling torrent_handle::set_ssl_ca_for_metadata
when you receive the add_torrent_alert alert.
That way you can have a fully SSL controlled environment and use magnet links.

Any comment is appreciated.