### PR TITLE
Backport to 1.2: fix issue when asking for file progress right when starting a force-recheck

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10616,7 +10616,8 @@ bool is_downloading_state(int const st)
 		if (flags & torrent_handle::piece_granularity)
 			return;
 
-		TORRENT_ASSERT(has_picker());
+		if (!has_picker())
+			return;
 
 		std::vector<piece_picker::downloading_piece> q = m_picker->get_download_queue();
 


### PR DESCRIPTION
Original PR is #6316

I've verified this fixes the crash I was seeing with deluge