### PR TITLE
Clean up tests for python demo scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,9 +38,6 @@ repos:
       exclude: |
           (?x)^(
             # Enable these later, avoid bloating this PR
-            bindings/python/tests/client_test.py|
-            bindings/python/tests/simple_client_test.py|
-            bindings/python/tests/make_torrent_test.py|
             docs/gen_reference_doc.py|
             examples/run_benchmarks.py|
             fuzzers/tools/generate_initial_corpus.py|
@@ -72,9 +69,6 @@ repos:
       # Avoiding PR bloat
       exclude: |
           (?x)^(
-               bindings/python/tests/client_test.py|
-               bindings/python/tests/simple_client_test.py|
-               bindings/python/tests/make_torrent_test.py|
                docs/filter-rst.py|
                docs/gen_reference_doc.py|
                docs/gen_settings_doc.py|
@@ -117,9 +111,6 @@ repos:
       # Avoiding PR bloat
       exclude: |
           (?x)^(
-              bindings/python/tests/client_test.py|
-              bindings/python/tests/simple_client_test.py|
-              bindings/python/tests/make_torrent_test.py|
               docs/filter-rst.py|
               docs/gen_reference_doc.py|
               docs/gen_settings_doc.py|
@@ -156,9 +147,6 @@ repos:
     exclude: |
         (?x)^(
             # Enable these later, avoid bloating this PR
-            bindings/python/tests/client_test.py|
-            bindings/python/tests/simple_client_test.py|
-            bindings/python/tests/make_torrent_test.py|
             docs/gen_todo.py|
             docs/gen_reference_doc.py|
             docs/gen_settings_doc.py|

--- a/bindings/python/tests/client_test.py
+++ b/bindings/python/tests/client_test.py
@@ -1,46 +1,115 @@
-
-import unittest
-import time
+import functools
+import http.server
+import logging
 import os
-import subprocess as sub
+import pathlib
+import subprocess
 import sys
+import tempfile
+import threading
+from typing import Any
+import unittest
 
+import libtorrent as lt
 
-# include terminal interface for travis parallel executions of scripts which use
-# terminal features: fix multiple stdin assignment at termios.tcgetattr
-if os.name != 'nt':
+from . import lib
+from . import tdummy
+
+# import fails on windows
+if os.name != "nt":
     import pty
 
 
-class test_example_client(unittest.TestCase):
+class Handler(http.server.BaseHTTPRequestHandler):
+    def __init__(self, *args: Any, serve_data: bytes, **kwargs: Any) -> None:
+        self.serve_data = serve_data
+        super().__init__(*args, **kwargs)
 
-    def test_execute_client(self):
-        if os.name == 'nt':
-            # TODO: fix windows includes of client.py
-            return
-        my_stdin = sys.stdin
-        if os.name != 'nt':
-            master_fd, slave_fd = pty.openpty()
-            # slave_fd fix multiple stdin assignment at termios.tcgetattr
-            my_stdin = slave_fd
+    def do_GET(self) -> None:
+        logging.info("%s", self.requestline)
+        self.send_response(200)
+        self.send_header("content-length", str(len(self.serve_data)))
+        self.end_headers()
+        self.wfile.write(self.serve_data)
 
-        process = sub.Popen(
-            [sys.executable, "client.py", "url_seed_multi.torrent"],
-            stdin=my_stdin, stdout=sub.PIPE, stderr=sub.PIPE)
-        # python2 has no Popen.wait() timeout
-        time.sleep(5)
-        returncode = process.poll()
-        if returncode is None:
-            # this is an expected use-case
-            process.kill()
-        err = process.stderr.read().decode("utf-8")
-        self.assertEqual('', err, 'process throw errors: \n' + err)
-        # check error code if process did unexpected end
-        if returncode is not None:
-            # in case of error return: output stdout if nothing was on stderr
-            if returncode != 0:
-                print("stdout:\n" + process.stdout.read().decode("utf-8"))
-            self.assertEqual(returncode, 0, "returncode: " + str(returncode) + "\n"
-                             + "stderr: empty\n"
-                             + "some configuration does not output errors like missing module members,"
-                             + "try to call it manually to get the error message\n")
+
+@unittest.skipIf(sys.platform != "linux", "pty control only works on linux")
+class TestClient(unittest.TestCase):
+    def setUp(self) -> None:
+        # path relative to this file
+        self.script_path = pathlib.Path(__file__).parent / ".." / "client.py"
+
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.tempdir_path = pathlib.Path(self.tempdir.name)
+
+        self.torrent = tdummy.get_default()
+
+        # set up a web seed to serve dummy torrent data
+        self.server = http.server.HTTPServer(
+            ("127.0.0.1", 0), functools.partial(Handler, serve_data=self.torrent.data)
+        )
+        addr, port = self.server.server_address
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.start()
+
+        # construct a .torrent to point to our web seed
+        self.tdict = dict(self.torrent.dict)
+        self.tdict[b"url-list"] = b"".join(
+            [b"http://", addr.encode(), b":", str(port).encode()]
+        )
+        self.torrent_path = self.tempdir_path / "dummy.torrent"
+        self.torrent_path.write_bytes(lt.bencode(self.tdict))
+
+        self.pty_master, self.pty_slave = pty.openpty()
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.tempdir.cleanup()
+        os.close(self.pty_master)
+        os.close(self.pty_slave)
+
+    def test_download_from_web_seed(self) -> None:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(self.script_path),
+                "--port",
+                "0",
+                "--listen-interface",
+                "127.0.0.1",
+                str(self.torrent_path),
+            ],
+            cwd=self.tempdir_path,
+            stdin=self.pty_slave,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+        try:
+            # wait for the file to be downloaded from the web seed
+            file_path = self.tempdir_path / os.fsdecode(self.torrent.files[0].path)
+            for _ in lib.loop_until_timeout(15):
+                try:
+                    if file_path.read_bytes() == self.torrent.data:
+                        break
+                except FileNotFoundError:
+                    pass
+
+            # send a 'q' command
+            os.write(self.pty_master, b"q")
+            # process should terminate on its own
+            returncode = proc.wait(15)
+        finally:
+            proc.kill()
+
+        # process should complete without errors or warnings
+        self.assertEqual(returncode, 0)
+        assert proc.stderr is not None  # helps mypy
+        self.assertEqual(proc.stderr.read(), "")
+        proc.stderr.close()
+
+        # fastresume should be written
+        fastresume = pathlib.Path(f"{file_path}.fastresume")
+        lt.bdecode(fastresume.read_bytes())

--- a/bindings/python/tests/make_torrent_test.py
+++ b/bindings/python/tests/make_torrent_test.py
@@ -1,23 +1,83 @@
-
-import unittest
-import subprocess as sub
+import hashlib
+import pathlib
+import random
+import subprocess
 import sys
+import tempfile
+from typing import Set
+import unittest
+
+import libtorrent as lt
 
 
-class test_example_client(unittest.TestCase):
+class TestMakeTorrent(unittest.TestCase):
+    maxDiff = None
 
-    def test_execute_make_torrent(self):
-        process = sub.Popen(
-            [sys.executable, "make_torrent.py", "url_seed_multi.torrent",
-             "http://test.com/test"], stdout=sub.PIPE, stderr=sub.PIPE)
-        returncode = process.wait()
-        # python2 has no Popen.wait() timeout
-        err = process.stderr.read().decode("utf-8")
-        self.assertEqual('', err, 'process throw errors: \n' + err)
-        # in case of error return: output stdout if nothing was on stderr
-        if returncode != 0:
-            print("stdout:\n" + process.stdout.read().decode("utf-8"))
-        self.assertEqual(returncode, 0, "returncode: " + str(returncode) + "\n"
-                         + "stderr: empty\n"
-                         + "some configuration does not output errors like missing module members,"
-                         + "try to call it manually to get the error message\n")
+    def setUp(self) -> None:
+        # path relative to this file
+        self.script_path = pathlib.Path(__file__).parent / ".." / "make_torrent.py"
+
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.tempdir_path = pathlib.Path(self.tempdir.name)
+
+        self.out_path = self.tempdir_path / "out.torrent"
+        self.tracker_url = "http://test-tracker.com"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_single_file(self) -> None:
+        data = bytes(random.getrandbits(8) for _ in range(1024))
+        name = "test.txt"
+        file_path = self.tempdir_path / name
+        file_path.write_bytes(data)
+
+        proc = subprocess.run(
+            [sys.executable, str(self.script_path), str(file_path), self.tracker_url],
+            cwd=self.tempdir_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            universal_newlines=True,
+        )
+
+        self.assertEqual(proc.stderr, "")
+
+        ti = lt.torrent_info(str(self.out_path))
+        self.assertEqual(list(tr.url for tr in ti.trackers()), [self.tracker_url])
+        fs = ti.files()
+        self.assertEqual(fs.num_files(), 1)
+        self.assertEqual(fs.file_name(0), name)
+        self.assertEqual(hashlib.sha1(data).digest(), ti.hash_for_piece(0))
+
+    def test_directory(self) -> None:
+        data1 = bytes(random.getrandbits(8) for _ in range(1024))
+        data2 = bytes(random.getrandbits(8) for _ in range(1024))
+        (self.tempdir_path / "test1.txt").write_bytes(data1)
+        (self.tempdir_path / "test2.txt").write_bytes(data2)
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(self.script_path),
+                str(self.tempdir_path),
+                self.tracker_url,
+            ],
+            cwd=self.tempdir_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            universal_newlines=True,
+        )
+
+        self.assertEqual(proc.stderr, "")
+
+        ti = lt.torrent_info(str(self.out_path))
+        self.assertEqual(list(tr.url for tr in ti.trackers()), [self.tracker_url])
+        fs = ti.files()
+        non_pad_filenames: Set[str] = set()
+        for i in range(fs.num_files()):
+            if fs.file_flags(i) & lt.file_flags_t.flag_pad_file:
+                continue
+            non_pad_filenames.add(fs.file_name(i))
+        self.assertEqual(non_pad_filenames, {"test1.txt", "test2.txt"})

--- a/bindings/python/tests/simple_client_test.py
+++ b/bindings/python/tests/simple_client_test.py
@@ -1,30 +1,75 @@
-
-import unittest
-import time
-import subprocess as sub
+import functools
+import http.server
+import logging
+import os
+import pathlib
+import subprocess
 import sys
+import tempfile
+import threading
+from typing import Any
+import unittest
+
+import libtorrent as lt
+
+from . import tdummy
 
 
-class test_example_client(unittest.TestCase):
+class Handler(http.server.BaseHTTPRequestHandler):
+    def __init__(self, *args: Any, serve_data: bytes, **kwargs: Any) -> None:
+        self.serve_data = serve_data
+        super().__init__(*args, **kwargs)
 
-    def test_execute_simple_client(self):
-        process = sub.Popen(
-            [sys.executable, "simple_client.py", "url_seed_multi.torrent"],
-            stdout=sub.PIPE, stderr=sub.PIPE)
-        # python2 has no Popen.wait() timeout
-        time.sleep(5)
-        returncode = process.poll()
-        if returncode is None:
-            # this is an expected use-case
-            process.kill()
-        err = process.stderr.read().decode("utf-8")
-        self.assertEqual('', err, 'process throw errors: \n' + err)
-        # check error code if process did unexpected end
-        if returncode is not None:
-            # in case of error return: output stdout if nothing was on stderr
-            if returncode != 0:
-                print("stdout:\n" + process.stdout.read().decode("utf-8"))
-            self.assertEqual(returncode, 0, "returncode: " + str(returncode) + "\n"
-                             + "stderr: empty\n"
-                             + "some configuration does not output errors like missing module members,"
-                             + "try to call it manually to get the error message\n")
+    def do_GET(self) -> None:
+        logging.info("%s", self.requestline)
+        self.send_response(200)
+        self.send_header("content-length", str(len(self.serve_data)))
+        self.end_headers()
+        self.wfile.write(self.serve_data)
+
+
+class TestSimpleClient(unittest.TestCase):
+    def setUp(self) -> None:
+        # path relative to this file
+        self.script_path = pathlib.Path(__file__).parent / ".." / "simple_client.py"
+
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.tempdir_path = pathlib.Path(self.tempdir.name)
+
+        self.torrent = tdummy.get_default()
+
+        # set up a web seed to serve dummy torrent data
+        self.server = http.server.HTTPServer(
+            ("127.0.0.1", 0), functools.partial(Handler, serve_data=self.torrent.data)
+        )
+        addr, port = self.server.server_address
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.start()
+
+        # construct a .torrent to point to our web seed
+        self.tdict = dict(self.torrent.dict)
+        self.tdict[b"url-list"] = b"".join(
+            [b"http://", addr.encode(), b":", str(port).encode()]
+        )
+        self.torrent_path = self.tempdir_path / "dummy.torrent"
+        self.torrent_path.write_bytes(lt.bencode(self.tdict))
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.tempdir.cleanup()
+
+    def test_download_from_web_seed(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(self.script_path), str(self.torrent_path)],
+            cwd=self.tempdir_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            universal_newlines=True,
+            timeout=20,
+        )
+
+        self.assertEqual(proc.stderr, "")
+        file_path = self.tempdir_path / os.fsdecode(self.torrent.files[0].path)
+        self.assertEqual(file_path.read_bytes(), self.torrent.data)

--- a/bindings/python/url_seed_multi.torrent
+++ b/bindings/python/url_seed_multi.torrent
@@ -1,1 +1,0 @@
-../../test/test_torrents/url_seed_multi.torrent


### PR DESCRIPTION
Currently, these tests must be run from `bindings/python` as the working directory.

With this change, they can be run from anywhere.

This also strengthens the tests, rather than just ensuring the scripts don't crash.