### PR TITLE
bump timeouts for tests on linux CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -231,7 +231,7 @@ jobs:
       - name: build and run tests
         run: |
           cd test
-          b2 ${{ matrix.config }} -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
+          b2 ${{ matrix.config }} -l500 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
 
       - name: run tests (flaky)
         uses: nick-invision/retry@v2
@@ -239,7 +239,7 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 4
           max_attempts: 3
-          command: (cd test; b2 ${{ matrix.config }} -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on)
+          command: (cd test; b2 ${{ matrix.config }} -l500 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on)
 
 
 


### PR DESCRIPTION
test_recheck seems to sometimes take a long time