### PR TITLE
allow unspecified address for android api >= 24

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2076,7 +2076,19 @@ namespace {
 #endif
 			}
 
+#if defined TORRENT_ANDROID && __ANDROID_API__ >= 24
+			// For Android API >= 24, enum_routes with the current NETLINK based
+			// implementation is unsupported (maybe in the future the operation
+			// will be restore using another implementation). If routes is empty,
+			// allow using unspecified address is a best effort approach that
+			// seems to work. The issue with this approach is with the DHTs,
+			// because for IPv6 this is not following BEP 32 and BEP 45. See:
+			// https://www.bittorrent.org/beps/bep_0032.html
+			// https://www.bittorrent.org/beps/bep_0045.html
+			if (!routes.empty()) expand_unspecified_address(ifs, routes, eps);
+#else
 			expand_unspecified_address(ifs, routes, eps);
+#endif
 			expand_devices(ifs, eps);
 		}
 


### PR DESCRIPTION
Hi @arvidn, this is the remaining change for the android fix. I kind of understand the implications, but I can't gauge the actual negative effect, since I don't know what's the likelihood of a phone having multiple routable IPv6 addresses (I have never seen one).