### PR TITLE
silence conversion signedness warning on file.cpp

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -583,7 +583,7 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 
 		// rely on default umask to filter x and w permissions
 		// for group and others
-		int permissions = S_IRUSR | S_IWUSR
+		mode_t permissions = S_IRUSR | S_IWUSR
 			| S_IRGRP | S_IWGRP
 			| S_IROTH | S_IWOTH;
 


### PR DESCRIPTION
fixes warning: implicit conversion changes signedness: 'int' to 'mode_t'