### PR TITLE
Fix seed rank calculation when we're the only known seed (#6311)

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8616,7 +8616,11 @@ bool is_downloading_state(int const st)
 		int seeds = 0;
 		int downloaders = 0;
 
-		if (m_complete != 0xffffff) seeds = m_complete;
+		// If we're currently seeding and using tracker supplied scrape
+		// data, we should remove ourselves from the seed count
+		int const self_seed = is_seed() && !is_paused() ? 1 : 0;
+
+		if (m_complete != 0xffffff) seeds = std::max(0, int(m_complete) - self_seed);
 		else seeds = m_peer_list ? m_peer_list->num_seeds() : 0;
 
 		if (m_incomplete != 0xffffff) downloaders = m_incomplete;


### PR DESCRIPTION
Consider a torrent to be seedless if there is a single known seed and we are currently seeding, as that seed is likely us. This prevents the seed rank from osciallating, potentially causing the torrent to be repeatedly switched from active to queued whenever the seed rank is recalculated.