### PR TITLE
Handle all "fastresume rejected" cases consistently

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2004,13 +2004,9 @@ bool is_downloading_state(int const st)
 		if (status == status_t::fatal_disk_error)
 		{
 			TORRENT_ASSERT(m_outstanding_check_files == false);
-			m_add_torrent_params.reset();
 			handle_disk_error("check_resume_data", error);
 			auto_managed(false);
 			pause();
-			set_state(torrent_status::checking_files);
-			if (should_check_files()) start_checking();
-			return;
 		}
 
 		state_updated();


### PR DESCRIPTION
Issue a "fastresume rejected" alert in all the cases. Otherwise, it's damn hard to determine that an I/O error occurred precisely during "fastresume data" checking. Also, I don't see the point in completely discarding "fastresume data" (e.g. peers), but just continue processing it the same way as in other cases.