### PR TITLE
simplify storage-utils by removing the (unused) vector-I/O API

### DIFF
--- a/include/libtorrent/aux_/path.hpp
+++ b/include/libtorrent/aux_/path.hpp
@@ -41,7 +41,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/span.hpp"
-#include "libtorrent/aux_/storage_utils.hpp" // for iovec_t
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
@@ -180,8 +179,6 @@ namespace libtorrent {
 // internal export should be used at unit tests only
 	TORRENT_EXTRA_EXPORT std::string convert_from_native_path(char const* s);
 #endif
-
-	TORRENT_EXTRA_EXPORT int bufs_size(span<iovec_t const> bufs);
 }
 
 #endif // TORRENT_PATH_HPP_INCLUDED

--- a/include/libtorrent/aux_/posix_storage.hpp
+++ b/include/libtorrent/aux_/posix_storage.hpp
@@ -57,13 +57,13 @@ namespace aux {
 		file_storage const& files() const;
 		~posix_storage();
 
-		int readv(settings_interface const& sett
-			, span<iovec_t const> bufs
+		int read(settings_interface const& sett
+			, span<char> bufs
 			, piece_index_t const piece, int const offset
 			, storage_error& error);
 
-		int writev(settings_interface const& sett
-			, span<iovec_t const> bufs
+		int write(settings_interface const& sett
+			, span<char> bufs
 			, piece_index_t const piece, int const offset
 			, storage_error& error);
 

--- a/include/libtorrent/aux_/storage_utils.hpp
+++ b/include/libtorrent/aux_/storage_utils.hpp
@@ -57,9 +57,6 @@ namespace libtorrent {
 
 namespace aux {
 
-	TORRENT_EXTRA_EXPORT int copy_bufs(span<iovec_t const> bufs
-		, int bytes, span<iovec_t> target);
-
 	// this is a read or write operation so that readwrite() knows
 	// what to do when it's actually touching the file
 	using fileop = std::function<int(file_index_t, std::int64_t, span<char>, storage_error&)>;

--- a/include/libtorrent/aux_/storage_utils.hpp
+++ b/include/libtorrent/aux_/storage_utils.hpp
@@ -60,7 +60,6 @@ namespace aux {
 	TORRENT_EXTRA_EXPORT int copy_bufs(span<iovec_t const> bufs
 		, int bytes, span<iovec_t> target);
 	TORRENT_EXTRA_EXPORT span<iovec_t> advance_bufs(span<iovec_t> bufs, int bytes);
-	TORRENT_EXTRA_EXPORT void clear_bufs(span<iovec_t const> bufs);
 
 	// this is a read or write operation so that readwrite() knows
 	// what to do when it's actually touching the file

--- a/include/libtorrent/aux_/storage_utils.hpp
+++ b/include/libtorrent/aux_/storage_utils.hpp
@@ -59,7 +59,6 @@ namespace aux {
 
 	TORRENT_EXTRA_EXPORT int copy_bufs(span<iovec_t const> bufs
 		, int bytes, span<iovec_t> target);
-	TORRENT_EXTRA_EXPORT span<iovec_t> advance_bufs(span<iovec_t> bufs, int bytes);
 
 	// this is a read or write operation so that readwrite() knows
 	// what to do when it's actually touching the file

--- a/include/libtorrent/aux_/storage_utils.hpp
+++ b/include/libtorrent/aux_/storage_utils.hpp
@@ -62,15 +62,15 @@ namespace aux {
 	TORRENT_EXTRA_EXPORT span<iovec_t> advance_bufs(span<iovec_t> bufs, int bytes);
 	TORRENT_EXTRA_EXPORT void clear_bufs(span<iovec_t const> bufs);
 
-	// this is a read or write operation so that readwritev() knows
+	// this is a read or write operation so that readwrite() knows
 	// what to do when it's actually touching the file
-	using fileop = std::function<int(file_index_t, std::int64_t, span<iovec_t const>, storage_error&)>;
+	using fileop = std::function<int(file_index_t, std::int64_t, span<char>, storage_error&)>;
 
 	// this function is responsible for turning read and write operations in the
 	// torrent space (pieces) into read and write operations in the filesystem
 	// space (files on disk).
-	TORRENT_EXTRA_EXPORT int readwritev(file_storage const& files
-		, span<iovec_t const> bufs, piece_index_t piece, int offset
+	TORRENT_EXTRA_EXPORT int readwrite(file_storage const& files
+		, span<char> buf, piece_index_t piece, int offset
 		, storage_error& ec, fileop op);
 
 	// moves the files in file_storage f from ``save_path`` to
@@ -106,7 +106,7 @@ namespace aux {
 		, stat_cache& cache
 		, storage_error& ec);
 
-	TORRENT_EXTRA_EXPORT int read_zeroes(span<iovec_t const> bufs);
+	TORRENT_EXTRA_EXPORT int read_zeroes(span<char> bufs);
 
 	TORRENT_EXTRA_EXPORT void initialize_storage(
 		file_storage const& fs

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -105,18 +105,18 @@ namespace aux {
 			, storage_error&);
 		bool tick();
 
-		int readv(settings_interface const&, span<iovec_t const> bufs
+		int read(settings_interface const&, span<char> bufs
 			, piece_index_t piece, int offset, aux::open_mode_t mode
 			, disk_job_flags_t flags
 			, storage_error&);
-		int writev(settings_interface const&, span<iovec_t const> bufs
+		int write(settings_interface const&, span<char> bufs
 			, piece_index_t piece, int offset, aux::open_mode_t mode
 			, disk_job_flags_t flags
 			, storage_error&);
-		int hashv(settings_interface const&, hasher& ph, std::ptrdiff_t len
+		int hash(settings_interface const&, hasher& ph, std::ptrdiff_t len
 			, piece_index_t piece, int offset, aux::open_mode_t mode
 			, disk_job_flags_t flags, storage_error&);
-		int hashv2(settings_interface const&, hasher256& ph, std::ptrdiff_t len
+		int hash2(settings_interface const&, hasher256& ph, std::ptrdiff_t len
 			, piece_index_t piece, int offset, aux::open_mode_t mode
 			, disk_job_flags_t flags, storage_error&);
 

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -497,8 +497,8 @@ error_code translate_error(std::system_error const& err, bool const write)
 		return { ret, m_save_path };
 	}
 
-	int mmap_storage::readv(settings_interface const& sett
-		, span<iovec_t const> bufs
+	int mmap_storage::read(settings_interface const& sett
+		, span<char> buffer
 		, piece_index_t const piece, int const offset
 		, aux::open_mode_t const mode
 		, disk_job_flags_t const flags
@@ -507,13 +507,13 @@ error_code translate_error(std::system_error const& err, bool const write)
 #ifdef TORRENT_SIMULATE_SLOW_READ
 		std::this_thread::sleep_for(seconds(1));
 #endif
-		return readwritev(files(), bufs, piece, offset, error
+		return readwrite(files(), buffer, piece, offset, error
 			, [this, mode, flags, &sett](file_index_t const file_index
 				, std::int64_t const file_offset
-				, span<iovec_t const> vec, storage_error& ec)
+				, span<char> buf, storage_error& ec)
 		{
 			// reading from a pad file yields zeroes
-			if (files().pad_file_at(file_index)) return aux::read_zeroes(vec);
+			if (files().pad_file_at(file_index)) return aux::read_zeroes(buf);
 
 			if (file_index < m_file_priority.end_index()
 				&& m_file_priority[file_index] == dont_download
@@ -523,7 +523,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 
 				error_code e;
 				peer_request map = files().map_file(file_index, file_offset, 0);
-				int const ret = m_part_file->readv(vec, map.piece, map.start, e);
+				int const ret = m_part_file->readv(buf, map.piece, map.start, e);
 
 				if (e)
 				{
@@ -546,28 +546,32 @@ error_code translate_error(std::system_error const& err, bool const write)
 			// short reads as errors
 			ec.operation = operation_t::file_read;
 
+			if (file_range.size() <= file_offset)
+			{
+				ec.ec = boost::asio::error::eof;
+				ec.file(file_index);
+				return -1;
+			}
+
 			try
 			{
-				if (file_range.size() > file_offset)
+				file_range = file_range.subspan(static_cast<std::ptrdiff_t>(file_offset));
+				if (!file_range.empty())
 				{
-					file_range = file_range.subspan(static_cast<std::ptrdiff_t>(file_offset));
-					for (auto buf : vec)
-					{
-						if (file_range.empty()) break;
-						if (file_range.size() < buf.size()) buf = buf.first(file_range.size());
+					if (file_range.size() < buf.size()) buf = buf.first(file_range.size());
 
-						sig::try_signal([&]{
-							std::memcpy(buf.data(), const_cast<char*>(file_range.data())
-								, static_cast<std::size_t>(buf.size()));
-							});
+					sig::try_signal([&]{
+						std::memcpy(buf.data(), const_cast<char*>(file_range.data())
+							, static_cast<std::size_t>(buf.size()));
+						});
 
-						file_range = file_range.subspan(buf.size());
-						ret += static_cast<int>(buf.size());
-					}
 					if (flags & disk_interface::volatile_read)
-						handle->dont_need(file_range);
+						handle->dont_need(file_range.first(buf.size()));
 					if (flags & disk_interface::flush_piece)
-						handle->page_out(file_range);
+						handle->page_out(file_range.first(buf.size()));
+
+					file_range = file_range.subspan(buf.size());
+					ret += static_cast<int>(buf.size());
 				}
 			}
 			catch (std::system_error const& err)
@@ -579,7 +583,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 
 			// we either get an error or 0 or more bytes read
 			TORRENT_ASSERT(e || ret > 0);
-			TORRENT_ASSERT(ret <= bufs_size(vec));
 
 			if (e)
 			{
@@ -592,22 +595,22 @@ error_code translate_error(std::system_error const& err, bool const write)
 		});
 	}
 
-	int mmap_storage::writev(settings_interface const& sett
-		, span<iovec_t const> bufs
+	int mmap_storage::write(settings_interface const& sett
+		, span<char> buffer
 		, piece_index_t const piece, int const offset
 		, aux::open_mode_t const mode
 		, disk_job_flags_t const flags
 		, storage_error& error)
 	{
-		return readwritev(files(), bufs, piece, offset, error
+		return readwrite(files(), buffer, piece, offset, error
 			, [this, mode, flags, &sett](file_index_t const file_index
 				, std::int64_t const file_offset
-				, span<iovec_t const> vec, storage_error& ec)
+				, span<char> buf, storage_error& ec)
 		{
 			if (files().pad_file_at(file_index))
 			{
 				// writing to a pad-file is a no-op
-				return bufs_size(vec);
+				return int(buf.size());
 			}
 
 			if (file_index < m_file_priority.end_index()
@@ -619,7 +622,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 				error_code e;
 				peer_request map = files().map_file(file_index
 					, file_offset, 0);
-				int const ret = m_part_file->writev(vec, map.piece, map.start, e);
+				int const ret = m_part_file->writev(buf, map.piece, map.start, e);
 
 				if (e)
 				{
@@ -649,22 +652,19 @@ error_code translate_error(std::system_error const& err, bool const write)
 
 			try
 			{
-				for (auto buf : vec)
-				{
-					TORRENT_ASSERT(file_range.size() >= buf.size());
+				TORRENT_ASSERT(file_range.size() >= buf.size());
 
-					sig::try_signal([&]{
-						std::memcpy(const_cast<char*>(file_range.data()), buf.data(), static_cast<std::size_t>(buf.size()));
-						});
+				sig::try_signal([&]{
+					std::memcpy(const_cast<char*>(file_range.data()), buf.data(), static_cast<std::size_t>(buf.size()));
+					});
 
-					file_range = file_range.subspan(buf.size());
-					ret += static_cast<int>(buf.size());
-				}
+				file_range = file_range.subspan(buf.size());
+				ret += static_cast<int>(buf.size());
 
 				if (flags & disk_interface::volatile_read)
-					handle->dont_need(file_range);
+					handle->dont_need(file_range.first(buf.size()));
 				if (flags & disk_interface::flush_piece)
-					handle->page_out(file_range);
+					handle->page_out(file_range.first(buf.size()));
 			}
 			catch (std::system_error const& err)
 			{
@@ -688,7 +688,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 		});
 	}
 
-	int mmap_storage::hashv(settings_interface const& sett
+	int mmap_storage::hash(settings_interface const& sett
 		, hasher& ph, std::ptrdiff_t const len
 		, piece_index_t const piece, int const offset
 		, aux::open_mode_t const mode
@@ -698,27 +698,23 @@ error_code translate_error(std::system_error const& err, bool const write)
 #ifdef TORRENT_SIMULATE_SLOW_READ
 		std::this_thread::sleep_for(seconds(1));
 #endif
-		char dummy = 0;
-		iovec_t dummy1 = {&dummy, len};
-		span<iovec_t> dummy2(&dummy1, 1);
 
-		return readwritev(files(), dummy2, piece, offset, error
+		char dummy;
+		return readwrite(files(), {&dummy, len}, piece, offset, error
 			, [this, mode, flags, &ph, &sett](file_index_t const file_index
 				, std::int64_t const file_offset
-				, span<iovec_t const> vec, storage_error& ec)
+				, span<char> const buf, storage_error& ec)
 		{
-			auto const read_size = bufs_size(vec);
-
 			if (files().pad_file_at(file_index))
 			{
 				std::array<char, 64> zero_buf;
 				zero_buf.fill(0);
 				span<char> zeroes = zero_buf;
-				for (std::ptrdiff_t left = read_size; left > 0; left -= zeroes.size())
+				for (std::ptrdiff_t left = buf.size(); left > 0; left -= zeroes.size())
 				{
 					ph.update({zeroes.data(), std::min(zeroes.size(), left)});
 				}
-				return read_size;
+				return int(buf.size());
 			}
 
 			if (file_index < m_file_priority.end_index()
@@ -727,7 +723,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 			{
 				error_code e;
 				peer_request map = files().map_file(file_index, file_offset, 0);
-				int const ret = m_part_file->hashv(ph, read_size
+				int const ret = m_part_file->hashv(ph, buf.size()
 					, map.piece, map.start, e);
 
 				if (e)
@@ -748,7 +744,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 			if (file_range.size() > file_offset)
 			{
 				file_range = file_range.subspan(std::ptrdiff_t(file_offset)
-					, std::min(std::ptrdiff_t(read_size), std::ptrdiff_t(file_range.size() - file_offset)));
+					, std::min(buf.size(), std::ptrdiff_t(file_range.size() - file_offset)));
 
 				sig::try_signal([&]{
 					ph.update({const_cast<char const*>(file_range.data()), file_range.size()});
@@ -764,7 +760,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 		});
 	}
 
-	int mmap_storage::hashv2(settings_interface const& sett
+	int mmap_storage::hash2(settings_interface const& sett
 		, hasher256& ph, std::ptrdiff_t const len
 		, piece_index_t const piece, int const offset
 		, aux::open_mode_t const mode

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -528,7 +528,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 				if (e)
 				{
 					ec.ec = e;
-					ec.file(file_index);
 					ec.operation = operation_t::partfile_read;
 					return -1;
 				}
@@ -549,7 +548,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 			if (file_range.size() <= file_offset)
 			{
 				ec.ec = boost::asio::error::eof;
-				ec.file(file_index);
 				return -1;
 			}
 
@@ -576,7 +574,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 			}
 			catch (std::system_error const& err)
 			{
-				ec.file(file_index);
 				ec.ec = translate_error(err, false);
 				return -1;
 			}
@@ -587,7 +584,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 			if (e)
 			{
 				ec.ec = e;
-				ec.file(file_index);
 				return -1;
 			}
 
@@ -627,7 +623,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 				if (e)
 				{
 					ec.ec = e;
-					ec.file(file_index);
 					ec.operation = operation_t::partfile_write;
 					return -1;
 				}
@@ -643,7 +638,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 			if (ec) return -1;
 
 			int ret = 0;
-			error_code e;
 			span<byte> file_range = handle->range().subspan(static_cast<std::ptrdiff_t>(file_offset));
 
 			// set this unconditionally in case the upper layer would like to treat
@@ -668,7 +662,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 			}
 			catch (std::system_error const& err)
 			{
-				ec.file(file_index);
 				ec.ec = translate_error(err, true);
 				return -1;
 			}
@@ -676,13 +669,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 			m_pool.record_file_write(storage_index(), file_index, ret);
 #endif
-
-			if (e)
-			{
-				ec.ec = e;
-				ec.file(file_index);
-				return -1;
-			}
 
 			return ret;
 		});
@@ -729,7 +715,6 @@ error_code translate_error(std::system_error const& err, bool const write)
 				if (e)
 				{
 					ec.ec = e;
-					ec.file(file_index);
 					ec.operation = operation_t::partfile_read;
 					return -1;
 				}
@@ -901,9 +886,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 			mode |= aux::open_mode::sparse;
 
 		if (sett.get_bool(settings_pack::no_atime_storage))
-		{
 			mode |= aux::open_mode::no_atime;
-		}
 
 		// if we have a cache already, don't store the data twice by leaving it in the OS cache as well
 		auto const write_mode = sett.get_int(settings_pack::disk_io_write_mode);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -110,13 +110,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent {
 
-	int bufs_size(span<iovec_t const> bufs)
-	{
-		std::ptrdiff_t size = 0;
-		for (auto buf : bufs) size += buf.size();
-		return int(size);
-	}
-
 #if defined TORRENT_WINDOWS
 	std::string convert_from_native_path(wchar_t const* s)
 	{

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -186,7 +186,6 @@ namespace aux {
 				if (e)
 				{
 					ec.ec = e;
-					ec.file(file_index);
 					ec.operation = operation_t::partfile_read;
 					return -1;
 				}
@@ -214,13 +213,6 @@ namespace aux {
 			// we either get an error or 0 or more bytes read
 			TORRENT_ASSERT(ec.ec || ret > 0);
 			TORRENT_ASSERT(ret <= buf.size());
-
-			if (ec.ec)
-			{
-				ec.file(file_index);
-				return -1;
-			}
-
 			return ret;
 		});
 	}
@@ -255,7 +247,6 @@ namespace aux {
 				if (e)
 				{
 					ec.ec = e;
-					ec.file(file_index);
 					ec.operation = operation_t::partfile_write;
 				}
 				return ret;
@@ -282,13 +273,6 @@ namespace aux {
 			// invalidate our stat cache for this file, since
 			// we're writing to it
 			m_stat_cache.set_dirty(file_index);
-
-			if (ec)
-			{
-				ec.file(file_index);
-				return -1;
-			}
-
 			return ret;
 		});
 	}

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 #include "libtorrent/settings_pack.hpp"
 #include "libtorrent/aux_/posix_storage.hpp"
-#include "libtorrent/aux_/path.hpp" // for bufs_size
+#include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/open_mode.hpp"
 #include "libtorrent/aux_/file_pointer.hpp"
 #include "libtorrent/torrent_status.hpp"

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -160,18 +160,18 @@ namespace aux {
 		}
 	}
 
-	int posix_storage::readv(settings_interface const&
-		, span<iovec_t const> bufs
+	int posix_storage::read(settings_interface const&
+		, span<char> buffer
 		, piece_index_t const piece, int const offset
 		, storage_error& error)
 	{
-		return readwritev(files(), bufs, piece, offset, error
+		return readwrite(files(), buffer, piece, offset, error
 			, [this](file_index_t const file_index
 				, std::int64_t const file_offset
-				, span<iovec_t const> vec, storage_error& ec)
+				, span<char> buf, storage_error& ec)
 		{
 			// reading from a pad file yields zeroes
-			if (files().pad_file_at(file_index)) return aux::read_zeroes(vec);
+			if (files().pad_file_at(file_index)) return aux::read_zeroes(buf);
 
 			if (file_index < m_file_priority.end_index()
 				&& m_file_priority[file_index] == dont_download
@@ -181,7 +181,7 @@ namespace aux {
 
 				error_code e;
 				peer_request map = files().map_file(file_index, file_offset, 0);
-				int const ret = m_part_file->readv(vec, map.piece, map.start, e);
+				int const ret = m_part_file->readv(buf, map.piece, map.start, e);
 
 				if (e)
 				{
@@ -202,25 +202,18 @@ namespace aux {
 			ec.operation = operation_t::file_read;
 
 			int ret = 0;
-			for (auto buf : vec)
+			int const r = static_cast<int>(::fread(buf.data(), 1
+				, static_cast<std::size_t>(buf.size()), f.file()));
+			if (r == 0)
 			{
-				int const r = static_cast<int>(fread(buf.data(), 1
-					, static_cast<std::size_t>(buf.size()), f.file()));
-				if (r == 0)
-				{
-					if (ferror(f.file())) ec.ec.assign(errno, generic_category());
-					else ec.ec.assign(errors::file_too_short, libtorrent_category());
-					break;
-				}
-				ret += r;
-
-				// the file may be shorter than we think
-				if (r < buf.size()) break;
+				if (::ferror(f.file())) ec.ec.assign(errno, generic_category());
+				else ec.ec.assign(errors::file_too_short, libtorrent_category());
 			}
+			ret += r;
 
 			// we either get an error or 0 or more bytes read
 			TORRENT_ASSERT(ec.ec || ret > 0);
-			TORRENT_ASSERT(ret <= bufs_size(vec));
+			TORRENT_ASSERT(ret <= buf.size());
 
 			if (ec.ec)
 			{
@@ -232,20 +225,20 @@ namespace aux {
 		});
 	}
 
-	int posix_storage::writev(settings_interface const&
-		, span<iovec_t const> bufs
+	int posix_storage::write(settings_interface const&
+		, span<char> buffer
 		, piece_index_t const piece, int const offset
 		, storage_error& error)
 	{
-		return readwritev(files(), bufs, piece, offset, error
+		return readwrite(files(), buffer, piece, offset, error
 			, [this](file_index_t const file_index
 				, std::int64_t const file_offset
-				, span<iovec_t const> vec, storage_error& ec)
+				, span<char> buf, storage_error& ec)
 		{
 			if (files().pad_file_at(file_index))
 			{
 				// writing to a pad-file is a no-op
-				return bufs_size(vec);
+				return int(buf.size());
 			}
 
 			if (file_index < m_file_priority.end_index()
@@ -257,14 +250,13 @@ namespace aux {
 				error_code e;
 				peer_request map = files().map_file(file_index
 					, file_offset, 0);
-				int const ret = m_part_file->writev(vec, map.piece, map.start, e);
+				int const ret = m_part_file->writev(buf, map.piece, map.start, e);
 
 				if (e)
 				{
 					ec.ec = e;
 					ec.file(file_index);
 					ec.operation = operation_t::partfile_write;
-					return -1;
 				}
 				return ret;
 			}
@@ -278,18 +270,14 @@ namespace aux {
 			ec.operation = operation_t::file_write;
 
 			int ret = 0;
-			for (auto buf : vec)
+			auto const r = static_cast<int>(::fwrite(buf.data(), 1
+				, static_cast<std::size_t>(buf.size()), f.file()));
+			if (r != buf.size())
 			{
-				auto const r = static_cast<int>(fwrite(buf.data(), 1
-					, static_cast<std::size_t>(buf.size()), f.file()));
-				if (r != buf.size())
-				{
-					if (ferror(f.file())) ec.ec.assign(errno, generic_category());
-					else ec.ec.assign(errors::file_too_short, libtorrent_category());
-					break;
-				}
-				ret += r;
+				if (::ferror(f.file())) ec.ec.assign(errno, generic_category());
+				else ec.ec.assign(errors::file_too_short, libtorrent_category());
 			}
+			ret += r;
 
 			// invalidate our stat cache for this file, since
 			// we're writing to it

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/storage_utils.hpp"
 #include "libtorrent/file_storage.hpp"
 #include "libtorrent/aux_/alloca.hpp"
-#include "libtorrent/aux_/path.hpp" // for count_bufs
+#include "libtorrent/aux_/path.hpp"
 #include "libtorrent/session.hpp" // for session::delete_files
 #include "libtorrent/stat_cache.hpp"
 #include "libtorrent/add_torrent_params.hpp"
@@ -94,43 +94,22 @@ namespace libtorrent { namespace aux {
 			std::fill(buf.begin(), buf.end(), char(0));
 	}
 
-#if TORRENT_USE_ASSERTS
-	namespace {
-
-	int count_bufs(span<iovec_t const> bufs, int bytes)
-	{
-		std::ptrdiff_t size = 0;
-		int count = 0;
-		if (bytes == 0) return count;
-		for (auto b : bufs)
-		{
-			++count;
-			size += b.size();
-			if (size >= bytes) return count;
-		}
-		return count;
-	}
-
-	}
-#endif
-
 	// much of what needs to be done when reading and writing is buffer
 	// management and piece to file mapping. Most of that is the same for reading
 	// and writing. This function is a template, and the fileop decides what to
 	// do with the file and the buffers.
-	int readwritev(file_storage const& files, span<iovec_t const> const bufs
+	int readwrite(file_storage const& files, span<char> buf
 		, piece_index_t const piece, const int offset
 		, storage_error& ec, fileop op)
 	{
 		TORRENT_ASSERT(piece >= piece_index_t(0));
 		TORRENT_ASSERT(piece < files.end_piece());
 		TORRENT_ASSERT(offset >= 0);
-		TORRENT_ASSERT(bufs.size() > 0);
+		TORRENT_ASSERT(buf.size() > 0);
 
-		const int size = bufs_size(bufs);
-		TORRENT_ASSERT(size > 0);
+		TORRENT_ASSERT(buf.size() > 0);
 		TORRENT_ASSERT(static_cast<int>(piece) * static_cast<std::int64_t>(files.piece_length())
-			+ offset + size <= files.total_size());
+			+ offset + buf.size() <= files.total_size());
 
 		// find the file iterator and file offset
 		std::int64_t const torrent_offset = static_cast<int>(piece) * std::int64_t(files.piece_length()) + offset;
@@ -139,78 +118,61 @@ namespace libtorrent { namespace aux {
 		TORRENT_ASSERT(torrent_offset < files.file_offset(file_index) + files.file_size(file_index));
 		std::int64_t file_offset = torrent_offset - files.file_offset(file_index);
 
-		// the number of bytes left before this read or write operation is
-		// completely satisfied.
-		int bytes_left = size;
+		int ret = 0;
 
-		TORRENT_ASSERT(bytes_left >= 0);
-
-		// copy the iovec array so we can use it to keep track of our current
-		// location by updating the head base pointer and size. (see
-		// advance_bufs())
-		TORRENT_ALLOCA(current_buf, iovec_t, bufs.size());
-		copy_bufs(bufs, size, current_buf);
-		TORRENT_ASSERT(count_bufs(current_buf, size) == int(bufs.size()));
-
-		TORRENT_ALLOCA(tmp_buf, iovec_t, bufs.size());
-
-		while (bytes_left > 0)
+		while (buf.size() > 0)
 		{
 			// the number of bytes left to read in the current file (specified by
 			// file_index). This is the minimum of (file_size - file_offset) and
-			// bytes_left.
-			int file_bytes_left = bytes_left;
+			// buf.size().
+			int file_bytes_left = int(buf.size());
 			if (file_offset + file_bytes_left > files.file_size(file_index))
 				file_bytes_left = std::max(static_cast<int>(files.file_size(file_index) - file_offset), 0);
 
 			// there are no bytes left in this file, move to the next one
 			// this loop skips over empty files
-			while (file_bytes_left == 0)
+			if (file_bytes_left == 0)
 			{
-				++file_index;
-				file_offset = 0;
-				TORRENT_ASSERT(file_index < files.end_file());
+				do
+				{
+					++file_index;
+					file_offset = 0;
+					TORRENT_ASSERT(file_index < files.end_file());
 
-				// this should not happen. bytes_left should be clamped by the total
-				// size of the torrent, so we should never run off the end of it
-				if (file_index >= files.end_file()) return size;
+					// this should not happen. buf.size() should be clamped by the total
+					// size of the torrent, so we should never run off the end of it
+					if (file_index >= files.end_file()) return ret;
 
-				file_bytes_left = bytes_left;
+					// skip empty files
+				}
+				while (files.file_size(file_index) == 0);
+
+				file_bytes_left = int(buf.size());
 				if (file_offset + file_bytes_left > files.file_size(file_index))
 					file_bytes_left = std::max(static_cast<int>(files.file_size(file_index) - file_offset), 0);
+				TORRENT_ASSERT(file_bytes_left > 0);
 			}
-
-			// make a copy of the iovec array that _just_ covers the next
-			// file_bytes_left bytes, i.e. just this one operation
-			int const tmp_bufs_used = copy_bufs(current_buf, file_bytes_left, tmp_buf);
 
 			int const bytes_transferred = op(file_index, file_offset
-				, tmp_buf.first(tmp_bufs_used), ec);
+				, buf.first(file_bytes_left), ec);
 			TORRENT_ASSERT(bytes_transferred <= file_bytes_left);
-			if (ec) return -1;
+			if (ec) return ret;
 
-			// advance our position in the iovec array and the file offset.
-			current_buf = advance_bufs(current_buf, bytes_transferred);
-			bytes_left -= bytes_transferred;
+			buf = buf.subspan(bytes_transferred);
 			file_offset += bytes_transferred;
-
-			TORRENT_ASSERT(count_bufs(current_buf, bytes_left) <= int(bufs.size()));
+			ret += bytes_transferred;
 
 			// if the file operation returned 0, we've hit end-of-file. We're done
-			if (bytes_transferred == 0)
+			if (bytes_transferred == 0 && file_bytes_left > 0 )
 			{
-				if (file_bytes_left > 0 )
-				{
-					// fill in this information in case the caller wants to treat
-					// a short-read as an error
-					ec.operation = operation_t::file_read;
-					ec.ec = boost::asio::error::eof;
-					ec.file(file_index);
-				}
-				return size - bytes_left;
+				// fill in this information in case the caller wants to treat
+				// a short-read as an error
+				ec.operation = operation_t::file_read;
+				ec.ec = boost::asio::error::eof;
+				ec.file(file_index);
 			}
 		}
-		return size;
+		return ret;
 	}
 
 	std::pair<status_t, std::string> move_storage(file_storage const& f
@@ -673,15 +635,10 @@ std::int64_t get_filesize(stat_cache& stat, file_index_t const file_index
 		return false;
 	}
 
-	int read_zeroes(span<iovec_t const> bufs)
+	int read_zeroes(span<char> buf)
 	{
-		int ret = 0;
-		for (auto buf : bufs)
-		{
-			ret += static_cast<int>(buf.size());
-			std::fill(buf.begin(), buf.end(), '\0');
-		}
-		return ret;
+		std::fill(buf.begin(), buf.end(), '\0');
+		return int(buf.size());
 	}
 
 	void initialize_storage(file_storage const& fs

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -88,12 +88,6 @@ namespace libtorrent { namespace aux {
 		}
 	}
 
-	void clear_bufs(span<iovec_t const> bufs)
-	{
-		for (auto buf : bufs)
-			std::fill(buf.begin(), buf.end(), char(0));
-	}
-
 	// much of what needs to be done when reading and writing is buffer
 	// management and piece to file mapping. Most of that is the same for reading
 	// and writing. This function is a template, and the fileop decides what to

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -53,25 +53,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace libtorrent { namespace aux {
 
-	int copy_bufs(span<iovec_t const> bufs, int bytes
-		, span<iovec_t> target)
-	{
-		TORRENT_ASSERT(bytes >= 0);
-		auto dst = target.begin();
-		int ret = 0;
-		if (bytes == 0) return ret;
-		for (iovec_t const& src : bufs)
-		{
-			auto const to_copy = std::min(src.size(), std::ptrdiff_t(bytes));
-			*dst = src.first(to_copy);
-			bytes -= int(to_copy);
-			++ret;
-			++dst;
-			if (bytes <= 0) return ret;
-		}
-		return ret;
-	}
-
 	// much of what needs to be done when reading and writing is buffer
 	// management and piece to file mapping. Most of that is the same for reading
 	// and writing. This function is a template, and the fileop decides what to

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -72,22 +72,6 @@ namespace libtorrent { namespace aux {
 		return ret;
 	}
 
-	span<iovec_t> advance_bufs(span<iovec_t> bufs, int const bytes)
-	{
-		TORRENT_ASSERT(bytes >= 0);
-		std::ptrdiff_t size = 0;
-		for (;;)
-		{
-			size += bufs.front().size();
-			if (size >= bytes)
-			{
-				bufs.front() = bufs.front().last(size - bytes);
-				return bufs;
-			}
-			bufs = bufs.subspan(1);
-		}
-	}
-
 	// much of what needs to be done when reading and writing is buffer
 	// management and piece to file mapping. Most of that is the same for reading
 	// and writing. This function is a template, and the fileop decides what to

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -115,7 +115,11 @@ namespace libtorrent { namespace aux {
 			int const bytes_transferred = op(file_index, file_offset
 				, buf.first(file_bytes_left), ec);
 			TORRENT_ASSERT(bytes_transferred <= file_bytes_left);
-			if (ec) return ret;
+			if (ec)
+			{
+				ec.file(file_index);
+				return ret;
+			}
 
 			buf = buf.subspan(bytes_transferred);
 			file_offset += bytes_transferred;

--- a/test/make_torrent.cpp
+++ b/test/make_torrent.cpp
@@ -202,9 +202,9 @@ void generate_files(lt::torrent_info const& ti, std::string const& path
 			buffer[static_cast<std::size_t>(o)] = data;
 		}
 
-		iovec_t b = { &buffer[0], piece_size };
+		span<char> const b = { &buffer[0], piece_size };
 		storage_error ec;
-		int ret = st.writev(sett, b, i, 0, ec);
+		int ret = st.write(sett, b, i, 0, ec);
 		if (ret != piece_size || ec)
 		{
 			std::printf("ERROR writing files: (%d expected %d) %s\n"

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -1112,23 +1112,6 @@ TORRENT_TEST(iovec_copy_bufs)
 	free_iov(iov1, 10);
 }
 
-TORRENT_TEST(iovec_clear_bufs)
-{
-	iovec_t iov[10];
-	alloc_iov(iov, 10);
-	fill_pattern(iov, 10);
-
-	lt::aux::clear_bufs({iov, 10});
-	for (int i = 0; i < 10; ++i)
-	{
-		for (char v : iov[i])
-		{
-			TEST_EQUAL(int(v), 0);
-		}
-	}
-	free_iov(iov, 10);
-}
-
 TORRENT_TEST(iovec_advance_bufs)
 {
 	iovec_t iov1[10];

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -1084,34 +1084,6 @@ bool check_pattern(std::vector<char> const& buf, int counter)
 
 } // anonymous namespace
 
-TORRENT_TEST(iovec_copy_bufs)
-{
-	span<char> iov1[10];
-	span<char> iov2[10];
-
-	alloc_iov(iov1, 10);
-	fill_pattern(iov1, 10);
-
-	// copy exactly 106 bytes from iov1 to iov2
-	int num_bufs = aux::copy_bufs(iov1, 106, iov2);
-
-	// verify that the first 100 bytes is pattern 1
-	// and that the remaining bytes are pattern 2
-
-	int counter = 0;
-	for (int i = 0; i < num_bufs; ++i)
-	{
-		for (char v : iov2[i])
-		{
-			TEST_EQUAL(int(v), (counter & 0xff));
-			++counter;
-		}
-	}
-	TEST_EQUAL(counter, 106);
-
-	free_iov(iov1, 10);
-}
-
 #if TORRENT_HAVE_MMAP
 TORRENT_TEST(mmap_disk_io) { run_test<mmap_storage>(); }
 #endif

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -1112,35 +1112,6 @@ TORRENT_TEST(iovec_copy_bufs)
 	free_iov(iov1, 10);
 }
 
-TORRENT_TEST(iovec_advance_bufs)
-{
-	iovec_t iov1[10];
-	iovec_t iov2[10];
-	alloc_iov(iov1, 10);
-	fill_pattern(iov1, 10);
-
-	memcpy(iov2, iov1, sizeof(iov1));
-
-	span<iovec_t> iov = iov2;
-
-	// advance iov 13 bytes. Make sure what's left fits pattern 1 shifted
-	// 13 bytes
-	iov = aux::advance_bufs(iov, 13);
-
-	// make sure what's in
-	int counter = 13;
-	for (auto buf : iov)
-	{
-		for (char v : buf)
-		{
-			TEST_EQUAL(v, static_cast<char>(counter));
-			++counter;
-		}
-	}
-
-	free_iov(iov1, 10);
-}
-
 #if TORRENT_HAVE_MMAP
 TORRENT_TEST(mmap_disk_io) { run_test<mmap_storage>(); }
 #endif


### PR DESCRIPTION
instead, make the interface operate on single buffers at a time.