### PR TITLE
Fix seed rank calculation when we're the only known seed

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9181,7 +9181,9 @@ namespace {
 		if (m_incomplete != 0xffffff) downloaders = m_incomplete;
 		else downloaders = m_peer_list ? m_peer_list->num_peers() - m_peer_list->num_seeds() : 0;
 
-		if (seeds == 0)
+		// If there is a single known seed and we're currently seeding then it's
+		// likely us, so consider the torrent otherwise seedless
+		if (seeds == 0 || (seeds == 1 && !is_paused()))
 		{
 			ret |= no_seeds;
 			ret |= downloaders & prio_mask;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9177,9 +9177,9 @@ namespace {
 
 		// If we're currently seeding and using tracker supplied scrape
 		// data, we should remove ourselves from the seed count
-		int const self_seed = is_seed() && !is_paused() ? 1 : 0;
+		std::uint32_t const self_seed = is_seed() && !is_paused() ? std::uint32_t(1) : std::uint32_t(0);
 
-		if (m_complete != 0xffffff) seeds = std::max(0, m_complete - self_seed);
+		if (m_complete != 0xffffff) seeds = std::max(std::uint32_t(0), m_complete - self_seed);
 		else seeds = m_peer_list ? m_peer_list->num_seeds() : 0;
 
 		if (m_incomplete != 0xffffff) downloaders = m_incomplete;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9177,9 +9177,9 @@ namespace {
 
 		// If we're currently seeding and using tracker supplied scrape
 		// data, we should remove ourselves from the seed count
-		std::uint32_t const self_seed = is_seed() && !is_paused() ? std::uint32_t(1) : std::uint32_t(0);
+		int const self_seed = is_seed() && !is_paused() ? 1 : 0;
 
-		if (m_complete != 0xffffff) seeds = std::max(std::uint32_t(0), m_complete - self_seed);
+		if (m_complete != 0xffffff) seeds = std::max(0, int(m_complete) - self_seed);
 		else seeds = m_peer_list ? m_peer_list->num_seeds() : 0;
 
 		if (m_incomplete != 0xffffff) downloaders = m_incomplete;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -9175,15 +9175,17 @@ namespace {
 		int seeds = 0;
 		int downloaders = 0;
 
-		if (m_complete != 0xffffff) seeds = m_complete;
+		// If we're currently seeding and using tracker supplied scrape
+		// data, we should remove ourselves from the seed count
+		int const self_seed = is_seed() && !is_paused() ? 1 : 0;
+
+		if (m_complete != 0xffffff) seeds = std::max(0, m_complete - self_seed);
 		else seeds = m_peer_list ? m_peer_list->num_seeds() : 0;
 
 		if (m_incomplete != 0xffffff) downloaders = m_incomplete;
 		else downloaders = m_peer_list ? m_peer_list->num_peers() - m_peer_list->num_seeds() : 0;
 
-		// If there is a single known seed and we're currently seeding then it's
-		// likely us, so consider the torrent otherwise seedless
-		if (seeds == 0 || (seeds == 1 && !is_paused()))
+		if (seeds == 0)
 		{
 			ret |= no_seeds;
 			ret |= downloaders & prio_mask;


### PR DESCRIPTION
When seeding, torrents with no other known seeds receive a boost to their seed rank so as to take priority. Currently this boost is only applied when there are no known seeds (ie `seeds == 0`). However, once we begin seeding, `seed_rank()` now sees that `seeds > 0` and no longer considers the torrent seedless, even though that single seed is itself. This causes queued seeds to repeatedly alternate between seeding/queued whenever the seed rank is recalculated.

See #6302 