### PR TITLE
fix issue with merging two magnet link torrents into one hybrid

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* fix issue with duplicate hybrid torrent via separate v1 and v2 magnet links
 	* added new function to load torrent files, load_torrent_*()
 	* support sync_file_range() on linux
 	* fix issue in write_torrent_file() when file size is exactly piece size

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -272,6 +272,8 @@ namespace boost
 	POLY(session_stats_alert)
 	POLY(socks5_alert)
 	POLY(file_prio_alert)
+	POLY(oversized_file_alert)
+	POLY(torrent_conflict_alert)
 
 #if TORRENT_ABI_VERSION == 1
 	POLY(anonymous_mode_alert)
@@ -1139,6 +1141,16 @@ void bind_alert()
 
     class_<dht_bootstrap_alert, bases<alert>, noncopyable>(
         "dht_bootstrap_alert", no_init)
+        ;
+
+    class_<oversized_file_alert, bases<torrent_alert>, noncopyable>(
+        "oversized_file_alert", no_init)
+        ;
+
+    class_<torrent_conflict_alert, bases<torrent_alert>, noncopyable>(
+        "torrent_conflict_alert", no_init)
+        .add_property("conflicting_torrent", make_getter(&torrent_conflict_alert::conflicting_torrent, by_value()))
+        .add_property("metadata", make_getter(&torrent_conflict_alert::metadata, by_value()))
         ;
 
 }

--- a/docs/gen_reference_doc.py
+++ b/docs/gen_reference_doc.py
@@ -64,7 +64,8 @@ symbols = \
         "ssl-torrents_": "manual-ref.html#ssl-torrents",
         "dynamic-loading-of-torrent-files_": "manual-ref.html#dynamic-loading-of-torrent-files",
         "session-statistics_": "manual-ref.html#session-statistics",
-        "peer-classes_": "manual-ref.html#peer-classes"
+        "peer-classes_": "manual-ref.html#peer-classes",
+        "BitTorrent-v2-torrents_": "manual-ref.html#bittorrent-v2-torrents",
     }
 
 # parse out names of settings, and add them to the symbols list, to get cross
@@ -85,6 +86,7 @@ static_links = \
         ".. _`BEP 19`: https://www.bittorrent.org/beps/bep_0019.html",
         ".. _`BEP 38`: https://www.bittorrent.org/beps/bep_0038.html",
         ".. _`BEP 42`: https://www.bittorrent.org/beps/bep_0042.html",
+        ".. _`BEP 52`: https://www.bittorrent.org/beps/bep_0052.html",
         ".. _`rate based choking`: manual-ref.html#rate-based-choking",
         ".. _extensions: manual-ref.html#extensions",
     }

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -213,6 +213,29 @@ The resume data format is very similar to the .torrent file format, and when
 including the info-dict in the resume data, the resume file can be used as a
 .torrent file (with just a few minor exceptions).
 
+BitTorrent v2 torrents
+======================
+
+BitTorrent v2 introduces a number of features outlined in `this blog post`_ as
+well as `BEP 52`_. The v2 protocol introduces the possibility to use a merkle
+hash tree instead of a flat list of piece hashes. It also supports *hybrid* torrents,
+that are both valid classing torrents (v1) as well as valid v2 torrents. Hybrid
+torrents contain both a flat list of piece hashes as well as a merkle hash tree.
+
+.. _`this blog post`: https://blog.libtorrent.org/2020/09/bittorrent-v2/
+.. _`BEP 52`: https://www.bittorrent.org/beps/bep_0052.html
+
+This introduces a few new error cases. A hybrid torrent may have mismatching v1
+and v2 hashes. Since v2 torrents use SHA-256 and v1 uses SHA-1 the fact that the
+hashes are mismatching won't be detectable until the piece has been downloaded.
+It results in a ``torrent_inconsistent_hashes`` error.
+
+A magnet link may contain just a v1 info-hash or a v2 info-hash. If two separate
+magnet links, one v1-only and one v2-only, end up resolving to the same hybrid torrent,
+both torrent_handle objects are put into an error state of ``duplicate_torrent``.
+In this state, one of them has to be removed, and the other one can be resumed,
+in order to download the metadata again.
+
 queuing
 =======
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -236,6 +236,18 @@ both torrent_handle objects are put into an error state of ``duplicate_torrent``
 In this state, one of them has to be removed, and the other one can be resumed,
 in order to download the metadata again.
 
