### PR TITLE
Exporting SYSTEM_VERSION_COMPAT to fix tox failing on macOS

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -129,14 +129,9 @@ jobs:
         set PYTHON_INTERPRETER=python
         tox -e py
 
-    - name: build/install (MacOS)
-      if: runner.os == 'macOS'
-      run: |
-        # Install to Homebrew's python site-packages. no need for --user and --prefix
-        cd bindings/python
-        python3 setup.py build_ext install --install-lib $(brew --prefix)/lib/python3.9/site-packages
-
     - name: tests
       if: runner.os != 'Windows'
       run: |
+        # Exporting SYSTEM_VERSION_COMPAT=0 helps pip allow install macos 11 tagged wheels. Ref https://github.com/pypa/packaging/issues/497
+        export SYSTEM_VERSION_COMPAT=0
         tox -e py


### PR DESCRIPTION
Currently tox is failing on macOS [run](https://github.com/arvidn/libtorrent/runs/5101876524?check_suite_focus=true)

The `SYSTEM_VERSION_COMPAT` env var will help installing macos 11 tagged wheels on macOS 11. It is a temporary fix until the appropriate patch is applied to `packaging` and `wheel`. [Reference](https://github.com/pypa/packaging/issues/497#issuecomment-1012665274)

And also the `build/install (MacOS)` is not need because tox create an a virtual environment and in tox.ini setup.py is called with bdist_wheel which will build the wheel from scratch

I tested the change on master with dummy trigger. Here is the [run](https://github.com/Samfun75/libtorrent/actions/runs/1812608579)