### PR TITLE
Removed some unused tests

### DIFF
--- a/bindings/python/tests/torrent_handle_test.py
+++ b/bindings/python/tests/torrent_handle_test.py
@@ -735,16 +735,6 @@ class CertificateTest(TorrentHandleTest):
             cert_path, privkey_path, dhparam_path, passphrase="passphrase"
         )
 
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5988")
-    def test_passphrase_str_deprecated(self) -> None:
-        cert_path = os.path.join(self.dir.name, "cert")
-        privkey_path = os.path.join(self.dir.name, "privkey")
-        dhparam_path = os.path.join(self.dir.name, "dhparam")
-        with self.assertWarns(DeprecationWarning):
-            self.handle.set_ssl_certificate(
-                cert_path, privkey_path, dhparam_path, passphrase="passphrase"
-            )
-
 
 class FlagsTest(TorrentHandleTest):
     def test_flags(self) -> None:

--- a/bindings/python/tests/torrent_info_test.py
+++ b/bindings/python/tests/torrent_info_test.py
@@ -128,28 +128,12 @@ class ConstructorTest(unittest.TestCase):
             ti = lt.torrent_info(path)
         self.assertEqual(ti.name(), "test.txt")
 
-    @unittest.skip("bytes argument broke")
     def test_filename(self) -> None:
         # ascii str
         self.do_test_filename("test.torrent")
 
-        # ascii bytes
-        self.do_test_filename(b"test.torrent")
-
         # non-ascii str
         self.do_test_filename("test-\u1234.torrent")
-
-        # non-ascii str
-        self.do_test_filename(os.fsencode("test-\u1234.torrent"))
-
-    @unittest.skip("bytes argument broke")
-    @lib.uses_non_unicode_paths()
-    def test_filename_non_unicode(self) -> None:
-        # non-unicode str
-        # self.do_test_filename(os.fsdecode(b"test-\xff.torrent"))
-
-        # non-unicode bytes
-        self.do_test_filename(b"test-\xff.torrent")
 
     @unittest.skip("https://github.com/arvidn/libtorrent/issues/5984")
     @lib.uses_non_unicode_paths()
@@ -181,23 +165,6 @@ class ConstructorTest(unittest.TestCase):
                     }
                 }
             )
-        self.assertEqual(ti.name(), "test.txt")
-
-    @unittest.skip("constructor is mapped, but doesn't recognize valid data")
-    def test_buffer(self) -> None:
-        entry = {
-            b"info": {
-                b"name": b"test.txt",
-                b"piece length": 16384,
-                b"pieces": lib.get_random_bytes(20),
-                b"length": 1024,
-            }
-        }
-        data = lt.bencode(entry)
-
-        ti = lt.torrent_info(bytearray(data))
-        self.assertEqual(ti.name(), "test.txt")
-        ti = lt.torrent_info(memoryview(data))
         self.assertEqual(ti.name(), "test.txt")
 
     def test_copy_constructor(self) -> None:


### PR DESCRIPTION
I originally wrote these tests so they could just have the `@unittest.skip()` removed when functions were implemented/fixed.

I later decided that the fixes weren't necessary in each case.