### PR TITLE
Use ccache on github actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           sudo apt update
 
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -67,6 +71,10 @@ jobs:
         run: |
           sudo apt update
 
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+
       - name: install clang-9
         continue-on-error: true
         run: |
@@ -99,6 +107,10 @@ jobs:
         run: |
           sudo apt update
 
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -124,6 +136,10 @@ jobs:
         continue-on-error: true
         run: |
           sudo apt update
+
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
 
       - name: install clang-tidy
         run: sudo apt install clang-tidy libc++-dev
@@ -158,6 +174,10 @@ jobs:
         continue-on-error: true
         run: |
           sudo apt update
+
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
 
       - name: install clang-10
         continue-on-error: true
@@ -195,6 +215,10 @@ jobs:
         run: |
           sudo apt update
 
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
@@ -224,6 +248,12 @@ jobs:
         continue-on-error: true
         run: |
           sudo apt update
+
+      - uses: Chocobo1/setup-ccache-action@v1
+        # the ccache version on ubuntu-18.04 is too old
+        if: matrix.os != 'ubuntu-18.04'
+        with:
+          update_packager_index: false
 
       - name: install dependencies
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,8 @@ jobs:
         with:
            submodules: recursive
 
+      - uses: Chocobo1/setup-ccache-action@v1
+
       - name: install boost
         run: |
           brew install boost-build boost
@@ -46,6 +48,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
            submodules: recursive
+
+      - uses: Chocobo1/setup-ccache-action@v1
 
       - name: install boost
         run: |
@@ -72,6 +76,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
            submodules: recursive
+
+      - uses: Chocobo1/setup-ccache-action@v1
 
       - name: install boost
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,6 +31,12 @@ jobs:
       run: |
         sudo apt update
 
+    - uses: Chocobo1/setup-ccache-action@v1
+      # the ccache version on ubuntu-18.04 is too old
+      if: matrix.os != 'ubuntu-18.04'
+      with:
+        update_packager_index: false
+
     - name: dependencies (linux)
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
@Chocobo1 created a github action to set up ccache. I've applied it to github actions.

When it gets a cache hit, it appears to shave minutes off of CI runtime.

We could probably fine-tune cache keys, and maybe we should set eviction config, but I think this is a good start.