### PR TITLE
document root_hash parameter to file_storage::add_file()

### DIFF
--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -169,8 +169,17 @@ void bind_create_torrent()
         .def("file_path", file_storage_file_path, (arg("idx"), arg("save_path") = ""))
         .def("file_name", file_storage_file_name)
         .def("file_size", file_storage_file_size)
+        .def("root", &file_storage::root)
         .def("file_offset", file_storage_file_offset)
         .def("file_flags", file_storage_file_flags)
+
+        .def("file_index_for_root", &file_storage::file_index_for_root)
+        .def("piece_index_at_file", &file_storage::piece_index_at_file)
+        .def("file_index_at_piece", &file_storage::file_index_at_piece)
+        .def("file_index_at_offset", &file_storage::file_index_at_offset)
+        .def("file_absolute_path", &file_storage::file_absolute_path)
+
+        .def("v2", &file_storage::v2)
 
         .def("total_size", &file_storage::total_size)
         .def("set_num_pieces", &file_storage::set_num_pieces)

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -287,6 +287,16 @@ namespace aux {
 		// ``symlink_path`` is the path the file is a symlink to. To make this a
 		// symlink you also need to set the file_storage::flag_symlink file flag.
 		//
+		// ``root_hash`` is an optional pointer to a 32 byte SHA-256 hash, being
+		// the merkle tree root hash for this file. This is only used for v2
+		// torrents. If the ``root hash`` is specified for one file, it has to
+		// be specified for all, otherwise this function will fail.
+		// Note that the buffer ``root_hash`` points to must out-live the
+		// file_storage object, it will not be copied. This parameter is only
+		// used when *loading* torrents, that already have their file hashes
+		// computed. When creating torrents, the file hashes will be computed by
+		// the piece hashes.
+		//
 		// If more files than one are added, certain restrictions to their paths
 		// apply. In a multi-file file storage (torrent), all files must share
 		// the same root directory.


### PR DESCRIPTION
Add missing members to python binding of file_storage