### PR TITLE
fix typo clearing the dht_torrents counter in deprecated dht_tracker::dht_status()

### DIFF
--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -203,7 +203,6 @@ namespace libtorrent { namespace dht {
 		s.dht_nodes = 0;
 		s.dht_node_cache = 0;
 		s.dht_global_nodes = 0;
-		s.dht_torrents = 0;
 		s.active_requests.clear();
 		s.dht_total_allocations = 0;
 


### PR DESCRIPTION
as highlighted by https://pvs-studio.com/en/blog/posts/cpp/0846/