### PR TITLE
Prevent 'slack' connections triggering a disconnect when falling back under the peer limit

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1373,6 +1373,15 @@ namespace libtorrent {
 			TORRENT_ASSERT(t->info_hash().has_v2());
 		}
 
+		// Since accepting the slack connection, we might have fallen below the connections limit in which case we
+		// no longer need to disconnect anything
+		if (m_exceeded_limit
+			&& m_counters[counters::num_peers_connected] + m_counters[counters::num_peers_half_open]
+			<= m_settings.get_int(settings_pack::connections_limit))
+		{
+			m_exceeded_limit = false;
+		}
+
 		if (m_exceeded_limit)
 		{
 			// find a peer in some torrent (presumably the one with most peers)


### PR DESCRIPTION
When a 'slack' connection is accepted it gets tagged so as to force a disconnection - of either itself or another peer - once it gets attached to a torrent. It's possible to drop below the connection limit while waiting for that to happen though, meaning we could end up disconnecting a peer needlessly.

This change adds a check to see if we're still over the connection limit before choosing which peer to disconnect.
