### PR TITLE
bump cibuildwheel workflow version

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -103,7 +103,7 @@ jobs:
     - uses: docker/setup-qemu-action@v1
       if: steps.cache-wheel.outputs.cache-hit != 'true' && runner.os == 'Linux'
 
-    - uses: pypa/cibuildwheel@v2.2.2
+    - uses: pypa/cibuildwheel@v2.9.0
       if: steps.cache-wheel.outputs.cache-hit != 'true'
 
     - uses: actions/upload-artifact@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires-python = ">=3.7"
 
 [tool.cibuildwheel]
-skip = "pp*"
+skip = "{pp*,cp311-*}"
 
 [tool.cibuildwheel.macos]
 before-all = [


### PR DESCRIPTION
This includes various bugfixes.

NB: As of 2.9.0, cibuildwheel now includes python 3.11 in the default list of build flavors. However boost.python is broken at runtime in python 3.11. The fix was applied in https://github.com/boostorg/python/pull/385, however the fix hasn't been included in a release, as of 1.80. We must disable python 3.11 for now.