### PR TITLE
Add a pre-commit autoupdate cron job

### DIFF
--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -1,0 +1,26 @@
+name: Pre-commit auto-update
+
+on:
+  # every day at midnight
+  schedule:
+    - cron: "0 0 * * *"
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+
+      - uses: browniebroke/pre-commit-autoupdate-action@main
+
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.


### PR DESCRIPTION
This will auto-generate PRs to update our pre-commit hooks.

On my fork, it auto-generated this PR:
 - https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/48

I believe the scheduled workflow will only run once this change is merged to `RC_2_0`.