### PR TITLE
Fix deprecated session.add_torrent form to prevent crash

### DIFF
--- a/bindings/python/install_data/libtorrent/__init__.pyi
+++ b/bindings/python/install_data/libtorrent/__init__.pyi
@@ -1277,8 +1277,8 @@ class session:
     @overload
     def add_torrent(
         self,
-        _ti: torrent_info,
-        _save: _PathLike,
+        ti: torrent_info,
+        save: _PathLike,
         resume_data: Optional[_Entry] = ...,
         storage_mode: storage_mode_t = ...,
         paused: bool = ...,

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -1177,6 +1177,8 @@ void bind_session()
         .def(
             "add_torrent", depr(&add_torrent_depr)
           , (
+                arg("ti"),
+                arg("save"),
                 arg("resume_data") = entry(),
                 arg("storage_mode") = storage_mode_sparse,
                 arg("paused") = false

--- a/bindings/python/tests/session_test.py
+++ b/bindings/python/tests/session_test.py
@@ -1107,7 +1107,6 @@ class AddTorrentTest(unittest.TestCase):
     def tearDown(self) -> None:
         lib.cleanup_with_windows_fix(self.dir, timeout=5)
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5989")
     def test_old_style_with_wrong_args(self) -> None:
         with self.assertRaises(TypeError):
             self.session.add_torrent(  # type: ignore


### PR DESCRIPTION
Last task for #5989

It looks like boost-python crashes if the `arg("...")` names don't match the wrapped function, and the wrong form of args are passed from python.