### PR TITLE
add settings_for_path() utility function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(libtorrent_include_files
 	session_stats.hpp
 	session_status.hpp
 	session_types.hpp
+	settings_for_path.hpp
 	settings_pack.hpp
 	sha1.hpp
 	sha1_hash.hpp
@@ -222,6 +223,8 @@ set(libtorrent_aux_include_files
 	escape_string.hpp
 	export.hpp
 	ffs.hpp
+	file_descriptor.hpp
+	file_handle.hpp
 	file_progress.hpp
 	file_view_pool.hpp
 	has_block.hpp
@@ -382,6 +385,7 @@ set(sources
 	session_params.cpp
 	session_settings.cpp
 	session_stats.cpp
+	settings_for_path.cpp
 	settings_pack.cpp
 	sha1.cpp
 	sha1_hash.cpp

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+
+	* added settings_for_path() utility, to optimize disk settings based on save directory
+
 * 2.0.6 released
 
 	* fix issue creating a v2 torrent from torrent_info containing an empty file

--- a/Jamfile
+++ b/Jamfile
@@ -771,6 +771,7 @@ SOURCES =
 	session_handle
 	session_impl
 	session_call
+	settings_for_path
 	settings_pack
 	sha1
 	sha1_hash

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,8 @@ TOOLS_FILES= \
   parse_sample.py        \
   parse_session_stats.py \
   parse_utp_log.py       \
-  session_log_alerts.cpp
+  session_log_alerts.cpp \
+  settings_for_path.cpp
 
 KADEMLIA_SOURCES = \
   dht_settings.cpp     \
@@ -380,6 +381,7 @@ SOURCES = \
   session_params.cpp              \
   session_settings.cpp            \
   session_stats.cpp               \
+  settings_for_path.cpp           \
   settings_pack.cpp               \
   sha1.cpp                        \
   sha1_hash.cpp                   \
@@ -517,6 +519,7 @@ HEADERS = \
   session_stats.hpp            \
   session_status.hpp           \
   session_types.hpp            \
+  settings_for_path.hpp        \
   settings_pack.hpp            \
   sha1.hpp                     \
   sha1_hash.hpp                \
@@ -594,6 +597,8 @@ HEADERS = \
   aux_/escape_string.hpp            \
   aux_/export.hpp                   \
   aux_/ffs.hpp                      \
+  aux_/file_descriptor.hpp          \
+  aux_/file_handle.hpp              \
   aux_/file_pointer.hpp             \
   aux_/file_progress.hpp            \
   aux_/file_view_pool.hpp           \

--- a/include/libtorrent/aux_/file_descriptor.hpp
+++ b/include/libtorrent/aux_/file_descriptor.hpp
@@ -1,0 +1,64 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_FILE_DESCRIPTOR_HPP_INCLUDED
+#define TORRENT_FILE_DESCRIPTOR_HPP_INCLUDED
+
+#include <unistd.h>
+
+namespace libtorrent {
+namespace aux {
+
+struct file_descriptor
+{
+	file_descriptor(int fd) : m_fd(fd) {}
+
+	~file_descriptor()
+	{
+		if (m_fd >= 0) ::close(m_fd);
+	}
+
+	file_descriptor(file_descriptor const&) = delete;
+	file_descriptor(file_descriptor&& rhs)
+		: m_fd(rhs.m_fd)
+	{
+		rhs.m_fd = -1;
+	}
+	int fd() const { return m_fd; }
+private:
+	int m_fd;
+};
+
+}
+}
+
+#endif

--- a/include/libtorrent/aux_/file_handle.hpp
+++ b/include/libtorrent/aux_/file_handle.hpp
@@ -1,0 +1,64 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_WIN_FILE_HANDLE_HPP_INCLUDED
+#define TORRENT_WIN_FILE_HANDLE_HPP_INCLUDED
+
+#include "libtorrent/aux_/windows.hpp"
+
+namespace libtorrent {
+namespace aux {
+
+struct win_file_handle
+{
+	win_file_handle(HANDLE h) : m_h(h) {}
+
+	~win_file_handle()
+	{
+		if (m_h != INVALID_HANDLE_VALUE) ::CloseHandle(m_h);
+	}
+
+	win_file_handle(win_file_handle const&) = delete;
+	win_file_handle(win_file_handle&& rhs)
+		: m_h(rhs.m_h)
+	{
+		rhs.m_h = INVALID_HANDLE_VALUE;
+	}
+	HANDLE handle() const { return m_h; }
+private:
+	HANDLE m_h;
+};
+
+}
+}
+
+#endif

--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -482,7 +482,22 @@ namespace aux {
 	// 	void Fun(piece_index_t);
 	//
 	// The overloads taking a settings_pack may be used to configure the
-	// underlying disk access. Such as ``settings_pack::aio_threads``.
+	// underlying disk access. Such as ``settings_pack::hashing_threads``. Note
+	// that the ideal number of hashing threads is most likely 1 for an HDD and
+	// close to the number of CPU cores
+	// (``std::thread::hardware_concurrency()``) on an SSD.
+	// For optimal performance, set the number of hashing threads depending on
+	// the drive type. This is also the default. See settings_for_path():
+	//
+	// .. code:: c++
+	//
+	// 	create_torrent t;
+	// 	std::string path = ...
+	// 	...
+	// 	lt::error_code ec;
+	// 	lt::settings_pack sett;
+	// 	lt::settings_for_path(sett, path);
+	// 	lt::set_piece_hashes(t, path, sett, {}, ec);
 	//
 	// The overloads that don't take an ``error_code&`` may throw an exception in case of a
 	// file error, the other overloads sets the error code to reflect the error, if any.

--- a/include/libtorrent/settings_for_path.hpp
+++ b/include/libtorrent/settings_for_path.hpp
@@ -1,0 +1,46 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_SETTINGS_FOR_PATH_HPP_INCLUDED
+#define TORRENT_SETTINGS_FOR_PATH_HPP_INCLUDED
+
+#include "libtorrent/fwd.hpp"
+
+#include <string>
+
+namespace libtorrent {
+	// This function adds or overwrites settings in the ``settings`` pack to
+	// optimize disk performance for the specified download directory (path).
+	void settings_for_path(settings_interface& settings, std::string const& path);
+}
+
+#endif

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifdef TORRENT_WINDOWS
 // windows part
 #include "libtorrent/aux_/windows.hpp"
+#include "libtorrent/aux_/file_handle.hpp"
 #else
 
 #ifndef _GNU_SOURCE
@@ -47,6 +48,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
+
+#include "libtorrent/aux_/file_descriptor.hpp"
 
 #include <unistd.h>
 #include <sys/stat.h>
@@ -106,26 +109,6 @@ std::pair<std::int64_t, std::int64_t> next_allocated_region(HANDLE file
 
 	return {out.FileOffset.QuadPart, out.FileOffset.QuadPart + out.Length.QuadPart};
 }
-
-struct file_handle
-{
-	file_handle(HANDLE h) : m_h(h) {}
-
-	~file_handle()
-	{
-		if (m_h != INVALID_HANDLE_VALUE) ::CloseHandle(m_h);
-	}
-
-	file_handle(file_handle const&) = delete;
-	file_handle(file_handle&& rhs)
-		: m_h(rhs.m_h)
-	{
-		rhs.m_h = INVALID_HANDLE_VALUE;
-	}
-	HANDLE handle() const { return m_h; }
-private:
-	HANDLE m_h;
-};
 
 void copy_range(HANDLE const in_handle, HANDLE const out_handle
 	, std::int64_t in_offset, std::int64_t len, error_code& ec)
@@ -196,13 +179,13 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 		| in_stat.nFileSizeLow;
 
 #ifdef TORRENT_WINRT
-	file_handle in_handle = ::CreateFile2(f1.c_str()
+	aux::win_file_handle in_handle = ::CreateFile2(f1.c_str()
 			, GENERIC_READ
 			, FILE_SHARE_READ
 			, OPEN_EXISTING
 			, nullptr);
 #else
-	file_handle in_handle = ::CreateFileW(f1.c_str()
+	aux::win_file_handle in_handle = ::CreateFileW(f1.c_str()
 			, GENERIC_READ
 			, FILE_SHARE_READ
 			, nullptr
@@ -217,13 +200,13 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	}
 
 #ifdef TORRENT_WINRT
-	file_handle out_handle = ::CreateFile2(f1.c_str()
+	aux::win_file_handle out_handle = ::CreateFile2(f1.c_str()
 			, GENERIC_WRITE
 			, FILE_SHARE_WRITE
 			, OPEN_ALWAYS
 			, nullptr);
 #else
-	file_handle out_handle = ::CreateFileW(f2.c_str()
+	aux::win_file_handle out_handle = ::CreateFileW(f2.c_str()
 			, GENERIC_WRITE
 			, FILE_SHARE_WRITE
 			, nullptr
@@ -264,26 +247,6 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 // Generic/linux implementation
 
 namespace {
-
-struct file_descriptor
-{
-	file_descriptor(int fd) : m_fd(fd) {}
-
-	~file_descriptor()
-	{
-		if (m_fd >= 0) ::close(m_fd);
-	}
-
-	file_descriptor(file_descriptor const&) = delete;
-	file_descriptor(file_descriptor&& rhs)
-		: m_fd(rhs.m_fd)
-	{
-		rhs.m_fd = -1;
-	}
-	int fd() const { return m_fd; }
-private:
-	int m_fd;
-};
 
 ssize_t copy_range(int const fd_in, int const fd_out, off_t in_offset
 	, std::int64_t len, error_code& ec)
@@ -346,7 +309,7 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	native_path_string f1 = convert_to_native_path_string(inf);
 	native_path_string f2 = convert_to_native_path_string(newf);
 
-	file_descriptor const infd = ::open(f1.c_str(), O_RDONLY);
+	aux::file_descriptor const infd = ::open(f1.c_str(), O_RDONLY);
 	if (infd.fd() < 0)
 	{
 		ec.assign(errno, system_category());
@@ -365,7 +328,7 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	// if the source file is not sparse we'll end up copying every byte anyway,
 	// there's no point in passing O_TRUNC. However, in order to preserve sparse
 	// regions, we *do* need to truncate the output file.
-	file_descriptor const outfd = ::open(f2.c_str()
+	aux::file_descriptor const outfd = ::open(f2.c_str()
 		, input_is_sparse ? (O_RDWR | O_CREAT | O_TRUNC) : (O_RDWR | O_CREAT), in_stat.st_mode);
 	if (outfd.fd() < 0)
 	{

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/throw.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
+#include "libtorrent/settings_for_path.hpp"
 #include "libtorrent/session.hpp" // for default_disk_io_constructor
 #include "libtorrent/aux_/directory.hpp"
 #include "libtorrent/disk_interface.hpp"
@@ -290,8 +291,7 @@ namespace {
 		, std::function<void(piece_index_t)> const& f, error_code& ec)
 	{
 		aux::session_settings sett;
-		int const num_threads = std::max(1, static_cast<int>(std::thread::hardware_concurrency() / 2));
-		sett.set_int(settings_pack::hashing_threads, num_threads);
+		settings_for_path(sett, p);
 		set_piece_hashes(t, p, sett, f, ec);
 	}
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -328,6 +328,8 @@ private:
 	// synchronize with the writing thread(s)
 	aux::store_buffer m_store_buffer;
 
+	// this points to the internal settings of the main thread. Technically we
+	// should only access this in settings_updated().
 	settings_interface const& m_settings;
 
 	// LRU cache of open files

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -91,8 +91,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <winioctl.h>
 #ifndef TORRENT_MINGW
 #include <direct.h> // for _getcwd, _mkdir
-#else
-#include <dirent.h>
 #endif
 #include <sys/types.h>
 #else
@@ -101,7 +99,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <sys/types.h>
 #include <cerrno>
-#include <dirent.h>
 #include <sys/ioctl.h>
 
 #endif // posix part

--- a/src/settings_for_path.cpp
+++ b/src/settings_for_path.cpp
@@ -1,0 +1,277 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/config.hpp"
+#include "libtorrent/settings_for_path.hpp"
+#include "libtorrent/settings_pack.hpp"
+#include "libtorrent/string_view.hpp"
+
+#include <iostream>
+#include <thread>
+
+#ifdef TORRENT_LINUX
+#include <sys/stat.h>
+#include <sys/fcntl.h>
+#include <sys/sysmacros.h> // for major()/minor()
+#include <dirent.h>
+#include <unistd.h>
+
+#include "libtorrent/aux_/file_descriptor.hpp"
+
+#include <boost/optional.hpp>
+
+namespace {
+
+struct directory
+{
+	directory() : ptr(nullptr) {}
+	explicit directory(DIR* p) : ptr(p) {}
+	~directory() { if (ptr != nullptr) ::closedir(ptr); }
+	directory(directory const&) = delete;
+	directory(directory&& f) : ptr(f.ptr) { f.ptr = nullptr; }
+	directory& operator=(directory const&) = delete;
+	directory& operator=(directory&& f)
+	{
+		std::swap(ptr, f.ptr);
+		return *this;
+	}
+	DIR* dir() const { return ptr; }
+private:
+	DIR* ptr;
+};
+
+boost::optional<std::string> read_file(char const* dev_name, char const* path)
+{
+	char p[300];
+	std::snprintf(p, sizeof(p), "/sys/block/%s/%s", dev_name, path);
+
+	lt::aux::file_descriptor f = ::open(p, 0);
+	if (f.fd() == -1)
+		return boost::none;
+
+
+	auto size = ::read(f.fd(), p, sizeof(p));
+	if (size <= 0 || size > sizeof(p))
+		return boost::none;
+
+	return std::string(p, size);
+}
+}
+
+#elif defined TORRENT_WINDOWS
+
+#include "libtorrent/aux_/windows.hpp"
+#include "libtorrent/aux_/path.hpp"
+#include "libtorrent/aux_/file_handle.hpp"
+
+#include <boost/optional.hpp>
+
+#endif
+
+namespace {
+
+int num_threads(int const scale = 1)
+{
+	return std::max(1, static_cast<int>(
+		std::thread::hardware_concurrency() / scale));
+}
+}
+
+namespace libtorrent {
+
+void settings_for_path(settings_interface& settings, std::string const& path)
+{
+#ifdef TORRENT_LINUX
+	struct stat st{};
+	if (stat(path.c_str(), &st) == 0)
+	{
+		char device_id[50];
+		std::snprintf(device_id, sizeof(device_id), "%d:%d\n", major(st.st_dev), minor(st.st_dev));
+
+		directory dir(opendir("/sys/block"));
+		if (dir.dir() != nullptr)
+		{
+
+			struct dirent* de;
+			while ((de = readdir(dir.dir())))
+			{
+				if (de->d_name[0] == '.')
+					continue;
+
+				auto content = read_file(de->d_name, "/dev");
+				if (!content)
+					continue;
+
+				if (*content != device_id)
+					continue;
+
+				content = read_file(de->d_name, "/queue/rotational");
+				if (!content)
+					continue;
+
+				if (*content == "1\n")
+				{
+					settings.set_int(settings_pack::hashing_threads, 1);
+				}
+				else if (*content == "0\n")
+				{
+					content = read_file(de->d_name, "/queue/dax");
+					int scale = 2;
+					if (content && *content == "1\n")
+					{
+						// if we have DAX storage, max out the threads accessing
+						// the disk
+						scale = 1;
+						settings.set_int(settings_pack::aio_threads, num_threads());
+					}
+
+					settings.set_int(settings_pack::hashing_threads, num_threads(scale));
+				}
+				return;
+			}
+		}
+	}
+
+#elif defined TORRENT_WINDOWS
+
+	auto const native_path = convert_to_native_path_string(path);
+
+	std::array<wchar_t, 300> volume_path;
+	if (GetVolumePathNameW(native_path.c_str(), volume_path.data(), volume_path.size()) == 0)
+		goto failed;
+
+	int const drive_type = GetDriveTypeW(volume_path.data());
+	if (drive_type == DRIVE_REMOTE)
+	{
+		settings.set_int(settings_pack::hashing_threads, 1);
+		return;
+	}
+	if (drive_type == DRIVE_RAMDISK)
+	{
+		auto const n = num_threads();
+		settings.set_int(settings_pack::aio_threads, n);
+		settings.set_int(settings_pack::hashing_threads, n);
+		return;
+	}
+	DWORD fs_flags = 0;
+	if (GetVolumeInformationW(volume_path.data()
+		, nullptr, 0, nullptr, nullptr, &fs_flags, nullptr, 0))
+	{
+		if (fs_flags & FILE_DAX_VOLUME)
+		{
+			// if we have DAX storage, max out the threads accessing
+			// the disk
+			auto const n = num_threads();
+			settings.set_int(settings_pack::aio_threads, n);
+			settings.set_int(settings_pack::hashing_threads, n);
+			return;
+		}
+	}
+
+	// these steps are documented here:
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/basic-and-dynamic-disks
+	std::array<wchar_t, 300> volume_name;
+	if (GetVolumeNameForVolumeMountPointW(volume_path.data()
+		, volume_name.data(), volume_name.size()))
+	{
+		// strip trailing backslash
+		auto const vol_name_len = ::wcslen(volume_name.data());
+		if (vol_name_len > 0 && volume_name[vol_name_len-1] == L'\\')
+			volume_name[vol_name_len - 1] = 0;
+
+		aux::win_file_handle vol = CreateFileW(volume_name.data(), 0
+			, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr
+			, OPEN_EXISTING, {}, nullptr);
+		if (vol.handle() != INVALID_HANDLE_VALUE)
+		{
+			struct extents_t
+			{
+				DWORD NumberOfDiskExtents;
+				DISK_EXTENT Extents[4];
+			};
+			extents_t extents{};
+			DWORD output_len = 0;
+			if (DeviceIoControl(vol.handle(), IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS
+				, nullptr, 0, &extents, sizeof(extents), &output_len, nullptr))
+			{
+				boost::optional<bool> seek_penalty;
+				// a volume may span multiple physical disks, since we won't
+				// know which physical disk we will access, make the
+				// conservative assumption that we'll be on the worst one. If
+				// one of the disks has seek-penalty, consider the whole volume
+				// as a spinning disk and we should use a single hasher thread.
+				for (int i = 0; i < extents.NumberOfDiskExtents; ++i)
+				{
+					std::array<wchar_t, 50> device_name{};
+					::_snwprintf(device_name.data(), device_name.size()
+						, L"\\\\?\\PhysicalDrive%d", extents.Extents[i].DiskNumber);
+
+					aux::win_file_handle dev = CreateFileW(device_name.data(), 0
+						, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr
+						, OPEN_EXISTING, {}, nullptr);
+					if (dev.handle() != INVALID_HANDLE_VALUE)
+					{
+						STORAGE_PROPERTY_QUERY query{};
+						query.PropertyId = StorageDeviceSeekPenaltyProperty;
+						query.QueryType = PropertyExistsQuery;
+						DEVICE_SEEK_PENALTY_DESCRIPTOR dev_seek{};
+
+						DWORD output_len = 0;
+						query.QueryType = PropertyStandardQuery;
+						if (DeviceIoControl(dev.handle(), IOCTL_STORAGE_QUERY_PROPERTY, &query, sizeof(query), &dev_seek, sizeof(dev_seek), &output_len, nullptr))
+						{
+							if (dev_seek.IncursSeekPenalty)
+							{
+								seek_penalty = true;
+								break;
+							}
+							else if (!seek_penalty)
+							{
+								seek_penalty = false;
+							}
+						}
+					}
+				}
+				if (seek_penalty && !*seek_penalty)
+				{
+					settings.set_int(settings_pack::hashing_threads, num_threads(2));
+					return;
+				}
+			}
+		}
+	}
+failed:
+#endif
+	settings.set_int(settings_pack::hashing_threads, 1);
+}
+}
+

--- a/tools/Jamfile
+++ b/tools/Jamfile
@@ -44,4 +44,5 @@ exe dht : dht_put.cpp : <include>../ed25519/src ;
 exe dht-sample : dht_sample.cpp : <include>../ed25519/src ;
 exe session_log_alerts : session_log_alerts.cpp ;
 exe disk_io_stress_test : disk_io_stress_test.cpp ;
+exe settings_for_path : settings_for_path.cpp ;
 

--- a/tools/settings_for_path.cpp
+++ b/tools/settings_for_path.cpp
@@ -1,0 +1,60 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/settings_for_path.hpp"
+#include "libtorrent/settings_pack.hpp"
+
+#include <iostream>
+#include <string>
+
+struct print_setting
+{
+	template <typename T>
+	void operator()(int const name, T const value)
+	{
+		std::cout << lt::name_for_setting(name) << ": " << value << '\n';
+	}
+
+};
+
+int main(int argc, char const* argv[])
+{
+	if (argc != 2)
+	{
+		std::cerr << "USAGE: settings_for_path <path>\n";
+		return 1;
+	}
+	lt::settings_pack pack;
+	lt::settings_for_path(pack, std::string(argv[1]));
+	pack.for_each(print_setting{});
+}
+


### PR DESCRIPTION
to optimize disk I/O settings based on the save path. This patch looks at these properties of the drive of the specified path:

1. Is it a spinning disk or SSD (windows boils this down to, is there a penalty to seek)
2. If it's an SSD, is it DAX? (which is really where memory mapped files would shine)
3. Is it a network share (where memory mapped files probably won't to so well)

This is still work in progress and I'm interested in feedback.

- [ ] python binding
- [ ] consider feasibility to also hint on what disk I/O back-end to use
- [ ] consider feasibility to also provide per-torrent settings