### PR TITLE
default TOS marking to 0x04 (LE)

### DIFF
--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1152,10 +1152,9 @@ namespace aux {
 
 			// ``peer_tos`` determines the TOS byte set in the IP header of every
 			// packet sent to peers (including web seeds). ``0x0`` means no marking,
-			// ``0x20`` represents the *QBone scavenger service*. For more
-			// details, see QBSS_.
+			// ``0x04`` represents Lower Effort. For more details see `RFC 8622`_.
 			//
-			// .. _`QBSS`: http://qbone.internet2.edu/qbss/
+			// .. _`RFC 8622`: http://www.faqs.org/rfcs/rfc8622.html
 			peer_tos,
 
 			// for auto managed torrents, these are the limits they are subject

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -257,7 +257,7 @@ constexpr int CLOSE_FILE_INTERVAL = 0;
 		SET(disk_io_read_mode, settings_pack::enable_os_cache, nullptr),
 		SET(outgoing_port, 0, nullptr),
 		SET(num_outgoing_ports, 0, nullptr),
-		SET(peer_tos, 0x20, &session_impl::update_peer_tos),
+		SET(peer_tos, 0x04, &session_impl::update_peer_tos),
 		SET(active_downloads, 3, &session_impl::trigger_auto_manage),
 		SET(active_seeds, 5, &session_impl::trigger_auto_manage),
 		SET(active_checking, 1, &session_impl::trigger_auto_manage),


### PR DESCRIPTION
[RFC 8622](http://www.faqs.org/rfcs/rfc8622.html) has added a new "Lower Effort" codepoint to supersede 0x20 (CS1), avoiding the potential problem with CS1 being interpreted as higher precedence than default.

Use of LE rather than CS1 is now recommended:

> Existing implementations SHOULD transition to use the unambiguous LE codepoint '000001' whenever possible.