### PR TITLE
improve error reporting from file copy and move

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* improve error reporting from file copy and move
 	* tweak pad file placement to match reference implementation (tail-padding)
 	* uTP performance, more lenient nagle's algorithm to always allow one outstanding undersized packet
 	* uTP performance, piggy-back held back undersized packet with ACKs

--- a/include/libtorrent/aux_/path.hpp
+++ b/include/libtorrent/aux_/path.hpp
@@ -116,10 +116,6 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT bool exists(std::string const& f, error_code& ec);
 	TORRENT_EXTRA_EXPORT bool is_directory(std::string const& f
 		, error_code& ec);
-	TORRENT_EXTRA_EXPORT void copy_file(std::string const& f
-		, std::string const& newf, error_code& ec);
-	TORRENT_EXTRA_EXPORT void move_file(std::string const& f
-		, std::string const& newf, error_code& ec);
 
 	// file is expected to exist, link will be created to point to it. If hard
 	// links are not supported by the filesystem or OS, the file will be copied.

--- a/include/libtorrent/aux_/storage_utils.hpp
+++ b/include/libtorrent/aux_/storage_utils.hpp
@@ -119,6 +119,12 @@ namespace aux {
 		std::string const& target
 		, std::string const& link
 		, storage_error& ec);
+
+	TORRENT_EXTRA_EXPORT void move_file(std::string const& f
+		, std::string const& newf, storage_error& se);
+
+	TORRENT_EXTRA_EXPORT void copy_file(std::string const& f
+		, std::string const& newf, storage_error& ec);
 }}
 
 #endif

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/aux_/path.hpp"
+#include "libtorrent/aux_/storage_utils.hpp"
 
 #ifdef TORRENT_WINDOWS
 // windows part
