### PR TITLE
Reference major version for actions on Github CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
 
       - name: update package lists
         continue-on-error: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,8 +250,6 @@ jobs:
           sudo apt update
 
       - uses: Chocobo1/setup-ccache-action@v1
-        # the ccache version on ubuntu-18.04 is too old
-        if: matrix.os != 'ubuntu-18.04'
         with:
           update_packager_index: false
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -62,7 +62,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -98,7 +98,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -128,7 +128,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -166,7 +166,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -206,7 +206,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -240,7 +240,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -45,7 +45,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 
@@ -73,7 +73,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019 ]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,8 +32,7 @@ jobs:
         sudo apt update
 
     - uses: Chocobo1/setup-ccache-action@v1
-      # the ccache version on ubuntu-18.04 is too old
-      if: matrix.os != 'ubuntu-18.04'
+      if: runner.os != 'Windows'
       with:
         update_packager_index: false
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
            submodules: recursive
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
 
    tests:
       name: Test
-      runs-on: windows-2019
+      runs-on: windows-latest
       continue-on-error: true
 
       steps:


### PR DESCRIPTION
* Reference major version for actions on Github CI
  https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses
  > Using the specific major action version allows you to receive critical fixes and security patches while still maintaining compatibility. It also assures that your workflow should still work.
* Remove ccache action conditional
  The latest release added support to Ubuntu-18.04:
  https://github.com/Chocobo1/setup-ccache-action/releases/tag/v1.1.1
* Use latest OS for CI jobs that are agnostic to the underlying platform 

I would advise to apply them to other branches (RC_2_0, master) as well.