### PR TITLE
interrupt http_connection::on_resolve() for closed commection

### DIFF
--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -494,6 +494,9 @@ void http_connection::on_resolve(error_code const& e
 {
 	COMPLETE_ASYNC("http_connection::on_resolve");
 	m_resolving_host = false;
+
+	if (m_abort) return;
+
 	if (e)
 	{
 		callback(e);
@@ -508,8 +511,6 @@ void http_connection::on_resolve(error_code const& e
 		m_endpoints.emplace_back(addr, m_port);
 
 	if (m_filter_handler) m_filter_handler(*this, m_endpoints);
-
-	if (m_abort) return;
 
 	if (m_endpoints.empty())
 	{

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -494,14 +494,14 @@ void http_connection::on_resolve(error_code const& e
 {
 	COMPLETE_ASYNC("http_connection::on_resolve");
 	m_resolving_host = false;
-
-	if (m_abort) return;
-
 	if (e)
 	{
 		callback(e);
 		return;
 	}
+
+	if (m_abort) return;
+	
 	TORRENT_ASSERT(!addresses.empty());
 
 	// reset timeout
@@ -511,7 +511,6 @@ void http_connection::on_resolve(error_code const& e
 		m_endpoints.emplace_back(addr, m_port);
 
 	if (m_filter_handler) m_filter_handler(*this, m_endpoints);
-
 	if (m_endpoints.empty())
 	{
 		close();

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -508,6 +508,9 @@ void http_connection::on_resolve(error_code const& e
 		m_endpoints.emplace_back(addr, m_port);
 
 	if (m_filter_handler) m_filter_handler(*this, m_endpoints);
+
+	if (m_abort) return;
+
 	if (m_endpoints.empty())
 	{
 		close();

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -501,7 +501,7 @@ void http_connection::on_resolve(error_code const& e
 	}
 
 	if (m_abort) return;
-	
+
 	TORRENT_ASSERT(!addresses.empty());
 
 	// reset timeout


### PR DESCRIPTION
Do not try to connect() in http_connection::on_resolve if connection is closed. Otherwise, there is a delay about 30 seconds on libtorrent session close if on_resolve() runs after http_connection::close()