### PR TITLE
Update state when need to save resume data

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10038,6 +10038,7 @@ namespace {
 		// these counters are saved in the resume data, since they updated
 		// we need to save the resume data too
 		m_need_save_resume_data = true;
+		state_updated();
 
 		// if the rate is 0, there's no update because of network transfers
 		if (m_stat.low_pass_upload_rate() > 0 || m_stat.low_pass_download_rate() > 0)


### PR DESCRIPTION
Otherwise checking for `torrent_status.need_save_resume_data` isn't so useful and we need yet another blocking call to `torrent_handle::need_save_resume_data()` that can wait for all the current jobs are done just to obtain this `bool` value.