### PR TITLE
use pwrite() for writing to files in mmap_storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,10 +218,12 @@ set(libtorrent_aux_include_files
 	disk_io_thread_pool.hpp
 	disk_job_fence.hpp
 	disk_job_pool.hpp
+	drive_info.hpp
 	ed25519.hpp
 	escape_string.hpp
 	export.hpp
 	ffs.hpp
+	file_descriptor.hpp
 	file_progress.hpp
 	file_view_pool.hpp
 	has_block.hpp
@@ -275,6 +277,7 @@ set(libtorrent_aux_include_files
 	utp_stream.hpp
 	vector.hpp
 	win_crypto_provider.hpp
+	win_file_handle.hpp
 	win_util.hpp
 )
 
@@ -314,6 +317,7 @@ set(sources
 	disk_io_thread_pool.cpp
 	disk_job_fence.cpp
 	disk_job_pool.cpp
+	drive_info.cpp
 	entry.cpp
 	enum_net.cpp
 	error_code.cpp

--- a/Jamfile
+++ b/Jamfile
@@ -727,6 +727,7 @@ SOURCES =
 	disabled_disk_io
 	disk_job_fence
 	disk_job_pool
+	drive_info
 	entry
 	error_code
 	file_storage

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ SOURCES = \
   disk_io_thread_pool.cpp         \
   disk_job_fence.cpp              \
   disk_job_pool.cpp               \
+  drive_info.cpp                  \
   entry.cpp                       \
   enum_net.cpp                    \
   error_code.cpp                  \
@@ -596,10 +597,12 @@ HEADERS = \
   aux_/disk_io_thread_pool.hpp      \
   aux_/disk_job_fence.hpp           \
   aux_/disk_job_pool.hpp            \
+  aux_/drive_info.hpp               \
   aux_/ed25519.hpp                  \
   aux_/escape_string.hpp            \
   aux_/export.hpp                   \
   aux_/ffs.hpp                      \
+  aux_/file_descriptor.hpp          \
   aux_/file_pointer.hpp             \
   aux_/file_progress.hpp            \
   aux_/file_view_pool.hpp           \
@@ -664,6 +667,7 @@ HEADERS = \
   aux_/windows.hpp                  \
   aux_/win_cng.hpp                  \
   aux_/win_crypto_provider.hpp      \
+  aux_/win_file_handle.hpp          \
   aux_/win_util.hpp                 \
   \
   extensions/smart_ban.hpp          \

--- a/bindings/python/src/session_settings.cpp
+++ b/bindings/python/src/session_settings.cpp
@@ -28,6 +28,12 @@ void bind_session_settings()
         .value("anti_leech", settings_pack::anti_leech)
     ;
 
+    enum_<settings_pack::mmap_write_mode_t>("mmap_write_mode_t")
+        .value("always_pwrite", settings_pack::always_pwrite)
+        .value("always_mmap_write", settings_pack::always_mmap_write)
+        .value("auto_mmap_write", settings_pack::auto_mmap_write)
+    ;
+
     enum_<settings_pack::suggest_mode_t>("suggest_mode_t")
         .value("no_piece_suggestions", settings_pack::no_piece_suggestions)
         .value("suggest_read_cache", settings_pack::suggest_read_cache)

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -631,3 +631,5 @@ F7
 I1
 I2
 I3
+SSD
+DAX

--- a/include/libtorrent/aux_/drive_info.hpp
+++ b/include/libtorrent/aux_/drive_info.hpp
@@ -1,7 +1,6 @@
 /*
 
-Copyright (c) 2018, Arvid Norberg, Steven Siloti
-Copyright (c) 2018, 2020, Arvid Norberg
+Copyright (c) 2022, Arvid Norberg
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -31,21 +30,20 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#ifndef TORRENT_WINDOWS_HPP_INCLUDED
-#define TORRENT_WINDOWS_HPP_INCLUDED
+#include <string>
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN
-#endif
-#ifndef STRICT
-#define STRICT
-#endif
-#include <windows.h>
+namespace libtorrent {
+namespace aux {
 
-#endif // TORRENT_WINDOWS_HPP_INCLUDED
+enum class drive_info
+{
+	spinning,
+	ssd_disk,
+	ssd_dax,
+	remote,
+};
 
+drive_info get_drive_info(std::string const& path);
 
-
+}
+}

--- a/include/libtorrent/aux_/file_descriptor.hpp
+++ b/include/libtorrent/aux_/file_descriptor.hpp
@@ -1,13 +1,9 @@
 /*
-
-Copyright (c) 2018, Arvid Norberg, Steven Siloti
-Copyright (c) 2018, 2020, Arvid Norberg
+Copyright (c) 2022, Arvid Norberg
 All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
-
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -16,7 +12,6 @@ are met:
     * Neither the name of the author nor the names of its
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,24 +23,37 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
-
 */
 
-#ifndef TORRENT_WINDOWS_HPP_INCLUDED
-#define TORRENT_WINDOWS_HPP_INCLUDED
+#ifndef TORRENT_FILE_DESCRIPTOR_HPP_INCLUDED
+#define TORRENT_FILE_DESCRIPTOR_HPP_INCLUDED
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+#include <unistd.h>
+
+namespace libtorrent {
+namespace aux {
+
+struct file_descriptor
+{
+	file_descriptor(int fd) : m_fd(fd) {}
+
+	~file_descriptor()
+	{
+		if (m_fd >= 0) ::close(m_fd);
+	}
+
+	file_descriptor(file_descriptor const&) = delete;
+	file_descriptor(file_descriptor&& rhs)
+		: m_fd(rhs.m_fd)
+	{
+		rhs.m_fd = -1;
+	}
+	int fd() const { return m_fd; }
+private:
+	int m_fd;
+};
+
+}
+}
+
 #endif
-#ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN
-#endif
-#ifndef STRICT
-#define STRICT
-#endif
-#include <windows.h>
-
-#endif // TORRENT_WINDOWS_HPP_INCLUDED
-
-
-

--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -72,6 +72,7 @@ namespace aux {
 		file_mapping_handle& operator=(file_mapping_handle&& fm) &;
 
 		HANDLE handle() const { return m_mapping; }
+		handle_type fd() const { return m_file.fd(); }
 	private:
 		void close();
 		file_handle m_file;
@@ -103,6 +104,8 @@ namespace aux {
 
 		// ...
 		file_view view();
+
+		handle_type fd() const { return m_file.fd(); }
 	private:
 
 		void close();
@@ -162,6 +165,7 @@ namespace aux {
 			m_mapping->page_out(range);
 		}
 
+		handle_type fd() const { return m_mapping->fd(); }
 
 	private:
 		explicit file_view(std::shared_ptr<file_mapping> m) : m_mapping(std::move(m)) {}

--- a/include/libtorrent/aux_/win_file_handle.hpp
+++ b/include/libtorrent/aux_/win_file_handle.hpp
@@ -1,13 +1,9 @@
 /*
-
-Copyright (c) 2018, Arvid Norberg, Steven Siloti
-Copyright (c) 2018, 2020, Arvid Norberg
+Copyright (c) 2022, Arvid Norberg
 All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
-
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -16,7 +12,6 @@ are met:
     * Neither the name of the author nor the names of its
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,24 +23,41 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
-
 */
 
-#ifndef TORRENT_WINDOWS_HPP_INCLUDED
-#define TORRENT_WINDOWS_HPP_INCLUDED
+#ifndef TORRENT_WIN_FILE_HANDLE_HPP_INCLUDED
+#define TORRENT_WIN_FILE_HANDLE_HPP_INCLUDED
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+#if defined TORRENT_WINDOWS
+
+#include "libtorrent/aux_/windows.hpp"
+
+namespace libtorrent {
+namespace aux {
+
+struct win_file_handle
+{
+	win_file_handle(HANDLE h) : m_h(h) {}
+
+	~win_file_handle()
+	{
+		if (m_h != INVALID_HANDLE_VALUE) ::CloseHandle(m_h);
+	}
+
+	win_file_handle(win_file_handle const&) = delete;
+	win_file_handle(win_file_handle&& rhs)
+		: m_h(rhs.m_h)
+	{
+		rhs.m_h = INVALID_HANDLE_VALUE;
+	}
+	HANDLE handle() const { return m_h; }
+private:
+	HANDLE m_h;
+};
+
+}
+}
+
 #endif
-#ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN
+
 #endif
-#ifndef STRICT
-#define STRICT
-#endif
-#include <windows.h>
-
-#endif // TORRENT_WINDOWS_HPP_INCLUDED
-
-
-

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -145,6 +145,8 @@ namespace aux {
 	private:
 
 		bool m_need_tick = false;
+		bool m_use_mmap_writes = false;
+
 		file_storage const& m_files;
 
 		// the reason for this to be a void pointer

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -2028,6 +2028,15 @@ namespace aux {
 			// torrents, this limit may have to be raised.
 			metadata_token_limit,
 
+			// controls whether disk writes will be made through a memory mapped
+			// file or via normal write calls. This only affects the
+			// mmap_disk_io. When saving to a non-local drive (network share,
+			// NFS or NAS) using memory mapped files is most likely inferior.
+			// When writing to a local SSD (especially in DAX mode) using memory
+			// mapped files likely gives the best performance.
+			// The values for this setting are specified as mmap_write_mode_t.
+			disk_write_mode,
+
 			max_int_setting_internal
 		};
 
@@ -2035,6 +2044,20 @@ namespace aux {
 		constexpr static int num_string_settings = int(max_string_setting_internal) - int(string_type_base);
 		constexpr static int num_bool_settings = int(max_bool_setting_internal) - int(bool_type_base);
 		constexpr static int num_int_settings = int(max_int_setting_internal) - int(int_type_base);
+
+		enum mmap_write_mode_t : std::uint8_t
+		{
+			// disable writing to disk via mmap, always use normal write calls
+			always_pwrite = 0,
+
+			// prefer using memory mapped files for disk writes (at least for
+			// large files where it might make sense)
+			always_mmap_write,
+
+			// determine whether to use pwrite or memory mapped files for disk
+			// writes depending on the kind of storage behind the save path
+			auto_mmap_write,
+		};
 
 		enum suggest_mode_t : std::uint8_t { no_piece_suggestions = 0, suggest_read_cache = 1 };
 

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifdef TORRENT_WINDOWS
 // windows part
 #include "libtorrent/aux_/windows.hpp"
+#include "libtorrent/aux_/win_file_handle.hpp"
 #else
 
 #ifndef _GNU_SOURCE
@@ -47,6 +48,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
+
+#include "libtorrent/aux_/file_descriptor.hpp"
 
 #include <unistd.h>
 #include <sys/stat.h>
@@ -106,26 +109,6 @@ std::pair<std::int64_t, std::int64_t> next_allocated_region(HANDLE file
 
 	return {out.FileOffset.QuadPart, out.FileOffset.QuadPart + out.Length.QuadPart};
 }
-
-struct file_handle
-{
-	file_handle(HANDLE h) : m_h(h) {}
-
-	~file_handle()
-	{
-		if (m_h != INVALID_HANDLE_VALUE) ::CloseHandle(m_h);
-	}
-
-	file_handle(file_handle const&) = delete;
-	file_handle(file_handle&& rhs)
-		: m_h(rhs.m_h)
-	{
-		rhs.m_h = INVALID_HANDLE_VALUE;
-	}
-	HANDLE handle() const { return m_h; }
-private:
-	HANDLE m_h;
-};
 
 void copy_range(HANDLE const in_handle, HANDLE const out_handle
 	, std::int64_t in_offset, std::int64_t len, error_code& ec)
@@ -196,13 +179,13 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 		| in_stat.nFileSizeLow;
 
 #ifdef TORRENT_WINRT
-	file_handle in_handle = ::CreateFile2(f1.c_str()
+	aux::win_file_handle in_handle = ::CreateFile2(f1.c_str()
 			, GENERIC_READ
 			, FILE_SHARE_READ
 			, OPEN_EXISTING
 			, nullptr);
 #else
-	file_handle in_handle = ::CreateFileW(f1.c_str()
+	aux::win_file_handle in_handle = ::CreateFileW(f1.c_str()
 			, GENERIC_READ
 			, FILE_SHARE_READ
 			, nullptr
@@ -217,13 +200,13 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	}
 
 #ifdef TORRENT_WINRT
-	file_handle out_handle = ::CreateFile2(f1.c_str()
+	aux::win_file_handle out_handle = ::CreateFile2(f1.c_str()
 			, GENERIC_WRITE
 			, FILE_SHARE_WRITE
 			, OPEN_ALWAYS
 			, nullptr);
 #else
-	file_handle out_handle = ::CreateFileW(f2.c_str()
+	aux::win_file_handle out_handle = ::CreateFileW(f2.c_str()
 			, GENERIC_WRITE
 			, FILE_SHARE_WRITE
 			, nullptr
@@ -264,26 +247,6 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 // Generic/linux implementation
 
 namespace {
-
-struct file_descriptor
-{
-	file_descriptor(int fd) : m_fd(fd) {}
-
-	~file_descriptor()
-	{
-		if (m_fd >= 0) ::close(m_fd);
-	}
-
-	file_descriptor(file_descriptor const&) = delete;
-	file_descriptor(file_descriptor&& rhs)
-		: m_fd(rhs.m_fd)
-	{
-		rhs.m_fd = -1;
-	}
-	int fd() const { return m_fd; }
-private:
-	int m_fd;
-};
 
 struct copy_range_mode
 {
@@ -369,7 +332,7 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	native_path_string f1 = convert_to_native_path_string(inf);
 	native_path_string f2 = convert_to_native_path_string(newf);
 
-	file_descriptor const infd = ::open(f1.c_str(), O_RDONLY);
+	aux::file_descriptor const infd = ::open(f1.c_str(), O_RDONLY);
 	if (infd.fd() < 0)
 	{
 		ec.assign(errno, system_category());
@@ -388,7 +351,7 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	// if the source file is not sparse we'll end up copying every byte anyway,
 	// there's no point in passing O_TRUNC. However, in order to preserve sparse
 	// regions, we *do* need to truncate the output file.
-	file_descriptor const outfd = ::open(f2.c_str()
+	aux::file_descriptor const outfd = ::open(f2.c_str()
 		, input_is_sparse ? (O_RDWR | O_CREAT | O_TRUNC) : (O_RDWR | O_CREAT), in_stat.st_mode);
 	if (outfd.fd() < 0)
 	{

--- a/src/drive_info.cpp
+++ b/src/drive_info.cpp
@@ -1,0 +1,279 @@
+/*
+
+Copyright (c) 2022, Arvid Norberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "libtorrent/config.hpp"
+#include "libtorrent/aux_/drive_info.hpp"
+
+#include <iostream>
+#include <thread>
+#include <string>
+
+#ifdef TORRENT_LINUX
+#include <sys/vfs.h>
+#include <linux/magic.h>
+#include <sys/stat.h>
+#include <sys/fcntl.h>
+#include <sys/sysmacros.h> // for major()/minor()
+#include <dirent.h>
+#include <unistd.h>
+
+#include "libtorrent/aux_/file_descriptor.hpp"
+
+#include "libtorrent/optional.hpp"
+
+namespace {
+
+struct directory
+{
+	explicit directory(DIR* p) : ptr(p) {}
+	~directory() { if (ptr != nullptr) ::closedir(ptr); }
+	directory(directory const&) = delete;
+	directory(directory&& f) = delete;
+	directory& operator=(directory const&) = delete;
+	directory& operator=(directory&& f) = delete;
+	DIR* dir() const { return ptr; }
+private:
+	DIR* ptr;
+};
+
+boost::optional<std::string> read_file(char const* dev_name, char const* path)
+{
+	char p[300];
+	std::snprintf(p, sizeof(p), "/sys/block/%s/%s", dev_name, path);
+
+	lt::aux::file_descriptor f = ::open(p, 0);
+	if (f.fd() == -1)
+		return boost::none;
+
+
+	auto size = ::read(f.fd(), p, sizeof(p));
+	if (size <= 0 || size > static_cast<decltype(size)>(sizeof(p)))
+		return boost::none;
+
+	return std::string(p, std::size_t(size));
+}
+}
+
+#elif defined TORRENT_WINDOWS && !defined TORRENT_WINRT
+
+#include "libtorrent/aux_/windows.hpp"
+#include "libtorrent/aux_/path.hpp"
+#include "libtorrent/aux_/win_file_handle.hpp"
+
+#include "libtorrent/optional.hpp"
+
+#endif
+
+namespace libtorrent {
+namespace aux {
+
+#ifdef TORRENT_LINUX
+drive_info get_drive_info(std::string const& path)
+{
+	// make a conservative default assumption
+	drive_info const def = drive_info::spinning;
+
+	struct statfs stfs{};
+	if (statfs(path.c_str(), &stfs) != 0)
+	{
+		if (stfs.f_type == TMPFS_MAGIC
+			|| stfs.f_type == RAMFS_MAGIC)
+			return drive_info::ssd_dax;
+
+#ifndef FUSE_SUPER_MAGIC
+#define FUSE_SUPER_MAGIC      0x65735546
+#endif
+
+		// most fuse-based filesystems are probably not remote
+		// but sshfs is and fuse appears to not like memory mapped files very
+		// much. So this is a conservative assumption.
+		if (stfs.f_type == FUSE_SUPER_MAGIC
+			|| stfs.f_type == NFS_SUPER_MAGIC)
+			return drive_info::remote;
+	}
+
+	struct stat st{};
+	if (stat(path.c_str(), &st) != 0)
+		return def;
+
+	char device_id[50];
+	std::snprintf(device_id, sizeof(device_id), "%d:%d\n", major(st.st_dev), minor(st.st_dev));
+
+	directory dir(opendir("/sys/block"));
+	if (dir.dir() == nullptr)
+		return def;
+
+	struct dirent* de;
+	while ((de = readdir(dir.dir())))
+	{
+		if (de->d_name[0] == '.')
+			continue;
+
+		auto content = read_file(de->d_name, "/dev");
+		if (!content)
+			continue;
+
+		if (*content != device_id)
+			continue;
+
+		content = read_file(de->d_name, "/queue/rotational");
+		if (!content)
+			continue;
+
+		if (*content == "1\n")
+		{
+			return drive_info::spinning;
+		}
+		else if (*content == "0\n")
+		{
+			content = read_file(de->d_name, "/queue/dax");
+			if (content && *content == "1\n")
+				return drive_info::ssd_dax;
+			else
+				return drive_info::ssd_disk;
+		}
+	}
+	return def;
+}
+
+#elif defined TORRENT_WINDOWS && !defined TORRENT_WINRT
+
+drive_info get_drive_info(std::string const& path)
+{
+	// make a conservative default assumption
+	drive_info const def = drive_info::spinning;
+
+	auto const native_path = convert_to_native_path_string(path);
+
+	std::array<wchar_t, 300> volume_path;
+	if (GetVolumePathNameW(native_path.c_str(), volume_path.data(), DWORD(volume_path.size())) == 0)
+		return def;
+
+	int const drive_type = GetDriveTypeW(volume_path.data());
+	if (drive_type == DRIVE_REMOTE)
+		return drive_info::remote;
+
+	if (drive_type == DRIVE_RAMDISK)
+		return drive_info::ssd_dax;
+
+	DWORD fs_flags = 0;
+	if (GetVolumeInformationW(volume_path.data()
+		, nullptr, 0, nullptr, nullptr, &fs_flags, nullptr, 0))
+	{
+#ifndef FILE_DAX_VOLUME
+#define FILE_DAX_VOLUME 0x20000000
+#endif
+		if (fs_flags & FILE_DAX_VOLUME)
+			return drive_info::ssd_dax;
+	}
+
+	// these steps are documented here:
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/basic-and-dynamic-disks
+	std::array<wchar_t, 300> volume_name;
+	if (!GetVolumeNameForVolumeMountPointW(volume_path.data()
+		, volume_name.data(), DWORD(volume_name.size())))
+		return def;
+
+	// strip trailing backslash
+	auto const vol_name_len = ::wcslen(volume_name.data());
+	if (vol_name_len > 0 && volume_name[vol_name_len-1] == L'\\')
+		volume_name[vol_name_len - 1] = 0;
+
+	aux::win_file_handle vol = CreateFileW(volume_name.data(), 0
+		, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr
+		, OPEN_EXISTING, {}, nullptr);
+	if (vol.handle() == INVALID_HANDLE_VALUE)
+		return def;
+
+	struct extents_t
+	{
+		DWORD NumberOfDiskExtents;
+		DISK_EXTENT Extents[4];
+	};
+	extents_t extents{};
+	DWORD output_len = 0;
+	if (!DeviceIoControl(vol.handle(), IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS
+		, nullptr, 0, &extents, sizeof(extents), &output_len, nullptr))
+		return def;
+
+	boost::optional<bool> seek_penalty;
+	// a volume may span multiple physical disks, since we won't
+	// know which physical disk we will access, make the
+	// conservative assumption that we'll be on the worst one. If
+	// one of the disks has seek-penalty, consider the whole volume
+	// as a spinning disk and we should use a single hasher thread.
+	for (int i = 0; i < int(extents.NumberOfDiskExtents); ++i)
+	{
+		std::array<wchar_t, 50> device_name{};
+		::_snwprintf(device_name.data(), device_name.size()
+			, L"\\\\?\\PhysicalDrive%d", extents.Extents[i].DiskNumber);
+
+		aux::win_file_handle dev = CreateFileW(device_name.data(), 0
+			, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr
+			, OPEN_EXISTING, {}, nullptr);
+		if (dev.handle() == INVALID_HANDLE_VALUE)
+			continue;
+
+		STORAGE_PROPERTY_QUERY query{};
+		query.PropertyId = StorageDeviceSeekPenaltyProperty;
+		query.QueryType = PropertyExistsQuery;
+		DEVICE_SEEK_PENALTY_DESCRIPTOR dev_seek{};
+
+		output_len = 0;
+		query.QueryType = PropertyStandardQuery;
+		if (!DeviceIoControl(dev.handle(), IOCTL_STORAGE_QUERY_PROPERTY, &query, sizeof(query), &dev_seek, sizeof(dev_seek), &output_len, nullptr))
+			continue;
+
+		if (dev_seek.IncursSeekPenalty)
+		{
+			seek_penalty = true;
+			break;
+		}
+		else if (!seek_penalty)
+		{
+			seek_penalty = false;
+		}
+	}
+	if (seek_penalty && !*seek_penalty)
+		return drive_info::ssd_disk;
+	return def;
+}
+#else
+
+drive_info get_drive_info(std::string const&)
+{
+	return drive_info::spinning;
+}
+#endif
+}
+}
+

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -607,7 +607,7 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 		if (ec) session_log("SSL set_default verify_paths failed: %s", ec.message().c_str());
 		ec.clear();
 #endif
-#if defined TORRENT_WINDOWS && defined TORRENT_USE_OPENSSL
+#if defined TORRENT_WINDOWS && defined TORRENT_USE_OPENSSL && !defined TORRENT_WINRT
 		// TODO: come up with some abstraction to do this for gnutls as well
 		// load certificates from the windows system certificate store
 		X509_STORE* store = X509_STORE_new();

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -396,6 +396,7 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(dht_max_infohashes_sample_count, 20, nullptr),
 		SET(max_piece_count, 0x200000, nullptr),
 		SET(metadata_token_limit, 2500000, nullptr),
+		SET(disk_write_mode, settings_pack::mmap_write_mode_t::auto_mmap_write, nullptr),
 	}});
 
 #undef SET


### PR DESCRIPTION
This is an experiment to use `pwrite()` instead of writing into a memory mapped file. This can improve performance when downloading to a network share, since a write operations can be sent directly to the remove machine without first reading a full page (or edges of the write operation that don't fully cover a page).

This appears to be working on windows, linux and MacOS. It requires that the operating system synchronizes the two ways of writing to files.

Perhaps there should be a configuration option to pick which mechanism to use when writing.