### PR TITLE
Revert "Change python package name to libtorrent"

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -451,7 +451,7 @@ class LibtorrentBuildExt(BuildExtBase):
 
 
 setuptools.setup(
-    name="libtorrent",
+    name="python-libtorrent",
     version="1.2.15",
     author="Arvid Norberg",
     author_email="arvid@libtorrent.org",


### PR DESCRIPTION
This reverts commit 8ea0e60fbee8c594b7aa01fbb2445afa5c0414b3.

Per https://github.com/arvidn/libtorrent/issues/5333#issuecomment-986308800