### PR TITLE
manually run pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
     #-   id: trailing-whitespace
     #-   id: end-of-file-fixer
@@ -27,17 +27,17 @@ repos:
     -   id: check-symlinks
     -   id: check-toml
 - repo: https://github.com/pappasam/toml-sort
-  rev: v0.19.0
+  rev: v0.20.1
   hooks:
   - id: toml-sort
     args: [--all, --in-place]
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.7.0
+  rev: v1.9.0
   hooks:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 - repo: https://github.com/PyCQA/isort
-  rev: 5.7.0
+  rev: 5.10.1
   hooks:
     - id: isort
       exclude: |
@@ -67,7 +67,7 @@ repos:
             tools/update_copyright.py
           )$
 - repo: https://github.com/myint/autoflake
-  rev: v1.4
+  rev: v1.5.3
   hooks:
     - id: autoflake
       args: [--in-place, --remove-unused-variables, --remove-all-unused-imports, --remove-duplicate-keys]
@@ -78,7 +78,7 @@ repos:
                bindings/python/test.py
           )
 - repo: https://github.com/python/black
-  rev: 20.8b1
+  rev: 22.8.0
   hooks:
     - id: black
       # Avoiding PR bloat
@@ -123,7 +123,7 @@ repos:
       name: black (pyi)
       types: [pyi]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.800
+  rev: v0.971
   hooks:
     - id: mypy
       # Avoiding PR bloat
@@ -160,7 +160,7 @@ repos:
               tools/update_copyright.py
           )$
 - repo: https://gitlab.com/pycqa/flake8.git
-  rev: 3.8.4
+  rev: 3.9.2
   hooks:
   - id: flake8
     exclude: |


### PR DESCRIPTION
Manually run `pre-commit autoupdate`.

In particular the `black` hook is currently outdated and doesn't work. See #7040