### PR TITLE
V2 magnet check files

### DIFF
--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -69,6 +69,7 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT int merkle_get_parent(int);
 	TORRENT_EXTRA_EXPORT int merkle_get_sibling(int);
 	TORRENT_EXTRA_EXPORT int merkle_get_first_child(int);
+	TORRENT_EXTRA_EXPORT int merkle_get_first_child(int tree_node, int depth);
 
 	// given a tree and the number of leaves, expect all leaf hashes to be set and
 	// compute all other hashes starting with the leaves.

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -117,7 +117,8 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	// returns the index of the pieces that passed the hash check
 	std::vector<piece_index_t> check_pieces(int base
 		, int index, int file_piece_offset
-		, span<sha256_hash const> hashes);
+		, span<sha256_hash const> hashes
+		, std::map<piece_index_t, std::vector<int>>& failed_blocks);
 
 	aux::vector<sha256_hash> get_piece_layer() const;
 

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -50,6 +50,12 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace libtorrent {
 namespace aux {
 
+struct add_hashes_result_t
+{
+	std::vector<piece_index_t> passed;
+	std::vector<piece_index_t> failed;
+};
+
 // represents the merkle tree for files belonging to a torrent.
 // Each file has a root-hash and a "piece layer", i.e. the level in the tree
 // representing whole pieces. Those hashes are likely to be included in .torrent
@@ -109,16 +115,11 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	// be valid.
 	// if the hashes are not valid, or the uncle hashes fail validation, nullopt
 	// is returned.
-	boost::optional<std::map<piece_index_t, std::vector<int>>> add_hashes(
+	boost::optional<add_hashes_result_t> add_hashes(
 		int dest_start_idx
-		, span<sha256_hash const> tree
-		, span<sha256_hash const> uncle_hashes);
-
-	// returns the index of the pieces that passed the hash check
-	std::vector<piece_index_t> check_pieces(int base
-		, int index, int file_piece_offset
+		, piece_index_t::diff_type file_piece_offset
 		, span<sha256_hash const> hashes
-		, std::map<piece_index_t, std::vector<int>>& failed_blocks);
+		, span<sha256_hash const> uncle_hashes);
 
 	aux::vector<sha256_hash> get_piece_layer() const;
 
@@ -141,6 +142,9 @@ private:
 	sha256_hash get_impl(int idx, std::vector<sha256_hash>& scratch_space) const;
 
 	int blocks_per_piece() const { return 1 << m_blocks_per_piece_log; }
+	// the number tree levels per piece. This is 0 if the block layer is also
+	// the piece layer.
+	int piece_levels() const { return m_blocks_per_piece_log; }
 
 	int block_layer_start() const;
 	int piece_layer_start() const;

--- a/include/libtorrent/hash_picker.hpp
+++ b/include/libtorrent/hash_picker.hpp
@@ -84,7 +84,7 @@ namespace libtorrent
 		bool valid;
 		// the vector contains the block indices (within the piece) that failed
 		// the hash check
-		std::map<piece_index_t, std::vector<int>> hash_failed;
+		std::vector<piece_index_t> hash_failed;
 		std::vector<piece_index_t> hash_passed;
 	};
 

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -991,7 +991,8 @@ namespace libtorrent {
 		// for failures detected with v2 hashes the failing blocks(s)
 		// are specified in blocks
 		// *blocks must be sorted in acending order*
-		void piece_failed(piece_index_t index, std::vector<int> blocks = std::vector<int>());
+		void piece_failed(piece_index_t index//, std::vector<int> blocks = std::vector<int>()
+			, bool got_hashes = false);
 
 		// this is the handler for hash failure piece synchronization
 		// i.e. resetting the piece

--- a/simulation/disk_io.cpp
+++ b/simulation/disk_io.cpp
@@ -240,10 +240,10 @@ std::shared_ptr<lt::torrent_info> create_test_torrent(int const piece_size
 }
 
 lt::add_torrent_params create_test_torrent(
-	int const num_pieces, lt::create_flags_t const flags)
+	int const num_pieces, lt::create_flags_t const flags, int const blocks_per_piece)
 {
 	lt::add_torrent_params params;
-	params.ti = ::create_test_torrent(lt::default_block_size * 2, num_pieces, flags);
+	params.ti = ::create_test_torrent(lt::default_block_size * blocks_per_piece, num_pieces, flags);
 	// this is unused by the test disk I/O
 	params.save_path = ".";
 	return params;

--- a/simulation/disk_io.cpp
+++ b/simulation/disk_io.cpp
@@ -197,11 +197,14 @@ int pads_in_req(std::unordered_map<lt::piece_index_t, int> const& pb
 }
 
 std::shared_ptr<lt::torrent_info> create_test_torrent(int const piece_size
-	, int const num_pieces, lt::create_flags_t const flags)
+	, int const num_pieces, lt::create_flags_t const flags, int const num_files)
 {
 	lt::file_storage fs;
 	int const total_size = piece_size * num_pieces;
-	fs.add_file("file-1", total_size);
+	for (int i = 0; i < num_files; ++i)
+	{
+		fs.add_file("file-" + std::to_string(i + 1), total_size);
+	}
 	lt::create_torrent t(fs, piece_size, flags);
 
 	auto const pad_bytes = compute_pad_bytes(fs);
@@ -240,10 +243,11 @@ std::shared_ptr<lt::torrent_info> create_test_torrent(int const piece_size
 }
 
 lt::add_torrent_params create_test_torrent(
-	int const num_pieces, lt::create_flags_t const flags, int const blocks_per_piece)
+	int const num_pieces, lt::create_flags_t const flags, int const blocks_per_piece
+	, int const num_files)
 {
 	lt::add_torrent_params params;
-	params.ti = ::create_test_torrent(lt::default_block_size * blocks_per_piece, num_pieces, flags);
+	params.ti = ::create_test_torrent(lt::default_block_size * blocks_per_piece, num_pieces, flags, num_files);
 	// this is unused by the test disk I/O
 	params.save_path = ".";
 	return params;

--- a/simulation/disk_io.hpp
+++ b/simulation/disk_io.hpp
@@ -45,12 +45,12 @@ std::array<char, 0x4000> generate_block_fill(lt::piece_index_t const p, int cons
 lt::sha1_hash generate_hash1(lt::piece_index_t const p, lt::file_storage const& fs);
 lt::sha1_hash generate_hash2(lt::piece_index_t p, lt::file_storage const& fs
 	, lt::span<lt::sha256_hash> const hashes);
-lt::sha256_hash generate_block_hash(lt::piece_index_t p, int const offset);
+lt::sha256_hash generate_block_hash(lt::piece_index_t p, int offset);
 void generate_block(char* b, lt::peer_request const& r);
-std::shared_ptr<lt::torrent_info> create_test_torrent(int const piece_size
-	, int const num_pieces, lt::create_flags_t const flags);
+std::shared_ptr<lt::torrent_info> create_test_torrent(int piece_size
+	, int num_pieces, lt::create_flags_t flags);
 lt::add_torrent_params create_test_torrent(
-	int const num_pieces, lt::create_flags_t const flags);
+	int num_pieces, lt::create_flags_t flags, int blocks_per_piece);
 
 struct test_disk
 {

--- a/simulation/disk_io.hpp
+++ b/simulation/disk_io.hpp
@@ -60,6 +60,12 @@ struct test_disk
 		ret.seed = s;
 		return ret;
 	}
+	test_disk set_partial_files(bool const s = true) const
+	{
+		auto ret = *this;
+		ret.partial_files = s;
+		return ret;
+	}
 	test_disk set_space_left(int const left) const
 	{
 		auto ret = *this;
@@ -95,6 +101,7 @@ struct test_disk
 	lt::time_duration read_time = lt::microseconds(1);
 
 	bool seed = false;
+	bool partial_files = false;
 	bool recover_full_disk = false;
 	int space_left = std::numeric_limits<int>::max();
 

--- a/simulation/disk_io.hpp
+++ b/simulation/disk_io.hpp
@@ -48,9 +48,9 @@ lt::sha1_hash generate_hash2(lt::piece_index_t p, lt::file_storage const& fs
 lt::sha256_hash generate_block_hash(lt::piece_index_t p, int offset);
 void generate_block(char* b, lt::peer_request const& r);
 std::shared_ptr<lt::torrent_info> create_test_torrent(int piece_size
-	, int num_pieces, lt::create_flags_t flags);
+	, int num_pieces, lt::create_flags_t flags, int num_files = 1);
 lt::add_torrent_params create_test_torrent(
-	int num_pieces, lt::create_flags_t flags, int blocks_per_piece);
+	int num_pieces, lt::create_flags_t flags, int blocks_per_piece, int num_files = 1);
 
 struct test_disk
 {

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -406,6 +406,44 @@ TORRENT_TEST(v2_only_magnet)
 	TEST_EQUAL(passed.size(), 10);
 }
 
+TORRENT_TEST(v2_only_magnet_existing_files)
+{
+	using namespace lt;
+	std::set<piece_index_t> passed;
+	run_test(
+		[](lt::session& ses0, lt::session& ses1) {},
+		[&](lt::session&, lt::alert const* a) {
+			if (auto const* pf = alert_cast<piece_finished_alert>(a))
+				passed.insert(pf->piece_index);
+		},
+		[](std::shared_ptr<lt::session> ses[2]) {
+			TEST_EQUAL(is_seed(*ses[0]), true);
+		}
+		, tx::v2_only | tx::magnet_download
+		, test_disk().set_partial_files()
+	);
+	TEST_EQUAL(passed.size(), 10);
+}
+
+TORRENT_TEST(hybrid_magnet_existing_files)
+{
+	using namespace lt;
+	std::set<piece_index_t> passed;
+	run_test(
+		[](lt::session& ses0, lt::session& ses1) {},
+		[&](lt::session&, lt::alert const* a) {
+			if (auto const* pf = alert_cast<piece_finished_alert>(a))
+				passed.insert(pf->piece_index);
+		},
+		[](std::shared_ptr<lt::session> ses[2]) {
+			TEST_EQUAL(is_seed(*ses[0]), true);
+		}
+		, tx::magnet_download
+		, test_disk().set_partial_files()
+	);
+	TEST_EQUAL(passed.size(), 10);
+}
+
 TORRENT_TEST(v1_only)
 {
 	using namespace lt;

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -423,7 +423,7 @@ TORRENT_TEST(v2_only_magnet_multi_file)
 		}
 		, tx::v2_only | tx::magnet_download | tx::multiple_files
 	);
-	TEST_EQUAL(passed.size(), 10);
+	TEST_EQUAL(passed.size(), 30);
 }
 
 TORRENT_TEST(v2_only_magnet_existing_files)
