### PR TITLE
Fix build errors involving unsatisfied constraints

### DIFF
--- a/include/libtorrent/ssl_stream.hpp
+++ b/include/libtorrent/ssl_stream.hpp
@@ -133,11 +133,11 @@ struct ssl_stream
 	}
 
 	template <class Handler>
-	void async_shutdown(Handler const& handler)
+	void async_shutdown(Handler handler)
 	{
 		error_code ec;
 		m_sock->next_layer().cancel(ec);
-		m_sock->async_shutdown(handler);
+		m_sock->async_shutdown(std::move(handler));
 	}
 
 	void shutdown(error_code& ec)
@@ -146,9 +146,9 @@ struct ssl_stream
 	}
 
 	template <class Mutable_Buffers, class Handler>
-	void async_read_some(Mutable_Buffers const& buffers, Handler const& handler)
+	void async_read_some(Mutable_Buffers const& buffers, Handler handler)
 	{
-		m_sock->async_read_some(buffers, handler);
+		m_sock->async_read_some(buffers, std::move(handler));
 	}
 
 	template <class Mutable_Buffers>
@@ -213,9 +213,9 @@ struct ssl_stream
 	{ m_sock->next_layer().non_blocking(b, ec); }
 
 	template <class Const_Buffers, class Handler>
-	void async_write_some(Const_Buffers const& buffers, Handler const& handler)
+	void async_write_some(Const_Buffers const& buffers, Handler handler)
 	{
-		m_sock->async_write_some(buffers, handler);
+		m_sock->async_write_some(buffers, std::move(handler));
 	}
 
 	template <class Const_Buffers>


### PR DESCRIPTION
On MSVC 19.29, building fails with error C7601: the associated constraints are not satisfied. This has to do with C++20's constraints and concepts.