### PR TITLE
Unique trackers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ set(libtorrent_aux_include_files
 	torrent_list.hpp
 	torrent_peer.hpp
 	torrent_peer_allocator.hpp
+	tracker_list.hpp
 	tracker_manager.hpp
 	udp_socket.hpp
 	udp_tracker_connection.hpp
@@ -407,6 +408,7 @@ set(sources
 	torrent_peer_allocator.cpp
 	torrent_status.cpp
 	tracker_manager.cpp
+	tracker_list.cpp
 	truncate.cpp
 	udp_socket.cpp
 	udp_tracker_connection.cpp

--- a/Jamfile
+++ b/Jamfile
@@ -808,6 +808,7 @@ SOURCES =
 	torrent_peer
 	torrent_peer_allocator
 	torrent_status
+	tracker_list
 	time
 	tracker_manager
 	http_tracker_connection

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,7 @@ SOURCES = \
   torrent_peer.cpp                \
   torrent_peer_allocator.cpp      \
   torrent_status.cpp              \
+  tracker_list.cpp                \
   tracker_manager.cpp             \
   truncate.cpp                    \
   udp_socket.cpp                  \
@@ -652,6 +653,7 @@ HEADERS = \
   aux_/torrent_list.hpp             \
   aux_/torrent_peer.hpp             \
   aux_/torrent_peer_allocator.hpp   \
+  aux_/tracker_list.hpp             \
   aux_/tracker_manager.hpp          \
   aux_/udp_socket.hpp               \
   aux_/udp_tracker_connection.hpp   \
@@ -936,6 +938,7 @@ TEST_SOURCES = \
   test_torrent_info.cpp \
   test_torrent_list.cpp \
   test_tracker.cpp \
+  test_tracker_list.cpp \
   test_tracker_manager.cpp \
   test_truncate.cpp \
   test_transfer.cpp \

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -457,6 +457,11 @@ void bind_torrent_handle()
 {
     // arguments are: number of seconds and tracker index
     void (torrent_handle::*force_reannounce0)(int, int, reannounce_flags_t) const = &torrent_handle::force_reannounce;
+    void (torrent_handle::*force_reannounce1)(int, std::string const&, reannounce_flags_t) const = &torrent_handle::force_reannounce;
+    void (torrent_handle::*force_reannounce3)(int, reannounce_flags_t) const = &torrent_handle::force_reannounce;
+    void (torrent_handle::*scrape_tracker0)() const = &torrent_handle::scrape_tracker;
+    void (torrent_handle::*scrape_tracker1)(int) const = &torrent_handle::scrape_tracker;
+    void (torrent_handle::*scrape_tracker2)(std::string) const = &torrent_handle::scrape_tracker;
 
 #if TORRENT_ABI_VERSION == 1
     bool (torrent_handle::*super_seeding0)() const = &torrent_handle::super_seeding;
@@ -541,12 +546,15 @@ void bind_torrent_handle()
         .def("file_status", _(file_status0))
         .def("save_resume_data", _(&torrent_handle::save_resume_data), arg("flags") = 0)
         .def("need_save_resume_data", _(&torrent_handle::need_save_resume_data))
-        .def("force_reannounce", _(force_reannounce0)
-            , (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))
+        .def("force_reannounce", _(force_reannounce0), (arg("seconds"), arg("tracker_idx"), arg("flags") = reannounce_flags_t{}))
+        .def("force_reannounce", _(force_reannounce1), (arg("seconds"), arg("url"), arg("flags") = reannounce_flags_t{}))
+        .def("force_reannounce", _(force_reannounce3), (arg("seconds") = 0, arg("flags") = reannounce_flags_t{}))
 #ifndef TORRENT_DISABLE_DHT
         .def("force_dht_announce", _(&torrent_handle::force_dht_announce))
 #endif
-        .def("scrape_tracker", _(&torrent_handle::scrape_tracker), arg("index") = -1)
+        .def("scrape_tracker", _(scrape_tracker0))
+        .def("scrape_tracker", _(scrape_tracker1), (arg("index")))
+        .def("scrape_tracker", _(scrape_tracker2), (arg("url")))
         .def("flush_cache", &torrent_handle::flush_cache)
         .def("set_upload_limit", _(&torrent_handle::set_upload_limit))
         .def("upload_limit", _(&torrent_handle::upload_limit))

--- a/include/libtorrent/aux_/announce_entry.hpp
+++ b/include/libtorrent/aux_/announce_entry.hpp
@@ -173,6 +173,10 @@ namespace aux {
 		// list contains state per endpoint.
 		std::vector<announce_endpoint> endpoints;
 
+		// last time we ran "refresh_endpoint_list()" on this tracker entry,
+		// this was the version of listen sockets in the session.
+		std::uint32_t listen_socket_version = 0;
+
 		// the tier this tracker belongs to
 		std::uint8_t tier = 0;
 

--- a/include/libtorrent/aux_/announce_entry.hpp
+++ b/include/libtorrent/aux_/announce_entry.hpp
@@ -22,6 +22,10 @@ see LICENSE file.
 #include "libtorrent/aux_/array.hpp"
 #include "libtorrent/info_hash.hpp"
 
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/intrusive/list.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+
 #include <string>
 #include <cstdint>
 #include <vector>
@@ -150,7 +154,12 @@ namespace aux {
 		announce_entry();
 		~announce_entry();
 		announce_entry(announce_entry const&);
+		announce_entry(announce_entry&&);
 		announce_entry& operator=(announce_entry const&) &;
+		announce_entry& operator=(announce_entry&&) &;
+
+		// next and prev pointers for the list of
+		boost::intrusive::list_member_hook<> list_hook;
 
 		// tracker URL as it appeared in the torrent file
 		std::string url;
@@ -185,6 +194,7 @@ namespace aux {
 
 		// internal
 		announce_endpoint* find_endpoint(aux::listen_socket_handle const& s);
+		announce_endpoint const* find_endpoint(aux::listen_socket_handle const& s) const;
 	};
 
 }

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -666,6 +666,7 @@ namespace aux {
 			// or zero if no matching listen socket is found
 			int listen_port(transport ssl, address const& local_addr) const override;
 
+			std::uint32_t listen_socket_version() const override { return m_listen_socket_version; }
 			void for_each_listen_socket(std::function<void(aux::listen_socket_handle const&)> f) const override
 			{
 				for (auto& s : m_listen_sockets)
@@ -1003,6 +1004,9 @@ namespace aux {
 			// since we might be listening on multiple interfaces
 			// we might need more than one listen socket
 			std::vector<std::shared_ptr<listen_socket_t>> m_listen_sockets;
+
+			// increment every time we change which sockets we're listening on
+			std::uint32_t m_listen_socket_version = 0;
 
 #if TORRENT_USE_I2P
 			i2p_connection m_i2p_conn;

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -172,6 +172,7 @@ namespace libtorrent::aux {
 
 		virtual int listen_port(aux::transport ssl, address const& local_addr) const = 0;
 
+		virtual std::uint32_t listen_socket_version() const = 0;
 		virtual void for_each_listen_socket(std::function<void(aux::listen_socket_handle const&)> f) const = 0;
 
 		// ask for which interface and port to bind outgoing peer connections on

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -771,7 +771,10 @@ namespace libtorrent::aux {
 
 		// forcefully sets next_announce to the current time
 		void force_tracker_request(time_point, int tracker_idx, reannounce_flags_t flags);
+		void force_tracker_request_url(time_point, std::string const& url, reannounce_flags_t flags);
 		void scrape_tracker(int idx, bool user_triggered);
+		void scrape_tracker_url(std::string url, bool user_triggered);
+		void scrape_tracker_impl(aux::announce_entry& ae, bool user_triggered);
 		void announce_with_tracker(event_t e = event_t::none);
 
 #ifndef TORRENT_DISABLE_DHT

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -71,6 +71,7 @@ see LICENSE file.
 #include "libtorrent/aux_/announce_entry.hpp"
 #include "libtorrent/extensions.hpp" // for add_peer_flags_t
 #include "libtorrent/aux_/ssl.hpp"
+#include "libtorrent/aux_/tracker_list.hpp"
 
 #if TORRENT_USE_RTC
     #include "libtorrent/aux_/rtc_signaling.hpp"
@@ -783,8 +784,6 @@ namespace libtorrent::aux {
 		void set_tracker_login(std::string const& name, std::string const& pw);
 #endif
 
-		aux::announce_entry* find_tracker(std::string const& url);
-
 // --------------------------------------------
 		// PIECE MANAGEMENT
 
@@ -1264,10 +1263,7 @@ namespace libtorrent::aux {
 		void set_limit_impl(int limit, int channel, bool state_update = true);
 		int limit_impl(int channel) const;
 
-		int deprioritize_tracker(int tracker_index);
-
 		void update_peer_interest(bool was_finished);
-		void prioritize_udp_trackers();
 
 		void update_tracker_timer(time_point32 now);
 
@@ -1357,7 +1353,7 @@ namespace libtorrent::aux {
 		// us.
 		aux::suggest_piece m_suggest_pieces;
 
-		aux::vector<aux::announce_entry> m_trackers;
+		aux::tracker_list m_trackers;
 
 #ifndef TORRENT_DISABLE_STREAMING
 		// this list is sorted by time_critical_piece::deadline
@@ -1571,9 +1567,6 @@ namespace libtorrent::aux {
 		// the torrent this last time. When the torrent is paused, this counter is
 		// incremented to include this current session.
 		seconds32 m_active_time{0};
-
-		// the index to the last tracker that worked
-		std::int8_t m_last_working_tracker = -1;
 
 // ----
 

--- a/include/libtorrent/aux_/tracker_list.hpp
+++ b/include/libtorrent/aux_/tracker_list.hpp
@@ -1,0 +1,124 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TORRENT_TRACKER_LIST_HPP_INCLUDED
+#define TORRENT_TRACKER_LIST_HPP_INCLUDED
+
+#include <string>
+#include <unordered_map>
+
+#include "libtorrent/aux_/announce_entry.hpp"
+#include "libtorrent/announce_entry.hpp"
+#include "libtorrent/aux_/vector.hpp"
+#include "libtorrent/aux_/invariant_check.hpp"
+
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/intrusive/list.hpp>
+#include <boost/pool/object_pool.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+
+
+namespace libtorrent::aux {
+
+struct TORRENT_EXTRA_EXPORT tracker_list
+{
+	using trackers_t = boost::intrusive::list<aux::announce_entry
+		, boost::intrusive::member_hook<aux::announce_entry
+			, boost::intrusive::list_member_hook<>
+			, &aux::announce_entry::list_hook>
+		>;
+	using iterator = typename trackers_t::iterator;
+	using const_iterator = typename trackers_t::const_iterator;
+
+	aux::announce_entry* find_tracker(std::string const& url);
+
+	// returns true if the tracker was added, and false if it was already
+	// in the tracker list (in which case the source was added to the
+	// entry in the list)
+	bool add_tracker(announce_entry const& ae);
+
+	void prioritize_udp_trackers();
+
+	void deprioritize_tracker(aux::announce_entry* ae);
+	void dont_try_again(aux::announce_entry* ae);
+
+	bool empty() const { return m_trackers.empty(); }
+	std::size_t size() const { return m_trackers.size(); }
+
+	std::string last_working_url() const;
+	aux::announce_entry* last_working();
+	aux::announce_entry* first();
+
+	void record_working(aux::announce_entry const* ae);
+
+	void replace(std::vector<lt::announce_entry> const& aes);
+
+	void enable_all();
+
+	void completed(time_point32 now);
+
+	void set_complete_sent();
+
+	void reset();
+
+	void stop_announcing(time_point32 now);
+
+	bool any_verified() const;
+
+	// TODO: make these iterators const
+	iterator begin() { return m_trackers.begin(); }
+	iterator end() { return m_trackers.end(); }
+
+	const_iterator begin() const { return m_trackers.begin(); }
+	const_iterator end() const { return m_trackers.end(); }
+
+	aux::announce_entry const* find(int const idx) const;
+	aux::announce_entry* find(int const idx);
+
+private:
+
+#if TORRENT_USE_INVARIANT_CHECKS
+	friend struct libtorrent::invariant_access;
+	void check_invariant() const;
+#endif
+
+	boost::object_pool<aux::announce_entry> m_storage;
+	trackers_t m_trackers;
+	std::unordered_map<string_view, aux::announce_entry*> m_url_index;
+
+	// the index to the last tracker that worked
+	aux::announce_entry* m_last_working_tracker = nullptr;
+};
+
+}
+#endif
+

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1109,7 +1109,9 @@ namespace aux {
 		//
 		// ``force_lsd_announce`` will announce the torrent on LSD
 		// immediately.
-		void force_reannounce(int seconds = 0, int idx = -1, reannounce_flags_t = {}) const;
+		void force_reannounce(int seconds, int idx, reannounce_flags_t = {}) const;
+		void force_reannounce(int seconds, std::string const& url, reannounce_flags_t = {}) const;
+		void force_reannounce(int seconds = 0, reannounce_flags_t = {}) const;
 		void force_dht_announce() const;
 		void force_lsd_announce() const;
 
@@ -1133,7 +1135,9 @@ namespace aux {
 		// ``num_incomplete`` fields in the torrent_status struct once it
 		// completes. When it completes, it will generate a scrape_reply_alert.
 		// If it fails, it will generate a scrape_failed_alert.
-		void scrape_tracker(int idx = -1) const;
+		void scrape_tracker(int idx) const;
+		void scrape_tracker() const;
+		void scrape_tracker(std::string url) const;
 
 		// ``set_upload_limit`` will limit the upload bandwidth used by this
 		// particular torrent to the limit you set. It is given as the number of

--- a/src/announce_entry.cpp
+++ b/src/announce_entry.cpp
@@ -203,7 +203,9 @@ namespace aux {
 
 	announce_entry::~announce_entry() = default;
 	announce_entry::announce_entry(announce_entry const&) = default;
+	announce_entry::announce_entry(announce_entry&&) = default;
 	announce_entry& announce_entry::operator=(announce_entry const&) & = default;
+	announce_entry& announce_entry::operator=(announce_entry&&) & = default;
 
 	void announce_infohash::reset()
 	{
@@ -256,6 +258,14 @@ namespace aux {
 	}
 
 	announce_endpoint* announce_entry::find_endpoint(aux::listen_socket_handle const& s)
+	{
+		auto aep = std::find_if(endpoints.begin(), endpoints.end()
+			, [&](aux::announce_endpoint const& a) { return a.socket == s; });
+		if (aep != endpoints.end()) return &*aep;
+		else return nullptr;
+	}
+
+	announce_endpoint const* announce_entry::find_endpoint(aux::listen_socket_handle const& s) const
 	{
 		auto aep = std::find_if(endpoints.begin(), endpoints.end()
 			, [&](aux::announce_endpoint const& a) { return a.socket == s; });

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1986,6 +1986,7 @@ namespace {
 			listen_endpoint_t ep(address_v4::any(), port, {}
 				, transport::plaintext, listen_socket_t::proxy);
 			eps.emplace_back(ep);
+			++m_listen_socket_version;
 		}
 		else
 		{
@@ -2054,6 +2055,9 @@ namespace {
 		}
 
 		auto remove_iter = partition_listen_sockets(eps, m_listen_sockets);
+
+		if (remove_iter != m_listen_sockets.end() || !eps.empty())
+			++m_listen_socket_version;
 
 		while (remove_iter != m_listen_sockets.end())
 		{

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -777,9 +777,20 @@ namespace libtorrent {
 		async_call(&aux::torrent::lsd_announce);
 	}
 
-	void torrent_handle::force_reannounce(int s, int idx, reannounce_flags_t const flags) const
+	// TODO: deprecate the overload that takes an index
+	void torrent_handle::force_reannounce(int const s, int const idx, reannounce_flags_t const flags) const
 	{
 		async_call(&aux::torrent::force_tracker_request, aux::time_now() + seconds(s), idx, flags);
+	}
+
+	void torrent_handle::force_reannounce(int const s, std::string const& url, reannounce_flags_t const flags) const
+	{
+		async_call(&aux::torrent::force_tracker_request_url, aux::time_now() + seconds(s), url, flags);
+	}
+
+	void torrent_handle::force_reannounce(int const s, reannounce_flags_t const flags) const
+	{
+		async_call(&aux::torrent::force_tracker_request, aux::time_now() + seconds(s), -1, flags);
 	}
 
 	std::vector<open_file_state> torrent_handle::file_status() const
@@ -793,6 +804,16 @@ namespace libtorrent {
 	void torrent_handle::scrape_tracker(int idx) const
 	{
 		async_call(&aux::torrent::scrape_tracker, idx, true);
+	}
+
+	void torrent_handle::scrape_tracker(std::string url) const
+	{
+		async_call(&aux::torrent::scrape_tracker_url, std::move(url), true);
+	}
+
+	void torrent_handle::scrape_tracker() const
+	{
+		async_call(&aux::torrent::scrape_tracker, -1, true);
 	}
 
 #if TORRENT_ABI_VERSION == 1

--- a/src/tracker_list.cpp
+++ b/src/tracker_list.cpp
@@ -1,0 +1,298 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+
+#include <utility> // for swap()
+
+#include "libtorrent/aux_/tracker_list.hpp"
+#include "libtorrent/announce_entry.hpp"
+#include "libtorrent/aux_/parse_url.hpp"
+#include "libtorrent/aux_/invariant_check.hpp"
+
+namespace libtorrent::aux {
+
+aux::announce_entry* tracker_list::find_tracker(std::string const& url)
+{
+	INVARIANT_CHECK;
+
+	auto const i = m_url_index.find(url);
+	if (i == m_url_index.end()) return nullptr;
+	TORRENT_ASSERT(m_storage.is_from(i->second));
+	return i->second;
+}
+
+aux::announce_entry const* tracker_list::find(int const idx) const
+{
+	TORRENT_ASSERT(idx >= 0);
+	TORRENT_ASSERT(std::size_t(idx) < m_trackers.size());
+	auto i = m_trackers.begin();
+	std::advance(i, idx);
+	return &*i;
+}
+
+aux::announce_entry* tracker_list::find(int const idx)
+{
+	TORRENT_ASSERT(idx >= 0);
+	TORRENT_ASSERT(std::size_t(idx) < m_trackers.size());
+	auto i = m_trackers.begin();
+	std::advance(i, idx);
+	return &*i;
+}
+
+void tracker_list::deprioritize_tracker(aux::announce_entry* ae)
+{
+	INVARIANT_CHECK;
+
+	TORRENT_ASSERT(m_storage.is_from(ae));
+	auto iter = m_trackers.iterator_to(*ae);
+	iter = m_trackers.erase(iter);
+
+	for (; iter != m_trackers.end()
+		&& ae->tier == iter->tier; ++iter);
+
+	m_trackers.insert(iter, *ae);
+}
+
+void tracker_list::dont_try_again(aux::announce_entry* ae)
+{
+	ae->fail_limit = 1;
+}
+
+bool tracker_list::add_tracker(announce_entry const& ae)
+{
+	INVARIANT_CHECK;
+
+	if (ae.url.empty()) return false;
+	auto* k = find_tracker(ae.url);
+	if (k)
+	{
+		k->source |= ae.source;
+		return false;
+	}
+
+	auto* new_ae = m_storage.construct(ae);
+	if (m_trackers.empty())
+	{
+		m_trackers.push_back(*new_ae);
+		// TODO: if this throws, new_ae needs to be freed
+		m_url_index.insert(std::make_pair(string_view(new_ae->url), new_ae));
+		return true;
+	}
+
+	auto iter = m_trackers.end();
+	while (iter != m_trackers.begin() && std::prev(iter)->tier > new_ae->tier)
+		--iter;
+
+	m_trackers.insert(iter, *new_ae);
+	// TODO: if this throws, new_ae needs to be freed
+	m_url_index.insert(std::make_pair(string_view(new_ae->url), new_ae));
+
+	if (new_ae->source == 0) new_ae->source = lt::announce_entry::source_client;
+	return true;
+}
+
+void tracker_list::prioritize_udp_trackers()
+{
+	INVARIANT_CHECK;
+
+	// look for udp-trackers
+	for (auto i = m_trackers.begin(), end(m_trackers.end()); i != end; ++i)
+	{
+		if (i->url.substr(0, 6) != "udp://") continue;
+		// now, look for trackers with the same hostname
+		// that is has higher priority than this one
+		// if we find one, swap with the udp-tracker
+		error_code ec;
+		std::string udp_hostname;
+		using std::ignore;
+		std::tie(ignore, ignore, udp_hostname, ignore, ignore)
+			= parse_url_components(i->url, ec);
+		for (auto j = m_trackers.begin(); j != i; ++j)
+		{
+			if (j->url.substr(0, 6) == "udp://") continue;
+			std::string hostname;
+			std::tie(ignore, ignore, hostname, ignore, ignore)
+				= parse_url_components(j->url, ec);
+			if (hostname != udp_hostname) continue;
+			auto* ae1 = &*i;
+			auto* ae2 = &*j;
+			i = m_trackers.erase(i);
+			m_trackers.insert(j, *ae1);
+			j = m_trackers.erase(j);
+			m_trackers.insert(i, *ae2);
+			break;
+		}
+	}
+}
+
+void tracker_list::record_working(aux::announce_entry const* ae)
+{
+	m_last_working_tracker = const_cast<aux::announce_entry*>(ae);
+	TORRENT_ASSERT(m_storage.is_from(m_last_working_tracker));
+}
+
+void tracker_list::replace(std::vector<lt::announce_entry> const& aes)
+{
+	INVARIANT_CHECK;
+
+	m_trackers.clear();
+	m_url_index.clear();
+
+	m_storage.~object_pool<aux::announce_entry>();
+	new (&m_storage) boost::object_pool<aux::announce_entry>();
+
+	for (auto const& ae : aes)
+	{
+		if (ae.url.empty()) continue;
+		aux::announce_entry* new_ae = m_storage.construct(ae);
+		auto const [iter, added] = m_url_index.insert(std::make_pair(string_view(new_ae->url), new_ae));
+		if (!added)
+		{
+			// if we already have an entry with this URL, skip it
+			// but merge the source bits
+			m_storage.destroy(new_ae);
+			iter->second->source |= ae.source;
+			continue;
+		}
+		m_trackers.push_back(*new_ae);
+	}
+
+	// make sure the trackers are correctly ordered by tier
+	m_trackers.sort([](aux::announce_entry const& lhs, aux::announce_entry const& rhs)
+	{ return lhs.tier < rhs.tier; });
+
+	m_last_working_tracker = nullptr;
+}
+
+void tracker_list::enable_all()
+{
+	INVARIANT_CHECK;
+	for (aux::announce_entry& ae : m_trackers)
+		for (aux::announce_endpoint& aep : ae.endpoints)
+			aep.enabled = true;
+}
+
+void tracker_list::completed(time_point32 const now)
+{
+	INVARIANT_CHECK;
+	for (auto& t : m_trackers)
+	{
+		for (auto& aep : t.endpoints)
+		{
+			if (!aep.enabled) continue;
+			for (auto& a : aep.info_hashes)
+			{
+				if (a.complete_sent) continue;
+				a.next_announce = now;
+				a.min_announce = now;
+			}
+		}
+	}
+}
+
+void tracker_list::set_complete_sent()
+{
+	INVARIANT_CHECK;
+	for (auto& t : m_trackers)
+	{
+		for (auto& aep : t.endpoints)
+		{
+			for (auto& a : aep.info_hashes)
+				a.complete_sent = true;
+		}
+	}
+}
+
+void tracker_list::reset()
+{
+	INVARIANT_CHECK;
+	for (auto& t : m_trackers) t.reset();
+}
+
+void tracker_list::stop_announcing(time_point32 const now)
+{
+	INVARIANT_CHECK;
+
+	for (auto& t : m_trackers)
+	{
+		for (auto& aep : t.endpoints)
+		{
+			for (auto& a : aep.info_hashes)
+			{
+				a.next_announce = now;
+				a.min_announce = now;
+			}
+		}
+	}
+}
+
+std::string tracker_list::last_working_url() const
+{
+	if (m_last_working_tracker == nullptr) return {};
+	return m_last_working_tracker->url;
+}
+
+aux::announce_entry* tracker_list::last_working()
+{
+	return m_last_working_tracker;
+}
+
+aux::announce_entry* tracker_list::first()
+{
+	if (m_trackers.empty()) return nullptr;
+	return &*m_trackers.begin();
+}
+
+bool tracker_list::any_verified() const
+{
+	return std::any_of(m_trackers.begin(), m_trackers.end()
+		, [](aux::announce_entry const& t) { return t.verified; });
+}
+
+#if TORRENT_USE_INVARIANT_CHECKS
+void tracker_list::check_invariant() const
+{
+	m_trackers.check();
+	for (auto const& ae : m_trackers)
+	{
+		TORRENT_ASSERT(m_storage.is_from(const_cast<aux::announce_entry*>(&ae)));
+		auto i = m_url_index.find(ae.url);
+		TORRENT_ASSERT(i != m_url_index.end());
+		TORRENT_ASSERT(i->second == &ae);
+	}
+
+	TORRENT_ASSERT(m_url_index.size() == m_trackers.size());
+	TORRENT_ASSERT(m_last_working_tracker == nullptr || m_storage.is_from(m_last_working_tracker));
+}
+#endif
+
+}

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -207,6 +207,7 @@ run test_ssl.cpp : :
 	: <crypto>openssl:<library>/torrent//ssl
 	<crypto>openssl:<library>/torrent//crypto ;
 run test_tracker.cpp ;
+run test_tracker_list.cpp ;
 run test_tracker_manager.cpp ;
 run test_checking.cpp ;
 run test_url_seed.cpp ;
@@ -314,6 +315,7 @@ alias deterministic-tests :
 	test_torrent
 	test_torrent_info
 	test_torrent_list
+	test_tracker_list
 	test_utf8
 	test_xml
 	test_store_buffer

--- a/test/session_mock.hpp
+++ b/test/session_mock.hpp
@@ -91,6 +91,7 @@ struct session_mock : aux::session_interface
 
 	int listen_port(aux::transport, address const&) const override { return 0; }
 
+	std::uint32_t listen_socket_version() const override { return 1; }
 	void for_each_listen_socket(std::function<void(aux::listen_socket_handle const&)>) const override {}
 
 	tcp::endpoint bind_outgoing_socket(aux::socket_type&, address const&, error_code&) const override { return {}; }

--- a/test/test_tracker_list.cpp
+++ b/test/test_tracker_list.cpp
@@ -1,0 +1,469 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#include "libtorrent/aux_/tracker_list.hpp"
+#include "libtorrent/aux_/announce_entry.hpp"
+#include "libtorrent/aux_/listen_socket_handle.hpp"
+#include "libtorrent/announce_entry.hpp"
+#include "test.hpp"
+
+using namespace libtorrent::aux;
+
+TORRENT_TEST(test_initial_state)
+{
+	tracker_list tl;
+	TEST_EQUAL(tl.empty(), true);
+	TEST_EQUAL(tl.size(), 0);
+	TEST_CHECK(tl.begin() == tl.end());
+	TEST_CHECK(tl.last_working() == nullptr);
+	TEST_EQUAL(tl.last_working_url(), "");
+}
+
+TORRENT_TEST(test_duplicate_add)
+{
+	tracker_list tl;
+
+	tl.add_tracker(announce_entry("http://example1.com/announce"));
+	TEST_EQUAL(tl.size(), 1);
+	tl.add_tracker(announce_entry("http://example2.com/announce"));
+	TEST_EQUAL(tl.size(), 2);
+	tl.add_tracker(announce_entry("http://example3.com/announce"));
+	TEST_EQUAL(tl.size(), 3);
+
+	// duplicate ignored
+	tl.add_tracker(announce_entry("http://example1.com/announce"));
+	TEST_EQUAL(tl.size(), 3);
+
+	// we want the trackers to have been inserted in the most efficient order
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_add_sort_by_tier)
+{
+	tracker_list tl;
+	announce_entry ae;
+
+	ae.url = "http://example1.com/announce";
+	ae.tier = 5;
+	tl.add_tracker(ae);
+	TEST_EQUAL(tl.size(), 1);
+
+	ae.url = "http://example2.com/announce";
+	ae.tier = 4;
+	tl.add_tracker(ae);
+	TEST_EQUAL(tl.size(), 2);
+
+	ae.url = "http://example3.com/announce";
+	ae.tier = 3;
+	tl.add_tracker(ae);
+	TEST_EQUAL(tl.size(), 3);
+
+	ae.url = "http://example1.com/announce";
+	ae.tier = 2;
+	tl.add_tracker(ae);
+
+	// duplicate ignored
+	TEST_EQUAL(tl.size(), 3);
+
+	// the trackers should be ordered by low tiers first
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_replace_duplicate)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://example1.com/announce");
+	trackers.emplace_back("http://example2.com/announce");
+	trackers.emplace_back("http://example3.com/announce");
+	trackers.emplace_back("http://example1.com/announce");
+
+	tl.replace(trackers);
+
+	// duplicate ignored
+	TEST_EQUAL(tl.size(), 3);
+
+	// we want the trackers to have been inserted in the most efficient order
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_replace_sort_by_tier)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://example1.com/announce");
+	trackers.back().tier = 5;
+	trackers.emplace_back("http://example2.com/announce");
+	trackers.back().tier = 4;
+	trackers.emplace_back("http://example3.com/announce");
+	trackers.back().tier = 3;
+	trackers.emplace_back("http://example1.com/announce");
+	trackers.back().tier = 1;
+
+	tl.replace(trackers);
+
+	// duplicate ignored
+	TEST_EQUAL(tl.size(), 3);
+
+	// the trackers should be ordered by low tiers first
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_prioritize_udp_noop)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://example1.com/announce");
+	trackers.emplace_back("http://example2.com/announce");
+	trackers.emplace_back("http://example3.com/announce");
+	trackers.emplace_back("udp://example4.com/announce");
+
+	tl.replace(trackers);
+
+	// duplicate ignored
+	TEST_EQUAL(tl.size(), 4);
+
+	// the trackers should be ordered by low tiers first
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "udp://example4.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	tl.prioritize_udp_trackers();
+
+	// UDP trackers are prioritized over HTTP for the same hostname. These
+	// hostnames are all different, so no reordering happens
+	i = tl.begin();
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "udp://example4.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_prioritize_udp)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://example1.com/announce");
+	trackers.emplace_back("http://example2.com/announce");
+	trackers.emplace_back("http://example3.com/announce");
+	trackers.emplace_back("udp://example1.com/announce");
+
+	tl.replace(trackers);
+
+	// duplicate ignored
+	TEST_EQUAL(tl.size(), 4);
+
+	// the trackers should be ordered by low tiers first
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "udp://example1.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	tl.prioritize_udp_trackers();
+
+	i = tl.begin();
+	TEST_EQUAL(i->url, "udp://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example2.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example3.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_prioritize_udp_tier)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://example1.com/announce");
+	trackers.emplace_back("udp://example1.com/announce");
+	trackers.back().tier = 2;
+
+	tl.replace(trackers);
+
+	// the trackers should be ordered by low tiers first
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "udp://example1.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	tl.prioritize_udp_trackers();
+
+	// trackers are also re-ordered across tiers
+	i = tl.begin();
+	TEST_EQUAL(i->url, "udp://example1.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://example1.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_replace_find_tracker)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://a.com/announce");
+	trackers.emplace_back("http://b.com/announce");
+	trackers.emplace_back("http://c.com/announce");
+	tl.replace(trackers);
+
+	TEST_EQUAL(tl.find_tracker("http://a.com/announce")->url, "http://a.com/announce");
+	TEST_EQUAL(tl.find_tracker("http://b.com/announce")->url, "http://b.com/announce");
+	TEST_EQUAL(tl.find_tracker("http://c.com/announce")->url, "http://c.com/announce");
+	TEST_CHECK(tl.find_tracker("http://d.com/announce") == nullptr);
+}
+
+TORRENT_TEST(test_add_find_tracker)
+{
+	tracker_list tl;
+
+	tl.add_tracker(announce_entry("http://a.com/announce"));
+	tl.add_tracker(announce_entry("http://b.com/announce"));
+	tl.add_tracker(announce_entry("http://c.com/announce"));
+
+	TEST_EQUAL(tl.find_tracker("http://a.com/announce")->url, "http://a.com/announce");
+	TEST_EQUAL(tl.find_tracker("http://b.com/announce")->url, "http://b.com/announce");
+	TEST_EQUAL(tl.find_tracker("http://c.com/announce")->url, "http://c.com/announce");
+	TEST_CHECK(tl.find_tracker("http://d.com/announce") == nullptr);
+}
+
+TORRENT_TEST(test_deprioritize_tracker)
+{
+	tracker_list tl;
+
+	tl.add_tracker(announce_entry("http://a.com/announce"));
+	tl.add_tracker(announce_entry("http://b.com/announce"));
+	tl.add_tracker(announce_entry("http://c.com/announce"));
+
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://a.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://b.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://c.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	tl.deprioritize_tracker(tl.first());
+
+	i = tl.begin();
+	TEST_EQUAL(i->url, "http://b.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://c.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://a.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	tl.deprioritize_tracker(&*std::next(tl.begin()));
+
+	i = tl.begin();
+	TEST_EQUAL(i->url, "http://b.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://a.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://c.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_deprioritize_tracker_tier)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("http://a.com/announce");
+	trackers.back().tier = 1;
+	trackers.emplace_back("http://b.com/announce");
+	trackers.back().tier = 1;
+	trackers.emplace_back("http://c.com/announce");
+	tl.replace(trackers);
+
+	auto i = tl.begin();
+	TEST_EQUAL(i->url, "http://c.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://a.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://b.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	// the tracker won't move across the tier
+	tl.deprioritize_tracker(tl.first());
+
+	i = tl.begin();
+	TEST_EQUAL(i->url, "http://c.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://a.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://b.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+
+	tl.deprioritize_tracker(&*std::next(tl.begin()));
+
+	i = tl.begin();
+	TEST_EQUAL(i->url, "http://c.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://b.com/announce");
+	++i;
+	TEST_EQUAL(i->url, "http://a.com/announce");
+	++i;
+	TEST_CHECK(i == tl.end());
+}
+
+TORRENT_TEST(test_add_empty)
+{
+	tracker_list tl;
+
+	tl.add_tracker(announce_entry(""));
+	TEST_EQUAL(tl.size(), 0);
+}
+
+TORRENT_TEST(test_replace_empty)
+{
+	tracker_list tl;
+
+	std::vector<lt::announce_entry> trackers;
+	trackers.emplace_back("");
+	tl.replace(trackers);
+	TEST_EQUAL(tl.size(), 0);
+}
+
+TORRENT_TEST(test_last_working)
+{
+	tracker_list tl;
+	tl.add_tracker(announce_entry("http://a.com/announce"));
+	tl.add_tracker(announce_entry("http://b.com/announce"));
+	tl.add_tracker(announce_entry("http://c.com/announce"));
+
+	TEST_CHECK(tl.last_working() == nullptr);
+	TEST_EQUAL(tl.last_working_url(), "");
+
+	tl.record_working(tl.first());
+	TEST_EQUAL(tl.last_working()->url, "http://a.com/announce");
+	TEST_EQUAL(tl.last_working_url(), "http://a.com/announce");
+
+	tl.record_working(&*std::next(tl.begin()));
+	TEST_EQUAL(tl.last_working()->url, "http://b.com/announce");
+	TEST_EQUAL(tl.last_working_url(), "http://b.com/announce");
+
+	tl.record_working(&*std::next(std::next(tl.begin())));
+	TEST_EQUAL(tl.last_working()->url, "http://c.com/announce");
+	TEST_EQUAL(tl.last_working_url(), "http://c.com/announce");
+}
+
+TORRENT_TEST(complete_sent)
+{
+	tracker_list tl;
+	tl.add_tracker(announce_entry("http://a.com/announce"));
+	tl.add_tracker(announce_entry("http://b.com/announce"));
+	tl.add_tracker(announce_entry("http://c.com/announce"));
+
+	listen_socket_handle s;
+	for (auto& ae : tl)
+		ae.endpoints.emplace_back(s, false);
+
+	for (auto const& ae : tl)
+		for (auto const& aep : ae.endpoints)
+			for (auto const& a : aep.info_hashes)
+				TEST_EQUAL(a.complete_sent, false);
+
+	tl.set_complete_sent();
+
+	for (auto const& ae : tl)
+		for (auto const& aep : ae.endpoints)
+			for (auto const& a : aep.info_hashes)
+				TEST_EQUAL(a.complete_sent, true);
+}
+
+TORRENT_TEST(enable_all)
+{
+	tracker_list tl;
+	tl.add_tracker(announce_entry("http://a.com/announce"));
+	tl.add_tracker(announce_entry("http://b.com/announce"));
+	tl.add_tracker(announce_entry("http://c.com/announce"));
+
+	listen_socket_handle s;
+	for (auto& ae : tl)
+		ae.endpoints.emplace_back(s, false);
+
+	for (auto& ae : tl)
+		for (auto& aep : ae.endpoints)
+		{
+			TEST_EQUAL(aep.enabled, true);
+			aep.enabled = false;
+		}
+
+	tl.enable_all();
+
+	for (auto const& ae : tl)
+		for (auto const& aep : ae.endpoints)
+			TEST_EQUAL(aep.enabled, true);
+}
+
+// TODO: reset
+// TODO: completed
+// TODO: dont_try_again


### PR DESCRIPTION
This patch enforces unique URLs for trackers. It also factors out the tracker list into its own class to make it clearer what its invariants are.

With a clearer separation of torrent.cop and tracker_list.cpp I could make the data structure more sophisticated without complexity going out of control.

The new data structure allocates the announce_entry objects in a pool allocator (instead of a vector) and inserts them into an intrusive linked list. This means their addresses are stable and can be referenced by an index mapping URL to announce entry.

This makes it more efficient to map a response from a tracker to its announce_entry. It also makes it more efficient to reorder trackers when they fail (to deprioritise) as well as prioritise (when preferring udp trackers).

As a result, handling torrents with a large number of trackers is more efficient with this patch. (But there's still room for improvements).