### PR TITLE
Fix dht_[im]mutable_item_alert.item to just be the item

### DIFF
--- a/bindings/python/install_data/libtorrent/__init__.pyi
+++ b/bindings/python/install_data/libtorrent/__init__.pyi
@@ -479,7 +479,7 @@ class dht_get_peers_reply_alert(alert):
     info_hash: sha1_hash
 
 class dht_immutable_item_alert(alert):
-    item: _Entry
+    item: Optional[_Entry]
     target: sha1_hash
 
 class _DhtNodeDict(TypedDict):
@@ -513,7 +513,7 @@ class dht_module_t:
 
 class dht_mutable_item_alert(alert):
     authoritative: bool
-    item: _Entry
+    item: Optional[_Entry]
     key: bytes
     salt: bytes
     seq: int

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -91,26 +91,6 @@ list dht_stats_routing_table(dht_stats_alert const& a)
    return result;
 }
 
-dict dht_immutable_item(dht_immutable_item_alert const& alert)
-{
-    dict d;
-    d["key"] = alert.target;
-    d["value"] = bytes(alert.item.string());
-    return d;
-}
-
-dict dht_mutable_item(dht_mutable_item_alert const& alert)
-{
-    dict d;
-    d["key"] = bytes(alert.key.data(), alert.key.size());
-    d["value"] = bytes(alert.item.string());
-    d["signature"] = bytes(alert.signature.data(), alert.signature.size());
-    d["seq"] = alert.seq;
-    d["salt"] = bytes(alert.salt);
-    d["authoritative"] = alert.authoritative;
-    return d;
-}
-
 bytes dht_mutable_item_salt(dht_mutable_item_alert const& alert)
 {
     return bytes(alert.salt);
@@ -119,20 +99,6 @@ bytes dht_mutable_item_salt(dht_mutable_item_alert const& alert)
 bytes dht_put_alert_salt(dht_put_alert const& alert)
 {
     return bytes(alert.salt);
-}
-
-dict dht_put_item(dht_put_alert const& alert)
-{
-    dict d;
-    if (alert.target.is_all_zeros()) {
-        d["public_key"] = bytes(alert.public_key.data(), alert.public_key.size());
-        d["signature"] = bytes(alert.signature.data(), alert.signature.size());
-        d["seq"] = alert.seq;
-        d["salt"] = bytes(alert.salt);
-    } else {
-        d["target"] = alert.target;
-    }
-    return d;
 }
 
 dict session_stats_values(session_stats_alert const& alert)
@@ -1063,7 +1029,7 @@ void bind_alert()
     class_<dht_immutable_item_alert, bases<alert>, noncopyable>(
        "dht_immutable_item_alert", no_init)
         .add_property("target", make_getter(&dht_immutable_item_alert::target, by_value()))
-        .add_property("item", &dht_immutable_item)
+        .add_property("item", make_getter(&dht_immutable_item_alert::item, by_value()))
         ;
 
     class_<dht_mutable_item_alert, bases<alert>, noncopyable>(
@@ -1072,7 +1038,7 @@ void bind_alert()
         .add_property("signature", make_getter(&dht_mutable_item_alert::signature, by_value()))
         .def_readonly("seq", &dht_mutable_item_alert::seq)
         .add_property("salt", &dht_mutable_item_salt)
-        .add_property("item", &dht_mutable_item)
+        .add_property("item", make_getter(&dht_mutable_item_alert::item, by_value()))
         .def_readonly("authoritative", &dht_mutable_item_alert::authoritative)
         ;
 

--- a/bindings/python/tests/alert_test.py
+++ b/bindings/python/tests/alert_test.py
@@ -2016,18 +2016,8 @@ class DhtImmutableItemAlertTest(DhtAlertTest):
 
         self.assert_alert(alert, lt.alert_category.dht, "dht_immutable_item")
         self.assertEqual(alert.target, sha1)
-        # self.assertEqual(alert.item, item)
-
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
-    def test_broken(self) -> None:
-        item = {b"test": b"test"}
-        sha1 = self.peer.dht_put_immutable_item(item)
-        self.session.apply_settings({"dht_bootstrap_nodes": self.peer_endpoint_str})
-        self.session.dht_get_immutable_item(sha1)
-
-        alert = wait_for(self.session, lt.dht_immutable_item_alert, timeout=5)
-
-        self.assertEqual(alert.item, item)
+        # TODO: rewrite this test so we get real data
+        self.assertIsNone(alert.item, None)
 
 
 class DhtMutableItemAlertTest(DhtAlertTest):
@@ -2045,26 +2035,12 @@ class DhtMutableItemAlertTest(DhtAlertTest):
 
         self.assert_alert(alert, lt.alert_category.dht, "dht_mutable_item")
         self.assertEqual(alert.key, public.to_bytes())
-        # self.assertEqual(alert.item, data)
+        # TODO: rewrite this test so we get real data
+        self.assertIsNone(alert.item, None)
         self.assertIsInstance(alert.signature, bytes)
         self.assertEqual(alert.salt, salt)
         self.assertIsInstance(alert.seq, int)
         self.assertTrue(alert.authoritative)
-
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
-    def test_broken(self) -> None:
-        private, public = ed25519.create_keypair()
-        data = b"test"
-        salt = b"salt"
-        self.peer.dht_put_mutable_item(
-            private.to_bytes(), public.to_bytes(), data, salt
-        )
-        self.session.apply_settings({"dht_bootstrap_nodes": self.peer_endpoint_str})
-        self.session.dht_get_mutable_item(public.to_bytes(), salt)
-
-        alert = wait_for(self.session, lt.dht_mutable_item_alert, timeout=5)
-
-        self.assertEqual(alert.item, data)
 
 
 class DhtPutAlertTest(DhtAlertTest):


### PR DESCRIPTION
Progress toward #5995

This is a radical change of the binding in the alerts, but I think it makes sense. It looks like the existing binding hasn't really worked for some time, or at least I haven't been able to make it work. Anyway this makes much more sense than having `alert.item` return a dict of all the other members of the alert.

My current tests are only generating "failure" versions of `dht_[im]mutable_item_alert`, where the item is unset. I need to redo the tests to generate real data. I expect I need to change dht bootstrapping, which will probably change *all* the dht tests, so I will do that in a later PR after the current ones are done.