### PR TITLE
fix refactoring bug where buffer read_pos was checked after being used

### DIFF
--- a/include/libtorrent/http_stream.hpp
+++ b/include/libtorrent/http_stream.hpp
@@ -163,7 +163,7 @@ private:
 		// look for \n\n and \r\n\r\n
 		// both of which means end of http response header
 		bool found_end = false;
-		if (m_buffer[read_pos - 1] == '\n' && read_pos > 2)
+		if (read_pos > 2 && m_buffer[read_pos - 1] == '\n')
 		{
 			if (m_buffer[read_pos - 2] == '\n')
 			{


### PR DESCRIPTION
introduced when turning http_stream handlers into templates
as highlighted by https://pvs-studio.com/en/blog/posts/cpp/0846/