@@ -461,7 +461,7 @@ TORRENT_TEST(v2_only_magnet_existing_files_multiple_files)
 		, tx::v2_only | tx::magnet_download | tx::multiple_files
 		, test_disk().set_partial_files()
 	);
-	TEST_EQUAL(passed.size(), 10);
+	TEST_EQUAL(passed.size(), 30);
 }
 
 TORRENT_TEST(v2_only_magnet_existing_files_large_pieces)
@@ -499,7 +499,7 @@ TORRENT_TEST(v2_only_magnet_existing_files_large_pieces_multiple_files)
 		, tx::v2_only | tx::magnet_download | tx::large_pieces | tx::multiple_files
 		, test_disk().set_partial_files()
 	);
-	TEST_EQUAL(passed.size(), 10);
+	TEST_EQUAL(passed.size(), 30);
 }
 
 TORRENT_TEST(hybrid_magnet_existing_files)

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -149,7 +149,8 @@ void run_test(
 		, (flags & tx::v2_only) ? create_torrent::v2_only
 		: (flags & tx::v1_only) ? create_torrent::v1_only
 		: create_flags_t{}
-		, (flags & tx::large_pieces) ? 16 : 2);
+		, (flags & tx::large_pieces) ? 16 : 2
+		, (flags & tx::multiple_files) ? 3 : 1);
 	atp.flags &= ~lt::torrent_flags::auto_managed;
 	atp.flags &= ~lt::torrent_flags::paused;
 
