### PR TITLE
fix cmake pkg-config file generation

### DIFF
--- a/cmake/Modules/GeneratePkgConfig.cmake
+++ b/cmake/Modules/GeneratePkgConfig.cmake
@@ -52,7 +52,7 @@ function(_get_target_property_merging_configs _var_name _target_name _propert_na
 	# but we need INSTALL_INTERFACE here.
 	# See https://gitlab.kitware.com/cmake/cmake/issues/17984
 	string(REPLACE "$<BUILD_INTERFACE:" "$<0:" vals "${vals}")
-	string(REPLACE "$<INSTALL_INTERFACE:" "@CMAKE_INSTALL_PREFIX@/$<1:" vals "${vals}")
+	string(REPLACE "$<INSTALL_INTERFACE:" "\${CMAKE_INSTALL_PREFIX}/$<1:" vals "${vals}")
 	set(${_var_name} "${vals}" PARENT_SCOPE)
 endfunction()
 

--- a/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
+++ b/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
@@ -1,3 +1,6 @@
+cmake_policy(SET CMP0007 NEW)
+cmake_policy(SET CMP0011 NEW)
+
 include("@_variables_file_name@")
 
 function (cmake_list_to_pkg_config _result _list _prefix)

--- a/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
+++ b/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
@@ -37,7 +37,12 @@ function(split_library_dirs _libraries _base_library_dir _library_dirs_var _libr
 endfunction()
 
 split_library_dirs("${_TARGET_INTERFACE_LINK_LIBRARIES}" "${CMAKE_INSTALL_PREFIX}/${_INSTALL_LIBDIR}" _lib_dirs _library_names)
+set(_linker_options "${_library_names}")
+list(FILTER _linker_options INCLUDE REGEX "^-.*")
+list(FILTER _library_names EXCLUDE REGEX "^-.*")
 cmake_list_to_pkg_config(_libs "${_library_names}" "-l")
+list(JOIN _linker_options " " _linker_options)
+string(JOIN " " _libs "${_linker_options}" "${_libs}")
 list(LENGTH _lib_dirs _additional_libdirs_count)
 if (_additional_libdirs_count GREATER 0)
 	cmake_list_to_pkg_config(_additional_libdirs "${_lib_dirs}" "-L")


### PR DESCRIPTION
fixes few cmake warnings and pkg-config file generation itself, see each commit message for details

there is Debian bug report about invalid pkg-config file https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009875
Debian package maintainer resolved it just by adding some hack (just fix string in generated .pc file using regexp), but this is just a workaround.