### PR TITLE
use MADV_DONTNEED/MADV_COLD for volatile_reads (when checking files)

### DIFF
--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -147,6 +147,10 @@ namespace aux {
 			return { static_cast<byte*>(m_mapping), static_cast<std::ptrdiff_t>(m_size) };
 		}
 
+		// hint the kernel that we probably won't need this part of the file
+		// anytime soon
+		void dont_need(span<byte const> range);
+
 		std::int64_t m_size;
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 		file_mapping_handle m_file;
@@ -173,6 +177,12 @@ namespace aux {
 		{
 			TORRENT_ASSERT(m_mapping);
 			return m_mapping->memory();
+		}
+
+		void dont_need(span<byte const> range)
+		{
+			TORRENT_ASSERT(m_mapping);
+			m_mapping->dont_need(range);
 		}
 
 	private:

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -51,6 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/span.hpp"
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/open_mode.hpp" // for aux::open_mode_t
+#include "libtorrent/disk_interface.hpp" // for disk_job_flags_t
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/optional.hpp>
@@ -110,9 +111,10 @@ namespace aux {
 			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error&);
 		int hashv(settings_interface const&, hasher& ph, std::ptrdiff_t len
 			, piece_index_t piece, int offset, aux::open_mode_t flags
-			, storage_error&);
+			, disk_job_flags_t mode, storage_error&);
 		int hashv2(settings_interface const&, hasher256& ph, std::ptrdiff_t len
-			, piece_index_t piece, int offset, aux::open_mode_t flags, storage_error&);
+			, piece_index_t piece, int offset, aux::open_mode_t flags
+			, disk_job_flags_t mode, storage_error&);
 
 		// if the files in this storage are mapped, returns the mapped
 		// file_storage, otherwise returns the original file_storage object.

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -114,6 +114,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 		return (in.Length.QuadPart != out[0].Length.QuadPart);
 	}
 
+#ifndef TORRENT_WINRT
 	std::once_flag g_once_flag;
 
 	void acquire_manage_volume_privs()
@@ -161,6 +162,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 
 		AdjustTokenPrivileges(token, FALSE, &privs, 0, nullptr, nullptr);
 	}
+#endif // TORRENT_WINRT
 
 #endif // TORRENT_WINDOWS
 
@@ -599,6 +601,10 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode, std::int64_
 		// with large disk caches)
 		// ignore errors here, since this is best-effort
 			| MADV_DONTDUMP
+#endif
+#ifdef MADV_NOCORE
+		// This is the BSD counterpart to exclude a range from core dumps
+			| MADV_NOCORE
 #endif
 		;
 		if (advise != 0)

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -1081,13 +1081,15 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 				if (v1)
 				{
 					j->error.ec.clear();
-					ret = j->storage->hashv(m_settings, h, len, j->piece, offset, file_mode, j->error);
+					ret = j->storage->hashv(m_settings, h, len, j->piece, offset
+						, file_mode, j->flags, j->error);
 					if (ret < 0) break;
 				}
 				if (v2_block)
 				{
 					j->error.ec.clear();
-					ret = j->storage->hashv2(m_settings, h2, len2, j->piece, offset, file_mode, j->error);
+					ret = j->storage->hashv2(m_settings, h2, len2, j->piece, offset
+						, file_mode, j->flags, j->error);
 					if (ret < 0) break;
 				}
 			}