@@ -407,6 +408,24 @@ TORRENT_TEST(v2_only_magnet)
 	TEST_EQUAL(passed.size(), 10);
 }
 
+TORRENT_TEST(v2_only_magnet_multi_file)
+{
+	using namespace lt;
+	std::set<piece_index_t> passed;
+	run_test(
+		[](lt::session& ses0, lt::session& ses1) {},
+		[&](lt::session&, lt::alert const* a) {
+			if (auto const* pf = alert_cast<piece_finished_alert>(a))
+				passed.insert(pf->piece_index);
+		},
+		[](std::shared_ptr<lt::session> ses[2]) {
+			TEST_EQUAL(is_seed(*ses[0]), true);
+		}
+		, tx::v2_only | tx::magnet_download | tx::multiple_files
+	);
+	TEST_EQUAL(passed.size(), 10);
+}
+
 TORRENT_TEST(v2_only_magnet_existing_files)
 {
 	using namespace lt;
@@ -426,6 +445,25 @@ TORRENT_TEST(v2_only_magnet_existing_files)
 	TEST_EQUAL(passed.size(), 10);
 }
 
+TORRENT_TEST(v2_only_magnet_existing_files_multiple_files)
+{
+	using namespace lt;
+	std::set<piece_index_t> passed;
+	run_test(
+		[](lt::session& ses0, lt::session& ses1) {},
+		[&](lt::session&, lt::alert const* a) {
+			if (auto const* pf = alert_cast<piece_finished_alert>(a))
+				passed.insert(pf->piece_index);
+		},
+		[](std::shared_ptr<lt::session> ses[2]) {
+			TEST_EQUAL(is_seed(*ses[0]), true);
+		}
+		, tx::v2_only | tx::magnet_download | tx::multiple_files
+		, test_disk().set_partial_files()
+	);
+	TEST_EQUAL(passed.size(), 10);
+}
+
 TORRENT_TEST(v2_only_magnet_existing_files_large_pieces)
 {
 	using namespace lt;
@@ -440,6 +478,25 @@ TORRENT_TEST(v2_only_magnet_existing_files_large_pieces)
 			TEST_EQUAL(is_seed(*ses[0]), true);
 		}
 		, tx::v2_only | tx::magnet_download | tx::large_pieces
