### PR TITLE
make `setup.py` identical on all branches

### DIFF
--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,0 +1,2 @@
+[build_ext]
+cxxstd = 11

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,2 +1,3 @@
 [build_ext]
 cxxstd = 11
+configure_from_autotools = true

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+version = 1.2.17
+
 [build_ext]
 cxxstd = 11
 configure_from_autotools = true

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -538,7 +538,6 @@ def find_all_files(path: str) -> Iterator[str]:
 
 setuptools.setup(
     name="libtorrent",
-    version="1.2.17",
     author="Arvid Norberg",
     author_email="arvid@libtorrent.org",
     description="Python bindings for libtorrent-rasterbar",

--- a/tools/set_version.py
+++ b/tools/set_version.py
@@ -45,8 +45,8 @@ def substitute_file(name):
             line = ':Version: %d.%d.%d\n' % (version[0], version[1], version[2])
         elif 'VERSION=' in line and name.endswith('build_dist.sh'):
             line = 'VERSION=%d.%d.%d\n' % (version[0], version[1], version[2])
-        elif 'version=' in line and name.endswith('setup.py'):
-            line = '    version="%d.%d.%d",\n' % (version[0], version[1], version[2])
+        elif 'version = ' in line and name.endswith('setup.cfg'):
+            line = '    version = "%d.%d.%d",\n' % (version[0], version[1], version[2])
         elif '"-LT' in line and name.endswith('settings_pack.cpp'):
             line = re.sub('"-LT[0-9A-Za-z]{4}-"', '"-LT%c%c%c%c-"' % v(version), line)
         elif 'local FULL_VERSION = ' in line and name == 'Jamfile':
@@ -62,7 +62,7 @@ substitute_file('include/libtorrent/version.hpp')
 substitute_file('CMakeLists.txt')
 substitute_file('configure.ac')
 substitute_file('build_dist.sh')
-substitute_file('bindings/python/setup.py')
+substitute_file('bindings/python/setup.cfg')
 substitute_file('docs/gen_reference_doc.py')
 substitute_file('src/settings_pack.cpp')
 for i in glob.glob('docs/*.rst'):


### PR DESCRIPTION
This makes `setup.py` identical on all branches.

I will continue to make changes to `setup.py` as I continue to find "quirks" in boost.build. This should make it easier for you to merge my changes.

I moved the version number and `cxxstd` value to `setup.cfg`. This works because distutils/setuptools use `setup.cfg` as a source of default argument values for various functions, so we can put anything in there with no special logic in `setup.py`.

Note that we now have two separate `setup.cfg`s. This is because having two separate `setup.py`s is a hack, and starting to show cracks. It might be nice to move some things to the root.

This also makes the following functional changes:
* `setup.py` is now sensitive to `b2 --version`. This may not be the best way to determine the version of `b2`, since the output of `b2 --version` did not always change in each release (!), but it was the best thing I could find
* Always pass `cxxstd=`, if supported by b2
* If `project-config.jam` exists, don't (over)-write our own

I think these commits are reasonable and don't need to be squashed.

I tested that these commits work well when merged to `RC_2_0` and `master`. See https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/70 and https://github.com/AllSeeingEyeTolledEweSew/libtorrent/pull/71