### PR TITLE
Default to libtorrent-link=static boost-link=static

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,7 +76,7 @@ jobs:
         # Homebrew's python "framework" sets a prefix via distutils config.
         # --prefix conflicts with --user, so null out prefix so we have one
         # command that works everywhere
-        python3 setup.py build_ext --b2-args="libtorrent-link=static" install --user --prefix=
+        python3 setup.py build_ext install --user --prefix=
 
     - name: tests
       if: runner.os != 'Windows'

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -379,11 +379,9 @@ class LibtorrentBuildExt(BuildExtBase):
     def _configure_b2_with_distutils(self, python_binding_dir):
         if os.name == "nt":
             self._maybe_add_arg("--abbreviate-paths")
-            self._maybe_add_arg("boost-link=static")
-            self._maybe_add_arg("libtorrent-link=static")
-        else:
-            self._maybe_add_arg("boost-link=shared")
-            self._maybe_add_arg("libtorrent-link=prebuilt")
+
+        self._maybe_add_arg("boost-link=static")
+        self._maybe_add_arg("libtorrent-link=static")
 
         if distutils.debug.DEBUG:
             self._maybe_add_arg("--debug-configuration")


### PR DESCRIPTION
This is in line with the principle that `setup.py` should produce "pypi wheel-ready" builds by default.

This is a prerequisite for #6188.