### PR TITLE
Refactor benchmark tools

### DIFF
--- a/tools/benchmark_checking.py
+++ b/tools/benchmark_checking.py
@@ -1,70 +1,64 @@
 #!/usr/bin/env python3
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 
+import argparse
 import os
 import shutil
 import subprocess
 import sys
 
-toolset = ''
-if len(sys.argv) > 1:
-    toolset = sys.argv[1]
 
-ret = os.system('cd ../examples && b2 release %s stage_client_test stage_connection_tester'
-                % toolset)
-if ret != 0:
-    print('ERROR: build failed: %d' % ret)
-    sys.exit(1)
+def main():
+    args = parse_args()
 
-try:
-    os.remove('.ses_state')
-except Exception:
-    pass
-try:
-    shutil.rmtree('.resume')
-except Exception:
-    pass
-
-if not os.path.exists('checking_benchmark.torrent'):
-    ret = os.system('../examples/connection_tester gen-torrent -s 10000 -n 15 -t checking_benchmark.torrent')
+    ret = os.system('cd ../examples && b2 release %s stage_client_test stage_connection_tester'
+                    % args.toolset)
     if ret != 0:
-        print('ERROR: connection_tester failed: %d' % ret)
+        print('ERROR: build failed: %d' % ret)
         sys.exit(1)
 
-if not os.path.exists('checking_benchmark'):
-    ret = os.system('../examples/connection_tester gen-data -t checking_benchmark.torrent -p .')
-    if ret != 0:
-        print('ERROR: connection_tester failed: %d' % ret)
-        sys.exit(1)
+    rm_file_or_dir(".ses_state")
+    rm_file_or_dir(".resume")
+
+    if not os.path.exists('checking_benchmark.torrent'):
+        ret = os.system('../examples/connection_tester gen-torrent -s 10000 -n 15 -t checking_benchmark.torrent')
+        if ret != 0:
+            print('ERROR: connection_tester failed: %d' % ret)
+            sys.exit(1)
+
+    if not os.path.exists('checking_benchmark'):
+        ret = os.system('../examples/connection_tester gen-data -t checking_benchmark.torrent -p .')
+        if ret != 0:
+            print('ERROR: connection_tester failed: %d' % ret)
+            sys.exit(1)
+
+    for threads in [4, 8, 16, 32, 64]:
+        run_test('%d' % threads, '--hashing_threads=%d' % threads)
 
 
 def run_test(name, client_arg):
     output_dir = 'logs_checking_%s' % name
 
-    if os.path.exists(output_dir) and os.path.exists(os.path.join(output_dir, 'timing.txt')):
+    timing_path = os.path.join(output_dir, 'timing.txt')
+    if os.path.exists(timing_path):
+        print('file "{path}" exists, skipping test "{name}"'.format(path=timing_path, name=name))
         return
 
-    try:
-        shutil.rmtree(output_dir)
-    except Exception:
-        pass
+    rm_file_or_dir(output_dir)
     try:
         os.mkdir(output_dir)
     except Exception:
         pass
 
-    try:
-        shutil.rmtree(".resume")
-    except Exception:
-        pass
+    rm_file_or_dir(".resume")
 
-    client_cmd = '../examples/client_test checking_benchmark.torrent ' \
-                 '--enable_dht=0 --enable_lsd=0 --enable_upnp=0 --enable_natpmp=0 ' \
-                 '-1 %s -s . -f %s/events.log --alert_mask=all' \
-                 % (client_arg, output_dir)
+    client_cmd = ('../examples/client_test checking_benchmark.torrent '
+                  '--enable_dht=0 --enable_lsd=0 --enable_upnp=0 --enable_natpmp=0 '
+                  '-1 %s -s . -f %s/events.log --alert_mask=all'
+                  ) % (client_arg, output_dir)
 
     client_out = open('%s/client.out' % output_dir, 'w+')
-    print(client_cmd)
+    print('client_cmd: "{cmd}"'.format(cmd=client_cmd))
     c = subprocess.Popen(client_cmd.split(' '), stdout=client_out, stderr=client_out, stdin=subprocess.PIPE)
     c.wait()
 
