### PR TITLE
don't memory map files smaller than 1 MiB

### DIFF
--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -89,7 +89,8 @@ namespace aux {
 		// return an open file handle to file at ``file_index`` in the
 		// file_storage ``fs`` opened at save path ``p``. ``m`` is the
 		// file open mode (see file::open_mode_t).
-		file_view open_file(storage_index_t st, std::string const& p
+		std::shared_ptr<file_mapping>
+		open_file(storage_index_t st, std::string const& p
 			, file_index_t file_index, file_storage const& fs, open_mode_t m
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 			, std::shared_ptr<std::mutex> open_unmap_lock

--- a/include/libtorrent/aux_/mmap.hpp
+++ b/include/libtorrent/aux_/mmap.hpp
@@ -56,9 +56,11 @@ using byte = char;
 
 namespace aux {
 
-	using namespace flags;
+	// files smaller than this will not be mapped into memory, they will just
+	// have a file descriptor to be used with regular pread/pwrite calls
+	std::int64_t const mapped_file_cutoff = 1024 * 1024;
 
-	struct file_view;
+	using namespace flags;
 
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 	struct TORRENT_EXTRA_EXPORT file_mapping_handle
@@ -82,8 +84,6 @@ namespace aux {
 
 	struct TORRENT_EXTRA_EXPORT file_mapping : std::enable_shared_from_this<file_mapping>
 	{
-		friend struct file_view;
-
 		file_mapping(file_handle file, open_mode_t mode, std::int64_t file_size
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 			, std::shared_ptr<std::mutex> open_unmap_lock
@@ -102,18 +102,14 @@ namespace aux {
 		file_mapping& operator=(file_mapping&& rhs) &;
 		~file_mapping();
 
-		// ...
-		file_view view();
-
 		handle_type fd() const { return m_file.fd(); }
-	private:
 
-		void close();
+		bool has_memory_map() const { return m_mapping != nullptr; }
 
 		// the memory range this file has been mapped into
-		span<byte> memory()
+		span<byte> range()
 		{
-			TORRENT_ASSERT(m_mapping || m_size == 0);
+			TORRENT_ASSERT(m_mapping || m_size < aux::mapped_file_cutoff);
 			return { static_cast<byte*>(m_mapping), static_cast<std::ptrdiff_t>(m_size) };
 		}
 
@@ -125,6 +121,10 @@ namespace aux {
 		// flushed to disk
 		void page_out(span<byte const> range);
 
+	private:
+
+		void close();
+
 		std::int64_t m_size;
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 		file_mapping_handle m_file;
@@ -134,44 +134,6 @@ namespace aux {
 #endif
 		void* m_mapping;
 	};
-
-	struct TORRENT_EXTRA_EXPORT file_view
-	{
-		friend struct file_mapping;
-		file_view(file_view&&) = default;
-		file_view& operator=(file_view&&) = default;
-
-		span<byte const> range() const
-		{
-			TORRENT_ASSERT(m_mapping);
-			return m_mapping->memory();
-		}
-
-		span<byte> range()
-		{
-			TORRENT_ASSERT(m_mapping);
-			return m_mapping->memory();
-		}
-
-		void dont_need(span<byte const> range)
-		{
-			TORRENT_ASSERT(m_mapping);
-			m_mapping->dont_need(range);
-		}
-
-		void page_out(span<byte const> range)
-		{
-			TORRENT_ASSERT(m_mapping);
-			m_mapping->page_out(range);
-		}
-
-		handle_type fd() const { return m_mapping->fd(); }
-
-	private:
-		explicit file_view(std::shared_ptr<file_mapping> m) : m_mapping(std::move(m)) {}
-		std::shared_ptr<file_mapping> m_mapping;
-	};
-
 } // aux
 } // libtorrent
 

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -38,6 +38,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/config.hpp"
 
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
+
 #include <mutex>
 #include <atomic>
 #include <memory>
@@ -52,6 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/open_mode.hpp" // for aux::open_mode_t
 #include "libtorrent/disk_interface.hpp" // for disk_job_flags_t
+#include "libtorrent/aux_/mmap.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/optional.hpp>
@@ -62,7 +65,6 @@ namespace libtorrent {
 namespace aux {
 	struct session_settings;
 	struct file_view_pool;
-	struct file_view;
 }
 
 	struct TORRENT_EXTRA_EXPORT mmap_storage
@@ -170,9 +172,9 @@ namespace aux {
 		mutable stat_cache m_stat_cache;
 
 		// helper function to open a file in the file pool with the right mode
-		boost::optional<aux::file_view> open_file(settings_interface const&, file_index_t
+		std::shared_ptr<aux::file_mapping> open_file(settings_interface const&, file_index_t
 			, aux::open_mode_t, storage_error&) const;
-		boost::optional<aux::file_view> open_file_impl(settings_interface const&
+		std::shared_ptr<aux::file_mapping> open_file_impl(settings_interface const&
 			, file_index_t, aux::open_mode_t, storage_error&) const;
 
 		bool use_partfile(file_index_t index) const;
@@ -224,5 +226,7 @@ namespace aux {
 	};
 
 }
+
+#endif // TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 
 #endif // TORRENT_STORAGE_HPP_INCLUDED

--- a/src/file_view_pool.cpp
+++ b/src/file_view_pool.cpp
@@ -64,7 +64,8 @@ namespace libtorrent { namespace aux {
 	file_view_pool::file_view_pool(int size) : m_size(size) {}
 	file_view_pool::~file_view_pool() = default;
 
-	file_view file_view_pool::open_file(storage_index_t st, std::string const& p
+	std::shared_ptr<file_mapping>
+	file_view_pool::open_file(storage_index_t st, std::string const& p
 		, file_index_t const file_index, file_storage const& fs
 		, open_mode_t const m
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
@@ -120,7 +121,7 @@ namespace libtorrent { namespace aux {
 				std::cout << std::this_thread::get_id() << " file opened: ("
 					<< file_key.first << ", " << file_key.second << ")\n";
 #endif
-				return woe.mapping->view();
+				return woe.mapping;
 			}
 		}
 
@@ -139,7 +140,7 @@ namespace libtorrent { namespace aux {
 			auto& lru_view = m_files.get<1>();
 			lru_view.relocate(m_files.project<1>(i), lru_view.begin());
 
-			return i->mapping->view();
+			return i->mapping;
 		}
 
 		if (int(m_files.size()) >= m_size - 1)
@@ -202,7 +203,7 @@ namespace libtorrent { namespace aux {
 				lru_view.relocate(m_files.project<1>(i), lru_view.begin());
 			}
 			notify_file_open(ofe, i->mapping, storage_error());
-			return i->mapping->view();
+			return i->mapping;
 		}
 		catch (storage_error const& se)
 		{

--- a/test/test_copy_file.cpp
+++ b/test/test_copy_file.cpp
@@ -154,7 +154,6 @@ TORRENT_TEST(sparse_file)
 {
 	using lt::aux::file_handle;
 	using lt::aux::file_mapping;
-	using lt::aux::file_view;
 	namespace open_mode = lt::aux::open_mode;
 
 	{
@@ -169,8 +168,7 @@ TORRENT_TEST(sparse_file)
 			, open_unmap_lock
 #endif
 			);
-		file_view view = map->view();
-		auto range = view.range();
+		auto range = map->range();
 		TEST_CHECK(range.size() == 50'000'000);
 
 		range[0] = 1;


### PR DESCRIPTION
use pwrite/pread calls.

perhaps the file size cut-off should be configurable. That would enable not using memory mapped files at all.