### PR TITLE
More python deprecations

### DIFF
--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -221,7 +221,7 @@ void bind_create_torrent()
 #endif
         .def("add_url_seed", &create_torrent::add_url_seed)
 #if TORRENT_ABI_VERSION < 4
-        .def("add_http_seed", &create_torrent::add_http_seed)
+        .def("add_http_seed", depr(&create_torrent::add_http_seed))
 #endif
         .def("add_node", &add_node)
         .def("add_tracker", add_tracker, (arg("announce_url"), arg("tier") = 0))

--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -217,7 +217,7 @@ void bind_create_torrent()
         .def("set_creation_date", &create_torrent::set_creation_date)
         .def("set_hash", &set_hash)
 #if TORRENT_ABI_VERSION < 3
-        .def("set_file_hash", &set_file_hash)
+        .def("set_file_hash", depr(&set_file_hash))
 #endif
         .def("add_url_seed", &create_torrent::add_url_seed)
 #if TORRENT_ABI_VERSION < 4

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -337,6 +337,7 @@ namespace
 #if TORRENT_ABI_VERSION < 4
             else if(key == "http_seeds")
             {
+                python_deprecated("the http_seeds member is deprecated");
                 p.http_seeds =
                     extract<decltype(add_torrent_params::http_seeds)>(value);
                 continue;

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -494,9 +494,9 @@ void bind_torrent_handle()
         .def("remove_url_seed", _(&torrent_handle::remove_url_seed))
         .def("url_seeds", url_seeds)
 #if TORRENT_ABI_VERSION < 4
-        .def("add_http_seed", _(&torrent_handle::add_http_seed))
-        .def("remove_http_seed", _(&torrent_handle::remove_http_seed))
-        .def("http_seeds", http_seeds)
+        .def("add_http_seed", depr(&torrent_handle::add_http_seed))
+        .def("remove_http_seed", depr(&torrent_handle::remove_http_seed))
+        .def("http_seeds", depr(http_seeds))
 #endif
         .def("torrent_file", _(&torrent_handle::torrent_file))
         .def("set_metadata", set_metadata)

--- a/bindings/python/src/utility.cpp
+++ b/bindings/python/src/utility.cpp
@@ -7,6 +7,7 @@
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/bdecode.hpp>
 #include "bytes.hpp"
+#include "gil.hpp"
 
 using namespace boost::python;
 using namespace lt;
@@ -88,6 +89,12 @@ struct bytes_from_python
 };
 
 #if TORRENT_ABI_VERSION == 1
