### PR TITLE
bump python version to 3.7+ in CI and docs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
            submodules: recursive
       - uses: actions/setup-python@v2
         with:
-           python-version: 3.6
+           python-version: 3.7
       - uses: pre-commit/action@v2.0.0
 
    build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,13 +43,13 @@ install:
   - echo %BOOST_ROOT%
   - echo %BOOST_BUILD_PATH%
   - set PATH=%PATH%;%BOOST_BUILD_PATH%
-  - ps: '"using msvc : 14.0 ;`nusing gcc : : : <cxxflags>-std=c++11 ;`nusing python : 3.6 : c:\\Python36-x64 : c:\\Python36-x64\\include : c:\\Python36-x64\\libs ;`n" | Set-Content $env:HOMEDRIVE\$env:HOMEPATH\user-config.jam'
+  - ps: '"using msvc : 14.0 ;`nusing gcc : : : <cxxflags>-std=c++11 ;`nusing python : 3.7 : c:\\Python37-x64 : c:\\Python37-x64\\include : c:\\Python37-x64\\libs ;`n" | Set-Content $env:HOMEDRIVE\$env:HOMEPATH\user-config.jam'
   - type %HOMEDRIVE%%HOMEPATH%\user-config.jam
   - cd %ROOT_DIRECTORY%
   - set PATH=c:\msys64\mingw32\bin;%PATH%
   - g++ --version
-  - set PATH=c:\Python36-x64;%PATH%
-  - set PYTHON_INTERPRETER=c:\Python36-x64\python.exe
+  - set PATH=c:\Python37-x64;%PATH%
+  - set PYTHON_INTERPRETER=c:\Python37-x64\python.exe
   - python --version
   - echo %ROOT_DIRECTORY%
   - cd %BOOST_BUILD_PATH%
@@ -106,7 +106,7 @@ test_script:
   # we use 64 bit python build
   - if defined python (
     copy dependencies\*.* .
-    & c:\Python36-x64\python.exe test.py -b
+    & c:\Python37-x64\python.exe test.py -b
     )
 
   - if defined cmake (

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -5,8 +5,8 @@ cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR) # Configurable policies: <= C
 # The code below assumes default boost installation, when the module for python 3 is named 'python3'.
 # To customize that one can provide a name for the Boost::python module via
 # 'boost-python-module-name' variable when invoking cmake.
-# E.g. on Gentoo with python 3.6 and Boost::python library name 'libboost_python-3.6.so'
-# the parameter would be -Dboost-python-module-name="python-3.6".
+# E.g. on Gentoo with python 3.7 and Boost::python library name 'libboost_python-3.7.so'
+# the parameter would be -Dboost-python-module-name="python-3.7".
 
 # The extension module and the cpython executable have to use the same C runtime library. On Windows
 # Python is compiled with MSVC and we will test MSVC version to make sure that it is the same for
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR) # Configurable policies: <= C
 # See https://devguide.python.org/#status-of-python-branches for supported python versions
 function(_get_compatible_python_versions _ret)
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20)
-		list(APPEND _tmp 3.6 3.7 3.8 3.9)
+		list(APPEND _tmp 3.6 3.7 3.8 3.9 3.10)
 	endif()
 	set(${_ret} ${_tmp} PARENT_SCOPE)
 endfunction()
@@ -37,7 +37,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND NOT skip-python-runtime-test)
 	endif()
 endif()
 
-set(boost-python-module-name "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" CACHE STRING "Boost::python module name, e.g. 'python-3.6'")
+set(boost-python-module-name "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" CACHE STRING "Boost::python module name, e.g. 'python-3.7'")
 
 find_package(Boost REQUIRED COMPONENTS ${boost-python-module-name})
 