@@ -85,5 +79,26 @@ def run_test(name, client_arg):
         f.write('%s: %d\n' % (name, end_time - start_time))
 
 
-for threads in [4, 8, 16, 32, 64]:
-    run_test('%d' % threads, '--hashing_threads=%d ' % threads)
+def rm_file_or_dir(path):
+    """ Attempt to remove file or directory at path
+    """
+    try:
+        shutil.rmtree(path)
+    except Exception:
+        pass
+
+    try:
+        os.remove(path)
+    except Exception:
+        pass
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument('--toolset', default="")
+
+    return p.parse_args()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/benchmark_checking.py
+++ b/tools/benchmark_checking.py
@@ -70,7 +70,7 @@ def run_test(name, client_arg):
         if 'checking_benchmark: start_checking, m_checking_piece: ' in l \
                 and start_time == 0:
             start_time = int(l.split(' ')[0][1:-1])
-        if 'checking_benchmark: on_piece_hashed, completed' in l \
+        if 'state changed to: finished' in l \
                 and start_time != 0:
             end_time = int(l.split(' ')[0][1:-1])
 

--- a/tools/run_benchmark.py
+++ b/tools/run_benchmark.py
@@ -1,60 +1,49 @@
 #!/usr/bin/env python3
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 
+import argparse
 import os
 import time
 import shutil
 import subprocess
 import sys
 
-toolset = ''
-if len(sys.argv) > 1:
-    toolset = sys.argv[1]
 
-ret = os.system('cd ../examples && b2 profile %s stage_client_test'
-                % toolset)
-if ret != 0:
-    print('ERROR: build failed: %d' % ret)
-    sys.exit(1)
+def main():
+    args = parse_args()
 
-ret = os.system('cd ../examples && b2 release %s stage_connection_tester'
-                % toolset)
-if ret != 0:
-    print('ERROR: build failed: %d' % ret)
-    sys.exit(1)
-
-try:
-    os.remove('.ses_state')
-except Exception:
-    pass
-try:
-    shutil.rmtree('.resume')
-except Exception:
-    pass
-try:
-    shutil.rmtree('cpu_benchmark')
-except Exception:
-    pass
-
-if not os.path.exists('cpu_benchmark.torrent'):
-    ret = os.system('../examples/connection_tester gen-torrent -s 10000 -n 15 -t cpu_benchmark.torrent')
+    ret = os.system('cd ../examples && b2 profile %s stage_client_test'
+                    % args.toolset)
     if ret != 0:
-        print('ERROR: connection_tester failed: %d' % ret)
+        print('ERROR: build failed: %d' % ret)
         sys.exit(1)
 
-try:
-    shutil.rmtree('t')
-except Exception:
-    pass
+    ret = os.system('cd ../examples && b2 release %s stage_connection_tester'
+                    % args.toolset)
+    if ret != 0:
+        print('ERROR: build failed: %d' % ret)
+        sys.exit(1)
+
+    rm_file_or_dir('.ses_state')
+    rm_file_or_dir('.resume')
+    rm_file_or_dir('cpu_benchmark')
+
+    if not os.path.exists('cpu_benchmark.torrent'):
+        ret = os.system('../examples/connection_tester gen-torrent -s 10000 -n 15 -t cpu_benchmark.torrent')
+        if ret != 0:
+            print('ERROR: connection_tester failed: %d' % ret)
+            sys.exit(1)
+
+    rm_file_or_dir('t')
+
+    run_test('download', 'upload', '', args.download_peers)
+    run_test('upload', 'download', '-G', args.download_peers)
 
 
 def run_test(name, test_cmd, client_arg, num_peers):
     output_dir = 'logs_%s' % name
 
-    try:
-        shutil.rmtree(output_dir)
-    except Exception:
-        pass
+    rm_file_or_dir(output_dir)
     try:
         os.mkdir(output_dir)
     except Exception:
@@ -62,30 +51,26 @@ def run_test(name, test_cmd, client_arg, num_peers):
 
     port = (int(time.time()) % 50000) + 2000
 
