### PR TITLE
make file_pool_view serialize opening of files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* avoid open-file race in the file_view_pool
 	* fix issue where stop-when-ready would not close files
 	* fix issue with duplicate hybrid torrent via separate v1 and v2 magnet links
 	* added new function to load torrent files, load_torrent_*()

--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -43,10 +43,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <mutex>
 #include <vector>
 #include <memory>
+#include <condition_variable>
 
 #include "libtorrent/aux_/time.hpp"
 #include "libtorrent/units.hpp"
 #include "libtorrent/storage_defs.hpp"
+#include "libtorrent/error_code.hpp"
 #include "libtorrent/aux_/mmap.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
@@ -57,6 +59,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/member.hpp>
+
+#include <boost/intrusive/list.hpp>
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
@@ -69,7 +73,7 @@ namespace aux {
 
 	namespace mi = boost::multi_index;
 
-	TORRENT_EXTRA_EXPORT file_open_mode_t to_file_open_mode(open_mode_t const);
+	TORRENT_EXTRA_EXPORT file_open_mode_t to_file_open_mode(open_mode_t);
 
 	// this is an internal cache of open file mappings.
 	struct TORRENT_EXTRA_EXPORT file_view_pool
@@ -165,6 +169,54 @@ namespace aux {
 #endif
 			>
 		>;
+
+		struct wait_open_entry
+		{
+			boost::intrusive::list_member_hook<> list_hook;
+
+			std::condition_variable cond;
+
+			// the open file is passed back to the waiting threads, just in case
+			// the pool size is so small that it's otherwise evicted between
+			// being notified and waking up to look for it.
+			std::shared_ptr<file_mapping> mapping;
+
+			// if opening the file fails, waiters are also notified but there
+			// won't be a mapping. Then this error code is set.
+			lt::storage_error error = {};
+		};
+
+		struct opening_file_entry
+		{
+			boost::intrusive::list_member_hook<> list_hook;
+
+			file_id file_key;
+
+			// the open mode for the file the thread is opening. A thread
+			// needing a file opened in read-write mode should not wait for a
+			// thread opening the file in read mode
+			open_mode_t mode{};
+
+			boost::intrusive::list<wait_open_entry
+				, boost::intrusive::member_hook<wait_open_entry
+				, boost::intrusive::list_member_hook<>
+				, &wait_open_entry::list_hook>
+			> waiters;
+		};
+
+		void notify_file_open(opening_file_entry& ofe, std::shared_ptr<file_mapping>, lt::storage_error const&);
+
+		// In order to avoid multiple threads opening the same file in parallel,
+		// just to race to add it to the pool. This list, also protected by
+		// m_mutex, contains files that one thread is currently opening. If
+		// another thread also need this file, it can add itself to the waiters
+		// list. The condition variable will then be notified when the file has
+		// been opened.
+		boost::intrusive::list<opening_file_entry
+			, boost::intrusive::member_hook<opening_file_entry
+			, boost::intrusive::list_member_hook<>
+			, &opening_file_entry::list_hook>
+			> m_opening_files;
 
 		// maps storage pointer, file index pairs to the lru entry for the file
 		files_container m_files;

--- a/include/libtorrent/error_code.hpp
+++ b/include/libtorrent/error_code.hpp
@@ -546,6 +546,8 @@ namespace errors {
 		explicit storage_error(error_code e): ec(e), file_idx(-1), operation(operation_t::unknown) {}
 		storage_error(error_code e, operation_t const op)
 			: ec(e), file_idx(-1), operation(op) {}
+		storage_error(error_code e, file_index_t f, operation_t const op)
+			: ec(e), file_idx(f), operation(op) {}
 
 		// explicitly converts to true if this object represents an error, and
 		// false if it does not.

--- a/src/file_view_pool.cpp
+++ b/src/file_view_pool.cpp
@@ -42,6 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/units.hpp"
 #include "libtorrent/disk_interface.hpp"
 #include "libtorrent/aux_/path.hpp"
+#include "libtorrent/aux_/throw.hpp"
 #ifdef TORRENT_WINDOWS
 #include "libtorrent/aux_/win_util.hpp"
 #endif
@@ -75,7 +76,30 @@ namespace libtorrent { namespace aux {
 
 		TORRENT_ASSERT(is_complete(p));
 		auto& key_view = m_files.get<0>();
-		auto i = key_view.find(file_id{st, file_index});
+		file_id const file_key{st, file_index};
+		auto i = key_view.find(file_key);
+
+		if (i == key_view.end())
+		{
+			auto opening = std::find_if(m_opening_files.begin(), m_opening_files.end()
+				, [&file_key, m](opening_file_entry const& oe) {
+					return oe.file_key == file_key
+						&& (!(m & open_mode::write) || (oe.mode & open_mode::write));
+				});
+			if (opening != m_opening_files.end())
+			{
+				wait_open_entry woe;
+				opening->waiters.push_back(woe);
+
+				do {
+					woe.cond.wait(l);
+				} while (!woe.mapping && !woe.error);
+				if (woe.error)
+					throw_ex<storage_error>(woe.error);
+
+				return woe.mapping->view();
+			}
+		}
 
 		// make sure the write bit is set if we asked for it
 		// it's OK to use a read-write file if we just asked for read. But if
@@ -102,54 +126,103 @@ namespace libtorrent { namespace aux {
 			defer_destruction1 = remove_oldest(l);
 		}
 
+		opening_file_entry ofe;
+		ofe.file_key = file_key;
+		ofe.mode = m;
+		m_opening_files.push_back(ofe);
+
 		l.unlock();
 
-#if TORRENT_HAVE_MAP_VIEW_OF_FILE
-		std::unique_lock<std::mutex> lou(*open_unmap_lock);
-#endif
-		file_entry e({st, file_index}, fs.file_path(file_index, p), m
-			, fs.file_size(file_index)
-#if TORRENT_HAVE_MAP_VIEW_OF_FILE
-			, open_unmap_lock
-#endif
-			);
-#if TORRENT_HAVE_MAP_VIEW_OF_FILE
-		lou.unlock();
-#endif
-		l.lock();
-
-		// there's an edge case where two threads are racing to insert a newly
-		// opened file, one thread is opening a file for writing and the other
-		// fore reading. If the reading thread wins, it's important that the
-		// thread opening for writing still overwrites the file in the pool,
-		// since a file opened for reading and writing can be used for both.
-		// So, we can't move e in here, because we may need it again of the
-		// insertion failed.
-		// if the insertion failed, check to see if we can use the existing
-		// entry. If not, overwrite it with the newly opened file ``e``.
-		bool added;
-		std::tie(i, added) = key_view.insert(e);
-		if (added == false)
+		try
 		{
-			// this is the case where this file was already in the pool. Make
-			// sure we can use it. If we asked for write mode, it must have been
-			// opened in write mode too.
-			TORRENT_ASSERT(i != key_view.end());
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			std::unique_lock<std::mutex> lou(*open_unmap_lock);
+#endif
+			file_entry e(file_key, fs.file_path(file_index, p), m
+				, fs.file_size(file_index)
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+				, open_unmap_lock
+#endif
+				);
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+			lou.unlock();
+#endif
 
-			if ((m & open_mode::write) && !(i->mode & open_mode::write))
+			l.lock();
+
+			// there's an edge case where two threads are racing to insert a newly
+			// opened file, one thread is opening a file for writing and the other
+			// fore reading. If the reading thread wins, it's important that the
+			// thread opening for writing still overwrites the file in the pool,
+			// since a file opened for reading and writing can be used for both.
+			// So, we can't move e in here, because we may need it again of the
+			// insertion failed.
+			// if the insertion failed, check to see if we can use the existing
+			// entry. If not, overwrite it with the newly opened file ``e``.
+			bool added;
+			std::tie(i, added) = key_view.insert(e);
+			if (added == false)
 			{
-				key_view.modify(i, [&](file_entry& fe)
+				// this is the case where this file was already in the pool. Make
+				// sure we can use it. If we asked for write mode, it must have been
+				// opened in write mode too.
+				TORRENT_ASSERT(i != key_view.end());
+
+				if ((m & open_mode::write) && !(i->mode & open_mode::write))
 				{
-					defer_destruction2 = std::move(fe.mapping);
-					fe = std::move(e);
-				});
+					key_view.modify(i, [&](file_entry& fe)
+					{
+						defer_destruction2 = std::move(fe.mapping);
+						fe = std::move(e);
+					});
+				}
+
+				auto& lru_view = m_files.get<1>();
+				lru_view.relocate(m_files.project<1>(i), lru_view.begin());
 			}
-
-			auto& lru_view = m_files.get<1>();
-			lru_view.relocate(m_files.project<1>(i), lru_view.begin());
+			notify_file_open(ofe, i->mapping, storage_error());
+			return i->mapping->view();
 		}
+		catch (storage_error const& se)
+		{
+			if (!l.owns_lock()) l.lock();
+			notify_file_open(ofe, {}, se);
+			throw;
+		}
+		catch (std::bad_alloc const&)
+		{
+			if (!l.owns_lock()) l.lock();
+			notify_file_open(ofe, {}, storage_error(
+				errors::no_memory, file_index, operation_t::file_open));
+			throw;
+		}
+		catch (boost::system::system_error const& se)
+		{
+			if (!l.owns_lock()) l.lock();
+			notify_file_open(ofe, {}, storage_error(
+				se.code(), file_index, operation_t::file_open));
+			throw;
+		}
+		catch (...)
+		{
+			if (!l.owns_lock()) l.lock();
+			notify_file_open(ofe, {}, storage_error(
+				errors::no_memory, file_index, operation_t::file_open));
+			throw;
+		}
+	}
 
-		return i->mapping->view();
+	void file_view_pool::notify_file_open(opening_file_entry& ofe
+		, std::shared_ptr<file_mapping> mapping
+		, lt::storage_error const& se = lt::storage_error())
+	{
+		m_opening_files.erase(m_opening_files.s_iterator_to(ofe));
+		for (auto& woe : ofe.waiters)
+		{
+			woe.mapping = mapping;
+			woe.error = se;
+			woe.cond.notify_all();
+		}
 	}
 
 	file_open_mode_t to_file_open_mode(open_mode_t const mode)


### PR DESCRIPTION
rather than race each other. When the same file is needed by multiple threads