### PR TITLE
bump boost versions and windows-* runner for cibuildwheel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -48,7 +48,7 @@ jobs:
             {"os": "ubuntu-latest", "CIBW_BUILD": "cp37-manylinux_*", "CIBW_ARCHS": "x86_64"},
             {"os": "ubuntu-latest", "CIBW_BUILD": "cp37-musllinux_*", "CIBW_ARCHS": "x86_64"},
             {"os": "macos-12", "CIBW_BUILD": "cp37-*", "CIBW_ARCHS": "x86_64"},
-            {"os": "windows-2019", "CIBW_BUILD": "cp37-*", "CIBW_ARCHS": "AMD64"}
+            {"os": "windows-2022", "CIBW_BUILD": "cp37-*", "CIBW_ARCHS": "AMD64"}
           ]
         }
       MATRIX_WORKFLOW_DISPATCH: |
@@ -59,8 +59,8 @@ jobs:
             {"os": "ubuntu-latest", "CIBW_BUILD": "cp*-musllinux_*", "CIBW_ARCHS": "x86_64"},
             {"os": "ubuntu-latest", "CIBW_BUILD": "cp*-musllinux_*", "CIBW_ARCHS": "aarch64"},
             {"os": "macos-12", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "x86_64"},
-            {"os": "windows-2019", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "x86"},
-            {"os": "windows-2019", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "AMD64"}
+            {"os": "windows-2022", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp*", "CIBW_ARCHS": "AMD64"}
           ]
         }
 

--- a/bindings/python/src/boost_python.hpp
+++ b/bindings/python/src/boost_python.hpp
@@ -7,6 +7,8 @@
 
 #include <cstdio>
 #include <libtorrent/aux_/disable_warnings_push.hpp>
+// https://github.com/boostorg/system/issues/32#issuecomment-462912013
+#define HAVE_SNPRINTF
 #include <boost/python.hpp>
 
 #include <boost/bind/placeholders.hpp>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ test-command = [
 [tool.cibuildwheel.macos.environment]
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
-BOOST_VERSION = "1.76.0"
+BOOST_VERSION = "1.80.0"
 MACOSX_DEPLOYMENT_TARGET = "10.9"  # required for full C++11 support
 PATH = "/tmp/boost:$PATH"
 
@@ -38,7 +38,7 @@ test-command = [
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
-BOOST_VERSION = "1.76.0"
+BOOST_VERSION = "1.80.0"
 PATH = "/usr/local/ccache/bin:/tmp/boost:$PATH"
 
 [[tool.cibuildwheel.overrides]]
@@ -80,7 +80,7 @@ test-command = '''bash -c "cd '{project}/bindings/python' && python test.py"'''
 [tool.cibuildwheel.windows.environment]
 BOOST_BUILD_PATH = 'c:/boost/tools/build'
 BOOST_ROOT = 'c:/boost'
-BOOST_VERSION = "1.76.0"
+BOOST_VERSION = "1.80.0"
 PATH = 'c:/boost;$PATH'
 
 [tool.isort]


### PR DESCRIPTION
* Bump the cibuildwheel windows runner environment to `windows-2022`
* Bump the boost version used in cibuildwheel to latest (1.80)
  * ...except for the musllinux wheel due to a segfault, See #7074

Bumping the boost version was necessary for `windows-2022`, to pick up support for msvc-14.3. I would have bumped it anyway since we should probably always be statically linking the wheel with the newest boost.

The random `HAVE_SNPRINTF` define is necessary with the newer boost version. See https://github.com/boostorg/system/issues/32#issuecomment-462912013. We never hit this previously this because it's triggered by a combination of newer boost *and* older python. Our regular windows python build CI currently uses python 3.9, whereas cibuildwheel always uses the oldest supported python (3.7)