+std::string identify_client_(const peer_id& p)
+{
+    python_deprecated("identify_client is deprecated");
+    return lt::identify_client(p);
+}
+
 object client_fingerprint_(peer_id const& id)
 {
     python_deprecated("client_fingerprint is deprecated");
@@ -117,7 +124,7 @@ void bind_utility()
     bytes_from_python();
 
 #if TORRENT_ABI_VERSION == 1
-    def("identify_client", &lt::identify_client);
+    def("identify_client", &identify_client_);
     def("client_fingerprint", &client_fingerprint_);
 #endif
     def("bdecode", &bdecode_);

--- a/bindings/python/tests/create_torrent_test.py
+++ b/bindings/python/tests/create_torrent_test.py
@@ -433,17 +433,6 @@ class CreateTorrentTest(unittest.TestCase):
         entry = ct.generate()
         self.assertEqual(entry[b"url-list"], b"http://example.com")
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/6136")
-    def test_http_seed(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file("test.txt", 1024)
-        ct = lt.create_torrent(fs)
-        ct.add_http_seed("http://example.com")
-        ct.set_hash(0, lib.get_random_bytes(20))
-        entry = ct.generate()
-        self.assertEqual(entry[b"url-list"], [b"http://example.com"])
-
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
     def test_http_seed_deprecated(self) -> None:
         fs = lt.file_storage()
         ct = lt.create_torrent(fs)

--- a/bindings/python/tests/create_torrent_test.py
+++ b/bindings/python/tests/create_torrent_test.py
@@ -390,19 +390,12 @@ class CreateTorrentTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ct.set_hash(0, lib.get_random_bytes(19))
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
-    def test_set_file_hash_deprecated(self) -> None:
+    def test_set_file_hash(self) -> None:
         fs = lt.file_storage()
         fs.add_file("test.txt", 1024)
         ct = lt.create_torrent(fs)
         with self.assertWarns(DeprecationWarning):
             ct.set_file_hash(0, lib.get_random_bytes(20))
-
-    def test_set_file_hash(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file("test.txt", 1024)
-        ct = lt.create_torrent(fs)
-        ct.set_file_hash(0, lib.get_random_bytes(20))
         ct.set_hash(0, lib.get_random_bytes(20))
         entry = ct.generate()
         self.assertIn(b"sha1", entry[b"info"])

--- a/bindings/python/tests/torrent_handle_test.py
+++ b/bindings/python/tests/torrent_handle_test.py
@@ -306,15 +306,6 @@ class UrlSeedTest(TorrentHandleTest):
         self.handle.remove_url_seed("http://127.1.2.3")
         self.assertEqual(self.handle.url_seeds(), [])
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/6136")
-    def test_http_seeds(self) -> None:
-        self.assertEqual(self.handle.http_seeds(), [])
-        self.handle.add_http_seed("http://127.1.2.3")
-        self.assertEqual(self.handle.http_seeds(), ["http://127.1.2.3"])
-        self.handle.remove_http_seed("http://127.1.2.3")
-        self.assertEqual(self.handle.http_seeds(), [])
-
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
     def test_http_seeds_deprecated(self) -> None:
         with self.assertWarns(DeprecationWarning):
             self.handle.add_http_seed("http://127.1.2.3")

--- a/bindings/python/tests/torrent_handle_test.py
+++ b/bindings/python/tests/torrent_handle_test.py
@@ -672,11 +672,6 @@ class InfoHashTest(TorrentHandleTest):
             self.handle.info_hashes(), lt.info_hash_t(self.torrent.sha1_hash)
         )
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
-    def test_info_hash_deprecated(self) -> None:
-        with self.assertWarns(DeprecationWarning):
-            self.handle.info_hash()
-
 
 class ForceRecheckTest(TorrentHandleTest):
     def test_force_recheck(self) -> None:

--- a/bindings/python/tests/torrent_info_test.py
+++ b/bindings/python/tests/torrent_info_test.py
@@ -223,12 +223,6 @@ class ConstructorTest(unittest.TestCase):
         ti = lt.torrent_info(lt.info_hash_t(sha1))
         self.assertEqual(ti.info_hashes(), lt.info_hash_t(sha1))
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
-    def test_sha1_hash_deprecated(self) -> None:
-        sha1 = lt.sha1_hash(lib.get_random_bytes(20))
-        with self.assertWarns(DeprecationWarning):
-            lt.torrent_info(sha1)
-
     def test_sha1_hash(self) -> None:
         sha1 = lt.sha1_hash(lib.get_random_bytes(20))
         ti = lt.torrent_info(sha1)

--- a/bindings/python/tests/utility_test.py
+++ b/bindings/python/tests/utility_test.py
@@ -47,13 +47,9 @@ class BencodeTest(unittest.TestCase):
 
 
 class IdentifyClientTest(unittest.TestCase):
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
-    def test_deprecated(self) -> None:
-        with self.assertWarns(DeprecationWarning):
-            lt.identify_client(lt.sha1_hash())
-
     def test_identify_client(self) -> None:
-        self.assertEqual(lt.identify_client(lt.sha1_hash()), "Unknown")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(lt.identify_client(lt.sha1_hash()), "Unknown")
 
 
 class ClientFingerprintTest(unittest.TestCase):


### PR DESCRIPTION
Progress toward #5967

 * `create_torrent.set_file_hash()`
 * `create_torrent.add_http_seed()`
 * `torrent_handle.http_seeds()`
 * `torrent_handle.add_http_seed()`
 * `torrent_handle.remove_http_seed()`
 * `identify_client()`

I also removed some `skip()`ed tests that I added with a wrong understanding. I thought `sha1_hash` was going away, rather than staying around to mean "sha1 or truncated sha256", so I had added these tests with `@unittest.skip()` intending that the behavior be corrected and the `skip()` removed. These tests are now removed.