### PR TITLE
test_storage

### DIFF
--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -195,7 +195,7 @@ template <typename StorageType>
 std::shared_ptr<StorageType> make_storage(storage_params const& p
 	, aux::file_view_pool& fp);
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 template <>
 std::shared_ptr<mmap_storage> make_storage(storage_params const& p
 	, aux::file_view_pool& fp)
@@ -250,7 +250,7 @@ std::shared_ptr<StorageType> setup_torrent(file_storage& fs
 	return s;
 }
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 int write(std::shared_ptr<mmap_storage> s
 	, aux::session_settings const& sett
 	, span<char> buf
@@ -675,7 +675,7 @@ void run_test()
 	delete_dirs("temp_storage");
 }
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(check_files_sparse_mmap)
 {
 	test_check_files(sparse | zero_prio, lt::mmap_disk_io_constructor);
@@ -718,7 +718,7 @@ TORRENT_TEST(check_files_allocate_posix)
 	test_check_files(zero_prio, lt::posix_disk_io_constructor);
 }
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(rename_mmap_disk_io)
 {
 	test_rename<mmap_storage>(current_working_directory());
@@ -1084,7 +1084,7 @@ bool check_pattern(std::vector<char> const& buf, int counter)
 
 } // anonymous namespace
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(mmap_disk_io) { run_test<mmap_storage>(); }
 #endif
 TORRENT_TEST(posix_disk_io) { run_test<posix_storage>(); }
@@ -1369,7 +1369,7 @@ void test_move_storage_into_self()
 		, combine_path("_folder3", "test4.tmp")))));
 }
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(move_default_storage_to_self)
 {
 	test_move_storage_to_self<mmap_storage>();
@@ -1404,7 +1404,7 @@ TORRENT_TEST(storage_paths_string_pooling)
 	TEST_CHECK(file_storage.paths().size() <= 2);
 }
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(dont_move_intermingled_files)
 {
 	std::string const save_path = complete("save_path_1");
@@ -1648,7 +1648,7 @@ void none_from_store_buffer(lt::disk_interface* disk_io, lt::storage_holder cons
 
 }
 
-#if TORRENT_HAVE_MMAP
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(mmap_unaligned_read_both_store_buffer)
 {
 	test_unaligned_read(lt::mmap_disk_io_constructor, both_sides_from_store_buffer);


### PR DESCRIPTION
make sure test_storage uses memory mapped files on windows.
Generalize the test to be less hard coded to `mmap_storage` and `posix_storage`