### PR TITLE
Remove non-existant IFLA_* on non-x86_64 archs

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -338,20 +338,14 @@ namespace {
 				case IFLA_OPERSTATE: memcpy(&ret.oper_state, ptr, sizeof(int)); break;
 
 				// ignore these attributes
-				case IFLA_CARRIER:
 				case IFLA_ADDRESS:
 				case IFLA_BROADCAST:
 				case IFLA_QDISC:
 				case IFLA_COST:
-				case IFLA_PRIORITY:
-				case IFLA_MASTER:
 				case IFLA_WIRELESS:
 				case IFLA_WEIGHT:
 				case IFLA_LINKMODE:
 				case IFLA_LINKINFO:
-				case IFLA_STATS64:
-				case IFLA_STATS:
-				case IFLA_PROMISCUITY:
 				default:
 					break;
 			};


### PR DESCRIPTION
Fails to build on armv5, armv7, ppc and some i686 for Synology NAS due to non-existant IFLA_*

This is for `RC_1_2` branch (e.g. version 1.2.15+).  Same fix also applies to `RC_2_0` (ref: #6807)

Fixes: #6792 (relates to https://github.com/SynoCommunity/spksrc/pull/5180)