+		, test_disk().set_partial_files()
+	);
+	TEST_EQUAL(passed.size(), 10);
+}
+
+TORRENT_TEST(v2_only_magnet_existing_files_large_pieces_multiple_files)
+{
+	using namespace lt;
+	std::set<piece_index_t> passed;
+	run_test(
+		[](lt::session& ses0, lt::session& ses1) {},
+		[&](lt::session&, lt::alert const* a) {
+			if (auto const* pf = alert_cast<piece_finished_alert>(a))
+				passed.insert(pf->piece_index);
+		},
+		[](std::shared_ptr<lt::session> ses[2]) {
+			TEST_EQUAL(is_seed(*ses[0]), true);
+		}
+		, tx::v2_only | tx::magnet_download | tx::large_pieces | tx::multiple_files
 		, test_disk().set_partial_files()
 	);
 	TEST_EQUAL(passed.size(), 10);

--- a/simulation/utils.hpp
+++ b/simulation/utils.hpp
@@ -80,6 +80,7 @@ constexpr test_transfer_flags_t v1_only = 1_bit;
 constexpr test_transfer_flags_t v2_only = 2_bit;
 constexpr test_transfer_flags_t magnet_download = 3_bit;
 constexpr test_transfer_flags_t proxy_peers = 4_bit;
+constexpr test_transfer_flags_t large_pieces = 5_bit;
 }
 
 void set_proxy(lt::session& ses, int proxy_type, test_transfer_flags_t flags = tx::proxy_peers);

--- a/simulation/utils.hpp
+++ b/simulation/utils.hpp
@@ -81,6 +81,7 @@ constexpr test_transfer_flags_t v2_only = 2_bit;
 constexpr test_transfer_flags_t magnet_download = 3_bit;
 constexpr test_transfer_flags_t proxy_peers = 4_bit;
 constexpr test_transfer_flags_t large_pieces = 5_bit;
