### PR TITLE
fix peer_list::is_connect_candidate for share_mode

### DIFF
--- a/include/libtorrent/peer_list.hpp
+++ b/include/libtorrent/peer_list.hpp
@@ -97,7 +97,7 @@ namespace libtorrent {
 
 	struct TORRENT_EXTRA_EXPORT peer_list : single_threaded
 	{
-		explicit peer_list(torrent_peer_allocator_interface& alloc);
+		explicit peer_list(torrent_peer_allocator_interface& alloc, bool share_mode);
 		~peer_list();
 
 		void clear();
@@ -259,6 +259,9 @@ namespace libtorrent {
 		// if a peer has failed this many times or more, we don't consider
 		// it a connect candidate anymore.
 		int m_max_failcount = 3;
+
+        // torrent is share_mode
+        bool m_share_mode;
 	};
 
 }

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -143,11 +143,12 @@ namespace libtorrent {
 
 	constexpr erase_peer_flags_t peer_list::force_erase;
 
-	peer_list::peer_list(torrent_peer_allocator_interface& alloc)
+	peer_list::peer_list(torrent_peer_allocator_interface& alloc, bool share_mode)
 		: m_locked_peer(nullptr)
 		, m_peer_allocator(alloc)
 		, m_num_seeds(0)
 		, m_finished(0)
+        , m_share_mode(share_mode)
 	{
 		thread_started();
 	}
@@ -501,7 +502,7 @@ namespace libtorrent {
 			|| p.banned
 			|| p.web_seed
 			|| !p.connectable
-			|| (p.seed && m_finished)
+			|| !m_share_mode && (p.seed && m_finished)
 			|| int(p.failcount) >= m_max_failcount)
 			return false;
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1124,7 +1124,7 @@ bool is_downloading_state(int const st)
 	void torrent::need_peer_list()
 	{
 		if (m_peer_list) return;
-		m_peer_list.reset(new peer_list(m_ses.get_peer_allocator()));
+		m_peer_list.reset(new peer_list(m_ses.get_peer_allocator(), share_mode()));
 	}
 
 	void torrent::handle_exception()


### PR DESCRIPTION
In share_mode, the torrent maybe in seeding mode but not has all piece, so we still need to connect to seeds. 