### PR TITLE
Fix binding for file_progress_flags_t

### DIFF
--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -543,4 +543,5 @@ void bind_converters()
     to_bitfield_flag<lt::reannounce_flags_t>();
     to_string_view();
     to_bitfield_flag<lt::session_flags_t>();
+    to_bitfield_flag<lt::file_progress_flags_t>();
 }

--- a/bindings/python/tests/torrent_handle_test.py
+++ b/bindings/python/tests/torrent_handle_test.py
@@ -193,7 +193,6 @@ class DownloadQueueTest(TorrentHandleTest):
 
 
 class FileProgressTest(TorrentHandleTest):
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
     def test_file_progress(self) -> None:
         self.assertEqual(self.handle.file_progress(), [0])
         self.assertEqual(


### PR DESCRIPTION
This is the same as #6350, but it updates the new python test suite in master.

Progress toward #5995