@@ -1139,7 +1141,8 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			ret = int(len);
 		}))
 		{
-			ret = j->storage->hashv2(m_settings, h, len, j->piece, j->d.io.offset, file_mode, j->error);
+			ret = j->storage->hashv2(m_settings, h, len, j->piece, j->d.io.offset
+				, file_mode, j->flags, j->error);
 			if (ret < 0) return status_t::fatal_disk_error;
 		}
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -133,7 +133,7 @@ namespace {
 
 #endif // DEBUG_DISK_THREAD
 
-	aux::open_mode_t file_flags_for_job(aux::disk_io_job* j)
+	aux::open_mode_t file_mode_for_job(aux::disk_io_job* j)
 	{
 		aux::open_mode_t ret = aux::open_mode::read_only;
 		if (!(j->flags & disk_interface::sequential_access)) ret |= aux::open_mode::random_access;
@@ -594,11 +594,11 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 		time_point const start_time = clock_type::now();
 
-		aux::open_mode_t const file_flags = file_flags_for_job(j);
+		aux::open_mode_t const file_mode = file_mode_for_job(j);
 		iovec_t b = {buffer.data() + j->d.io.buffer_offset, j->d.io.buffer_size};
 
 		int const ret = j->storage->readv(m_settings, b
-			, j->piece, j->d.io.offset, file_flags, j->error);
+			, j->piece, j->d.io.offset, file_mode, j->error);
 
 		TORRENT_ASSERT(ret >= 0 || j->error.ec);
 		TORRENT_UNUSED(ret);
@@ -629,11 +629,11 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 		time_point const start_time = clock_type::now();
 
-		aux::open_mode_t const file_flags = file_flags_for_job(j);
+		aux::open_mode_t const file_mode= file_mode_for_job(j);
 		iovec_t b = {buffer.data(), j->d.io.buffer_size};
 
 		int const ret = j->storage->readv(m_settings, b
-			, j->piece, j->d.io.offset, file_flags, j->error);
+			, j->piece, j->d.io.offset, file_mode, j->error);
 
 		TORRENT_ASSERT(ret >= 0 || j->error.ec);
 		TORRENT_UNUSED(ret);
@@ -657,13 +657,13 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		auto buffer = std::move(boost::get<disk_buffer_holder>(j->argument));
 
 		iovec_t const b = { buffer.data(), j->d.io.buffer_size};
-		aux::open_mode_t const file_flags = file_flags_for_job(j);
+		aux::open_mode_t const file_mode= file_mode_for_job(j);
 
 		m_stats_counters.inc_stats_counter(counters::num_writing_threads, 1);
 
 		// the actual write operation
 		int const ret = j->storage->writev(m_settings, b
-			, j->piece, j->d.io.offset, file_flags, j->error);
+			, j->piece, j->d.io.offset, file_mode, j->error);
 
 		m_stats_counters.inc_stats_counter(counters::num_writing_threads, -1);
 
@@ -1041,7 +1041,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		int const piece_size2 = v2 ? j->storage->orig_files().piece_size2(j->piece) : 0;
 		int const blocks_in_piece = v1 ? (piece_size + default_block_size - 1) / default_block_size : 0;
 		int const blocks_in_piece2 = v2 ? j->storage->orig_files().blocks_in_piece2(j->piece) : 0;
-		aux::open_mode_t const file_flags = file_flags_for_job(j);
+		aux::open_mode_t const file_mode = file_mode_for_job(j);
 
 		TORRENT_ASSERT(!v2 || int(j->d.h.block_hashes.size()) >= blocks_in_piece2);
 		TORRENT_ASSERT(v1 || v2);
@@ -1081,13 +1081,13 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 				if (v1)
 				{
 					j->error.ec.clear();
-					ret = j->storage->hashv(m_settings, h, len, j->piece, offset, file_flags, j->error);
+					ret = j->storage->hashv(m_settings, h, len, j->piece, offset, file_mode, j->error);
 					if (ret < 0) break;
 				}
 				if (v2_block)
 				{
 					j->error.ec.clear();
-					ret = j->storage->hashv2(m_settings, h2, len2, j->piece, offset, file_flags, j->error);
+					ret = j->storage->hashv2(m_settings, h2, len2, j->piece, offset, file_mode, j->error);
 					if (ret < 0) break;
 				}
 			}
@@ -1120,7 +1120,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		TORRENT_ASSERT(m_magic == 0x1337);
 
 		int const piece_size = j->storage->files().piece_size2(j->piece);
-		aux::open_mode_t const file_flags = file_flags_for_job(j);
+		aux::open_mode_t const file_mode = file_mode_for_job(j);
 
 		hasher256 h;
 		int ret = 0;
