### PR TITLE
build against OpenSSL by default

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
 
       strategy:
          matrix:
-            config: [ crypto=openssl, deprecated-functions=off ]
+            config: [ crypto=built-in, deprecated-functions=off ]
 
       steps:
       - name: checkout
@@ -79,7 +79,7 @@ jobs:
 
       strategy:
          matrix:
-            config: [ crypto=openssl, release ]
+            config: [ crypto=built-in, release ]
 
       steps:
       - name: checkout
@@ -137,4 +137,4 @@ jobs:
 
       - name: build library
         run: |
-          b2 -l400 warnings-as-errors=on cxxstd=14 darwin-ios darwin-ios_sim link=static
+          b2 -l400 cxxstd=14 darwin-ios darwin-ios_sim address-model=64  link=static

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,8 +19,8 @@ jobs:
       strategy:
          matrix:
            include:
-             - config: address-model=32
-             - config: address-model=64 crypto=openssl
+             - config: address-model=32 crypto=built-in
+             - config: address-model=64
              - config: release
 
       steps:
@@ -30,9 +30,8 @@ jobs:
            submodules: true
 
       - name: install openssl (64 bit)
-        if: ${{ contains(matrix.config, 'crypto=openssl') }}
         shell: pwsh
-        run: choco install openssl
+        run: choco install openssl --limitoutput
 
       - name: install boost
         run: |
@@ -101,14 +100,14 @@ jobs:
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
           cd simulation
-          b2 --hash release address-model=64 link=static debug-iterators=off invariant-checks=on crypto=built-in define=BOOST_ASIO_DISABLE_IOCP asserts=on testing.execute=off
+          b2 --hash release address-model=64 link=static debug-iterators=off invariant-checks=on define=BOOST_ASIO_DISABLE_IOCP asserts=on testing.execute=off
 
       - name: run sims
         run: |
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
           cd simulation
-          b2 --hash -l700 release address-model=64 link=static debug-iterators=off invariant-checks=on crypto=built-in define=BOOST_ASIO_DISABLE_IOCP asserts=on
+          b2 --hash -l700 release address-model=64 link=static debug-iterators=off invariant-checks=on define=BOOST_ASIO_DISABLE_IOCP asserts=on
 
    build:
       name: Build
@@ -134,6 +133,10 @@ jobs:
           cd boost
           bootstrap.bat
 
+      - name: install openssl (64 bit)
+        shell: pwsh
+        run: choco install openssl --limitoutput
+
       - name: boost headers
         run: |
           cd boost
@@ -143,7 +146,7 @@ jobs:
         run: |
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
-          b2 ${{ matrix.config }} cxxstd=14 warnings=all warnings-as-errors=on
+          b2 ${{ matrix.config }} cxxstd=14 address-model=64 warnings=all warnings-as-errors=on
 
       - name: build examples
         if: ${{ ! contains(matrix.config, 'windows-api=store') }}
@@ -151,7 +154,7 @@ jobs:
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
           cd examples
-          b2 ${{ matrix.config }} warnings=all warnings-as-errors=on
+          b2 ${{ matrix.config }} address-model=64 warnings=all warnings-as-errors=on
 
       - name: build tools
         if: ${{ ! contains(matrix.config, 'windows-api=store') }}
@@ -159,5 +162,5 @@ jobs:
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
           cd tools
-          b2 ${{ matrix.config }} warnings=all warnings-as-errors=on
+          b2 ${{ matrix.config }} address-model=64 warnings=all warnings-as-errors=on
 

--- a/Jamfile
+++ b/Jamfile
@@ -585,7 +585,7 @@ feature.compose <encryption>off : <define>TORRENT_DISABLE_ENCRYPTION ;
 feature mutable-torrents : on off : composite propagated link-incompatible ;
 feature.compose <mutable-torrents>off : <define>TORRENT_DISABLE_MUTABLE_TORRENTS ;
 
-feature crypto : built-in openssl wolfssl gnutls libcrypto gcrypt : composite propagated ;
+feature crypto : openssl built-in wolfssl gnutls libcrypto gcrypt : composite propagated ;
 feature.compose <crypto>openssl
 	: <define>TORRENT_USE_LIBCRYPTO
 	<define>TORRENT_USE_OPENSSL

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -257,8 +257,7 @@ windows format (``c:/boost_1_68_0``).
 The ``Jamfile`` will define ``NDEBUG`` when it's building a release build.
 For more build configuration flags see `Build configurations`_.
 
-When enabling linking against openssl (by setting the ``crypto`` feature to
-``openssl``) the Jamfile will look in some default directory for the openssl
+Jamfile will look in some default directory for the openssl
 headers and libraries. On macOS, it will look for the homebrew openssl package.
 On Windows, it will look in ``C:\OpenSSL-Win32``, or ``C:\OpenSSL-Win64`` if
 compiling in 64-bit.
@@ -272,6 +271,9 @@ options: ``--enable-asio --enable-sni --enable-nginx``.
 
 To customize the library path and include path for wolfSSL, set the features
 ``wolfssl-lib`` and ``wolfssl-include`` respectively.
+
+To disable linking against any SSL library, set the ``crypto`` build feature to
+``built-in``. This will use an embedded version if SHA-1.
 
 Build features
 ~~~~~~~~~~~~~~
@@ -334,13 +336,13 @@ Build features
 |                          |   (`BEP 38`_) (default).                           |
 |                          | * ``off`` - mutable torrents are not supported.    |
 +--------------------------+----------------------------------------------------+
-| ``crypto``               | * ``built-in`` - (default) uses built-in SHA-1     |
-|                          |   implementation. In macOS/iOS it uses             |
-|                          |   CommonCrypto SHA-1 implementation.               |
-|                          | * ``openssl`` - links against openssl and          |
-|                          |   libcrypto to use for SHA-1 hashing.              |
+| ``crypto``               | * ``openssl`` - (default) links against openssl    |
+|                          |   and libcrypto to use for SHA-1 hashing.          |
 |                          |   This also enables HTTPS-tracker support and      |
 |                          |   support for bittorrent over SSL.                 |
+|                          | * ``built-in`` - (default) uses built-in SHA-1     |
+|                          |   implementation. In macOS/iOS it uses             |
+|                          |   CommonCrypto SHA-1 implementation.               |
 |                          | * ``wolfssl`` - links against wolfssl to use it    |
 |                          |   for SHA-1 hashing and HTTPS tracker support.     |
 |                          | * ``libcrypto`` - links against libcrypto          |

--- a/simulation/Jamfile
+++ b/simulation/Jamfile
@@ -26,6 +26,7 @@ project
 	<asserts>on
 	<picker-debugging>on
 	<cxxstd>14
+	<crypto>built-in
 	;
 
 run test_pause.cpp ;


### PR DESCRIPTION
I think this makes sense since I would think that users generally expect `https` trackers to just work.