### PR TITLE
explicitly FlushViewOfFile() on windows when closing a file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* on windows, explicitly flush memory mapped files periodically
 	* fix build with WolfSSL
 	* fix issue where incoming uTP connections were not accepted over SOCKS5
 	* fix several issues in handling of checking files of v2 torrents, esp. from magnet links

--- a/Jamfile
+++ b/Jamfile
@@ -309,7 +309,7 @@ rule building ( properties * )
 	if <toolset>msvc in $(properties) || <toolset>intel-win in $(properties)
 	{
 		# allow larger .obj files (with more sections)
-		result += <cflags>/bigobj ;
+		result += <cxxflags>/bigobj ;
 	}
 
 	if <toolset>gcc in $(properties) && <target-os>windows in $(properties)

--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -110,6 +110,12 @@ namespace aux {
 
 		void close_oldest();
 
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+		void flush_next_file();
+		void record_file_write(storage_index_t st, file_index_t file_index
+			, uint64_t pages);
+#endif
+
 	private:
 
 		std::shared_ptr<file_mapping> remove_oldest(std::unique_lock<std::mutex>&);
@@ -140,6 +146,9 @@ namespace aux {
 			file_id key;
 			std::shared_ptr<file_mapping> mapping;
 			time_point last_use{aux::time_now()};
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			std::uint64_t dirty_bytes;
+#endif
 			open_mode_t mode{};
 		};
 
@@ -150,6 +159,10 @@ namespace aux {
 			mi::ordered_unique<mi::member<file_entry, file_id, &file_entry::key>>,
 			// look up files by least recently used
 			mi::sequenced<>
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			// look up files with dirty pages
+			, mi::ordered_non_unique<mi::member<file_entry, std::uint64_t, &file_entry::dirty_bytes>>
+#endif
 			>
 		>;
 

--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -122,6 +122,10 @@ namespace aux {
 #endif
 			);
 
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+		void flush();
+#endif
+
 		// non-copyable
 		file_mapping(file_mapping const&) = delete;
 		file_mapping& operator=(file_mapping const&) = delete;

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -638,9 +638,18 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode
 		throw_ex<storage_error>(error_code(GetLastError(), system_category()), operation_t::file_mmap);
 }
 
+void file_mapping::flush()
+{
+	if (m_mapping == nullptr) return;
+
+	// ignore errors, this is best-effort
+	FlushViewOfFile(m_mapping, static_cast<std::size_t>(m_size));
+}
+
 void file_mapping::close()
 {
 	if (m_mapping == nullptr) return;
+	flush();
 	std::lock_guard<std::mutex> l(*m_open_unmap_lock);
 	UnmapViewOfFile(m_mapping);
 	m_mapping = nullptr;

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -663,6 +663,10 @@ namespace libtorrent {
 				ret += static_cast<int>(buf.size());
 			}
 
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			m_pool.record_file_write(storage_index(), file_index, ret);
+#endif
+
 			// set this unconditionally in case the upper layer would like to treat
 			// short reads as errors
 			ec.operation = operation_t::file_write;


### PR DESCRIPTION
This is to address the issue of windows not pre-emptively flushing dirty pages to disk in memory mapped files.