### PR TITLE
Run pre-commit hooks on gen_settings_doc.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,6 @@ repos:
           (?x)^(
                docs/filter-rst.py|
                docs/gen_reference_doc.py|
-               docs/gen_settings_doc.py|
                docs/gen_stats_doc.py|
                docs/gen_todo.py|
                docs/join_rst.py|
@@ -113,7 +112,6 @@ repos:
           (?x)^(
               docs/filter-rst.py|
               docs/gen_reference_doc.py|
-              docs/gen_settings_doc.py|
               docs/gen_stats_doc.py|
               docs/gen_todo.py|
               examples/run_benchmarks.py|
@@ -149,7 +147,6 @@ repos:
             # Enable these later, avoid bloating this PR
             docs/gen_todo.py|
             docs/gen_reference_doc.py|
-            docs/gen_settings_doc.py|
             docs/gen_stats_doc.py|
             examples/run_benchmarks.py|
             fuzzers/tools/generate_initial_corpus.py|

--- a/docs/gen_settings_doc.py
+++ b/docs/gen_settings_doc.py
@@ -1,104 +1,110 @@
 #!/usr/bin/env python3
-from __future__ import print_function
 
-f = open('../include/libtorrent/settings_pack.hpp')
+from typing import Dict
+from typing import List
+from typing import Sequence
+from typing import Set
 
-out = open('settings.rst', 'w+')
-all_names = set()
+f = open("../include/libtorrent/settings_pack.hpp")
+
+out = open("settings.rst", "w+")
+all_names: Set[str] = set()
 
 
-def print_field(str, width):
-    return '%s%s' % (str, ' ' * (width - len(str)))
+def ljust(values: Sequence[str], widths: Sequence[int]) -> Sequence[str]:
+    return [value.ljust(width) for value, width in zip(values, widths)]
 
 
-def render_section(names, description, type, default_values):
-    max_name_len = max(len(max(names, key=len)), len('name'))
-    max_type_len = max(len(type), len('type'))
-    max_val_len = max(len(max(default_values, key=len)), len('default'))
+def render_section(
+    names: List[str], description: str, type: str, default_values: List[str]
+) -> None:
+    widths = (
+        max(len(v) for v in names + ["name"]),
+        max(len(v) for v in (type, "type")),
+        max(len(v) for v in default_values + ["default"]),
+    )
 
     # add link targets for the rest of the manual to reference
-    for n in names:
-        print('.. _%s:\n' % n, file=out)
-        for w in n.split('_'):
-            all_names.add(w)
+    for name in names:
+        out.write(f".. _{name}:\n\n")
+        for part in name.split("_"):
+            all_names.add(part)
 
-    if len(names) > 0:
-        print('.. raw:: html\n', file=out)
-        for n in names:
-            print('\t<a name="%s"></a>' % n, file=out)
-        print('', file=out)
+    if names:
+        out.write(".. raw:: html\n\n")
+        for name in names:
+            out.write(f'\t<a name="{name}"></a>\n')
+        out.write("\n")
 
-    separator = '+-' + ('-' * max_name_len) + '-+-' + ('-' * max_type_len) + '-+-' + ('-' * max_val_len) + '-+'
+    separator = "+-" + "-+-".join("-" * w for w in widths) + "-+\n"
 
     # build a table for the settings, their type and default value
-    print(separator, file=out)
-    print(
-        '| %s | %s | %s |' %
-        (print_field(
-            'name', max_name_len), print_field(
-            'type', max_type_len), print_field(
-                'default', max_val_len)), file=out)
-    print(separator.replace('-', '='), file=out)
-    for i in range(len(names)):
-        print(
-            '| %s | %s | %s |' %
-            (print_field(
-                names[i], max_name_len), print_field(
-                type, max_type_len), print_field(
-                default_values[i], max_val_len)), file=out)
-        print(separator, file=out)
-    print(file=out)
-    print(description, file=out)
+    out.write(separator)
+
+    out.write("| ")
+    out.write(" | ".join(ljust(("name", "type", "default"), widths)))
+    out.write(" |\n")
+    out.write(separator.replace("-", "="))
+    for name, default_value in zip(names, default_values):
+        out.write("| ")
+        out.write(" | ".join(ljust((name, type, default_value), widths)))
+        out.write(" |\n")
+
+        out.write(separator)
+    out.write("\n")
+    out.write(f"{description}\n")
 
 
-mode = ''
+mode = ""
 
 # parse out default values for settings
-f2 = open('../src/settings_pack.cpp')
-def_map = {}
+f2 = open("../src/settings_pack.cpp")
+def_map: Dict[str, str] = {}
 for line in f2:
     line = line.strip()
-    if not line.startswith('SET(') \
-        and not line.startswith('SET_NOPREV(') \
-            and not line.startswith('DEPRECATED_SET('):
+    if (
+        not line.startswith("SET(")
+        and not line.startswith("SET_NOPREV(")
+        and not line.startswith("DEPRECATED_SET(")
+    ):
         continue
 
-    line = line.split('(')[1].split(',')
-    if line[1].strip()[0] == '"':
-        default = ','.join(line[1:]).strip()[1:].split('"')[0].strip()
+    args = line.split("(")[1].split(",")
+    if args[1].strip()[0] == '"':
+        default = ",".join(args[1:]).strip()[1:].split('"')[0].strip()
     else:
-        default = line[1].strip()
-    def_map[line[0]] = default
-    print('%s = %s' % (line[0], default))
+        default = args[1].strip()
+    def_map[args[0]] = default
+    print("%s = %s" % (args[0], default))
 
-description = ''
-names = []
+description = ""
+names: List[str] = []
 
 for line in f:
-    if 'enum string_types' in line:
-        mode = 'string'
-    if 'enum bool_types' in line:
-        mode = 'bool'
-    if 'enum int_types' in line:
-        mode = 'int'
-    if '#if TORRENT_ABI_VERSION == 1' in line:
-        mode += 'skip'
-    if '#if TORRENT_ABI_VERSION <= 2' in line:
-        mode += 'skip'
-    if '#if TORRENT_ABI_VERSION <= 3' in line:
-        mode += 'skip'
-    if '#endif' in line:
+    if "enum string_types" in line:
+        mode = "string"
+    if "enum bool_types" in line:
+        mode = "bool"
+    if "enum int_types" in line:
+        mode = "int"
+    if "#if TORRENT_ABI_VERSION == 1" in line:
+        mode += "skip"
+    if "#if TORRENT_ABI_VERSION <= 2" in line:
+        mode += "skip"
+    if "#if TORRENT_ABI_VERSION <= 3" in line:
+        mode += "skip"
+    if "#endif" in line:
         mode = mode[0:-4]
 
-    if mode == '':
+    if mode == "":
         continue
-    if mode[-4:] == 'skip':
+    if mode[-4:] == "skip":
         continue
 
     line = line.lstrip()
 
-    if line == '' and len(names) > 0:
-        if description == '':
+    if line == "" and len(names) > 0:
+        if description == "":
             for n in names:
                 print('WARNING: no description for "%s"' % n)
         else:
@@ -106,33 +112,33 @@ for line in f:
             for n in names:
                 default_values.append(def_map[n])
             render_section(names, description, mode, default_values)
-        description = ''
+        description = ""
         names = []
 
-    if line.startswith('};'):
-        mode = ''
+    if line.startswith("};"):
+        mode = ""
         continue
 
-    if line.startswith('//'):
-        if line[2] == ' ':
+    if line.startswith("//"):
+        if line[2] == " ":
             description += line[3:]
         else:
             description += line[2:]
         continue
 
     line = line.strip()
-    if line.endswith(','):
+    if line.endswith(","):
         line = line[:-1]  # strip trailing comma
-        if '=' in line:
-            line = line.split('=')[0].strip()
-        if line.endswith('_internal'):
+        if "=" in line:
+            line = line.split("=")[0].strip()
+        if line.endswith("_internal"):
             continue
 
         names.append(line)
 
-dictionary = open('hunspell/settings.dic', 'w+')
-for w in all_names:
-    dictionary.write(w + '\n')
+dictionary = open("hunspell/settings.dic", "w+")
+for w in sorted(all_names):
+    dictionary.write(w + "\n")
 dictionary.close()
 out.close()
 f.close()


### PR DESCRIPTION
Chipping away at the excluded files in `.pre-commit-config.yaml`.

I rewrote some parts of this to be simpler and/or more pythonic. I changed variable names to avoid treating variables as different types (e.g. `x` is initially a `int` but is later set to a `str`), as mypy does not allow this.

I changed it so it produces stable sorted output in `hunspell/settings.dic`, to more easily compare the output before and after the changes.

I tested this by running it before and after the changes. The output appears identical.