### PR TITLE
Fix #6683 macOS python binding build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,9 +106,7 @@ jobs:
     - name: build/install (MacOS)
       if: runner.os == 'macOS'
       run: |
-        # Add Homebrew's python site-packages to PYTHONPATH and
-        # install to it. no need for --user and --prefix
-        export PYTHONPATH=$(brew --prefix)/lib/python3.9/site-packages
+        # Install to Homebrew's python site-packages. no need for --user and --prefix
         cd bindings/python
         python3 setup.py build_ext install --install-lib $(brew --prefix)/lib/python3.9/site-packages
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,6 +106,8 @@ jobs:
     - name: build/install (MacOS)
       if: runner.os == 'macOS'
       run: |
+        # Add Homebrew's python site-packages to PYTHONPATH and
+        # install to it. no need for --user and --prefix
         export PYTHONPATH=$(brew --prefix)/lib/python3.9/site-packages
         cd bindings/python
         python3 setup.py build_ext install --install-lib $(brew --prefix)/lib/python3.9/site-packages

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -97,19 +97,21 @@ jobs:
         cd bindings\python
         python test.py
 
-    - name: build/install
-      if: runner.os != 'Windows'
+    - name: build/install (Linux)
+      if: runner.os == 'Linux'
       run: |
         cd bindings/python
-        # Homebrew's python "framework" sets a prefix via distutils config.
-        # --prefix conflicts with --user, so null out prefix so we have one
-        # command that works everywhere
         python3 setup.py build_ext install --user --prefix=
 
-    # TODO: we currently don't run the tests on MacOS, because something fails
-    # to install correctly. It needs to be resolved
+    - name: build/install (MacOS)
+      if: runner.os == 'macOS'
+      run: |
+        export PYTHONPATH=$(brew --prefix)/lib/python3.9/site-packages
+        cd bindings/python
+        python3 setup.py build_ext install --install-lib $(brew --prefix)/lib/python3.9/site-packages
+
     - name: tests
-      if: runner.os == 'Linux'
+      if: runner.os != 'Windows'
       run: |
         cd bindings/python
         python3 test.py


### PR DESCRIPTION
Install libtorrent in Homebrew's python site-packages by passing the location with `--install-lib` when running `setup.py`

Runs on branch:
- [RC_1_2 run](https://github.com/Samfun75/libtorrent/actions/runs/1789100101)
- [RC_2_0 run](https://github.com/Samfun75/libtorrent/actions/runs/1789100117)

Fixes #6683