### PR TITLE
use toolset=darwin by default on macos

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,6 @@ jobs:
       run: |
         brew update
         brew install boost-build boost boost-python3 python@3.10 openssl@1.1
-        echo "using darwin ;" >>~/user-config.jam
         export PATH=$(brew --prefix)/opt/python@3.10/bin:$PATH
 
     - name: update package lists (linux)

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -359,6 +359,10 @@ class LibtorrentBuildExt(build_ext_lib.build_ext):
             self._maybe_add_arg("--debug-generators")
 
         if sys.platform == "darwin":
+            # boost.build defaults to toolset=clang on mac. However python.jam
+            # on boost 1.77+ breaks with toolset=clang if using a framework-type
+            # python installation, such as installed by homebrew.
+            self._maybe_add_arg("toolset=darwin")
             self._maybe_add_arg("cxxstd=11")
 
         self._configure_from_autotools()


### PR DESCRIPTION
boost.build chooses `toolset=clang` by default on macos.

However I found that `python.jam` does not work with clang in boost 1.77+, when targeted to a "framework"-type python installation, which is common. In this case `python.jam` invokes features that are only defined with `toolset=darwin`.

I also see that CI had been targeting `toolset=darwin` anyway. If that's the reasonable default, then it's `setup.py`'s job to apply those defaults.