### PR TITLE
Backport d6b9d03a9 (remove since-long deprecated wstring overloads)

### DIFF
--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -105,14 +105,6 @@ namespace
 
     FileIter end_files(file_storage const& self)
     { return FileIter(self, self.end_file()); }
-
-#ifdef TORRENT_WINDOWS
-    void add_file_wstring(file_storage& fs, std::wstring const& file, std::int64_t size
-       , file_flags_t const flags, std::time_t md, std::string link)
-    {
-       fs.add_file(file, size, flags, md, link);
-    }
-#endif
 #endif // TORRENT_ABI_VERSION
 
     void add_files_callback(file_storage& fs, std::string const& file
@@ -140,12 +132,6 @@ void bind_create_torrent()
 {
     void (file_storage::*set_name0)(std::string const&) = &file_storage::set_name;
     void (file_storage::*rename_file0)(file_index_t, std::string const&) = &file_storage::rename_file;
-#if TORRENT_ABI_VERSION == 1
-#ifdef TORRENT_WINDOWS
-    void (file_storage::*set_name1)(std::wstring const&) = &file_storage::set_name;
-    void (file_storage::*rename_file1)(file_index_t, std::wstring const&) = &file_storage::rename_file;
-#endif
-#endif
 
 #ifndef BOOST_NO_EXCEPTIONS
     void (*set_piece_hashes0)(create_torrent&, std::string const&) = &set_piece_hashes;
@@ -175,9 +161,6 @@ void bind_create_torrent()
         .def("add_file", add_file_deprecated, arg("entry"))
         .def("__iter__", boost::python::range(&begin_files, &end_files))
         .def("__len__", depr(&file_storage::num_files))
-#ifdef TORRENT_WINDOWS
-        .def("add_file", add_file_wstring, (arg("path"), arg("size"), arg("flags") = 0, arg("mtime") = 0, arg("linkpath") = ""))
-#endif
 #endif // TORRENT_ABI_VERSION
         .def("hash", file_storage_hash)
         .def("symlink", file_storage_symlink, return_value_policy<copy_const_reference>())
@@ -195,12 +178,6 @@ void bind_create_torrent()
         .def("piece_size", &file_storage::piece_size)
         .def("set_name", set_name0)
         .def("rename_file", rename_file0)
-#if TORRENT_ABI_VERSION == 1
-#ifdef TORRENT_WINDOWS
-        .def("set_name", depr(set_name1))
-        .def("rename_file", depr(rename_file1))
-#endif
-#endif
         .def("name", &file_storage::name, return_value_policy<copy_const_reference>())
         ;
 

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -441,13 +441,6 @@ void bind_torrent_handle()
     void (torrent_handle::*move_storage0)(std::string const&, lt::move_flags_t) const = &torrent_handle::move_storage;
     void (torrent_handle::*rename_file0)(file_index_t, std::string const&) const = &torrent_handle::rename_file;
 
-#if TORRENT_ABI_VERSION == 1
-#ifdef TORRENT_WINDOWS
-    void (torrent_handle::*move_storage1)(std::wstring const&, int) const = &torrent_handle::move_storage;
-    void (torrent_handle::*rename_file1)(file_index_t, std::wstring const&) const = &torrent_handle::rename_file;
-#endif
-#endif
-
     std::vector<open_file_state> (torrent_handle::*file_status0)() const = &torrent_handle::file_status;
 
 #define _ allow_threads
@@ -569,10 +562,6 @@ void bind_torrent_handle()
         .def("set_ratio", depr(&torrent_handle::set_ratio))
         .def("save_path", depr(&torrent_handle::save_path))
         .def("set_tracker_login", depr(&torrent_handle::set_tracker_login))
-#ifdef TORRENT_WINDOWS
-        .def("move_storage", move_storage1, (arg("path"), arg("flags") = always_replace_files))
-        .def("rename_file", rename_file1)
-#endif
 #endif
         ;
 

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -332,11 +332,6 @@ void bind_torrent_info()
     return_value_policy<copy_const_reference> copy;
 
     void (torrent_info::*rename_file0)(file_index_t, std::string const&) = &torrent_info::rename_file;
-#if TORRENT_ABI_VERSION == 1
-#ifdef TORRENT_WINDOWS
-    void (torrent_info::*rename_file1)(file_index_t, std::wstring const&) = &torrent_info::rename_file;
-#endif
-#endif
 
     class_<file_slice>("file_slice")
         .add_property("file_index", make_getter((&file_slice::file_index), by_value()))
@@ -397,9 +392,6 @@ void bind_torrent_info()
         .def("orig_files", &torrent_info::orig_files, return_internal_reference<>())
 #if TORRENT_ABI_VERSION == 1
         .def("file_at", depr(&torrent_info::file_at))
-#ifdef TORRENT_WINDOWS
-        .def("rename_file", rename_file1)
-#endif
 #endif // TORRENT_ABI_VERSION
 
         .def("is_valid", &torrent_info::is_valid)


### PR DESCRIPTION
This has the same intent as #6509: to backport changes from `master`.

I thought this change deserved discussion on its own.

In python 3, the default boost.python converters for `std::string` and `std::wstring` both match `str` and `bytes`. So the `std::wstring` bindings here are always shadowed by the `std::string` functions in python 3.

In python 2, the `std::string` converter matches `str` but not `unicode`. So the `std::wstring` binding is functional there, and required to use `unicode` args.

Removing this binding could break users, but they would need to be
* using python 2 (EOL 2020-01-01)
* using `unicode` args to these functions (`unicode` won't work most places in the API, since it only matches `std::wstring` functions in python2)
* either Windows-only, or else using code like
```python
if sys.platform == "win32":
    handle.rename_file(0, u"file.txt")
else:
    handle.rename_file(0, "file.txt")
```

The only thing to gain from this PR is cleaner merges from `RC_1_2` to `master`. But the only thing to lose is the narrow case above.

Personally I think smoother development is the path to good code quality, so I favor clean merges.