### PR TITLE
bump boost version used in cibuildwheel for musllinux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test-command = [
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
-BOOST_VERSION = "1.76.0"
+BOOST_VERSION = "1.77.0"
 PATH = "/usr/lib/ccache/bin:/tmp/boost:$PATH"
 
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
This bumps the version of boost used when compiling python wheels on musllinux (alpine).

This segfaults when running the python tests. I've confirmed this happens with every boost version after 1.76.

@arvidn can you help me investigate?