### PR TITLE
Backport 2f9ed031d (disable deprecated boost.asio APIs)

### DIFF
--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -58,7 +58,7 @@ struct tuple_to_endpoint
         extract<std::uint16_t> port(object(borrowed(PyTuple_GetItem(x, 1))));
         if (!port.check()) return nullptr;
         lt::error_code ec;
-        lt::address::from_string(ip, ec);
+        lt::make_address(ip, ec);
         if (ec) return nullptr;
         return x;
     }
@@ -69,7 +69,7 @@ struct tuple_to_endpoint
            ->storage.bytes;
 
         object o(borrowed(x));
-        data->convertible = new (storage) T(lt::address::from_string(
+        data->convertible = new (storage) T(lt::make_address(
            extract<std::string>(o[0])), extract<std::uint16_t>(o[1]));
     }
 };
@@ -88,8 +88,7 @@ struct address_to_tuple
 {
     static PyObject* convert(Addr const& addr)
     {
-        lt::error_code ec;
-        return incref(bp::object(addr.to_string(ec)).ptr());
+        return incref(bp::object(addr.to_string()).ptr());
     }
 };
 

--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -58,7 +58,7 @@ struct tuple_to_endpoint
         extract<std::uint16_t> port(object(borrowed(PyTuple_GetItem(x, 1))));
         if (!port.check()) return nullptr;
         lt::error_code ec;
-        lt::make_address(ip, ec);
+        lt::make_address(static_cast<std::string>(ip), ec);
         if (ec) return nullptr;
         return x;
     }
@@ -70,7 +70,7 @@ struct tuple_to_endpoint
 
         object o(borrowed(x));
         data->convertible = new (storage) T(lt::make_address(
-           extract<std::string>(o[0])), extract<std::uint16_t>(o[1]));
+           static_cast<std::string>(extract<std::string>(o[0]))), extract<std::uint16_t>(o[1]));
     }
 };
 

--- a/bindings/python/src/ip_filter.cpp
+++ b/bindings/python/src/ip_filter.cpp
@@ -13,12 +13,12 @@ namespace
 {
     void add_rule(ip_filter& filter, std::string start, std::string end, int flags)
     {
-        return filter.add_rule(address::from_string(start), address::from_string(end), flags);
+        return filter.add_rule(make_address(start), make_address(end), flags);
     }
 
     int access0(ip_filter& filter, std::string addr)
     {
-        return filter.access(address::from_string(addr));
+        return filter.access(make_address(addr));
     }
 
     template <typename T>


### PR DESCRIPTION
This has the same intent as #6509: to backport changes from `master`.

I don't know if this change is appropriate. It breaks on `ubuntu-18.04`.