### PR TITLE
CMake: prefer `-pthread` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,7 @@ list(TRANSFORM try_signal_sources PREPEND "deps/try_signal/")
 feature_option(BUILD_SHARED_LIBS "build libtorrent as a shared library" ON)
 feature_option(static_runtime "build libtorrent with static runtime" OFF)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_public_dependency(Threads REQUIRED)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)


### PR DESCRIPTION
* Moved from qbittorrent/qBittorrent#16389.

ref: https://cmake.org/cmake/help/latest/module/FindThreads.html#variable:THREADS_PREFER_PTHREAD_FLAG

> Use of both the imported target as well as this switch is highly recommended for new code.

Note that this change also fixes build on RISC-V architecture, which needs `-pthread` flag for libpthread to function correctly.

See also: [Stack Overflow: Difference between -pthread and -lpthread](https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling)
