### PR TITLE
Change python package name to libtorrent

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -448,7 +448,7 @@ class LibtorrentBuildExt(BuildExtBase):
 
 
 setuptools.setup(
-    name="python-libtorrent",
+    name="libtorrent",
     version="1.2.14",
     author="Arvid Norberg",
     author_email="arvid@libtorrent.org",


### PR DESCRIPTION
Per discussions in #5333 and #6188.