### PR TITLE
Update boost on windows simulation and build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: install boost
         run: |
-          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.78.0 https://github.com/boostorg/boost.git
           cd boost
           bootstrap.bat
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: install boost
         run: |
-          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.72.0 https://github.com/boostorg/boost.git
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.78.0 https://github.com/boostorg/boost.git
           cd boost
           bootstrap.bat
 


### PR DESCRIPTION
I'm not sure if this was intentional or not but on windows ci, tests use boost 1.78 but simulation and build use boost 1.72, I figured since RC_1_2 windows ci don't run simulation and build it might have been forgotten when merging. If it was intentional, please close this PR.

Also android ci use boost 1.75, shouldn't it be upgraded to 1.78 for consistency if it doesn't cause problems?
This is not included in the PR.