### PR TITLE
Fixup fingerprint and its deprecations

### DIFF
--- a/bindings/python/src/fingerprint.cpp
+++ b/bindings/python/src/fingerprint.cpp
@@ -6,6 +6,18 @@
 #include "gil.hpp"
 #include <libtorrent/fingerprint.hpp>
 
+#if TORRENT_ABI_VERSION == 1
+#include "libtorrent/aux_/disable_deprecation_warnings_push.hpp"
+
+std::shared_ptr<lt::fingerprint> fingerprint_constructor(char const* name, int major, int minor, int revision, int tag)
+{
+    python_deprecated("the fingerprint class is deprecated");
+    return std::make_shared<lt::fingerprint>(name, major, minor, revision, tag);
+}
+
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif // TORRENT_ABI_VERSION
+
 void bind_fingerprint()
 {
     using namespace boost::python;
@@ -17,16 +29,12 @@ void bind_fingerprint()
 #include "libtorrent/aux_/disable_deprecation_warnings_push.hpp"
 
     class_<fingerprint>("fingerprint", no_init)
-        .def(
-            init<char const*,int,int,int,int>(
-                (arg("id"), "major", "minor", "revision", "tag")
-            )
-        )
-        .def("__str__", depr(&fingerprint::to_string))
-        .def_readonly("major_version", depr(&fingerprint::major_version))
-        .def_readonly("minor_version", depr(&fingerprint::minor_version))
-        .def_readonly("revision_version", depr(&fingerprint::revision_version))
-        .def_readonly("tag_version", depr(&fingerprint::tag_version))
+        .def("__init__", make_constructor(&fingerprint_constructor))
+        .def("__str__", &fingerprint::to_string)
+        .def_readonly("major_version", &fingerprint::major_version)
+        .def_readonly("minor_version", &fingerprint::minor_version)
+        .def_readonly("revision_version", &fingerprint::revision_version)
+        .def_readonly("tag_version", &fingerprint::tag_version)
         ;
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -706,7 +706,7 @@ namespace
 #ifndef TORRENT_DISABLE_DHT
     void dht_get_mutable_item(lt::session& ses, bytes key, bytes salt)
     {
-        if (key.size() != 32)
+        if (key.arr.size() != 32)
             throw std::invalid_argument("key has wrong size, should be 32");
         std::array<char, 32> public_key;
         std::copy(key.arr.begin(), key.arr.end(), public_key.begin());
@@ -733,9 +733,9 @@ namespace
     void dht_put_mutable_item(lt::session& ses, bytes private_key, bytes public_key,
         bytes data, bytes salt)
     {
-        if (private_key.size() != 64)
+        if (private_key.arr.size() != 64)
             throw std::invalid_argument("private key has wrong length, should be 64");
-        if (public_key.size() != 32)
+        if (public_key.arr.size() != 32)
             throw std::invalid_argument("public key has wrong length, should be 32");
         std::array<char, 32> key;
         std::copy(public_key.arr.begin(), public_key.arr.end(), key.begin());

--- a/bindings/python/tests/fingerprint_test.py
+++ b/bindings/python/tests/fingerprint_test.py
@@ -55,29 +55,16 @@ class GenerateFingerprintTest(unittest.TestCase):
 
 
 class FingerprintTest(unittest.TestCase):
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
-    def test_deprecations(self) -> None:
-        with self.assertWarns(DeprecationWarning):
-            lt.fingerprint("AB", 1, 2, 3, 4)
-
     def test_fingerprint(self) -> None:
-        fprint = lt.fingerprint("AB", 1, 2, 3, 4)
         with self.assertWarns(DeprecationWarning):
-            self.assertEqual(str(fprint), "-AB1234-")
-        # self.assertEqual(fprint.major_version, 1)
-        # self.assertEqual(fprint.minor_version, 2)
-        # self.assertEqual(fprint.revision_version, 3)
-        # self.assertEqual(fprint.tag_version, 4)
-
-        # short names behave differently
-        fprint = lt.fingerprint("A", 1, 2, 3, 4)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(str(fprint), "-A\x001234-")
-
-    @unittest.skip("fingerprint.<attr> broke")
-    def test_fingerprint_broken(self) -> None:
-        fprint = lt.fingerprint("AB", 1, 2, 3, 4)
+            fprint = lt.fingerprint("AB", 1, 2, 3, 4)
+        self.assertEqual(str(fprint), "-AB1234-")
         self.assertEqual(fprint.major_version, 1)
         self.assertEqual(fprint.minor_version, 2)
         self.assertEqual(fprint.revision_version, 3)
         self.assertEqual(fprint.tag_version, 4)
+
+        # short names behave differently
+        with self.assertWarns(DeprecationWarning):
+            fprint = lt.fingerprint("A", 1, 2, 3, 4)
+        self.assertEqual(str(fprint), "-A\x001234-")

--- a/bindings/python/tests/session_test.py
+++ b/bindings/python/tests/session_test.py
@@ -847,7 +847,8 @@ class ConstructorTest(unittest.TestCase):
         session.apply_settings(lib.get_isolated_settings())
 
     def test_fingerprint(self) -> None:
-        fingerprint = lt.fingerprint("AB", 1, 2, 3, 4)
+        with self.assertWarns(DeprecationWarning):
+            fingerprint = lt.fingerprint("AB", 1, 2, 3, 4)
 
         session = lt.session(fingerprint)
         session.apply_settings(lib.get_isolated_settings())

--- a/bindings/python/tests/utility_test.py
+++ b/bindings/python/tests/utility_test.py
@@ -56,5 +56,4 @@ class ClientFingerprintTest(unittest.TestCase):
     def test_identify_client(self) -> None:
         with self.assertWarns(DeprecationWarning):
             fprint = lt.client_fingerprint(lt.sha1_hash(b"-AB1200-............"))
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(str(fprint), "-AB1200-")
+        self.assertEqual(str(fprint), "-AB1200-")


### PR DESCRIPTION
`fingerprint`'s members were broken. We still want them to work, unless we want to delete the class altogether

I modified the `DeprecationWarning` so it fires in the constructor, rather than member functions.