+constexpr test_transfer_flags_t multiple_files = 6_bit;
 }
 
 void set_proxy(lt::session& ses, int proxy_type, test_transfer_flags_t flags = tx::proxy_peers);

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -297,20 +297,6 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 		TORRENT_ASSERT(uncle_hashes.size() == num_uncle_hashes);
 
-		aux::vector<sha256_hash> tree(merkle_num_nodes(leaf_count));
-		std::copy(hashes.begin(), hashes.end(), tree.end() - leaf_count);
-
-		// the end of a file is a special case, we may need to pad the leaf layer
-		if (req.base == m_piece_layer && leaf_count != req.count)
-		{
-			sha256_hash const pad_hash = merkle_pad(
-				m_files.piece_length() / default_block_size, 1);
-			for (int i = req.count; i < leaf_count; ++i)
-				tree[tree.end_index() - leaf_count + i] = pad_hash;
-		}
-
-		merkle_fill_tree(tree, leaf_count);
-
 		int const base_layer_idx = file_num_layers(req.file) - req.base;
 
 		if (base_layer_idx <= 0)
@@ -320,7 +306,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 		auto& dst_tree = m_merkle_trees[req.file];
 		int const dest_start_idx = merkle_to_flat_index(base_layer_idx, req.index);
-		auto hash_failed = dst_tree.add_hashes(dest_start_idx, tree, uncle_hashes);
+		auto hash_failed = dst_tree.add_hashes(dest_start_idx, hashes, uncle_hashes);
 
 		if (!hash_failed)
 			return add_hashes_result(false);

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -338,7 +338,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 			int const file_piece_offset = int(m_files.file_offset(req.file) / m_files.piece_length());
 
 			ret.hash_passed = dst_tree.check_pieces(req.base, req.index
-				, file_piece_offset, hashes);
+				, file_piece_offset, hashes, ret.hash_failed);
 		}
 
 #if TORRENT_USE_INVARIANT_CHECKS

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -306,7 +306,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 		auto& dst_tree = m_merkle_trees[req.file];
 		int const dest_start_idx = merkle_to_flat_index(base_layer_idx, req.index);
-		auto const file_piece_offset = *m_files.file_piece_range(req.file).begin();
+		auto const file_piece_offset = m_files.piece_index_at_file(req.file) - piece_index_t{0};
 		auto results = dst_tree.add_hashes(dest_start_idx, file_piece_offset, hashes, uncle_hashes);
 
 		if (!results)

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -306,13 +306,16 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 		auto& dst_tree = m_merkle_trees[req.file];
 		int const dest_start_idx = merkle_to_flat_index(base_layer_idx, req.index);
-		auto hash_failed = dst_tree.add_hashes(dest_start_idx, hashes, uncle_hashes);
+		auto const file_piece_offset = *m_files.file_piece_range(req.file).begin();
+		auto results = dst_tree.add_hashes(dest_start_idx, file_piece_offset, hashes, uncle_hashes);
 
-		if (!hash_failed)
+		if (!results)
 			return add_hashes_result(false);
 
-		ret.hash_failed = std::move(*hash_failed);
-
+		ret.hash_failed = std::move(results->failed);
+		ret.hash_passed = std::move(results->passed);
+		// TODO: fix the below code
+/*
 		if (req.base == 0)
 		{
 			std::fill_n(m_hash_verified[req.file].begin() + req.index, unpadded_count, true);
@@ -326,6 +329,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 			ret.hash_passed = dst_tree.check_pieces(req.base, req.index
 				, file_piece_offset, hashes, ret.hash_failed);
 		}
+*/
 
 #if TORRENT_USE_INVARIANT_CHECKS
 		check_invariant(req.file);

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -391,13 +391,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 #if TORRENT_USE_INVARIANT_CHECKS
 			check_invariant(f);
 #endif
