### PR TITLE
Python DHT alert test improvements

### DIFF
--- a/bindings/python/install_data/libtorrent/__init__.pyi
+++ b/bindings/python/install_data/libtorrent/__init__.pyi
@@ -479,7 +479,7 @@ class dht_get_peers_reply_alert(alert):
     info_hash: sha1_hash
 
 class dht_immutable_item_alert(alert):
-    item: _Entry
+    item: Optional[_Entry]
     target: sha1_hash
 
 class _DhtNodeDict(TypedDict):
@@ -513,7 +513,7 @@ class dht_module_t:
 
 class dht_mutable_item_alert(alert):
     authoritative: bool
-    item: _Entry
+    item: Optional[_Entry]
     key: bytes
     salt: bytes
     seq: int

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -91,26 +91,6 @@ list dht_stats_routing_table(dht_stats_alert const& a)
    return result;
 }
 
-dict dht_immutable_item(dht_immutable_item_alert const& alert)
-{
-    dict d;
-    d["key"] = alert.target;
-    d["value"] = bytes(alert.item.string());
-    return d;
-}
-
-dict dht_mutable_item(dht_mutable_item_alert const& alert)
-{
-    dict d;
-    d["key"] = bytes(alert.key.data(), alert.key.size());
-    d["value"] = bytes(alert.item.string());
-    d["signature"] = bytes(alert.signature.data(), alert.signature.size());
-    d["seq"] = alert.seq;
-    d["salt"] = bytes(alert.salt);
-    d["authoritative"] = alert.authoritative;
-    return d;
-}
-
 bytes dht_mutable_item_salt(dht_mutable_item_alert const& alert)
 {
     return bytes(alert.salt);
@@ -119,20 +99,6 @@ bytes dht_mutable_item_salt(dht_mutable_item_alert const& alert)
 bytes dht_put_alert_salt(dht_put_alert const& alert)
 {
     return bytes(alert.salt);
-}
-
-dict dht_put_item(dht_put_alert const& alert)
-{
-    dict d;
-    if (alert.target.is_all_zeros()) {
-        d["public_key"] = bytes(alert.public_key.data(), alert.public_key.size());
-        d["signature"] = bytes(alert.signature.data(), alert.signature.size());
-        d["seq"] = alert.seq;
-        d["salt"] = bytes(alert.salt);
-    } else {
-        d["target"] = alert.target;
-    }
-    return d;
 }
 
 dict session_stats_values(session_stats_alert const& alert)
@@ -1063,7 +1029,7 @@ void bind_alert()
     class_<dht_immutable_item_alert, bases<alert>, noncopyable>(
        "dht_immutable_item_alert", no_init)
         .add_property("target", make_getter(&dht_immutable_item_alert::target, by_value()))
-        .add_property("item", &dht_immutable_item)
+        .add_property("item", make_getter(&dht_immutable_item_alert::item, by_value()))
         ;
 
     class_<dht_mutable_item_alert, bases<alert>, noncopyable>(
@@ -1072,7 +1038,7 @@ void bind_alert()
         .add_property("signature", make_getter(&dht_mutable_item_alert::signature, by_value()))
         .def_readonly("seq", &dht_mutable_item_alert::seq)
         .add_property("salt", &dht_mutable_item_salt)
-        .add_property("item", &dht_mutable_item)
+        .add_property("item", make_getter(&dht_mutable_item_alert::item, by_value()))
         .def_readonly("authoritative", &dht_mutable_item_alert::authoritative)
         ;
 

--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -1,3 +1,2 @@
-ed25519
 importlib-resources
 typing-extensions

--- a/bindings/python/tests/alert_test.py
+++ b/bindings/python/tests/alert_test.py
@@ -16,8 +16,6 @@ from typing import Type
 from typing import TypeVar
 import unittest
 
-import ed25519
-
 import libtorrent as lt
 
 from . import lib
@@ -2051,20 +2049,37 @@ class DhtMutableItemAlertTest(DhtAlertTest):
     ALERT_MASK = lt.alert_category.dht
 
     def test_dht_mutable_item_alert(self) -> None:
-        private, public = ed25519.create_keypair()
+        # NB: libtorrent uses private keys in hased-and-exponentiated form, not
+        # concatenated <seed><pubkey> form used by some implementations
+        pk = bytes.fromhex(
+            "77ff84905a91936367c01360803104f92432fcd904a43511876df5cdf3e7e548"
+        )
+        sk = bytes.fromhex(
+            "e06d3183d14159228433ed599221b80bd0a5ce8352e4bdf0262f76786ef1c74d"
+            "b7e7a9fea2c0eb269d61e3b38e450a22e754941ac78479d6c54e1faf6037881d"
+        )
+        data = b"test"
         salt = b"salt"
-        self.session.dht_get_mutable_item(public.to_bytes(), salt)
+        # Put the item, and wait for success
+        self.session.dht_put_mutable_item(sk, pk, data, salt)
+        wait_for(self.session, lt.dht_put_alert, timeout=5)
+        self.session.dht_get_mutable_item(pk, salt)
 
         alert = wait_for(self.session, lt.dht_mutable_item_alert, timeout=5)
 
         self.assert_alert(alert, lt.alert_category.dht, "dht_mutable_item")
-        self.assertEqual(alert.key, public.to_bytes())
-        # TODO: rewrite this test so we get real data
-        self.assertIsNone(alert.item, None)
-        self.assertIsInstance(alert.signature, bytes)
+        self.assertEqual(alert.key, pk)
+        self.assertEqual(alert.item, data)
+        self.assertEqual(
+            alert.signature,
+            bytes.fromhex(
+                "aeaa269b37bab7f87126c8d0cc31fb9c88ea81f0d0d5338166d103be8ea16f16"
+                "2d017ce812926a24dc697beb6915bec986e9eb0a37f262150cd90f2add54f805"
+            ),
+        )
         self.assertEqual(alert.salt, salt)
-        self.assertIsInstance(alert.seq, int)
-        self.assertTrue(alert.authoritative)
+        self.assertEqual(alert.seq, 1)
+        self.assertFalse(alert.authoritative)
 
 
 class DhtPutAlertTest(DhtAlertTest):
@@ -2089,22 +2104,38 @@ class DhtPutAlertTest(DhtAlertTest):
         self.assertGreater(alert.num_success, 0)
 
     def test_dht_put_alert_with_mutable(self) -> None:
-        private, public = ed25519.create_keypair()
+        # NB: libtorrent uses private keys in hased-and-exponentiated form, not
+        # concatenated <seed><pubkey> form used by some implementations
+        pk = bytes.fromhex(
+            "77ff84905a91936367c01360803104f92432fcd904a43511876df5cdf3e7e548"
+        )
+        sk = bytes.fromhex(
+            "e06d3183d14159228433ed599221b80bd0a5ce8352e4bdf0262f76786ef1c74d"
+            "b7e7a9fea2c0eb269d61e3b38e450a22e754941ac78479d6c54e1faf6037881d"
+        )
         data = b"test"
         salt = b"salt"
-        self.session.dht_put_mutable_item(
-            private.to_bytes(), public.to_bytes(), data, salt
-        )
+        self.session.dht_put_mutable_item(sk, pk, data, salt)
 
         alert = wait_for(self.session, lt.dht_put_alert, timeout=5)
 
         self.assert_alert(alert, lt.alert_category.dht, "dht_put")
         self.assertEqual(alert.target, lt.sha1_hash())
-        self.assertEqual(alert.public_key, public.to_bytes())
-        self.assertIsInstance(alert.signature, bytes)
+        self.assertEqual(alert.public_key, pk)
+        self.assertEqual(
+            alert.signature,
+            bytes.fromhex(
+                "aeaa269b37bab7f87126c8d0cc31fb9c88ea81f0d0d5338166d103be8ea16f16"
+                "2d017ce812926a24dc697beb6915bec986e9eb0a37f262150cd90f2add54f805"
+            ),
+        )
         self.assertEqual(alert.salt, salt)
-        self.assertIsInstance(alert.seq, int)
-        self.assertIsInstance(alert.num_success, int)
+        self.assertEqual(alert.seq, 1)
+        # In our current setup, our peer returns us as a neighbor of itself,
+        # so we end up forwarding the put request to ourselves, so
+        # num_success is actually 2. This may change in the future, but it
+        # should at least be 1.
+        self.assertGreater(alert.num_success, 0)
 
 
 class SessionStatsAlertTest(AlertTest):

--- a/bindings/python/tests/alert_test.py
+++ b/bindings/python/tests/alert_test.py
@@ -2016,18 +2016,8 @@ class DhtImmutableItemAlertTest(DhtAlertTest):
 
         self.assert_alert(alert, lt.alert_category.dht, "dht_immutable_item")
         self.assertEqual(alert.target, sha1)
-        # self.assertEqual(alert.item, item)
-
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
-    def test_broken(self) -> None:
-        item = {b"test": b"test"}
-        sha1 = self.peer.dht_put_immutable_item(item)
-        self.session.apply_settings({"dht_bootstrap_nodes": self.peer_endpoint_str})
-        self.session.dht_get_immutable_item(sha1)
-
-        alert = wait_for(self.session, lt.dht_immutable_item_alert, timeout=5)
-
-        self.assertEqual(alert.item, item)
+        # TODO: rewrite this test so we get real data
+        self.assertIsNone(alert.item, None)
 
 
 class DhtMutableItemAlertTest(DhtAlertTest):
@@ -2045,26 +2035,12 @@ class DhtMutableItemAlertTest(DhtAlertTest):
 
         self.assert_alert(alert, lt.alert_category.dht, "dht_mutable_item")
         self.assertEqual(alert.key, public.to_bytes())
-        # self.assertEqual(alert.item, data)
+        # TODO: rewrite this test so we get real data
+        self.assertIsNone(alert.item, None)
         self.assertIsInstance(alert.signature, bytes)
         self.assertEqual(alert.salt, salt)
         self.assertIsInstance(alert.seq, int)
         self.assertTrue(alert.authoritative)
-
-    @unittest.skip("https://github.com/arvidn/libtorrent/issues/5995")
-    def test_broken(self) -> None:
-        private, public = ed25519.create_keypair()
-        data = b"test"
-        salt = b"salt"
-        self.peer.dht_put_mutable_item(
-            private.to_bytes(), public.to_bytes(), data, salt
-        )
-        self.session.apply_settings({"dht_bootstrap_nodes": self.peer_endpoint_str})
-        self.session.dht_get_mutable_item(public.to_bytes(), salt)
-
-        alert = wait_for(self.session, lt.dht_mutable_item_alert, timeout=5)
-
-        self.assertEqual(alert.item, data)
 
 
 class DhtPutAlertTest(DhtAlertTest):


### PR DESCRIPTION
This PR has 3 commits. I think the commits make sense as they are and don't need squashing.

 1. fc7c3c6: Changed the binding of `dht_[im]mutable_item_alert.item` to be just the item, rather than a string. This is a "breaking" change, but I couldn't make the existing binding work at all, so I believe it's reasonable. This is progress toward #5995
 2. e5b0a90: Refactored the DHT alert test setup to fire alerts more reliably. This let me enable (and fix up) some tests that had been disabled due to flakiness.
 3. 893cf45: Updated the ed25519 keys used for testing dht mutable items. The `ed25519` python library I was using uses a different private key form than what libtorrent expects, so the dht operations were actually always failing. I didn't see an easy way to convert between key forms, so I copied the key pair from `test_dht.cpp`.