### PR TITLE
Change default to boost-link=static

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -374,10 +374,8 @@ class LibtorrentBuildExt(BuildExtBase):
     def _configure_b2_with_distutils(self):
         if os.name == "nt":
             self._maybe_add_arg("--abbreviate-paths")
-            self._maybe_add_arg("boost-link=static")
-        else:
-            self._maybe_add_arg("boost-link=shared")
 
+        self._maybe_add_arg("boost-link=static")
         self._maybe_add_arg("libtorrent-link=static")
 
         if distutils.debug.DEBUG:


### PR DESCRIPTION
This is in line with the principle that `setup.py` should produce "pypi wheel-ready" builds by default.

This is a prerequisite for #6188.