@@ -1139,7 +1139,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			ret = int(len);
 		}))
 		{
-			ret = j->storage->hashv2(m_settings, h, len, j->piece, j->d.io.offset, file_flags, j->error);
+			ret = j->storage->hashv2(m_settings, h, len, j->piece, j->d.io.offset, file_mode, j->error);
 			if (ret < 0) return status_t::fatal_disk_error;
 		}
 

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -527,13 +527,13 @@ namespace libtorrent {
 	int mmap_storage::readv(settings_interface const& sett
 		, span<iovec_t const> bufs
 		, piece_index_t const piece, int const offset
-		, aux::open_mode_t const flags, storage_error& error)
+		, aux::open_mode_t const mode, storage_error& error)
 	{
 #ifdef TORRENT_SIMULATE_SLOW_READ
 		std::this_thread::sleep_for(seconds(1));
 #endif
 		return readwritev(files(), bufs, piece, offset, error
-			, [this, flags, &sett](file_index_t const file_index
+			, [this, mode, &sett](file_index_t const file_index
 				, std::int64_t const file_offset
 				, span<iovec_t const> vec, storage_error& ec)
 		{
@@ -560,7 +560,7 @@ namespace libtorrent {
 				return ret;
 			}
 
-			auto handle = open_file(sett, file_index, flags, ec);
+			auto handle = open_file(sett, file_index, mode, ec);
 			if (ec) return -1;
 
 			int ret = 0;
@@ -606,10 +606,10 @@ namespace libtorrent {
 	int mmap_storage::writev(settings_interface const& sett
 		, span<iovec_t const> bufs
 		, piece_index_t const piece, int const offset
-		, aux::open_mode_t const flags, storage_error& error)
+		, aux::open_mode_t const mode, storage_error& error)
 	{
 		return readwritev(files(), bufs, piece, offset, error
-			, [this, flags, &sett](file_index_t const file_index
+			, [this, mode, &sett](file_index_t const file_index
 				, std::int64_t const file_offset
 				, span<iovec_t const> vec, storage_error& ec)
 		{
@@ -645,7 +645,7 @@ namespace libtorrent {
 			m_stat_cache.set_dirty(file_index);
 
 			auto handle = open_file(sett, file_index
-				, aux::open_mode::write | flags, ec);
+				, aux::open_mode::write | mode, ec);
 			if (ec) return -1;
 
 			int ret = 0;
@@ -685,7 +685,7 @@ namespace libtorrent {
 	int mmap_storage::hashv(settings_interface const& sett
 		, hasher& ph, std::ptrdiff_t const len
 		, piece_index_t const piece, int const offset
-		, aux::open_mode_t const flags, storage_error& error)
+		, aux::open_mode_t const mode, storage_error& error)
 	{
 #ifdef TORRENT_SIMULATE_SLOW_READ
 		std::this_thread::sleep_for(seconds(1));
@@ -695,7 +695,7 @@ namespace libtorrent {
 		span<iovec_t> dummy2(&dummy1, 1);
 
 		return readwritev(files(), dummy2, piece, offset, error
-			, [this, flags, &ph, &sett](file_index_t const file_index
+			, [this, mode, &ph, &sett](file_index_t const file_index
 				, std::int64_t const file_offset
 				, span<iovec_t const> vec, storage_error& ec)
 		{
@@ -732,7 +732,7 @@ namespace libtorrent {
 				return ret;
 			}
 
-			auto handle = open_file(sett, file_index, flags, ec);
+			auto handle = open_file(sett, file_index, mode, ec);
 			if (ec) return -1;
 
 			int ret = 0;
@@ -755,7 +755,7 @@ namespace libtorrent {
 	int mmap_storage::hashv2(settings_interface const& sett
 		, hasher256& ph, std::ptrdiff_t const len
 		, piece_index_t const piece, int const offset
-		, aux::open_mode_t const flags, storage_error& error)
+		, aux::open_mode_t const mode, storage_error& error)
 	{
 		std::int64_t const start_offset = static_cast<int>(piece) * std::int64_t(files().piece_length()) + offset;
 		file_index_t const file_index = files().file_index_at_offset(start_offset);
@@ -782,7 +782,7 @@ namespace libtorrent {
 			return ret;
 		}
 
-		auto handle = open_file(sett, file_index, flags, error);
+		auto handle = open_file(sett, file_index, mode, error);
 		if (error) return -1;
 
 		span<byte const> file_range = handle->range();


### PR DESCRIPTION
This only affects unix systems, and it makes all the data read from disk when checking files have low priority, and among the first to be reclaimed by the kernel when it needs more pages.

Results from the checking benchmark before this change:

![memory_stats log](https://user-images.githubusercontent.com/661450/150651185-43f5c4d4-ec0e-431c-914e-1d6092f8157f.png)

And after this change:

![memory_stats log](https://user-images.githubusercontent.com/661450/150651191-6f070a21-76d5-4bd6-9f91-76b384891299.png)