### PR TITLE
Use job-specific ccaches

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-build-${{ github.base_ref }}-${{ matrix.config }}
+          ccache_options: |
+            max_size=5G
 
       - name: install boost
         run: |
@@ -74,6 +77,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-fuzzers-${{ github.base_ref }}
+          ccache_options: |
+            max_size=500M
 
       - name: install clang-9
         continue-on-error: true
@@ -110,6 +116,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-check-headers-${{ github.base_ref }}
+          ccache_options: |
+            max_size=500M
 
       - name: install boost
         run: |
@@ -140,6 +149,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-clang-tidy-${{ github.base_ref }}
+          ccache_options: |
+            max_size=500M
 
       - name: install clang-tidy
         run: sudo apt install clang-tidy libc++-dev
@@ -178,6 +190,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-tests-${{ matrix.config }}-${{ github.base_ref }}
+          ccache_options: |
+            max_size=5G
 
       - name: install clang-10
         continue-on-error: true
@@ -218,6 +233,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-simulations-${{ github.base_ref }}
+          ccache_options: |
+            max_size=5G
 
       - name: install boost
         run: |
@@ -252,6 +270,9 @@ jobs:
       - uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          override_cache_key: ccache-linux-dist-${{ matrix.os }}-${{ github.base_ref }}
+          ccache_options: |
+            max_size=15G
 
       - name: install dependencies
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,10 @@ jobs:
            submodules: recursive
 
       - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          override_cache_key: ccache-macos-test-${{ matrix.config }}-${{ github.base_ref }}
+          ccache_options: |
+            max_size=1G
 
       - name: install boost
         run: |
@@ -50,6 +54,10 @@ jobs:
            submodules: recursive
 
       - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          override_cache_key: ccache-macos-sim-${{ github.base_ref }}
+          ccache_options: |
+            max_size=1G
 
       - name: install boost
         run: |
@@ -78,6 +86,10 @@ jobs:
            submodules: recursive
 
       - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          override_cache_key: ccache-macos-build-${{ matrix.config }}-${{ github.base_ref }}
+          ccache_options: |
+            max_size=1G
 
       - name: install boost
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,6 +35,9 @@ jobs:
       if: runner.os != 'Windows'
       with:
         update_packager_index: false
+        override_cache_key: ccache-python-${{ matrix.os }}-${{ github.base_ref }}
+        ccache_options: |
+          max_size=500M
 
     - name: dependencies (linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
The ccache action prints stats at the end of the job. I notice that our cache hit rates are low, even when re-running a workflow without changes. I believe that matrix'ed jobs are stomping on each other's caches:
* multiple jobs start at the same time
* they load the same cache
* they modify the cache, each differently
* they finish at different times, and store their updated caches
* on the next workflow run, all the jobs only see the cache of the *last job to finish* from the previous workflow

I gave each ccache a separate key. This resulted in much higher hit rates, until we spill out of the cache within a single job.

I don't believe this strategy results in cache data being duplicated between isolated job caches, because that would mean two different jobs were are doing identical builds, and workflow jobs are generally written to avoid this.

I also separated caches by base ref (i.e. target branch). There's some chance that builds are partially identical across branches, but it should still be fairly low.

The default cache size of 500mb is too small for some jobs, especially the linux dist jobs. To pick cache sizes, I arbitrarily decided that our target workload is 5 active pull requests on a given branch. I ran the pull request workflows with cold caches, measured the cache sizes when each job was done, multiplied by 5 and rounded up a bit.

Note that caches are compressed ~75% when stored, so ccache with `max_size=400M` will only use about 100mb of `actions/cache` storage for libtorrent.

You can test cache hit rates by re-running checks after they've completed the first time.