@@ -61,6 +62,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 namespace libtorrent {
+namespace aux {
 
 #ifdef TORRENT_WINDOWS
 namespace {
@@ -111,7 +113,7 @@ std::pair<std::int64_t, std::int64_t> next_allocated_region(HANDLE file
 }
 
 void copy_range(HANDLE const in_handle, HANDLE const out_handle
-	, std::int64_t in_offset, std::int64_t len, error_code& ec)
+	, std::int64_t in_offset, std::int64_t len, storage_error& se)
 {
 	char buffer[16384];
 	while (len > 0)
@@ -126,7 +128,8 @@ void copy_range(HANDLE const in_handle, HANDLE const out_handle
 			int const error = ::GetLastError();
 			if (error == ERROR_HANDLE_EOF) return;
 
-			ec.assign(error, system_category());
+			se.operation = operation_t::file_read;
+			se.ec.assign(error, system_category());
 			return;
 		}
 
@@ -141,7 +144,8 @@ void copy_range(HANDLE const in_handle, HANDLE const out_handle
 			if (WriteFile(out_handle, buffer + buf_offset, DWORD(num_read - buf_offset)
 				, &num_written, &out_ol) == 0)
 			{
-				ec.assign(::GetLastError(), system_category());
+				se.operation = operation_t::file_write;
+				se.ec.assign(::GetLastError(), system_category());
 				return;
 			}
 			buf_offset += num_written;
@@ -154,16 +158,17 @@ void copy_range(HANDLE const in_handle, HANDLE const out_handle
 
 }
 
-void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
+void copy_file(std::string const& inf, std::string const& newf, storage_error& se)
 {
-	ec.clear();
+	se.ec.clear();
 	native_path_string f1 = convert_to_native_path_string(inf);
 	native_path_string f2 = convert_to_native_path_string(newf);
 
 	WIN32_FILE_ATTRIBUTE_DATA in_stat;
 	if (!GetFileAttributesExW(f1.c_str(), GetFileExInfoStandard, &in_stat))
 	{
-		ec.assign(GetLastError(), system_category());
+		se.ec.assign(GetLastError(), system_category());
+		se.operation = operation_t::file_stat;
 		return;
 	}
 
@@ -171,7 +176,10 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	{
 		// if the input file is not sparse, use the system copy function
 		if (CopyFileW(f1.c_str(), f2.c_str(), false) == 0)
-			ec.assign(GetLastError(), system_category());
+		{
+			se.operation = operation_t::file_copy;
+			se.ec.assign(GetLastError(), system_category());
+		}
 		return;
 	}
 
@@ -195,7 +203,8 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 #endif
 	if (in_handle.handle() == INVALID_HANDLE_VALUE)
 	{
-		ec.assign(GetLastError(), system_category());
+		se.operation = operation_t::file_open;
+		se.ec.assign(GetLastError(), system_category());
 		return;
 	}
 
@@ -216,7 +225,8 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 #endif
 	if (out_handle.handle() == INVALID_HANDLE_VALUE)
 	{
-		ec.assign(GetLastError(), system_category());
+		se.operation = operation_t::file_open;
+		se.ec.assign(GetLastError(), system_category());
 		return;
 	}
 
@@ -224,18 +234,23 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 	if (::DeviceIoControl(out_handle.handle(), FSCTL_SET_SPARSE
 		, nullptr, 0, nullptr, 0, &temp, nullptr) == 0)
 	{
-		ec.assign(GetLastError(), system_category());
+		se.operation = operation_t::iocontrol;
+		se.ec.assign(GetLastError(), system_category());
 		return;
 	}
 
 	std::pair<std::int64_t, std::int64_t> data(0, 0);
 	for (;;)
 	{
-		data = next_allocated_region(in_handle.handle(), data.second, in_size, ec);
-		if (ec) return;
+		data = next_allocated_region(in_handle.handle(), data.second, in_size, se.ec);
+		if (se.ec)
+		{
+			se.operation = operation_t::iocontrol;
+			return;
+		}
 
-		copy_range(in_handle.handle(), out_handle.handle(), data.first, data.second - data.first, ec);
-		if (ec) return;
+		copy_range(in_handle.handle(), out_handle.handle(), data.first, data.second - data.first, se);
+		if (se) return;
 		// There's a possible time-of-check-time-of-use race here.
 		// The source file may have grown during the copy operation, in which
 		// case data.second may exceed the initial size
@@ -254,7 +269,7 @@ struct copy_range_mode
 };
 
 ssize_t copy_range_fallback(int const fd_in, int const fd_out, off_t in_offset
-	, std::int64_t len, error_code& ec)
+	, std::int64_t len, storage_error& se)
 {
 	char buffer[16384];
 	ssize_t total_copied = 0;
@@ -265,7 +280,8 @@ ssize_t copy_range_fallback(int const fd_in, int const fd_out, off_t in_offset
 		if (num_read == 0) return total_copied;
 		if (num_read < 0)
 		{
-			ec.assign(errno, system_category());
+			se.operation = operation_t::file_read;
+			se.ec.assign(errno, system_category());
 			return -1;
 		}
 		len -= num_read;
@@ -276,7 +292,8 @@ ssize_t copy_range_fallback(int const fd_in, int const fd_out, off_t in_offset
 				, std::size_t(num_read - buf_offset), in_offset);
 			if (ret <= 0)
 			{
-				ec.assign(errno, system_category());
+				se.operation = operation_t::file_write;
+				se.ec.assign(errno, system_category());
 				return -1;
 			}
 			buf_offset += ret;
@@ -289,11 +306,11 @@ ssize_t copy_range_fallback(int const fd_in, int const fd_out, off_t in_offset
 }
 
 ssize_t copy_range(int const fd_in, int const fd_out, off_t in_offset
-	, std::int64_t len, copy_range_mode* const m, error_code& ec)
+	, std::int64_t len, copy_range_mode* const m, storage_error& se)
 {
 #if TORRENT_HAS_COPY_FILE_RANGE
 	if (m->use_fallback)
-		return copy_range_fallback(fd_in, fd_out, in_offset, len, ec);
+		return copy_range_fallback(fd_in, fd_out, in_offset, len, se);
 
 	ssize_t total_copied = 0;
 	off_t out_offset = in_offset;
@@ -305,12 +322,13 @@ ssize_t copy_range(int const fd_in, int const fd_out, off_t in_offset
 		if (ret < 0)
 		{
 			int const err = errno;
-			if (err == EXDEV)
+			if (err == EXDEV || err == ENOTSUP)
 			{
 				m->use_fallback = true;
-				return copy_range_fallback(fd_in, fd_out, in_offset, len, ec);
+				return copy_range_fallback(fd_in, fd_out, in_offset, len, se);
 			}
-			ec.assign(err, system_category());
+			se.operation = operation_t::file_copy;
+			se.ec.assign(err, system_category());
 			return -1;
 		}
 
@@ -320,29 +338,31 @@ ssize_t copy_range(int const fd_in, int const fd_out, off_t in_offset
 	return total_copied;
 #else
 	TORRENT_UNUSED(m);
-	return copy_range_fallback(fd_in, fd_out, in_offset, len, ec);
+	return copy_range_fallback(fd_in, fd_out, in_offset, len, se);
 #endif
 }
 
 } // anonymous namespace
 
-void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
+void copy_file(std::string const& inf, std::string const& newf, storage_error& se)
 {
-	ec.clear();
+	se.ec.clear();
 	native_path_string f1 = convert_to_native_path_string(inf);
 	native_path_string f2 = convert_to_native_path_string(newf);
 
 	aux::file_descriptor const infd = ::open(f1.c_str(), O_RDONLY);
 	if (infd.fd() < 0)
 	{
-		ec.assign(errno, system_category());
+		se.operation = operation_t::file_stat;
+		se.ec.assign(errno, system_category());
 		return;
 	}
 
 	struct stat in_stat;
 	if (::fstat(infd.fd(), &in_stat) != 0)
 	{
-		ec.assign(errno, system_category());
+		se.operation = operation_t::file_stat;
+		se.ec.assign(errno, system_category());
 		return;
 	}
 
@@ -355,7 +375,8 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 		, input_is_sparse ? (O_RDWR | O_CREAT | O_TRUNC) : (O_RDWR | O_CREAT), in_stat.st_mode);
 	if (outfd.fd() < 0)
 	{
-		ec.assign(errno, system_category());
+		se.operation = operation_t::file_open;
+		se.ec.assign(errno, system_category());
 		return;
 	}
 
@@ -367,7 +388,10 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 		// this only works on 10.5
 		copyfile_state_t state = copyfile_state_alloc();
 		if (fcopyfile(infd.fd(), outfd.fd(), state, COPYFILE_ALL) < 0)
-			ec.assign(errno, system_category());
+		{
+			se.operation = operation_t::file_copy;
+			se.ec.assign(errno, system_category());
+		}
 		copyfile_state_free(state);
 		return;
 	}
@@ -375,7 +399,8 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 
 	if (::ftruncate(outfd.fd(), in_stat.st_size) < 0)
 	{
-		ec.assign(errno, system_category());
+		se.operation = operation_t::file_truncate;
+		se.ec.assign(errno, system_category());
 		return;
 	}
 
@@ -391,18 +416,20 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 			data_start = ::lseek(infd.fd(), data_end, SEEK_DATA);
 			if (data_start == off_t(-1))
 			{
-				ec.assign(errno, system_category());
+				se.operation = operation_t::file_seek;
+				se.ec.assign(errno, system_category());
 				return;
 			}
 
 			data_end = ::lseek(infd.fd(), data_start, SEEK_HOLE);
 			if (data_end == off_t(-1))
 			{
-				ec.assign(errno, system_category());
+				se.operation = operation_t::file_seek;
+				se.ec.assign(errno, system_category());
 				return;
 			}
 
-			ret = copy_range(infd.fd(), outfd.fd(), data_start, data_end - data_start, &m, ec);
+			ret = copy_range(infd.fd(), outfd.fd(), data_start, data_end - data_start, &m, se);
 			if (ret <= 0) return;
 			if (data_end == in_stat.st_size) return;
 		}
@@ -410,10 +437,11 @@ void copy_file(std::string const& inf, std::string const& newf, error_code& ec)
 #endif
 
 	copy_range_mode m;
-	copy_range(infd.fd(), outfd.fd(), 0, in_stat.st_size, &m, ec);
+	copy_range(infd.fd(), outfd.fd(), 0, in_stat.st_size, &m, se);
 }
 
 #endif // TORRENT_WINDOWS
 
+}
 }
 

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -416,16 +416,20 @@ void copy_file(std::string const& inf, std::string const& newf, storage_error& s
 			data_start = ::lseek(infd.fd(), data_end, SEEK_DATA);
 			if (data_start == off_t(-1))
 			{
+				int const err = errno;
+				if (err == ENOTSUP) break;
 				se.operation = operation_t::file_seek;
-				se.ec.assign(errno, system_category());
+				se.ec.assign(err, system_category());
 				return;
 			}
 
 			data_end = ::lseek(infd.fd(), data_start, SEEK_HOLE);
 			if (data_end == off_t(-1))
 			{
+				int const err = errno;
+				if (err == ENOTSUP) break;
 				se.operation = operation_t::file_seek;
-				se.ec.assign(errno, system_category());
+				se.ec.assign(err, system_category());
 				return;
 			}
 

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -410,7 +410,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 			if (ec.ec)
 			{
 				ec.file(index);
-				ec.operation = operation_t::file_rename;
+				ec.operation = operation_t::mkdir;
 				return;
 			}
 
@@ -425,12 +425,11 @@ error_code translate_error(std::system_error const& err, bool const write)
 			if (ec)
 			{
 				ec.ec.clear();
-				copy_file(old_name, new_path, ec.ec);
+				aux::copy_file(old_name, new_path, ec);
 
 				if (ec)
 				{
 					ec.file(index);
-					ec.operation = operation_t::file_rename;
 					return;
 				}
 
@@ -442,7 +441,7 @@ error_code translate_error(std::system_error const& err, bool const write)
 		{
 			// if exists fails, report that error
 			ec.file(index);
-			ec.operation = operation_t::file_rename;
+			ec.operation = operation_t::file_stat;
 			return;
 		}
 

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -325,7 +325,9 @@ namespace libtorrent {
 
 			if (ec)
 			{
-				copy_file(old_path, new_path, ec);
+				storage_error se;
+				aux::copy_file(old_path, new_path, se);
+				ec = se.ec;
 				if (ec) return;
 				remove(old_path, ec);
 			}

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -107,6 +107,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif // posix part
 
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
+#include "libtorrent/aux_/storage_utils.hpp" // copy_file
 
 namespace libtorrent {
 
@@ -444,7 +445,9 @@ namespace {
 #endif
 
 		// if we get here, we should copy the file
-		copy_file(file, link, ec);
+		storage_error se;
+		aux::copy_file(file, link, se);
+		ec = se.ec;
 	}
 
 	bool is_directory(std::string const& f, error_code& ec)
@@ -456,23 +459,6 @@ namespace {
 		if (!e && s.mode & file_status::directory) return true;
 		ec = e;
 		return false;
-	}
-
-	void move_file(std::string const& inf, std::string const& newf, error_code& ec)
-	{
-		ec.clear();
-
-		file_status s;
-		stat_file(inf, &s, ec);
-		if (ec) return;
-
-		if (has_parent_path(newf))
-		{
-			create_directories(parent_path(newf), ec);
-			if (ec) return;
-		}
-
-		rename(inf, newf, ec);
 	}
 
 	std::string extension(std::string const& f)

--- a/src/posix_part_file.cpp
+++ b/src/posix_part_file.cpp
@@ -360,7 +360,9 @@ namespace aux {
 
 			if (ec)
 			{
-				copy_file(old_path, new_path, ec);
+				storage_error se;
+				aux::copy_file(old_path, new_path, se);
+				ec = se.ec;
 				if (ec) return;
 				remove(old_path, ec);
 			}

--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -205,7 +205,6 @@ namespace libtorrent { namespace aux {
 
 		// track how far we got in case of an error
 		file_index_t file_index{};
-		error_code e;
 		for (auto const i : f.file_range())
 		{
 			// files moved out to absolute paths are not moved
@@ -224,36 +223,35 @@ namespace libtorrent { namespace aux {
 			// TODO: ideally, if we end up copying files because of a move across
 			// volumes, the source should not be deleted until they've all been
 			// copied. That would let us rollback with higher confidence.
-			move_file(old_path, new_path, e);
+			move_file(old_path, new_path, ec);
 
 			// if the source file doesn't exist. That's not a problem
 			// we just ignore that file
-			if (e == boost::system::errc::no_such_file_or_directory)
-				e.clear();
-			else if (e
-				&& e != boost::system::errc::invalid_argument
-				&& e != boost::system::errc::permission_denied)
+			if (ec.ec == boost::system::errc::no_such_file_or_directory)
+				ec.ec.clear();
+			else if (ec
+				&& ec.ec != boost::system::errc::invalid_argument
+				&& ec.ec != boost::system::errc::permission_denied)
 			{
 				// moving the file failed
 				// on OSX, the error when trying to rename a file across different
 				// volumes is EXDEV, which will make it fall back to copying.
-				e.clear();
-				copy_file(old_path, new_path, e);
-				if (!e) copied_files[i] = true;
+				ec.ec.clear();
+				copy_file(old_path, new_path, ec);
+				if (!ec) copied_files[i] = true;
 			}
 
-			if (e)
+			if (ec)
 			{
-				ec.ec = e;
 				ec.file(i);
-				ec.operation = operation_t::file_rename;
 				file_index = i;
 				break;
 			}
 		}
 
-		if (!e && move_partfile)
+		if (!ec && move_partfile)
 		{
+			error_code e;
 			move_partfile(new_save_path, e);
 			if (e)
 			{
@@ -263,7 +261,7 @@ namespace libtorrent { namespace aux {
 			}
 		}
 
-		if (e)
+		if (ec)
 		{
 			// rollback
 			while (--file_index >= file_index_t(0))
@@ -279,7 +277,7 @@ namespace libtorrent { namespace aux {
 				std::string const new_path = combine_path(new_save_path, f.file_path(file_index));
 
 				// ignore errors when rolling back
-				error_code ignore;
+				storage_error ignore;
 				move_file(new_path, old_path, ignore);
 			}
 
@@ -732,6 +730,33 @@ std::int64_t get_filesize(stat_cache& stat, file_index_t const file_index
 		TORRENT_UNUSED(link);
 		TORRENT_UNUSED(ec);
 #endif
+	}
+
+	void move_file(std::string const& inf, std::string const& newf, storage_error& se)
+	{
+		se.ec.clear();
+
+		file_status s;
+		stat_file(inf, &s, se.ec);
+		if (se)
+		{
+			se.operation = operation_t::file_stat;
+			return;
+		}
+
+		if (has_parent_path(newf))
+		{
+			create_directories(parent_path(newf), se.ec);
+			if (se)
+			{
+				se.operation = operation_t::mkdir;
+				return;
+			}
+		}
+
+		rename(inf, newf, se.ec);
+		if (se)
+			se.operation = operation_t::file_rename;
 	}
 
 }}

--- a/test/test_copy_file.cpp
+++ b/test/test_copy_file.cpp
@@ -138,13 +138,13 @@ bool fs_supports_sparse_files()
 TORRENT_TEST(basic)
 {
 	write_file("basic-1", 10);
-	lt::error_code ec;
-	lt::copy_file("basic-1", "basic-1.copy", ec);
+	lt::storage_error ec;
+	lt::aux::copy_file("basic-1", "basic-1.copy", ec);
 	TEST_CHECK(!ec);
 	TEST_CHECK(compare_files("basic-1", "basic-1.copy"));
 
 	write_file("basic-2", 1000000);
-	lt::copy_file("basic-2", "basic-2.copy", ec);
+	lt::aux::copy_file("basic-2", "basic-2.copy", ec);
 	TEST_CHECK(!ec);
 	TEST_CHECK(compare_files("basic-2", "basic-2.copy"));
 }
@@ -200,8 +200,8 @@ TORRENT_TEST(sparse_file)
 		TEST_CHECK(original_size >= 50'000'000);
 	}
 
-	lt::error_code ec;
-	lt::copy_file("sparse-1", "sparse-1.copy", ec);
+	lt::storage_error ec;
+	lt::aux::copy_file("sparse-1", "sparse-1.copy", ec);
 	TEST_CHECK(!ec);
 
 	// make sure the copy is sparse

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -552,11 +552,12 @@ TORRENT_TEST(unc_tests)
 	TEST_CHECK(!exists(long_file_name1));
 	TEST_CHECK(exists(long_file_name2));
 
-	lt::copy_file(long_file_name2, long_file_name1, ec);
-	TEST_EQUAL(ec, error_code());
-	if (ec)
+	lt::storage_error se;
+	lt::aux::copy_file(long_file_name2, long_file_name1, se);
+	TEST_EQUAL(se.ec, error_code());
+	if (se.ec)
 	{
-		std::cout << "copy_file \"" << long_file_name2 << "\" failed " << ec.message() << "\n";
+		std::cout << "copy_file \"" << long_file_name2 << "\" failed " << se.ec.message() << "\n";
 		std::wcout << convert_to_native_path_string(long_file_name2) << L"\n";
 	}
 	TEST_CHECK(exists(long_file_name1));


### PR DESCRIPTION
This makes `copy_file` and `move_file` report higher fidelity errors, by changing their error types from `error_code` to `storage_error`, allowing them to report the underlying operation that failed.

This patch also corrects a few places where the operation was incorrectly reported as `file_rename`.

Lastly it adds one more error code (`ENOTSUP`) to when `copy_file_range()` will fall back to a plain read+write loop for copying files.