### PR TITLE
ref sanitize_symlinks: wo goto

### DIFF
--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -716,6 +716,12 @@ namespace aux {
 	TORRENT_EXTRA_EXPORT
 	std::int64_t size_on_disk(file_storage const& fs);
 
+	TORRENT_EXTRA_EXPORT
+	bool check_valid_symlink(std::string&& target
+				, const std::unordered_set<std::string>& dir_map
+				, const std::unordered_map<std::string, std::string>& dir_links
+				, const std::unordered_map<std::string, file_index_t>& file_map);
+
 } // namespace aux
 } // namespace libtorrent
 

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -718,9 +718,9 @@ namespace aux {
 
 	TORRENT_EXTRA_EXPORT
 	bool check_valid_symlink(std::string&& target
-				, const std::unordered_set<std::string>& dir_map
-				, const std::unordered_map<std::string, std::string>& dir_links
-				, const std::unordered_map<std::string, file_index_t>& file_map);
+				, std::unordered_set<std::string> const& dir_map
+				, std::unordered_map<std::string, std::string> const& dir_links
+				, std::unordered_map<std::string, file_index_t> const& file_map);
 
 } // namespace aux
 } // namespace libtorrent

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -1543,9 +1543,9 @@ namespace aux {
 	}
 
 	bool check_valid_symlink(std::string&& target
-			, const std::unordered_set<std::string>& dir_map
-			, const std::unordered_map<std::string, std::string>& dir_links
-			, const std::unordered_map<std::string, file_index_t>& file_map)
+			, std::unordered_set<std::string> const& dir_map
+			, std::unordered_map<std::string, std::string> const& dir_links
+			, std::unordered_map<std::string, file_index_t> const& file_map)
 	{
 		// to avoid getting stuck in an infinite loop, we only allow traversing
 		// a symlink once

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -1192,5 +1192,55 @@ TORRENT_TEST(size_on_disk_explicit_pads)
 	TEST_CHECK(aux::size_on_disk(fs) < fs.total_size());
 }
 
+TORRENT_TEST(check_valid_symlink_short_target)
+{
+	std::string target = "ZZ";
+	std::unordered_set<std::string> dir_map;
+	std::unordered_map<std::string, std::string> dir_links;
+	std::unordered_map<std::string, file_index_t> file_map;
+
+	bool result = lt::aux::check_valid_symlink(std::move(target),
+												 dir_map, dir_links,
+												 file_map);
+	TEST_EQUAL(result, false);
+
+	target = "ZZ";
+	dir_map.emplace("ZZ");
+	file_map.emplace("ZZ", 1);
+
+	result = lt::aux::check_valid_symlink(std::move(target),
+									  dir_map, dir_links,
+									  file_map);
+	TEST_EQUAL(result, true);
+}
+
+TORRENT_TEST(check_valid_symlink_no_target_in_dirlinks) {
+	std::string target = "B/B/ZZ";
+	std::unordered_set<std::string> dir_map;
+	std::unordered_map<std::string, std::string> dir_links;
+	std::unordered_map<std::string, file_index_t> file_map;
+
+	dir_links.emplace("2", "B/B/ZZ");
+
+	bool result = lt::aux::check_valid_symlink(std::move(target),
+											   dir_map, dir_links,
+											   file_map);
+	TEST_EQUAL(result, false);
+}
+
+TORRENT_TEST(check_valid_symlink_target_in_dirlinks) {
+	std::string target = "4/B";
+	std::unordered_set<std::string> dir_map;
+	std::unordered_map<std::string, std::string> dir_links;
+	std::unordered_map<std::string, file_index_t> file_map;
+
+	dir_links.emplace("4", "A");
+
+	bool result = lt::aux::check_valid_symlink(std::move(target),
+											   dir_map, dir_links,
+											   file_map);
+	TEST_EQUAL(result, false);
+}
+
 // TODO: test file attributes
 // TODO: test symlinks

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -1200,8 +1200,7 @@ TORRENT_TEST(check_valid_symlink_short_target)
 	std::unordered_map<std::string, file_index_t> file_map;
 
 	bool result = lt::aux::check_valid_symlink(std::move(target),
-												 dir_map, dir_links,
-												 file_map);
+				dir_map, dir_links, file_map);
 	TEST_EQUAL(result, false);
 
 	target = "ZZ";
@@ -1209,8 +1208,7 @@ TORRENT_TEST(check_valid_symlink_short_target)
 	file_map.emplace("ZZ", 1);
 
 	result = lt::aux::check_valid_symlink(std::move(target),
-									  dir_map, dir_links,
-									  file_map);
+				dir_map, dir_links, file_map);
 	TEST_EQUAL(result, true);
 }
 
@@ -1223,8 +1221,7 @@ TORRENT_TEST(check_valid_symlink_no_target_in_dirlinks) {
 	dir_links.emplace("2", "B/B/ZZ");
 
 	bool result = lt::aux::check_valid_symlink(std::move(target),
-											   dir_map, dir_links,
-											   file_map);
+				dir_map, dir_links, file_map);
 	TEST_EQUAL(result, false);
 }
 
@@ -1237,8 +1234,7 @@ TORRENT_TEST(check_valid_symlink_target_in_dirlinks) {
 	dir_links.emplace("4", "A");
 
 	bool result = lt::aux::check_valid_symlink(std::move(target),
-											   dir_map, dir_links,
-											   file_map);
+				dir_map, dir_links, file_map);
 	TEST_EQUAL(result, false);
 }
 


### PR DESCRIPTION
It seems to me that sanitize_symlinks is too large. I started to refactor it. I also got away from using goto.