### PR TITLE
Change the Nagle algorithm to allow a single undersized packet in flight at a time

### DIFF
--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -871,6 +871,12 @@ private:
 	// to that packet's sequence number
 	std::uint16_t m_fast_resend_seq_nr = 0;
 
+	// this is the sequence number of the last undersized
+	// packet that we sent. this is used to ensure there
+	// is no more than one undersized packet in flight
+	// at a time
+	std::uint16_t m_nagle_seq_nr = 0;
+
 	// this is the sequence number of the FIN packet
 	// we've received. This sequence number is only
 	// valid if m_eof is true. We should not accept

--- a/simulation/test_utp.cpp
+++ b/simulation/test_utp.cpp
@@ -139,7 +139,7 @@ TORRENT_TEST(utp_pmtud)
 	TEST_EQUAL(metric(cnt, "utp.utp_packets_in"), 593);
 	TEST_EQUAL(metric(cnt, "utp.utp_payload_pkts_in"), 66);
 
-	TEST_EQUAL(metric(cnt, "utp.utp_packets_out"), 602);
+	TEST_EQUAL(metric(cnt, "utp.utp_packets_out"), 603);
 
 	// we don't expect any invalid packets, since we're talking to ourself
 	TEST_EQUAL(metric(cnt, "utp.utp_invalid_pkts_in"), 0);
@@ -165,7 +165,7 @@ TORRENT_TEST(utp_plain)
 	TEST_EQUAL(metric(cnt, "utp.utp_packets_in"), 590);
 	TEST_EQUAL(metric(cnt, "utp.utp_payload_pkts_in"), 76);
 
-	TEST_EQUAL(metric(cnt, "utp.utp_packets_out"), 596);
+	TEST_EQUAL(metric(cnt, "utp.utp_packets_out"), 597);
 
 	// we don't expect any invalid packets, since we're talking to ourself
 	TEST_EQUAL(metric(cnt, "utp.utp_invalid_pkts_in"), 0);
@@ -188,8 +188,8 @@ TORRENT_TEST(utp_buffer_bloat)
 	TEST_EQUAL(metric(cnt, "utp.utp_fast_retransmit"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_resend"), 0);
 
-	TEST_EQUAL(metric(cnt, "utp.utp_samples_above_target"), 428);
-	TEST_EQUAL(metric(cnt, "utp.utp_samples_below_target"), 153);
+	TEST_EQUAL(metric(cnt, "utp.utp_samples_above_target"), 429);
+	TEST_EQUAL(metric(cnt, "utp.utp_samples_below_target"), 152);
 
 	TEST_EQUAL(metric(cnt, "utp.utp_packets_in"), 633);
 	TEST_EQUAL(metric(cnt, "utp.utp_payload_pkts_in"), 84);

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1523,11 +1523,12 @@ bool utp_socket_impl::send_pkt(int const flags)
 
 		// did we fill up the whole mtu?
 		// if we didn't, we may still send it if there's
-		// no bytes in flight
+		// no undersized packet currently in flight
 		if (m_bytes_in_flight > 0
 			&& int(p->size) < std::min(int(p->allocated), effective_mtu)
 			&& !force
-			&& m_nagle)
+			&& m_nagle
+			&& compare_less_wrap(m_acked_seq_nr, m_nagle_seq_nr, ACK_MASK))
 		{
 			// the packet is still not a full MSS, so put it back into the nagle
 			// packet
@@ -1559,11 +1560,12 @@ bool utp_socket_impl::send_pkt(int const flags)
 	if (m_bytes_in_flight > 0
 		&& int(p->size) < std::min(int(p->allocated), effective_mtu)
 		&& !force
-		&& m_nagle)
+		&& m_nagle
+		&& compare_less_wrap(m_acked_seq_nr, m_nagle_seq_nr, ACK_MASK))
 	{
 		// this is nagle. If we don't have a full packet
 		// worth of payload to send AND we have at least
-		// one outstanding packet, hold off. Once the
+		// one outstanding undersized packet, hold off. Once the
 		// outstanding packet is acked, we'll send this
 		// payload
 		UTP_LOGV("%8p: NAGLE not enough payload send_buffer_size:%d cwnd:%d "
@@ -1697,6 +1699,11 @@ bool utp_socket_impl::send_pkt(int const flags)
 		// we never send an mtu probe for sequence number 0
 		TORRENT_ASSERT(p->mtu_probe == (m_seq_nr == m_mtu_seq)
 			|| m_seq_nr == 0);
+
+		// If this packet is undersized then note the sequenece number so we
+		// never have more than one undersized packet in flight at once
+		if (int(p->size) < std::min(int(p->allocated), effective_mtu))
+			m_nagle_seq_nr = m_seq_nr;
 
 		// release the buffer, we're saving it in the circular
 		// buffer of outgoing packets
@@ -2366,7 +2373,7 @@ bool utp_socket_impl::incoming_packet(span<char const> b
 	// Note that when we send a FIN, we don't increment m_seq_nr
 	std::uint16_t const cmp_seq_nr =
 		((state() == state_t::syn_sent || state() == state_t::fin_sent)
-			&& ph->get_type() == ST_STATE)
+			&& (ph->get_type() == ST_STATE || ph->get_type() == ST_FIN))
 		? m_seq_nr : (m_seq_nr - 1) & ACK_MASK;
 
 	if ((state() != state_t::none || ph->get_type() != ST_SYN)


### PR DESCRIPTION
Currently, libtorrent will hold back an undersized uTP packet until all previously transmitted packets have been ack'd. This can add an extra RTT of delay when sending the last few bytes of a 'big' send (eg. a stream of data followed by a choke).

This suggested change will only hold back the undersized packet if there is currently an undersized packet in flight, essentially allowing one undersized packet to be sent per RTT. This would allow the tail of a 'big' send to go out immediatley without any extra delay.

This is done by noting the sequence number of the last undersized packet sent, as suggested [here
](https://datatracker.ietf.org/doc/html/draft-minshall-nagle-01)

See #6935