--- a/configure.ac
+++ b/configure.ac
@@ -486,6 +486,7 @@ AS_CASE(["$ARG_ENABLE_PYTHON_BINDING"],
   ["yes"], [
       AC_MSG_RESULT([yes])
 
+      # TODO: bump to 3.7+, once ubuntu-18.04 is EOL in 2023-04
       AM_PATH_PYTHON([3.6], [], AC_MSG_ERROR([Python interpreter not found.]))
       AX_PYTHON_DEVEL([>= '2.4'])
       AX_BOOST_PYTHON()

--- a/docs/python_binding.rst
+++ b/docs/python_binding.rst
@@ -30,7 +30,7 @@ install the build prerequisites on your system:
    boost libraries and ``b2``, and your building toolchain (``gcc``, visual
    studio, etc).
 2. Boost.Python, if not otherwise included in your boost installation
-3. Python 3.6+. Older versions may work, but are not tested.
+3. Python 3.7+. Older versions may work, but are not tested.
 
 .. __: building.html
 
@@ -71,8 +71,8 @@ build for a different python version
 ``setup.py`` will target the running interpreter. To build for different python
 versions, you must change how you invoke ``setup.py``::
 
-	# build for python3.6
-	python3.6 setup.py build
+	# build for python3.7
+	python3.7 setup.py build
 	# build for python3.7
 	python3.7 setup.py build
 
@@ -111,16 +111,16 @@ installation.
 
 ``b2`` has some auto-detection capabilities. You may be able to do just this::
 
-	using python : 3.6 ;
+	using python : 3.7 ;
 
 However you may need to specify full paths. On windows, it make look like
 this::
 
-	using python : 3.6 : C:/Users/<UserName>/AppData/Local/Programs/Python/Python36 : C:/Users/<UserName>/AppData/Local/Programs/Python/Python36/include : C:/Users/<UserName>/AppData/Local/Programs/Python/Python36/libs ;
+	using python : 3.7 : C:/Users/<UserName>/AppData/Local/Programs/Python/Python36 : C:/Users/<UserName>/AppData/Local/Programs/Python/Python36/include : C:/Users/<UserName>/AppData/Local/Programs/Python/Python36/libs ;
 
 Or on Linux, like this::
 
-	using python : 3.6 : /usr/bin/python3.6 : /usr/include/python3.6 : /usr/lib/python3.6 ;
+	using python : 3.7 : /usr/bin/python3.7 : /usr/include/python3.7 : /usr/lib/python3.7 ;
 
 Note that ``b2``'s python path detection is known to only work for global
 python installations. It is known to be broken for virtualenvs or ``pyenv``. If
@@ -133,7 +133,7 @@ invoking b2
 Build the bindings like so::
 
 	cd bindings/python
-	b2 release python=3.6 address-model=64
+	b2 release python=3.7 address-model=64
 
 Note that ``address-model`` should match the python installation you are
 building for.
@@ -161,14 +161,14 @@ root directory of the boost source distribution.
 
 For example, to build a self-contained python module::
 
-	b2 release python=3.6 libtorrent-link=static boost-link=static
+	b2 release python=3.7 libtorrent-link=static boost-link=static
 
 helper targets
 --------------
 
 There are some targets for placing the build artifact in a helpful location::
 
-	$ b2 release python=3.6 stage_module stage_dependencies
+	$ b2 release python=3.7 stage_module stage_dependencies
 
 This will produce a ``libtorrent`` python module in the current directory (file
 name extension depends on operating system). The libraries the python module depends
@@ -176,18 +176,18 @@ on will be copied into ``./dependencies``.
 
 To install the python module, build it with the following command::
 
-	b2 release python=3.6 install_module
+	b2 release python=3.7 install_module
 
 By default the module will be installed to the python user site. This can be
 changed with the ``python-install-scope`` feature. The valid values are ``user``
 (default) and ``system``. e.g.::
 
-	b2 release python=3.6 install_module python-install-scope=system
+	b2 release python=3.7 install_module python-install-scope=system
 
 To specify a custom installation path for the python module, specify the desired
 path with the ``python-install-path`` feature. e.g.::
 
-	b2 release python=3.6 install_module python-install-path=/home/foobar/python-site/
+	b2 release python=3.7 install_module python-install-path=/home/foobar/python-site/
 
 using libtorrent in python
 ==========================


### PR DESCRIPTION
[Python 3.6 is end-of-life as of 2021-12-23](https://peps.python.org/pep-0494/#lifespan).

In #6188 we added a requirement of python 3.7+, but only to the `setup.py` build path. The b2, autotools and cmake paths still require python 3.6+. Furthermore ubuntu-18.04 still only provides python 3.6, and [18.04 will be supported until 2023 or later](https://ubuntu.com/about/release-cycle). We probably must wait until then to drop 3.6 support, to avoid breaking too many people.

I thought we should at least bump the version in CI and documentation.