### PR TITLE
Remove msvc toolset pinning

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -18,19 +18,6 @@ import setuptools
 import setuptools.command.build_ext as _build_ext_lib
 
 
-def get_msvc_toolset():
-    # Reference: https://wiki.python.org/moin/WindowsCompilers
-    major_minor = sys.version_info[0:2]
-    if major_minor in ((2, 6), (2, 7), (3, 0), (3, 1), (3, 2)):
-        return "msvc-9.0"
-    if major_minor in ((3, 3), (3, 4)):
-        return "msvc-10.0"
-    if major_minor in ((3, 5), (3, 6)):
-        return "msvc-14.1"  # libtorrent requires VS 2017 or newer
-    # unknown python version
-    return "msvc"
-
-
 def b2_bool(value):
     if value:
         return "on"
@@ -244,10 +231,7 @@ class LibtorrentBuildExt(BuildExtBase):
         except OSError:
             pass
 
-        if os.name == "nt":
-            self.toolset = get_msvc_toolset()
-        else:
-            self.toolset = None
+        self.toolset = None
         self.libtorrent_link = None
         self.boost_link = None
         self.pic = None


### PR DESCRIPTION
The current logic breaks with boost 1.76 on windows github actions runners. The problem appears to be that `msvc-14.2` is the "correct" choice for the environment and boost-build scripts, but `get_msvc_toolset()` returns `msvc-14.1`, which fails with some error that `cl.exe` can't be found.

Allowing boost-build to autoselect the toolset appears to work better than `get_msvc_toolset()`. Ideally we want logic that selects something like `>=msvc-14.1`, but I don't see a way to do that.

The older python versions don't matter, since we only support python 3.6+.