### PR TITLE
use retry for windows simulations

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,6 +97,11 @@ jobs:
           cd boost
           .\b2 headers
 
+      - shell: pwsh
+        run: |
+          echo "BOOST_ROOT=$(pwd)/boost" >> $env:GITHUB_ENV
+          echo "$(pwd)/boost" >> $env:GITHUB_PATH
+
   # debug iterators are turned off here because msvc has issues with noexcept
   # specifiers when debug iterators are enabled. Specifically, constructors that
   # allocate memory are still marked as noexcept. That results in program
@@ -105,17 +110,19 @@ jobs:
   # certain unexpected terminations (through exceptions)
       - name: build sims
         run: |
-          set BOOST_ROOT=%CD%\boost
-          set PATH=%BOOST_ROOT%;%PATH%
+          echo %BOOST_ROOT%
+          echo %PATH%
           cd simulation
           b2 --hash release address-model=64 link=static debug-iterators=off invariant-checks=on define=BOOST_ASIO_DISABLE_IOCP asserts=on testing.execute=off
 
       - name: run sims
-        run: |
-          set BOOST_ROOT=%CD%\boost
-          set PATH=%BOOST_ROOT%;%PATH%
-          cd simulation
-          b2 --hash -l700 release address-model=64 link=static debug-iterators=off invariant-checks=on define=BOOST_ASIO_DISABLE_IOCP asserts=on
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 120
+          command: |
+            cd simulation
+            b2 --hash -l700 release address-model=64 link=static debug-iterators=off invariant-checks=on define=BOOST_ASIO_DISABLE_IOCP asserts=on
 
    build:
       name: Build


### PR DESCRIPTION
The simulations on Windows are flaky. Let's use a retry loop for them.

Same as #7069 but for Windows simulations on `RC_2_0`