### PR TITLE
don't open the piece in the piece picker if there still are outstanding hash jobs

### DIFF
--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -2977,7 +2977,7 @@ get_out:
 		{
 			new_state = piece_pos::piece_zero_prio;
 		}
-		else if (dp->requested + dp->finished + dp->writing == 0)
+		else if (dp->requested + dp->finished + dp->writing + dp->hashing == 0)
 		{
 			new_state = piece_pos::piece_open;
 		}


### PR DESCRIPTION
to handle write failures