### PR TITLE
Backport non-API-facing python bindings changes from master

### DIFF
--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -668,10 +668,10 @@ void bind_alert()
 
     enum_<socket_type_t>("socket_type_t")
        .value("tcp", socket_type_t::tcp)
-       .value("tcp_ssl", socket_type_t::tcp_ssl)
+       .value("socks5", socket_type_t::socks5)
        .value("udp", socket_type_t::udp)
        .value("i2p", socket_type_t::i2p)
-       .value("socks5", socket_type_t::socks5)
+       .value("tcp_ssl", socket_type_t::tcp_ssl)
        .value("utp_ssl", socket_type_t::utp_ssl)
        ;
 

--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -296,7 +296,7 @@ struct bitfield_to_list
     static PyObject* convert(T const& v)
     {
         list ret;
-        for (auto const& i : v)
+        for (auto const i : v)
             ret.append(i);
         return incref(ret.ptr());
     }

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -184,9 +184,10 @@ namespace
 
 	std::shared_ptr<lt::session> make_session(boost::python::dict sett, session_flags_t flags)
 	{
-		settings_pack p;
-		make_settings_pack(p, sett);
-		return std::make_shared<lt::session>(p, flags);
+		session_params p;
+		make_settings_pack(p.settings, sett);
+		p.flags = flags;
+		return std::make_shared<lt::session>(std::move(p));
 	}
 
 	void session_apply_settings(lt::session& ses, dict const& sett_dict)

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -33,7 +33,7 @@ namespace boost
 	// this fixes mysterious link error on msvc
 	template <>
 	inline lt::alert const volatile*
-	get_pointer(class lt::alert const volatile* p)
+	get_pointer(lt::alert const volatile* p)
 	{
 		return p;
 	}

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -231,7 +231,7 @@ namespace
         , storage_mode_t storage_mode, bool paused)
     {
         allow_threading_guard guard;
-        return s.add_torrent(ti, save, resume, storage_mode, paused, default_storage_constructor);
+        return s.add_torrent(ti, save, resume, storage_mode, paused);
     }
 #endif
 #endif


### PR DESCRIPTION
I want to backport the new tests and fixes to the python bindings from `master`. I don't want to expose anything that isn't already exposed, except where necessary to make the python bindings work consistently.

To do this, it's helpful to first backport all non-API-facing changes made prior to all the new python bindings work. This makes the source as close as possible to `master`, which helps the later commits merge more cleanly. It's also in the spirit of the work to have as many fixes on as many branches as possible.

In some cases the changes are just textual.