### PR TITLE
Fix build with i2p=OFF

### DIFF
--- a/src/http_seed_connection.cpp
+++ b/src/http_seed_connection.cpp
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/session_impl.hpp"
 #include "libtorrent/peer_info.hpp"
 #include "libtorrent/hex.hpp" // for is_hex
+#include "libtorrent/random.hpp"
 #include "libtorrent/optional.hpp"
 
 namespace libtorrent {

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -55,6 +55,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/alert_manager.hpp" // for alert_manager
 #include "libtorrent/aux_/escape_string.hpp" // for escape_path
 #include "libtorrent/hex.hpp" // for is_hex
+#include "libtorrent/random.hpp"
 #include "libtorrent/torrent.hpp"
 #include "libtorrent/http_parser.hpp"
 


### PR DESCRIPTION
Fixes the following issue:

Building with settings `cmake .. -DCMAKE_BUILD_TYPE=Release -Di2p=OFF`
fails with
```
src/http_seed_connection.cpp:83:8: error: ‘random_bytes’ is not a member of ‘libtorrent::aux’
   83 |   aux::random_bytes(pid);
src/web_peer_connection.cpp:144:7: error: ‘random_bytes’ is not a member of ‘libtorrent::aux’
  144 |  aux::random_bytes(pid);
```