### PR TITLE
Deprecate sha1_hash('str')

### DIFF
--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -706,7 +706,7 @@ namespace
 #ifndef TORRENT_DISABLE_DHT
     void dht_get_mutable_item(lt::session& ses, bytes key, bytes salt)
     {
-        if (key.size() != 32)
+        if (key.arr.size() != 32)
             throw std::invalid_argument("key has wrong size, should be 32");
         std::array<char, 32> public_key;
         std::copy(key.arr.begin(), key.arr.end(), public_key.begin());
@@ -733,9 +733,9 @@ namespace
     void dht_put_mutable_item(lt::session& ses, bytes private_key, bytes public_key,
         bytes data, bytes salt)
     {
-        if (private_key.size() != 64)
+        if (private_key.arr.size() != 64)
             throw std::invalid_argument("private key has wrong length, should be 64");
-        if (public_key.size() != 32)
+        if (public_key.arr.size() != 32)
             throw std::invalid_argument("public key has wrong length, should be 32");
         std::array<char, 32> key;
         std::copy(public_key.arr.begin(), public_key.arr.end(), key.begin());

--- a/bindings/python/tests/sha1_hash_test.py
+++ b/bindings/python/tests/sha1_hash_test.py
@@ -20,13 +20,9 @@ class Sha1HashTest(unittest.TestCase):
             sha1 = lt.sha1_hash(b"a" * 21)
         self.assertEqual(sha1.to_bytes(), b"a" * 20)
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5967")
-    def test_init_str_deprecated(self) -> None:
-        with self.assertWarns(DeprecationWarning):
-            lt.sha1_hash("a" * 20)  # type: ignore
-
     def test_init_str(self) -> None:
-        sha1 = lt.sha1_hash("a" * 20)  # type: ignore
+        with self.assertWarns(DeprecationWarning):
+            sha1 = lt.sha1_hash("a" * 20)  # type: ignore
         self.assertEqual(sha1.to_bytes(), b"a" * 20)
 
     def test_equal(self) -> None:


### PR DESCRIPTION
Progress toward #5988