### PR TITLE
Fix master merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ requires-python = ">=3.7"
 
 [tool.cibuildwheel]
 skip = "pp*"
+test-requires = [
+    "pytest",
+    "mypy",
+]
 
 [tool.cibuildwheel.macos]
 before-all = [
@@ -11,7 +15,9 @@ before-all = [
 ]
 test-command = [
     "cd {project}/bindings/python",
-    "tox -e",
+    "python -m pip install -r test-requirements.txt",
+    "python -X dev -m pytest --log-level=DEBUG --log-cli-level=DEBUG",
+    "python -m mypy --config-file mypy-tox.ini tests",
 ]
 
 [tool.cibuildwheel.macos.environment]
@@ -32,7 +38,9 @@ before-test = "ccache -s"
 select = "*-manylinux_*"
 test-command = [
     "cd {project}/bindings/python",
-    "tox -e",
+    "python -m pip install -r test-requirements.txt",
+    "python -X dev -m pytest --log-level=DEBUG --log-cli-level=DEBUG",
+    "python -m mypy --config-file mypy-tox.ini tests",
 ]
 
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
@@ -51,7 +59,9 @@ before-test = "ccache -s"
 select = "*-musllinux_*"
 test-command = [
     "cd {project}/bindings/python",
-    "tox -e",
+    "python -m pip install -r test-requirements.txt",
+    "python -X dev -m pytest --log-level=DEBUG --log-cli-level=DEBUG",
+    "python -m mypy --config-file mypy-tox.ini tests",
 ]
 
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
@@ -75,7 +85,7 @@ before-all = [
 select = "*-win_amd64"
 
 [tool.cibuildwheel.windows]
-test-command = '''bash -c "cd '{project}/bindings/python' && tox -e"'''
+test-command = '''bash -c "cd '{project}/bindings/python' && python -m pip install -r test-requirements.txt && python -X dev -m pytest --log-level=DEBUG --log-cli-level=DEBUG && python -m mypy --config-file mypy-tox.ini tests"'''
 
 [tool.cibuildwheel.windows.environment]
 BOOST_BUILD_PATH = 'c:/boost/tools/build'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ test-command = [
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
 BOOST_VERSION = "1.76.0"
-MACOSX_DEPLOYMENT_TARGET = "10.9"  # required for full C++11 support
+MACOSX_DEPLOYMENT_TARGET = "10.14"  # required for full C++17 support
 PATH = "/tmp/boost:$PATH"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires-python = ">=3.7"
 
 [tool.cibuildwheel]
+manylinux-i686-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux2014"
 skip = "pp*"
 test-requires = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ before-all = [
 ]
 test-command = [
     "cd {project}/bindings/python",
-    "python test.py",
+    "tox -e",
 ]
 
 [tool.cibuildwheel.macos.environment]
@@ -32,7 +32,7 @@ before-test = "ccache -s"
 select = "*-manylinux_*"
 test-command = [
     "cd {project}/bindings/python",
-    "python test.py",
+    "tox -e",
 ]
 
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
@@ -51,7 +51,7 @@ before-test = "ccache -s"
 select = "*-musllinux_*"
 test-command = [
     "cd {project}/bindings/python",
-    "python test.py",
+    "tox -e",
 ]
 
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
@@ -75,7 +75,7 @@ before-all = [
 select = "*-win_amd64"
 
 [tool.cibuildwheel.windows]
-test-command = '''bash -c "cd '{project}/bindings/python' && python test.py"'''
+test-command = '''bash -c "cd '{project}/bindings/python' && tox -e"'''
 
 [tool.cibuildwheel.windows.environment]
 BOOST_BUILD_PATH = 'c:/boost/tools/build'


### PR DESCRIPTION
The test config is definitely inelegant. There's probably a better way but I'll figure it out later.

There were some other build environment versions to bump for C++17 support.

I found that `export_filter()`'s output is normalized differently on alpine linux only. See [this workflow run](https://github.com/AllSeeingEyeTolledEweSew/libtorrent/runs/4423515749?check_suite_focus=true#step:5:2453). From what I can tell this normalization comes from boost, and we always build boost from source, so I'm very surprised.