### PR TITLE
Default python bindings to crypto=openssl

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,7 +40,7 @@ jobs:
     - name: dependencies (linux)
       if: runner.os == 'Linux'
       run: |
-        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev python3 python3-setuptools
+        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev python3 python3-setuptools libssl-dev
 
     - name: install boost (windows)
       if: runner.os == 'Windows'
@@ -56,6 +56,12 @@ jobs:
       run: |
         cd boost
         .\b2 headers
+
+    - name: install openssl (windows)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        choco install openssl
 
     - name: build/install (windows)
       if: runner.os == 'Windows'

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -385,6 +385,8 @@ class LibtorrentBuildExt(BuildExtBase):
             self._maybe_add_arg("boost-link=shared")
             self._maybe_add_arg("libtorrent-link=prebuilt")
 
+        self._maybe_add_arg("crypto=openssl")
+
         if distutils.debug.DEBUG:
             self._maybe_add_arg("--debug-configuration")
             self._maybe_add_arg("--debug-building")


### PR DESCRIPTION
Per discussion in #6188 and #6448.

Draft until there's consensus that this is a good plan.

The `test.py` changes backport a lot of infrastructure I added in `master`. I'll make a separate PR for `master` for a cleaner merge.