### PR TITLE
null pointer dereference in enum_net::iface_from_ifaddrs

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -545,7 +545,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 	bool iface_from_ifaddrs(ifaddrs *ifa, ip_interface &rv)
 	{
 		// determine address
-		rv.interface_address = sockaddr_to_address(ifa->ifa_addr);
+		if (ifa->ifa_addr) rv.interface_address = sockaddr_to_address(ifa->ifa_addr);
 		if (rv.interface_address.is_unspecified()) return false;
 
 		std::strncpy(rv.name, ifa->ifa_name, sizeof(rv.name) - 1);


### PR DESCRIPTION
Fixes crash Android arm/arm64 devices when `TORRENT_USE_IFADDRS` is used.
Solves [nasty crash found on frostwire for android](https://github.com/frostwire/frostwire-jlibtorrent/issues/261) that came up after Android 11+ decided to remove netlink sockets and we switched compilation to use ifaddrs.

Thanks to @aldeml for the assist.