### PR TITLE
fix renaming of filenames that are too long for the filesystem

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* fix renaming of filenames that are too long for the filesystem
 	* made UPnP and LSD code avoid using select_reactor (to work around an issue on windows in boost.asio < 1.80)
 
 1.2.17 released

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -824,7 +824,9 @@ namespace {
 		stat_file(f, &s, ec);
 		if (ec)
 		{
-			if (ec == boost::system::errc::no_such_file_or_directory)
+			// if the filename is too long, the file also cannot exist
+			if (ec == boost::system::errc::no_such_file_or_directory
+				|| ec == boost::system::errc::filename_too_long)
 				ec.clear();
 			return false;
 		}


### PR DESCRIPTION
Specifically where checking if the file exists would abort the rename operation.
patch by xnoreq