### PR TITLE
use ifaddrs for android api >= 24, implement enum_routes with operation_not_supported

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -188,6 +188,18 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_HAS_FTELLO 0
 #endif // API < 24
 
+// Starting Android 11 (API >= 30), the enum_routes using NETLINK
+// is not possible anymore. For other functions, it's not clear
+// that IFADDRS is working as expected for API >= 30, but at least
+// it is supported.
+// See https://developer.android.com/training/articles/user-data-ids#mac-11-plus
+#if __ANDROID_API__ >= 24
+#undef TORRENT_USE_NETLINK
+#undef TORRENT_USE_IFADDRS
+#define TORRENT_USE_NETLINK 0
+#define TORRENT_USE_IFADDRS 1
+#endif // API >= 24
+
 #else // ANDROID
 
 // posix_fallocate() is not available in glibc under these condition

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -1521,6 +1521,8 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 				i = reinterpret_cast<ifreq const*>(reinterpret_cast<char const*>(i) + skip);
 			}
 		}
+#elif defined TORRENT_ANDROID && __ANDROID_API__ >= 24
+		ec = boost::asio::error::operation_not_supported;
 #else
 #error "don't know how to enumerate network routes on this platform"
 #endif


### PR DESCRIPTION
Second PR for Android 11 fix. There is one more remaining change that I think could be a little contentious.