### PR TITLE
Make compare_disconnect_torrent() use is_finished() instead of is_seed()

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4640,10 +4640,10 @@ namespace {
 		if ((lhs->num_peers() == 0) != (rhs->num_peers() == 0))
 			return lhs->num_peers() != 0;
 
-		// other than that, always prefer to disconnect peers from seeding torrents
+		// other than that, always prefer to disconnect peers from finished torrents
 		// in order to not harm downloading ones
-		if (lhs->is_seed() != rhs->is_seed())
-			return lhs->is_seed();
+		if (lhs->is_finished() != rhs->is_finished())
+			return lhs->is_finished();
 
 		return lhs->num_peers() > rhs->num_peers();
 	}


### PR DESCRIPTION
When over the connection limit and looking for a peer to disconnect in favor of a potentially better one, current behavior is to prefer selecting a peer from torrents that are seeds so as not to effect download performance. However, this currently doesn't include torrents that are only partially downloaded, but aren't going to be downloading any more (selective downloading), causing such torrents to use disproportionately more connection slots than they otherwise would once complete.

For instance, currently a peer from a seeded torrent with 4 connected peers would be preferred for disconnection ahead of one from a completed selectively downloaded torrent with 25 connected peers.

This suggested change uses `is_finished()` instead of `is_seed()` when comparing torrents to prevent this from happening.