-    try:
-        shutil.rmtree('session_stats')
-    except Exception:
-        pass
-    try:
-        shutil.rmtree('session_stats_report')
-    except Exception:
-        pass
+    rm_file_or_dir('session_stats')
+    rm_file_or_dir('session_stats_report')
 
     start = time.time()
-    client_cmd = '../examples/client_test -k --listen_interfaces=127.0.0.1:%d cpu_benchmark.torrent ' \
-        '--disable_hash_checks=1 --enable_dht=0 --enable_lsd=0 --enable_upnp=0 --enable_natpmp=0 ' \
-        '-e 120 %s -O --allow_multiple_connections_per_ip=1 --connections_limit=%d -T %d ' \
-        '-f %s/events.log --alert_mask=8747' \
-        % (port, client_arg, num_peers * 2, num_peers * 2, output_dir)
-    test_cmd = '../examples/connection_tester %s -c %d -d 127.0.0.1 -p %d -t cpu_benchmark.torrent' % (
-        test_cmd, num_peers, port)
+    client_cmd = (
+        '../examples/client_test -k --listen_interfaces=127.0.0.1:{port} cpu_benchmark.torrent '
+        '--disable_hash_checks=1 --enable_dht=0 --enable_lsd=0 --enable_upnp=0 --enable_natpmp=0 '
+        '-e 120 {arg} -O --allow_multiple_connections_per_ip=1 --connections_limit={peers} -T {peers} '
+        '-f {output_dir}/events.log --alert_mask=8747'
+    ).format(port=port, arg=client_arg, peers=num_peers * 2, output_dir=output_dir)
+
+    test_cmd = ('../examples/connection_tester {cmd} -c {peers} -d 127.0.0.1 -p {port} -t cpu_benchmark.torrent'
+                .format(cmd=test_cmd, peers=num_peers, port=port))
 
     client_out = open('%s/client.out' % output_dir, 'w+')
     test_out = open('%s/test.out' % output_dir, 'w+')
-    print(client_cmd)
+    print('client_cmd: "{cmd}"'.format(cmd=client_cmd))
     c = subprocess.Popen(client_cmd.split(' '), stdout=client_out, stderr=client_out, stdin=subprocess.PIPE)
     time.sleep(2)
-    print(test_cmd)
+    print('test_cmd: "{cmd}"'.format(cmd=test_cmd))
     t = subprocess.Popen(test_cmd.split(' '), stdout=test_out, stderr=test_out)
 
     t.wait()
@@ -102,7 +87,7 @@ def run_test(name, test_cmd, client_arg, num_peers):
     test_out.close()
 
     print('runtime %d seconds' % (end - start))
-    print('analyzing proile...')
+    print('analyzing profile...')
     os.system('gprof ../examples/client_test >%s/gprof.out' % output_dir)
     print('generating profile graph...')
     try:
@@ -118,5 +103,28 @@ def run_test(name, test_cmd, client_arg, num_peers):
         pass
 
 
-run_test('download', 'upload', '', 50)
-run_test('upload', 'download', '-G', 20)
+def rm_file_or_dir(path):
+    """ Attempt to remove file or directory at path
+    """
+    try:
+        shutil.rmtree(path)
+    except Exception:
+        pass
+
+    try:
+        os.remove(path)
+    except Exception:
+        pass
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument('--toolset', default="")
+    p.add_argument('--download-peers', default=50, help="Number of peers to use for upload test")
+    p.add_argument('--upload-peers', default=20, help="Number of peers to use for upload test")
+
+    return p.parse_args()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Using the benchmark scripts you mentioned, I found a few things that I personally see as improvements.

Most of the diff of this PR is a refactoring away from executing everything in the global scope, but does include some minor changes to usage, e.g. taking `toolset` as an input flag instead of using the first argument of argv, and checking the event log in benchmark_checking for a different event than the existing one, which did not appear in all tests I ran.

Let me know if I there's anything I should change, split the changes into smaller commits, or if the global scope execution is there on purpose.