### PR TITLE
Add workaround for windows shared drive directory issue

### DIFF
--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -903,17 +903,15 @@ error_code translate_error(std::system_error const& err, bool const write)
 #endif
 
 		boost::optional<aux::file_view> h = open_file_impl(sett, file, mode, ec);
-		
-		bool should_retry = (mode & aux::open_mode::write)
-			&& ec.ec == boost::system::errc::no_such_file_or_directory;
+		if ((mode & aux::open_mode::write)
+			&& (ec.ec == boost::system::errc::no_such_file_or_directory
 #ifdef _WIN32
-		// this is a workaround for improper handling of files on windows shared drives.
-		// if the directory on a shared drive does not exist, 
-		// windows returns ERROR_IO_DEVICE instead of ERROR_FILE_NOT_FOUND
-		should_retry |= (ec.ec.value() == ERROR_IO_DEVICE);
+				// this is a workaround for improper handling of files on windows shared drives.
+				// if the directory on a shared drive does not exist, 
+				// windows returns ERROR_IO_DEVICE instead of ERROR_FILE_NOT_FOUND
+				|| ec.ec == error_code(ERROR_IO_DEVICE, boost::asio::error::system_category)
 #endif
-
-		if (should_retry)
+		))
 		{
 			// this means the directory the file is in doesn't exist.
 			// so create it


### PR DESCRIPTION
I've noticed an issue with the way file handles on shared drives are handled than can prevent libtorrent from downloading torrents to Windows shared drives. I also created a workaround that fixes this and a pull request.

The issue is this:
When starting to write a file in a torrent libtorrent checks if it can open the file using CreateFileW. If the directory doesn't exist then Windows responds with "ERROR_FILE_NOT_FOUND". Libtorrent then tries to create the directory tree and tries again.

However when we try to create a file on a Windows network drive, there can be some odd behavior. If the directory doesn't exist Windows instead returns error code 1117, "ERROR_IO_DEVICE". This doesn't really make sense to me because there is no real I/O error with the network drive, the directory just doesn't exist.

This causes libtorrent to fail instead of trying to create the directory.
As a workaround I just check for this code too on Windows platforms and also try to create the directory in this case. 

It's possible this could also occur when a real I/O device error occurs, however I don't see this having much impact as if there is a real I/O error, the subsequent directory creation will fail too.