+When a conflict between two torrents occur, a torrent_conflict_alert is posted.
+This alert derives from torrent_alert, so is associated with a torrent_handle.
+It contains a second torrent_handle referring to the other torrent in the
+conflict as well as the metadata that was downloaded. One way to resolve the
+conflict is to remove both torrents and add it back using the metadata supplied
+in the torrent_conflict_alert.
+
+When a v1-only or v2-only magnet link resolves to a hybrid torrent, the
+info_hash_t object associated with the torrent will be updated to include both
+the v1 and v2 info hash. This applies both to torrent_handle::info_hashes() as
+well as torrent_info::info_hashes().
+
 queuing
 =======
 

--- a/include/libtorrent/alert.hpp
+++ b/include/libtorrent/alert.hpp
@@ -107,7 +107,7 @@ namespace alert_category {
 	// Low level alerts for when peers are connected and disconnected.
 	constexpr alert_category_t connect = 5_bit;
 
-		// Enables alerts for when a torrent or the session changes state.
+	// Enables alerts for when a torrent or the session changes state.
 	constexpr alert_category_t status = 6_bit;
 
 	// Alerts when a peer is blocked by the ip blocker or port blocker.

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -1985,6 +1985,9 @@ TORRENT_VERSION_NAMESPACE_3
 	};
 
 	// This is posted whenever a torrent is transitioned into the error state.
