### PR TITLE
remove redundant calls to convert_from_native()

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -37,7 +37,6 @@ see LICENSE file.
 #include "libtorrent/operations.hpp" // for operation_t enum
 #include "libtorrent/close_reason.hpp"
 #include "libtorrent/piece_block.hpp"
-#include "libtorrent/aux_/escape_string.hpp" // for convert_from_native
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/aux_/stack_allocator.hpp"
 #include "libtorrent/aux_/noexcept_movable.hpp"

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -41,8 +41,6 @@ see LICENSE file.
 #include "libtorrent/write_resume_data.hpp"
 #endif
 
-#include "libtorrent/aux_/escape_string.hpp" // for convert_from_native
-
 namespace libtorrent {
 
 	alert::alert() : m_timestamp(clock_type::now()) {}
@@ -172,7 +170,7 @@ namespace libtorrent {
 		{
 			std::snprintf(msg, sizeof(msg), "%s: read_piece %d failed: %s"
 				, torrent_alert::message().c_str() , static_cast<int>(piece)
-				, convert_from_native(error.message()).c_str());
+				, error.message().c_str());
 		}
 		else
 		{
@@ -262,7 +260,7 @@ namespace libtorrent {
 		std::snprintf(msg, sizeof(msg), ": failed to rename file %d: "
 			, static_cast<int>(index));
 		ret.append(msg);
-		ret.append(convert_from_native(error.message()));
+		ret.append(error.message());
 		return ret;
 #endif
 	}
@@ -361,7 +359,7 @@ namespace libtorrent {
 		char ret[400];
 		std::snprintf(ret, sizeof(ret), "%s %s \"%s\" (%d)"
 			, tracker_alert::message().c_str()
-			, convert_from_native(error.message()).c_str(), error_message()
+			, error.message().c_str(), error_message()
 			, times_in_row);
 		return ret;
 #endif
@@ -421,7 +419,7 @@ namespace libtorrent {
 		: tracker_alert(alloc, h, ep, u)
 		, error(e)
 #if TORRENT_ABI_VERSION == 1
-		, msg(convert_from_native(e.message()))
+		, msg(e.message())
 #endif
 	{
 		TORRENT_ASSERT(!u.empty());
@@ -812,7 +810,7 @@ namespace libtorrent {
 #else
 		return torrent_alert::message() + " storage move failed. "
 			+ operation_name(op) + " (" + file_path() + "): "
-			+ convert_from_native(error.message());
+			+ error.message();
 #endif
 	}
 
@@ -841,7 +839,7 @@ namespace libtorrent {
 		, error(e)
 		, info_hashes(ih)
 #if TORRENT_ABI_VERSION == 1
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{
 #if TORRENT_ABI_VERSION < 3
@@ -855,7 +853,7 @@ namespace libtorrent {
 		return {};
 #else
 		return torrent_alert::message() + " torrent deletion failed: "
-			+ convert_from_native(error.message());
+			+ error.message();
 #endif
 	}
 
@@ -887,7 +885,7 @@ namespace libtorrent {
 		: torrent_alert(alloc, h)
 		, error(e)
 #if TORRENT_ABI_VERSION == 1
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{
 	}
@@ -898,7 +896,7 @@ namespace libtorrent {
 		return {};
 #else
 		return torrent_alert::message() + " resume data was not generated: "
-			+ convert_from_native(error.message());
+			+ error.message();
 #endif
 	}
 
@@ -1122,7 +1120,7 @@ namespace {
 			, listen_interface()
 			, operation_name(op)
 			, socket_type_name(socket_type)
-			, convert_from_native(error.message()).c_str());
+			, error.message().c_str());
 		return ret;
 #endif
 	}
@@ -1171,7 +1169,7 @@ namespace {
 #ifdef TORRENT_DISABLE_ALERT_MSG
 		return {};
 #else
-		return "UDP error: " + convert_from_native(error.message())
+		return "UDP error: " + error.message()
 			+ " from: " + endpoint.address().to_string()
 			+ " op: " + operation_name(operation);
 #endif
@@ -1243,7 +1241,7 @@ namespace {
 		, error(e)
 #if TORRENT_ABI_VERSION == 1
 		, map_type(static_cast<int>(t))
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{}
 
@@ -1255,7 +1253,7 @@ namespace {
 		return std::string("could not map port using ")
 			+ nat_type_str[static_cast<int>(map_transport)]
 			+ "[" + local_address.to_string() + "]: "
-			+ convert_from_native(error.message());
+			+ error.message();
 #endif
 	}
 
@@ -1331,7 +1329,7 @@ namespace {
 #if TORRENT_ABI_VERSION == 1
 		, operation(operation_name(op_))
 		, file(f)
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{
 	}
@@ -1343,7 +1341,7 @@ namespace {
 #else
 		return torrent_alert::message() + " fast resume rejected. "
 			+ operation_name(op) + "(" + file_path() + "): "
-			+ convert_from_native(error.message());
+			+ error.message();
 #endif
 	}
 
@@ -1590,7 +1588,7 @@ namespace {
 		if (error)
 		{
 			std::snprintf(msg, sizeof(msg), " ERROR: (%d %s) %s"
-				, error.value(), convert_from_native(error.message()).c_str()
+				, error.value(), error.message().c_str()
 				, filename());
 		}
 		else
@@ -1727,7 +1725,7 @@ namespace {
 		{
 			std::snprintf(msg, sizeof(msg), "failed to add torrent \"%s\": [%s] %s"
 				, torrent_name, error.category().name()
-				, convert_from_native(error.message()).c_str());
+				, error.message().c_str());
 		}
 		else
 		{
@@ -1765,7 +1763,7 @@ namespace {
 #else
 		char msg[600];
 		std::snprintf(msg, sizeof(msg), "mmap cache failed: (%d) %s", error.value()
-			, convert_from_native(error.message()).c_str());
+			, error.message().c_str());
 		return msg;
 #endif
 	}
@@ -1850,7 +1848,7 @@ namespace {
 		, error(e)
 #if TORRENT_ABI_VERSION == 1
 		, operation(static_cast<int>(op_))
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{}
 
@@ -1863,7 +1861,7 @@ namespace {
 		std::snprintf(buf, sizeof(buf), "%s peer error [%s] [%s]: %s"
 			, peer_alert::message().c_str()
 			, operation_name(op), error.category().name()
-			, convert_from_native(error.message()).c_str());
+			, error.message().c_str());
 		return buf;
 #endif
 	}
@@ -1879,7 +1877,7 @@ namespace {
 		, reason(r)
 #if TORRENT_ABI_VERSION == 1
 		, operation(static_cast<int>(op))
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{}
 
@@ -1893,7 +1891,7 @@ namespace {
 			, peer_alert::message().c_str()
 			, socket_type_name(socket_type)
 			, operation_name(op), error.category().name()
-			, convert_from_native(error.message()).c_str()
+			, error.message().c_str()
 			, int(reason));
 		return buf;
 #endif
@@ -1919,7 +1917,7 @@ namespace {
 		std::snprintf(msg, sizeof(msg), "DHT error [%s] (%d) %s"
 			, operation_name(op)
 			, error.value()
-			, convert_from_native(error.message()).c_str());
+			, error.message().c_str());
 		return msg;
 #endif
 	}
@@ -2027,7 +2025,7 @@ namespace {
 #else
 		char msg[600];
 		std::snprintf(msg, sizeof(msg), "i2p_error: [%s] %s"
-			, error.category().name(), convert_from_native(error.message()).c_str());
+			, error.category().name(), error.message().c_str());
 		return msg;
 #endif
 	}
@@ -2169,7 +2167,7 @@ namespace {
 		return {};
 #else
 		return "Local Service Discovery startup error [" + local_address.to_string() + "]: "
-			+ convert_from_native(error.message());
+			+ error.message();
 #endif
 	}
 
@@ -2275,7 +2273,7 @@ namespace {
 		, m_url_idx(alloc.copy_string(u))
 #if TORRENT_ABI_VERSION == 1
 		, url(u)
-		, msg(convert_from_native(e.message()))
+		, msg(e.message())
 #endif
 	{}
 
@@ -2296,7 +2294,7 @@ namespace {
 		return {};
 #else
 		return torrent_alert::message() + " url seed ("
-			+ server_url() + ") failed: " + convert_from_native(error.message());
+			+ server_url() + ") failed: " + error.message();
 #endif
 	}
 
@@ -2321,7 +2319,7 @@ namespace {
 #if TORRENT_ABI_VERSION == 1
 		, operation(operation_name(op_))
 		, file(f)
-		, msg(convert_from_native(error.message()))
+		, msg(error.message())
 #endif
 	{}
 
@@ -2337,7 +2335,7 @@ namespace {
 #else
 		return torrent_alert::message() + " "
 			+ operation_name(op) + " (" + filename()
-			+ ") error: " + convert_from_native(error.message());
+			+ ") error: " + error.message();
 #endif
 	}
 
@@ -2644,7 +2642,7 @@ namespace {
 		if (error)
 		{
 			std::snprintf(buf, sizeof(buf), "session error: (%d %s) %s"
-				, error.value(), convert_from_native(error.message()).c_str()
+				, error.value(), error.message().c_str()
 				, m_alloc.get().ptr(m_msg_idx));
 		}
 		else

--- a/src/natpmp.cpp
+++ b/src/natpmp.cpp
@@ -147,7 +147,7 @@ void natpmp::start(aux::ip_interface const& ip)
 		if (should_log())
 		{
 			log("failed to enumerate routes: %s"
-				, convert_from_native(ec.message()).c_str());
+				, ec.message().c_str());
 		}
 #endif
 		disable(ec);
@@ -591,7 +591,7 @@ void natpmp::on_reply(error_code const& e
 		if (should_log())
 		{
 			log("error on receiving reply: %s"
-				, convert_from_native(e.message()).c_str());
+				, e.message().c_str());
 		}
 #endif
 		return;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -11516,7 +11516,7 @@ namespace {
 		st->error_file = m_error_file;
 
 #if TORRENT_ABI_VERSION == 1
-		if (m_error) st->error = convert_from_native(m_error.message())
+		if (m_error) st->error = m_error.message()
 			+ ": " + resolve_filename(m_error_file);
 		st->seed_mode = m_seed_mode;
 #endif

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -24,7 +24,6 @@ see LICENSE file.
 #include "libtorrent/aux_/xml_parse.hpp"
 #include "libtorrent/aux_/random.hpp"
 #include "libtorrent/aux_/time.hpp" // for aux::time_now()
-#include "libtorrent/aux_/escape_string.hpp" // for convert_from_native
 #include "libtorrent/aux_/http_connection.hpp"
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/aux_/ssl.hpp"
@@ -120,7 +119,7 @@ void upnp::start()
 	if (ec && should_log())
 	{
 		log("failed to open multicast socket: \"%s\""
-			, convert_from_native(ec.message()).c_str());
+			, ec.message().c_str());
 		m_disabled = true;
 		return;
 	}
@@ -131,7 +130,7 @@ void upnp::start()
 	if (ec && should_log())
 	{
 		log("failed to open unicast socket: \"%s\""
-			, convert_from_native(ec.message()).c_str());
+			, ec.message().c_str());
 		m_disabled = true;
 		return;
 	}
@@ -234,8 +233,8 @@ void upnp::discover_device_impl()
 		if (should_log())
 		{
 			log("multicast send failed: \"%s\" and \"%s\". Aborting."
-				, convert_from_native(mcast_ec.message()).c_str()
-				, convert_from_native(ucast_ec.message()).c_str());
+				, mcast_ec.message().c_str()
+				, ucast_ec.message().c_str());
 		}
 #endif
 		disable(mcast_ec);
@@ -579,7 +578,7 @@ void upnp::on_reply(udp::socket& s, error_code const& ec)
 			if (should_log())
 			{
 				log("invalid URL %s from %s: %s"
-					, d.url.c_str(), print_endpoint(from).c_str(), convert_from_native(err.message()).c_str());
+					, d.url.c_str(), print_endpoint(from).c_str(), err.message().c_str());
 			}
 #endif
 			return;
@@ -965,7 +964,7 @@ void upnp::on_upnp_xml(error_code const& e
 		if (should_log())
 		{
 			log("error while fetching control url from: %s: %s"
-				, d.url.c_str(), convert_from_native(e.message()).c_str());
+				, d.url.c_str(), e.message().c_str());
 		}
 #endif
 		d.disabled = true;
@@ -988,7 +987,7 @@ void upnp::on_upnp_xml(error_code const& e
 		if (should_log())
 		{
 			log("error while fetching control url from: %s: %s"
-				, d.url.c_str(), convert_from_native(p.message()).c_str());
+				, d.url.c_str(), p.message().c_str());
 		}
 #endif
 		d.disabled = true;
@@ -1056,7 +1055,7 @@ void upnp::on_upnp_xml(error_code const& e
 		if (should_log())
 		{
 			log("failed to parse URL '%s': %s"
-				, d.control_url.c_str(), convert_from_native(ec.message()).c_str());
+				, d.control_url.c_str(), ec.message().c_str());
 		}
 #endif
 		d.disabled = true;
@@ -1252,7 +1251,7 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 		if (should_log())
 		{
 			log("error while getting external IP address: %s"
-				, convert_from_native(e.message()).c_str());
+				, e.message().c_str());
 		}
 #endif
 		if (num_mappings() > 0) update_map(d, port_mapping_t{0});
@@ -1274,7 +1273,7 @@ void upnp::on_upnp_get_ip_address_response(error_code const& e
 		if (should_log())
 		{
 			log("error while getting external IP address: %s"
-				, convert_from_native(p.message()).c_str());
+				, p.message().c_str());
 		}
 #endif
 		if (num_mappings() > 0) update_map(d, port_mapping_t{0});
@@ -1345,7 +1344,7 @@ void upnp::on_upnp_map_response(error_code const& e
 		if (should_log())
 		{
 			log("error while adding port map: %s"
-				, convert_from_native(e.message()).c_str());
+				, e.message().c_str());
 		}
 #endif
 		d.disabled = true;
@@ -1519,7 +1518,7 @@ void upnp::on_upnp_unmap_response(error_code const& e
 		if (should_log())
 		{
 			log("error while deleting portmap: %s"
-				, convert_from_native(e.message()).c_str());
+				, e.message().c_str());
 		}
 #endif
 	}
@@ -1535,7 +1534,7 @@ void upnp::on_upnp_unmap_response(error_code const& e
 		if (should_log())
 		{
 			log("error while deleting portmap: %s"
-				, convert_from_native(p.message()).c_str());
+				, p.message().c_str());
 		}
 #endif
 	}


### PR DESCRIPTION
 on system error messages (now that we build with BOOST_SYSTEM_USE_UTF8)