### PR TITLE
Migrate to OpenSSL EVP interface for hashing

### DIFF
--- a/include/libtorrent/aux_/hasher512.hpp
+++ b/include/libtorrent/aux_/hasher512.hpp
@@ -33,9 +33,9 @@ see LICENSE file.
 
 #elif defined TORRENT_USE_LIBCRYPTO
 
-	extern "C" {
-	#include <openssl/sha.h>
-	}
+extern "C" {
+#include <openssl/evp.h>
+}
 
 #else
 #include "libtorrent/aux_/sha512.hpp"
@@ -73,6 +73,8 @@ namespace aux {
 		explicit hasher512(span<char const> data);
 		hasher512(hasher512 const&);
 		hasher512& operator=(hasher512 const&) &;
+		hasher512(hasher512&&);
+		hasher512& operator=(hasher512&&) &;
 
 		// append the following bytes to what is being hashed
 		hasher512& update(span<char const> data);
@@ -99,7 +101,7 @@ namespace aux {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		aux::crypt_hash<CALG_SHA_512, PROV_RSA_AES> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_CTX m_context;
+		EVP_MD_CTX *m_context = nullptr;
 #else
 		sha512_ctx m_context;
 #endif

--- a/include/libtorrent/hasher.hpp
+++ b/include/libtorrent/hasher.hpp
@@ -40,7 +40,7 @@ see LICENSE file.
 #elif defined TORRENT_USE_LIBCRYPTO
 
 extern "C" {
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 }
 
 #else
@@ -81,6 +81,8 @@ TORRENT_CRYPTO_NAMESPACE
 		explicit hasher(span<char const> data);
 		hasher(hasher const&);
 		hasher& operator=(hasher const&) &;
+		hasher(hasher&&);
+		hasher& operator=(hasher&&) &;
 
 		// append the following bytes to what is being hashed
 		hasher& update(span<char const> data);
@@ -108,7 +110,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI
 		aux::crypt_hash<CALG_SHA1, PROV_RSA_FULL> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA_CTX m_context;
+		EVP_MD_CTX *m_context = nullptr;
 #else
 		aux::sha1_ctx m_context;
 #endif
@@ -125,6 +127,8 @@ TORRENT_CRYPTO_NAMESPACE
 		explicit hasher256(span<char const> data);
 		hasher256(hasher256 const&);
 		hasher256& operator=(hasher256 const&) &;
+		hasher256(hasher256&&);
+		hasher256& operator=(hasher256&&) &;
 
 		// append the following bytes to what is being hashed
 		hasher256& update(span<char const> data);
@@ -150,7 +154,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		aux::crypt_hash<CALG_SHA_256, PROV_RSA_AES> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_CTX m_context;
+		EVP_MD_CTX *m_context = nullptr;
 #else
 		aux::sha256_ctx m_context;
 #endif

--- a/test/test_hasher.cpp
+++ b/test/test_hasher.cpp
@@ -61,6 +61,20 @@ void test_vector(string_view s, string_view output, int const n = 1)
 	TEST_EQUAL(output_hex, digest_hex);
 }
 
+template<typename T>
+void test_move(string_view const input)
+{
+	std::string const digest = T(input).final().to_string();
+
+	T tmp1(input);
+	T h1(std::move(tmp1));
+	TEST_EQUAL(h1.final().to_string(), digest);
+
+	T tmp2(input);
+	T h2 = std::move(tmp2);
+	TEST_EQUAL(h2.final().to_string(), digest);
+}
+
 }
 
 TORRENT_TEST(hasher)
@@ -75,6 +89,11 @@ TORRENT_TEST(hasher)
 		aux::from_hex(t.hex_output, result.data());
 		TEST_CHECK(result == h.final());
 	}
+}
+
+TORRENT_TEST(hasher_move)
+{
+	test_move<hasher>("abc");
 }
 
 // http://www.di-mgt.com.au/sha_testvectors.html
@@ -121,3 +140,7 @@ TORRENT_TEST(hasher256)
 	}
 }
 
+TORRENT_TEST(hasher256_move)
+{
+	test_move<hasher256>("abc");
+}

--- a/test/test_hasher512.cpp
+++ b/test/test_hasher512.cpp
@@ -66,4 +66,18 @@ TORRENT_TEST(hasher512_test_vec1)
 	);
 }
 
+TORRENT_TEST(hasher512_move)
+{
+	std::string const input = "abc";
+	std::string const digest = aux::hasher512(input).final().to_string();
+
+	aux::hasher512 tmp1(input);
+	aux::hasher512 h1(std::move(tmp1));
+	TEST_EQUAL(h1.final().to_string(), digest);
+
+	aux::hasher512 tmp2(input);
+	aux::hasher512 h2 = std::move(tmp2);
+	TEST_EQUAL(h2.final().to_string(), digest);
+}
+
 #endif // TORRENT_DISABLE_DHT


### PR DESCRIPTION
The low-level interface is deprecated since OpenSSL v3.0 [1].

[1] https://www.openssl.org/docs/manmaster/man7/migration_guide.html "Deprecated low-level digest functions"