### PR TITLE
Set source and executable character sets to UTF-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES GNU)
 	)
 elseif(MSVC)
 	add_compile_options(
+		/utf-8
 		# https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
 		/Zc:__cplusplus
 		/W4


### PR DESCRIPTION
By default msvc assume the source file is encoded using the current user code page.
https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170

Reason I'm submitting this: I still see compiler warnings like in #3845 occasionally and this flag would eliminate them all.