### PR TITLE
enable volatile-read for peer connection read requests

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5322,9 +5322,15 @@ namespace libtorrent {
 				TORRENT_ASSERT(r.piece >= piece_index_t(0));
 				TORRENT_ASSERT(r.piece < t->torrent_file().end_piece());
 
+				disk_job_flags_t flags{};
+				auto const read_mode = m_settings.get_int(settings_pack::disk_io_read_mode);
+				if (read_mode == settings_pack::disable_os_cache)
+					flags |= disk_interface::volatile_read;
+
 				m_disk_thread.async_read(t->storage(), r
 					, [conn = self(), r](disk_buffer_holder buf, storage_error const& ec)
-					{ conn->wrap(&peer_connection::on_disk_read_complete, std::move(buf), ec, r, clock_type::now()); });
+					{ conn->wrap(&peer_connection::on_disk_read_complete, std::move(buf), ec, r, clock_type::now()); }
+					, flags);
 			}
 			m_last_sent_payload.set(m_connect, clock_type::now());
 			m_requests.erase(m_requests.begin() + i);


### PR DESCRIPTION
when disk_io_read_mode is disable_os_cache