### PR TITLE
buffer.hpp: Fix build on NetBSD and OpenBSD

### DIFF
--- a/include/libtorrent/buffer.hpp
+++ b/include/libtorrent/buffer.hpp
@@ -49,8 +49,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <malloc.h>
 #elif defined __FreeBSD__
 #include <malloc_np.h>
-#elif defined TORRENT_BSD
-#include <malloc/malloc.h>
 #endif
 
 namespace libtorrent {
@@ -89,8 +87,6 @@ public:
 		m_size = static_cast<difference_type>(::malloc_usable_size(m_begin));
 #elif defined _MSC_VER
 		m_size = static_cast<difference_type>(::_msize(m_begin));
-#elif defined TORRENT_BSD
-		m_size = static_cast<difference_type>(::malloc_size(m_begin));
 #else
 		m_size = size;
 #endif


### PR DESCRIPTION
OpenBSD, NetBSD and DragonFly have had the same patches in our ports / pkgsrc trees to fix the build on each respective OS.