### PR TITLE
Fix conversion of file_progress_flags_t from python

### DIFF
--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -549,4 +549,5 @@ void bind_converters()
     to_bitfield_flag<lt::reannounce_flags_t>();
     to_string_view();
     to_bitfield_flag<lt::session_flags_t>();
+    to_bitfield_flag<lt::file_progress_flags_t>();
 }

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -229,6 +229,9 @@ class test_torrent_handle(unittest.TestCase):
         self.setup()
         status = self.h.file_status()
         print(status)
+        progress = self.h.file_progress()
+        print(progress)
+        self.h.file_progress(lt.file_progress_flags_t.piece_granularity)
 
     def test_piece_deadlines(self):
         self.setup()


### PR DESCRIPTION
`torrent_handle.file_progress()` does not work as there is no conversion of `file_progress_flags_t` from python. 