### PR TITLE
Add missing include for get_ssl_category

### DIFF
--- a/bindings/python/src/error_code.cpp
+++ b/bindings/python/src/error_code.cpp
@@ -49,6 +49,7 @@ namespace boost
 
 #include <boost/asio/error.hpp>
 #if TORRENT_USE_SSL
+#include <boost/asio/ssl/error.hpp>
 #include <libtorrent/ssl.hpp>
 #endif
 #if TORRENT_USE_I2P


### PR DESCRIPTION
error::get_ssl_category is defined in boost/asio/ssl/error.hpp, so
include it when we're building with SSL support.

Fixes build failures like:
```
/var/tmp/portage/net-libs/libtorrent-rasterbar-2.0.4-r5/work/libtorrent-rasterbar-2.0.4/bindings/python/src/error_code.cpp: In static member function 'static void {anonymous}::ec_pickle_suite::setstate(libtorrent::error_code&, boost::python::tuple)':
/var/tmp/portage/net-libs/libtorrent-rasterbar-2.0.4-r5/work/libtorrent-rasterbar-2.0.4/bindings/python/src/error_code.cpp:112:70: error: 'get_ssl_category' is not a member of 'boost::asio::error'; did you mean 'get_misc_category'?
  112 |                                 ec.assign(value, boost::asio::error::get_ssl_category());
      |                                                                      ^~~~~~~~~~~~~~~~
      |                                                                      get_misc_category
```

Bug: https://bugs.gentoo.org/820836