### PR TITLE
Always send a User-Agent field in HTTP tracker requests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* send User-Agent field in anonymous mode
 	* fix python binding for settings_pack conversion
 	* fix DHT announce timer issue
 	* use DSCP_TRAFFIC_TYPE socket option on windows

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -607,19 +607,16 @@ namespace aux {
 			// will go straight to download mode.
 			no_recheck_incomplete_resume,
 
-			// ``anonymous_mode``: When set to true, the client
-			// tries to hide its identity to a certain degree. The user-agent will be
-			// reset to an empty string (except for private torrents). Trackers
-			// will only be used if they are using a proxy server.
-			// The listen sockets are closed, and incoming
-			// connections will only be accepted through a SOCKS5 or I2P proxy (if
-			// a peer proxy is set up and is run on the same machine as the
-			// tracker proxy). Since no incoming connections are accepted,
-			// NAT-PMP, UPnP, DHT and local peer discovery are all turned off when
-			// this setting is enabled.
+			// ``anonymous_mode``: When set to true, the client tries to hide
+			// its identity to a certain degree.
 			//
-			// If you're using I2P, it might make sense to enable anonymous mode
-			// as well.
+			// * A generic user-agent will be
+			//   used for trackers (except for private torrents).
+			// * Your local IPv4 and IPv6 address won't be sent as query string
+			//   parameters to private trackers.
+			// * If announce_ip is configured, it will not be sent to trackers
+			// * The client version will not be sent to peers in the extension
+			//   handshake.
 			anonymous_mode,
 
 			// specifies whether downloads from web seeds is reported to the

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -1310,8 +1310,8 @@ TORRENT_TEST(tracker_user_agent_privacy_mode_public_torrent)
 		{
 			got_announce = true;
 
-			// in anonymous mode we should not send a user agent
-			TEST_CHECK(headers["user-agent"] == "");
+			// in anonymous mode we should send a generic user agent
+			TEST_CHECK(headers["user-agent"] == "curl/7.81.0");
 			return sim::send_response(200, "OK", 11) + "d5:peers0:e";
 		}
 		, [](torrent_handle h) {}

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -233,8 +233,11 @@ namespace libtorrent {
 		// in anonymous mode we omit the user agent to mitigate fingerprinting of
 		// the client. Private torrents is an exception because some private
 		// trackers may require the user agent
-		std::string const user_agent = settings.get_bool(settings_pack::anonymous_mode)
-			&& !tracker_req().private_torrent ? "" : settings.get_str(settings_pack::user_agent);
+		bool const anon_user = settings.get_bool(settings_pack::anonymous_mode)
+			&& !tracker_req().private_torrent;
+		std::string const user_agent = anon_user
+			? "curl/7.81.0"
+			: settings.get_str(settings_pack::user_agent);
 
 		// when sending stopped requests, prefer the cached DNS entry
 		// to avoid being blocked for slow or failing responses. Chances


### PR DESCRIPTION
even when it's set to an empty string. It appears some trackers require this field and will fail with 'Forbidden' otherwise.