### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: RC_1_2


### PR DESCRIPTION
This lets github's dependabot auto-update our github actions, via auto-generated PRs.

On my fork, it generated the following PRs:
 - https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/44
 - https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/45
 - https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/46
 - https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/47

I believe this change needs to be in the default branch (`RC_2_0`) to be effective. Once there, dependabot be enabled automatically, and will start generating PRs like the above. However you may need to manually enable it: go to Settings > Code Security and Analysis > Dependabot Security Updates > Enable.

Dependabot can manage other package ecosystems like `pypi`. For the places where we do `pip install` in a github action, I believe we'd need to use separate requirements files like `pip install -r requirements-for-this-action.txt`, and dependabot would manage the requirements files. We can experiment with this later.