### PR TITLE
Migrate to OpenSSL EVP interface for hashing

### DIFF
--- a/include/libtorrent/aux_/hasher512.hpp
+++ b/include/libtorrent/aux_/hasher512.hpp
@@ -56,9 +56,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #elif defined TORRENT_USE_LIBCRYPTO
 
-	extern "C" {
-	#include <openssl/sha.h>
-	}
+extern "C" {
+#include <openssl/evp.h>
+}
 
 #else
 #include "libtorrent/aux_/sha512.hpp"
@@ -122,7 +122,7 @@ namespace aux {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		aux::crypt_hash<CALG_SHA_512, PROV_RSA_AES> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_CTX m_context;
+		EVP_MD_CTX *m_context;
 #else
 		sha512_ctx m_context;
 #endif

--- a/include/libtorrent/hasher.hpp
+++ b/include/libtorrent/hasher.hpp
@@ -63,7 +63,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #elif defined TORRENT_USE_LIBCRYPTO
 
 extern "C" {
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 }
 
 #else
@@ -131,7 +131,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI
 		aux::crypt_hash<CALG_SHA1, PROV_RSA_FULL> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA_CTX m_context;
+		EVP_MD_CTX *m_context;
 #else
 		sha1_ctx m_context;
 #endif
@@ -173,7 +173,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		aux::crypt_hash<CALG_SHA_256, PROV_RSA_AES> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_CTX m_context;
+		EVP_MD_CTX *m_context;
 #else
 		sha256_ctx m_context;
 #endif


### PR DESCRIPTION
The low-level interface is deprecated since OpenSSL v3.0 [1].

[1] https://www.openssl.org/docs/manmaster/man7/migration_guide.html "Deprecated low-level digest functions"