+	// If the error code is duplicate_torrent (error_code_enum) error, it suggests two magnet
+	// links ended up resolving to the same hybrid torrent. For more details,
+	// see BitTorrent-v2-torrents_.
 	struct TORRENT_EXPORT torrent_error_alert final : torrent_alert
 	{
 		// internal

--- a/include/libtorrent/aux_/torrent_list.hpp
+++ b/include/libtorrent/aux_/torrent_list.hpp
@@ -90,6 +90,7 @@ struct torrent_list
 
 	bool insert(info_hash_t const& ih, std::shared_ptr<T> t)
 	{
+		INVARIANT_CHECK;
 		TORRENT_ASSERT(t);
 
 		bool duplicate = false;

--- a/include/libtorrent/info_hash.hpp
+++ b/include/libtorrent/info_hash.hpp
@@ -126,7 +126,7 @@ namespace {
 		// calls the function object ``f`` for each hash that is available.
 		// starting with v1. The signature of ``F`` is::
 		//
-		//	void(sha1_hash, protocol_version);
+		//	void(sha1_hash const&, protocol_version);
 		template <typename F> void for_each(F f) const
 		{
 			if (has_v1()) f(v1, protocol_version::V1);

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -282,6 +282,10 @@ namespace libtorrent {
 		// torrent_flags::auto_managed. In order to add a magnet link that will
 		// just download the metadata, but no payload, set the
 		// torrent_flags::upload_mode flag.
+		//
+		// Special consideration has to be taken when adding hybrid torrents
+		// (i.e. torrents that are BitTorrent v2 torrents that are backwards
+		// compatible with v1). For more details, see BitTorrent-v2-torrents_.
 #ifndef BOOST_NO_EXCEPTIONS
 		torrent_handle add_torrent(add_torrent_params&& params);
 		torrent_handle add_torrent(add_torrent_params const& params);

--- a/simulation/Jamfile
+++ b/simulation/Jamfile
@@ -54,6 +54,7 @@ run test_thread_pool.cpp ;
 run test_ip_filter.cpp ;
 run test_dht_rate_limit.cpp ;
 run test_fast_extensions.cpp ;
+run test_v2.cpp ;
 # TODO figure out what to do with this
 # since v2 support was added re-mapped files are required to be piece aligned
 # but test_file_pool requires mapping more files than there are pieces

--- a/simulation/test_v2.cpp
+++ b/simulation/test_v2.cpp
@@ -1,0 +1,274 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "simulator/simulator.hpp"
+#include "simulator/utils.hpp"
+
+#include "test.hpp"
+#include "create_torrent.hpp"
+#include "settings.hpp"
+#include "setup_swarm.hpp"
+#include "utils.hpp"
+#include "test_utils.hpp"
+#include "setup_transfer.hpp" // for addr()
+#include "disk_io.hpp"
+
+#include "libtorrent/add_torrent_params.hpp"
+#include "libtorrent/alert_types.hpp"
+
+namespace {
+
+template <typename Setup, typename HandleAlerts>
+void run_test(
+	Setup setup
+	, HandleAlerts on_alert
+	, test_disk const downloader_disk_constructor = test_disk()
+	, test_disk const seed_disk_constructor = test_disk()
+	)
+{
+	char const* peer0_ip = "50.0.0.1";
+	char const* peer1_ip = "50.0.0.2";
+
+	lt::address peer0 = addr(peer0_ip);
+	lt::address peer1 = addr(peer1_ip);
+
+	// setup the simulation
+	sim::default_config network_cfg;
+	sim::simulation sim{network_cfg};
+	sim::asio::io_context ios0 { sim, peer0 };
+	sim::asio::io_context ios1 { sim, peer1 };
+
+	lt::session_proxy zombie[2];
+
+	lt::session_params params;
+	// setup settings pack to use for the session (customization point)
+	lt::settings_pack& pack = params.settings;
+	pack = settings();
+
+	pack.set_str(lt::settings_pack::listen_interfaces, make_ep_string(peer0_ip, false, "6881"));
+
+	// create session
+	std::shared_ptr<lt::session> ses[2];
+
+	// session 0 is a downloader, session 1 is a seed
+
+	params.disk_io_constructor = downloader_disk_constructor;
+	ses[0] = std::make_shared<lt::session>(params, ios0);
+
+	pack.set_str(lt::settings_pack::listen_interfaces, make_ep_string(peer1_ip, false, "6881"));
+
+	params.disk_io_constructor = seed_disk_constructor.set_files(existing_files_mode::full_valid);
+	ses[1] = std::make_shared<lt::session>(params, ios1);
+
+	setup(*ses[0], *ses[1]);
+
+	// only monitor alerts for session 0 (the downloader)
+	print_alerts(*ses[0], [=](lt::session& ses, lt::alert const* a) {
+		if (auto ta = lt::alert_cast<lt::add_torrent_alert>(a))
+			ta->handle.connect_peer(lt::tcp::endpoint(peer1, 6881));
+		on_alert(ses, a);
+	}, 0);
+
+	print_alerts(*ses[1], [](lt::session&, lt::alert const*){}, 1);
+
+	// the min reconnect time defaults to 60 seconds
+	sim::timer t(sim, lt::seconds(70), [&](boost::system::error_code const&)
+	{
+		// shut down
+		int idx = 0;
+		for (auto& s : ses)
+		{
+			zombie[idx++] = s->abort();
+			s.reset();
+		}
+	});
+
+	sim.run();
+}
+
+void setup_conflict(lt::session& seed, lt::session& downloader)
+{
+	lt::add_torrent_params atp = ::create_test_torrent(10, lt::create_flags_t{}, 2);
+	atp.flags &= ~lt::torrent_flags::auto_managed;
+	atp.flags &= ~lt::torrent_flags::paused;
+
+	// add the complete torrent to the seed
+	seed.async_add_torrent(atp);
+
+	lt::info_hash_t const ih = atp.ti->info_hashes();
+
+	// add v1-only magnet link
+	atp.ti.reset();
+	atp.info_hashes.v1 = ih.v1;
+	downloader.async_add_torrent(atp);
+
+	// add v2-only magnet link
+	atp.info_hashes.v1.clear();
+	atp.info_hashes.v2 = ih.v2;
+	downloader.async_add_torrent(atp);
+}
+
+} // anonymous namespace
+
+// This adds the same hybrid torrent twice, once via the v1 info-hash and once
+// via the v2 info-hash. Once the conflict is detected, both torrents should
+// fail with the duplicate_torrent error state.
+TORRENT_TEST(hybrid_torrent_conflict)
+{
+	std::vector<lt::torrent_handle> handles;
+
+	int errors = 0;
+	run_test([](lt::session& ses0, lt::session& ses1) {
+		setup_conflict(ses1, ses0);
+	},
+	[&](lt::session& ses, lt::alert const* a) {
+		if (auto const* ta = lt::alert_cast<lt::torrent_added_alert>(a))
+		{
+			handles.push_back(ta->handle);
+		}
+		else if (auto const* tr = lt::alert_cast<lt::torrent_removed_alert>(a))
+		{
+			TEST_ERROR("a torrent was removed");
+		}
+		else if (auto const* te = lt::alert_cast<lt::torrent_error_alert>(a))
+		{
+			++errors;
+			// both handles are expected to fail with duplicate torrent error
+			TEST_EQUAL(te->error, lt::error_code(lt::errors::duplicate_torrent));
+		}
+		for (auto& h : handles)
+			TEST_CHECK(h.is_valid());
+
+		auto torrents = ses.get_torrents();
+		if (handles.size() == 2)
+		{
+			TEST_EQUAL(torrents.size(), 2);
+		}
+	}
+	);
+
+	TEST_EQUAL(errors, 2);
+}
+
+// try to resume the torrents after failing with a conflict. Ensure they both
+// fail again with the same error
+TORRENT_TEST(resume_conflict)
+{
+	std::vector<lt::torrent_handle> handles;
+
+	int errors = 0;
+	int resume = 0;
+
+	run_test([](lt::session& ses0, lt::session& ses1) {
+		setup_conflict(ses1, ses0);
+	},
+	[&](lt::session& ses, lt::alert const* a) {
+		if (auto const* ta = lt::alert_cast<lt::torrent_added_alert>(a))
+		{
+			handles.push_back(ta->handle);
+		}
+		else if (auto const* tr = lt::alert_cast<lt::torrent_removed_alert>(a))
+		{
+			TEST_ERROR("a torrent was removed");
+		}
+		else if (auto const* te = lt::alert_cast<lt::torrent_error_alert>(a))
+		{
+			++errors;
+			// both handles are expected to fail with duplicate torrent error
+			TEST_EQUAL(te->error, lt::error_code(lt::errors::duplicate_torrent));
+			if (resume < 2)
+			{
+				te->handle.clear_error();
+				te->handle.resume();
+				++resume;
+			}
+		}
+		for (auto& h : handles)
+			TEST_CHECK(h.is_valid());
+
+		auto torrents = ses.get_torrents();
+		if (handles.size() == 2)
+		{
+			TEST_EQUAL(torrents.size(), 2);
+		}
+	}
+	);
+
+	TEST_EQUAL(errors, 4);
+	TEST_EQUAL(resume, 2);
+}
+
+TORRENT_TEST(resolve_conflict)
+{
+	int errors = 0;
+	int finished = 0;
+	int removed = 0;
+
+	run_test([](lt::session& ses0, lt::session& ses1) {
+		setup_conflict(ses1, ses0);
+	},
+	[&](lt::session& ses, lt::alert const* a) {
+		if (auto const* tr = lt::alert_cast<lt::torrent_removed_alert>(a))
+		{
+			++removed;
+		}
+		else if (auto const* te = lt::alert_cast<lt::torrent_error_alert>(a))
+		{
+			++errors;
+			// both handles are expected to fail with duplicate torrent error
+			TEST_EQUAL(te->error, lt::error_code(lt::errors::duplicate_torrent));
+			if (errors == 1)
+			{
+				ses.remove_torrent(te->handle);
+			}
+			else if (errors == 2)
+			{
+				te->handle.clear_error();
+				te->handle.resume();
+			}
+		}
+		else if (auto const* tf = lt::alert_cast<lt::torrent_finished_alert>(a))
+		{
+			++finished;
+		}
+
+		if (errors == 2)
+		{
+			auto torrents = ses.get_torrents();
+			TEST_EQUAL(torrents.size(), 1);
+		}
+	});
+
+	TEST_EQUAL(errors, 2);
+	TEST_EQUAL(finished, 1);
+	TEST_EQUAL(removed, 1);
+}

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -3021,7 +3021,7 @@ namespace {
 		"picker_log", "session_error", "dht_live_nodes",
 		"session_stats_header", "dht_sample_infohashes",
 		"block_uploaded", "alerts_dropped", "socks5",
-		"file_prio", "oversized_file"
+		"file_prio", "oversized_file", "torrent_conflict"
 		}};
 
 		TORRENT_ASSERT(alert_type >= 0);
@@ -3090,6 +3090,22 @@ namespace {
 		return {};
 #else
 		return torrent_alert::message() + " has an oversized file";
+#endif
+	}
+
+	torrent_conflict_alert::torrent_conflict_alert(aux::stack_allocator& alloc, torrent_handle h1
+		, torrent_handle h2, std::shared_ptr<torrent_info> ti)
+		: torrent_alert(alloc, h1)
+		, conflicting_torrent(h2)
+		, metadata(std::move(ti))
+	{}
+
+	std::string torrent_conflict_alert::message() const
+	{
+#ifdef TORRENT_DISABLE_ALERT_MSG
+		return {};
+#else
+		return torrent_alert::message() + " has a conflict with another torrent";
 #endif
 	}
 
@@ -3186,6 +3202,7 @@ namespace {
 	constexpr alert_category_t socks5_alert::static_category;
 	constexpr alert_category_t file_prio_alert::static_category;
 	constexpr alert_category_t oversized_file_alert::static_category;
+	constexpr alert_category_t torrent_conflict_alert::static_category;
 #if TORRENT_ABI_VERSION == 1
 	constexpr alert_category_t anonymous_mode_alert::static_category;
 	constexpr alert_category_t mmap_cache_alert::static_category;

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4536,7 +4536,7 @@ namespace {
 		, info_hash_t const& old_ih)
 	{
 		m_torrents.erase(old_ih);
-		m_torrents.insert(t->torrent_file().info_hashes(), t);
+		m_torrents.insert(t->info_hash(), t);
 	}
 
 	void session_impl::set_queue_position(torrent* me, queue_position_t p)
@@ -5236,7 +5236,7 @@ namespace {
 	void session_impl::remove_torrent_impl(std::shared_ptr<torrent> tptr
 		, remove_flags_t const options)
 	{
-		m_torrents.erase(tptr->torrent_file().info_hashes());
+		m_torrents.erase(tptr->info_hash());
 
 		torrent& t = *tptr;
 		if (options)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5555,7 +5555,6 @@ namespace {
 		if (m_torrent_file->num_pieces() == 0) return;
 
 		bool need_update = false;
-		std::int64_t position = 0;
 		// initialize the piece priorities to 0, then only allow
 		// setting higher priorities
 		aux::vector<download_priority_t, piece_index_t> pieces(aux::numeric_cast<std::size_t>(
@@ -5565,7 +5564,6 @@ namespace {
 		{
 			std::int64_t const size = m_torrent_file->files().file_size(i);
 			if (size == 0) continue;
-			position += size;
 
 			// pad files always have priority 0
 			download_priority_t const file_prio

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -894,12 +894,10 @@ void create_random_files(std::string const& path, span<const int> file_sizes
 		int to_write = file_sizes[i];
 		if (fs) fs->add_file(full_path, to_write);
 		ofstream f(full_path.c_str());
-		std::int64_t offset = 0;
 		while (to_write > 0)
 		{
 			int const s = std::min(to_write, static_cast<int>(random_data.size()));
 			f.write(random_data.data(), s);
-			offset += s;
 			to_write -= s;
 		}
 	}

--- a/test/test_alert_types.cpp
+++ b/test/test_alert_types.cpp
@@ -183,10 +183,11 @@ TORRENT_TEST(alerts_types)
 	TEST_ALERT_TYPE(socks5_alert, 96, alert_priority::normal, alert_category::error);
 	TEST_ALERT_TYPE(file_prio_alert, 97, alert_priority::normal, alert_category::storage);
 	TEST_ALERT_TYPE(oversized_file_alert, 98, alert_priority::normal, alert_category::storage);
+	TEST_ALERT_TYPE(torrent_conflict_alert, 99, alert_priority::high, alert_category::error);
 
 #undef TEST_ALERT_TYPE
 
-	TEST_EQUAL(num_alert_types, 99);
+	TEST_EQUAL(num_alert_types, 100);
 	TEST_EQUAL(num_alert_types, count_alert_types);
 }
 


### PR DESCRIPTION
Fix case where two magnet links (v1-only and v2-only) end up referring to the same hybrid torrent.

- [x] documentation