### PR TITLE
Fix missing macro definition when compiling in shared library mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ target_compile_features(torrent-rasterbar
 if (BUILD_SHARED_LIBS)
 	target_compile_definitions(torrent-rasterbar
 		PRIVATE TORRENT_BUILDING_SHARED
-		INTERFACE TORRENT_LINKING_SHARED
+		PUBLIC TORRENT_LINKING_SHARED
 	)
 endif()
 


### PR DESCRIPTION
When compiling in shared library mode with MSVC, the `TORRENT_LINKING_SHARED` macro is expected to be defined but it wasn't. This commit fixes it.

@arvidn 
Other branches (RC_1_2, master) also has this defect, please port it over.