### PR TITLE
added missed sources to Python bindings CMakeLists.txt

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -49,6 +49,7 @@ Python3_add_library(python-libtorrent MODULE WITH_SOABI
 	src/entry.cpp
 	src/error_code.cpp
 	src/fingerprint.cpp
+	src/info_hash.cpp
 	src/ip_filter.cpp
 	src/magnet_uri.cpp
 	src/module.cpp
@@ -56,6 +57,7 @@ Python3_add_library(python-libtorrent MODULE WITH_SOABI
 	src/session.cpp
 	src/session_settings.cpp
 	src/sha1_hash.cpp
+	src/sha256_hash.cpp
 	src/string.cpp
 	src/torrent_handle.cpp
 	src/torrent_info.cpp


### PR DESCRIPTION
fixes libtorrent module loading issues:
```
libtorrent.cpython-39-x86_64-linux-gnu.so: undefined symbol: _Z16bind_sha256_hashv
```
found this by myself thanks to own Debian packages nightly builds (cmake is used for building) and a lot of scripts using python bindings. no reported issues were found.

master branch is not tested, so that's why this PR to RC_2_0 branch