-			// If the hash failure was detected within a single piece then report a piece failure
-			// otherwise report unknown. The pieces will be checked once their hashes have been
-			// downloaded.
-			if (leafs_size <= m_files.piece_length() / default_block_size)
-				return set_block_hash_result::piece_hash_failed();
-			else
-				return set_block_hash_result::unknown();
+			return set_block_hash_result::piece_hash_failed();
 		}
 		else
 		{

--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -73,6 +73,11 @@ namespace libtorrent {
 		return tree_node * 2 + 1;
 	}
 
+	int merkle_get_first_child(int const tree_node, int depth)
+	{
+		return ((tree_node + 1) << depth) - 1;
+	}
+
 	int merkle_num_nodes(int const leafs)
 	{
 		TORRENT_ASSERT(leafs > 0);

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -323,7 +323,8 @@ namespace {
 
 	std::vector<piece_index_t> merkle_tree::check_pieces(int const base
 		, int const index, int const file_piece_offset
-		, span<sha256_hash const> hashes)
+		, span<sha256_hash const> hashes
+		, std::map<piece_index_t, std::vector<int>>& failed_blocks)
 	{
 		INVARIANT_CHECK;
 		std::vector<piece_index_t> passed_pieces;
@@ -363,8 +364,9 @@ namespace {
 				merkle_clear_tree(m_tree, num_leafs / 2, merkle_get_parent(file_first_leaf + first_leaf));
 				m_tree[base_layer_start + i] = hashes[i];
 				TORRENT_ASSERT(num_leafs == blocks_per_piece());
-				//verify_block_hashes(m_files.file_offset(req.file) / m_files.piece_length() + index);
-				// TODO: add to failed hashes
+				auto& blocks = failed_blocks[piece_index_t{piece}];
+				for (int block = 0; block < num_leafs; ++block)
+					blocks.push_back(block);
 			}
 			else
 			{

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -550,6 +550,7 @@ namespace {
 			// not the block hashes though, except for the one we just added
 			merkle_clear_tree(m_tree, leafs_size / 2, merkle_get_parent(first_leaf + leafs_start));
 			m_tree[root_index] = root;
+			m_tree[block_tree_index].clear();
 			return std::make_tuple(set_block_result::hash_failed, leafs_start, leafs_size);
 		}
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -550,7 +550,7 @@ namespace {
 			// not the block hashes though, except for the one we just added
 			merkle_clear_tree(m_tree, leafs_size / 2, merkle_get_parent(first_leaf + leafs_start));
 			m_tree[root_index] = root;
-//			m_tree[block_tree_index].clear();
+			m_tree[block_tree_index].clear();
 			return std::make_tuple(set_block_result::hash_failed, leafs_start, leafs_size);
 		}
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -357,6 +357,8 @@ namespace {
 			for (int i = 0; i < int(hashes.size()); ++i)
 			{
 				int const piece = dest_start_idx + i;
+				if (piece - first_piece_idx >= num_pieces())
+					break;
 				// the first block in this piece
 				int const block_idx = merkle_get_first_child(piece, base);
 
@@ -384,8 +386,6 @@ namespace {
 					ret.passed.push_back(piece_index_t{piece - first_piece_idx} + file_piece_offset);
 				}
 				TORRENT_ASSERT((piece - first_piece_idx) >= 0);
-				if (piece - first_piece_idx >= num_pieces())
-					break;
 			}
 		}
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -253,7 +253,6 @@ namespace {
 	//                           ^
 	//                           |
 	//                           dest_start_idx
-//#error this must be combined with check_pieces, in order to maintain the invariant check, since any failed pieces must be cleared from the tree immediately (since that would violating the invariant otherwise)
 	boost::optional<add_hashes_result_t> merkle_tree::add_hashes(
 		int const dest_start_idx
 		, piece_index_t::diff_type const file_piece_offset
@@ -355,7 +354,7 @@ namespace {
 
 			// it may now be possible to verify the hashes of previously received blocks
 			// try to verify as many child nodes of the received hashes as possible
-			for (int i = 0; i < num_pieces(); ++i)
+			for (int i = 0; i < std::min(int(hashes.size()), num_pieces() - (dest_start_idx - first_piece_idx)); ++i)
 			{
 				int const piece = dest_start_idx + i;
 				// the first block in this piece

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -354,7 +354,7 @@ namespace {
 
 			// it may now be possible to verify the hashes of previously received blocks
 			// try to verify as many child nodes of the received hashes as possible
-			for (int i = 0; i < std::min(int(hashes.size()), num_pieces() - (dest_start_idx - first_piece_idx)); ++i)
+			for (int i = 0; i < int(hashes.size()); ++i)
 			{
 				int const piece = dest_start_idx + i;
 				// the first block in this piece
@@ -384,7 +384,8 @@ namespace {
 					ret.passed.push_back(piece_index_t{piece - first_piece_idx} + file_piece_offset);
 				}
 				TORRENT_ASSERT((piece - first_piece_idx) >= 0);
-				TORRENT_ASSERT((piece - first_piece_idx) < num_pieces());
+				if (piece - first_piece_idx >= num_pieces())
+					break;
 			}
 		}
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -550,7 +550,7 @@ namespace {
 			// not the block hashes though, except for the one we just added
 			merkle_clear_tree(m_tree, leafs_size / 2, merkle_get_parent(first_leaf + leafs_start));
 			m_tree[root_index] = root;
-			m_tree[block_tree_index].clear();
+//			m_tree[block_tree_index].clear();
 			return std::make_tuple(set_block_result::hash_failed, leafs_start, leafs_size);
 		}
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -333,7 +333,6 @@ namespace {
 		int const count = static_cast<int>(hashes.size());
 		auto const file_num_leafs = merkle_num_leafs(m_num_blocks);
 		auto const file_first_leaf = merkle_first_leaf(file_num_leafs);
-		int const first_piece = file_first_leaf >> m_blocks_per_piece_log;
 
 		int const base_layer_index = merkle_num_layers(file_num_leafs) - base;
 		int const base_layer_start = merkle_to_flat_index(base_layer_index, index);
@@ -343,13 +342,6 @@ namespace {
 		for (int i = 0; i < count; ++i)
 		{
 			int const piece = index + i;
-			if (!m_tree[merkle_get_first_child(first_piece + piece)].is_all_zeros()
-				&& !m_tree[merkle_get_first_child(first_piece + piece) + 1].is_all_zeros())
-			{
-				// this piece is already verified
-				continue;
-			}
-
 			int const first_leaf = piece << base;
 			int const num_leafs = 1 << base;
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -1063,6 +1063,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		aux::open_mode_t const file_flags = file_flags_for_job(j);
 
 		TORRENT_ASSERT(!v2 || int(j->d.h.block_hashes.size()) >= blocks_in_piece2);
+		TORRENT_ASSERT(v1 || v2);
 
 		hasher h;
 		int ret = 0;

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1080,7 +1080,6 @@ namespace libtorrent {
 		std::cerr << "[" << this << "] " << "restore_piece(" << index << ")" << std::endl;
 #endif
 		auto const download_state = m_piece_map[index].download_queue();
-		TORRENT_ASSERT(download_state != piece_pos::piece_open);
 		if (download_state == piece_pos::piece_open) return;
 
 		auto i = find_dl_piece(download_state, index);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4200,7 +4200,7 @@ namespace {
 
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log())
-			debug_log("PIECE_PASSED (%d)", num_passed());
+			debug_log("PIECE_PASSED (%d)", int(index));
 #endif
 
 //		std::fprintf(stderr, "torrent::piece_passed piece:%d\n", index);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6654,8 +6654,7 @@ namespace {
 	{
 		need_hash_picker();
 		if (!m_hash_picker) return true;
-		add_hashes_result result = m_hash_picker->add_hashes(req, hashes);
-		TORRENT_ASSERT(!(!result.hash_failed.empty() && result.valid));
+		add_hashes_result const result = m_hash_picker->add_hashes(req, hashes);
 		for (auto& p : result.hash_failed)
 		{
 			if (torrent_file().info_hashes().has_v1() && have_piece(p.first))

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4330,7 +4330,7 @@ namespace {
 			m_predictive_pieces.erase(it);
 		}
 #endif
-
+/*
 		if (!torrent_file().info_hashes().has_v1() && blocks.empty())
 		{
 			// This is a v2 only torrent so we can definitely get block
@@ -4345,7 +4345,7 @@ namespace {
 			verify_block_hashes(index);
 			return;
 		}
-
+*/
 		// increase the total amount of failed bytes
 		if (blocks.empty())
 			add_failed_bytes(m_torrent_file->piece_size(index));
@@ -6659,19 +6659,21 @@ namespace {
 		add_hashes_result const result = m_hash_picker->add_hashes(req, hashes);
 		for (auto& p : result.hash_failed)
 		{
-			if (torrent_file().info_hashes().has_v1() && have_piece(p.first))
+			if (torrent_file().info_hashes().has_v1() && have_piece(p))
 			{
 				set_error(errors::torrent_inconsistent_hashes, torrent_status::error_file_none);
 				pause();
 				return result.valid;
 			}
 
-			TORRENT_ASSERT(!have_piece(p.first));
+			TORRENT_ASSERT(!have_piece(p));
 
 			// the piece may not have been downloaded in this session
 			// it should be open for downloading so nothing needs to be done here
-			if (!m_picker || !m_picker->is_downloading(p.first)) continue;
-			piece_failed(p.first, std::move(p.second));
+			if (!m_picker || !m_picker->is_downloading(p)) continue;
+			// TODO: in the future, reqest block hashes to know exactly which
+			// block failed the hash check
+			piece_failed(p);
 		}
 		for (piece_index_t p : result.hash_passed)
 		{

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -376,13 +376,7 @@ TORRENT_TEST(bad_block_hash)
 	add_hashes_result result = picker.add_hashes(hash_request(0_file, 0, 0, 512, 10)
 		, hashes);
 	TEST_CHECK(result.valid);
-	TEST_CHECK(result.hash_failed.count(1_piece) == 1);
-	if (result.hash_failed.count(1_piece) == 1)
-	{
-		TEST_CHECK(result.hash_failed[1_piece].size() == 1);
-		if (result.hash_failed[1_piece].size() == 1)
-			TEST_CHECK(result.hash_failed[1_piece][0] == 0);
-	}
+	TEST_CHECK(std::count(result.hash_failed.begin(), result.hash_failed.end(), 1_piece) == 1);
 }
 
 TORRENT_TEST(set_block_hash)

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -214,6 +214,31 @@ TORRENT_TEST(merkle_get_first_child)
 	TEST_EQUAL(merkle_get_first_child(16), 33);
 }
 
+TORRENT_TEST(merkle_get_first_child2)
+{
+	// this is the structure:
+	//                        0
+	//            1                      2
+	//      3           4           5           6
+	//   7     8     9     10    11    12    13    14
+	// 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+	// 31 ...
+
+	TEST_EQUAL(merkle_get_first_child(0, 0), 0);
+	TEST_EQUAL(merkle_get_first_child(0, 1), 1);
+	TEST_EQUAL(merkle_get_first_child(0, 2), 3);
+	TEST_EQUAL(merkle_get_first_child(0, 3), 7);
+	TEST_EQUAL(merkle_get_first_child(0, 4), 15);
+	TEST_EQUAL(merkle_get_first_child(0, 5), 31);
+
+	TEST_EQUAL(merkle_get_first_child(2, 0), 2);
+	TEST_EQUAL(merkle_get_first_child(2, 1), 5);
+	TEST_EQUAL(merkle_get_first_child(2, 2), 11);
+	TEST_EQUAL(merkle_get_first_child(2, 3), 23);
+	TEST_EQUAL(merkle_get_first_child(2, 4), 47);
+	TEST_EQUAL(merkle_get_first_child(2, 5), 95);
+}
+
 TORRENT_TEST(merkle_layer_start)
 {
 	TEST_EQUAL(merkle_layer_start(0), 0);


### PR DESCRIPTION
This is work in progress to fix bugs in the handling of merkle trees in v2 torrents, specifically the case of starting a magnet-link download against existing files on disk. This issue: https://github.com/arvidn/libtorrent/issues/6394

Being work in progress means this branch will be force pushed and and may also be lacking some tests.

The commit `5a0e766` appears to be working well though