### PR TITLE
openssl: Replace SHA* family by EVP_*

### DIFF
--- a/include/libtorrent/aux_/hasher512.hpp
+++ b/include/libtorrent/aux_/hasher512.hpp
@@ -58,6 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 	extern "C" {
 	#include <openssl/sha.h>
+	#include <openssl/evp.h>
 	}
 
 #else
@@ -122,7 +123,7 @@ namespace aux {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		aux::crypt_hash<CALG_SHA_512, PROV_RSA_AES> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_CTX m_context;
+		EVP_MD_CTX *m_context = EVP_MD_CTX_new();
 #else
 		sha512_ctx m_context;
 #endif

--- a/include/libtorrent/hasher.hpp
+++ b/include/libtorrent/hasher.hpp
@@ -64,6 +64,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 extern "C" {
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 }
 
 #else
@@ -131,7 +132,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI
 		aux::crypt_hash<CALG_SHA1, PROV_RSA_FULL> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA_CTX m_context;
+		EVP_MD_CTX *m_context = EVP_MD_CTX_new();
 #else
 		sha1_ctx m_context;
 #endif
@@ -173,7 +174,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		aux::crypt_hash<CALG_SHA_256, PROV_RSA_AES> m_context;
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_CTX m_context;
+		EVP_MD_CTX *m_context = EVP_MD_CTX_new();
 #else
 		sha256_ctx m_context;
 #endif

--- a/src/ed25519/hasher512.cpp
+++ b/src/ed25519/hasher512.cpp
@@ -49,7 +49,7 @@ namespace aux {
 #elif TORRENT_USE_CNG
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_Init(&m_context);
+		EVP_DigestInit(m_context, EVP_sha512());
 #else
 		SHA512_init(&m_context);
 #endif
@@ -91,8 +91,7 @@ namespace aux {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.update(data);
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
-			, static_cast<std::size_t>(data.size()));
+		EVP_DigestUpdate(m_context, data.data(), static_cast<std::size_t>(data.size()));
 #else
 		SHA512_update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
 			, static_cast<std::size_t>(data.size()));
@@ -113,7 +112,7 @@ namespace aux {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.get_hash(digest.data(), digest.size());
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
+		EVP_DigestFinal(m_context, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
 #else
 		SHA512_final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
 #endif
@@ -131,7 +130,7 @@ namespace aux {
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.reset();
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA512_Init(&m_context);
+		EVP_DigestInit(m_context, EVP_sha512());
 #else
 		SHA512_init(&m_context);
 #endif

--- a/src/hasher.cpp
+++ b/src/hasher.cpp
@@ -53,7 +53,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CNG
 #elif TORRENT_USE_CRYPTOAPI
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA1_Init(&m_context);
+		EVP_DigestInit(m_context, EVP_sha1());
 #else
 		SHA1_init(&m_context);
 #endif
@@ -107,8 +107,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI
 		m_context.update(data);
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA1_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
-			, static_cast<std::size_t>(data.size()));
+		EVP_DigestUpdate(m_context, data.data(), static_cast<std::size_t>(data.size()));
 #else
 		SHA1_update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
 			, static_cast<std::size_t>(data.size()));
@@ -129,7 +128,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI
 		m_context.get_hash(digest.data(), digest.size());
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA1_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
+		EVP_DigestFinal(m_context, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
 #else
 		SHA1_final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
 #endif
@@ -147,7 +146,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI
 		m_context.reset();
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA1_Init(&m_context);
+		EVP_DigestInit(m_context, EVP_sha1());
 #else
 		SHA1_init(&m_context);
 #endif
@@ -169,7 +168,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CNG
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_Init(&m_context);
+		EVP_DigestInit(m_context, EVP_sha256());
 #else
 		SHA256_init(m_context);
 #endif
@@ -223,8 +222,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.update(data);
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_Update(&m_context, reinterpret_cast<unsigned char const*>(data.data())
-			, static_cast<std::size_t>(data.size()));
+		EVP_DigestUpdate(m_context, data.data(), static_cast<std::size_t>(data.size()));
 #else
 		SHA256_update(m_context, reinterpret_cast<unsigned char const*>(data.data())
 			, static_cast<std::size_t>(data.size()));
@@ -245,7 +243,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.get_hash(digest.data(), digest.size());
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_Final(reinterpret_cast<unsigned char*>(digest.data()), &m_context);
+		EVP_DigestFinal(m_context, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
 #else
 		SHA256_final(reinterpret_cast<unsigned char*>(digest.data()), m_context);
 #endif
@@ -263,7 +261,7 @@ TORRENT_CRYPTO_NAMESPACE
 #elif TORRENT_USE_CRYPTOAPI_SHA_512
 		m_context.reset();
 #elif defined TORRENT_USE_LIBCRYPTO
-		SHA256_Init(&m_context);
+		EVP_DigestInit(m_context, EVP_sha256());
 #else
 		SHA256_init(m_context);
 #endif

--- a/src/ssl.cpp
+++ b/src/ssl.cpp
@@ -178,7 +178,7 @@ namespace {
 		{
 			// this is needed for openssl < 1.0 to decrypt keys created by openssl 1.0+
 #if !defined(OPENSSL_API_COMPAT) || (OPENSSL_API_COMPAT < 0x10100000L)
-			OpenSSL_add_all_algorithms();
+			// OpenSSL_add_all_algorithms();
 #else
 			OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS, nullptr);
 #endif
@@ -196,7 +196,7 @@ namespace {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 			// openssl requires this to clean up internal structures it allocates
-			CRYPTO_cleanup_all_ex_data();
+			// CRYPTO_cleanup_all_ex_data();
 #ifdef TORRENT_MACOS_DEPRECATED_LIBCRYPTO
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Built against openssl 1.1.1o and 3.0.3, which are both compiled with `no-deprecated`.
https://github.com/toooonyy/libtorrent/commit/1bfc03bb0616aa851db58c4238d2f5a288ffe649 this change might lead to recession(memory leaks?), but so far my qbit seems normal.