### PR TITLE
Fix uTP packets being timed out and resent before the minimum timeout has passed

### DIFF
--- a/simulation/test_torrent_status.cpp
+++ b/simulation/test_torrent_status.cpp
@@ -480,8 +480,8 @@ TORRENT_TEST(active_timer_no_seed)
 			{
 				// some part of the simulation is not deterministic, and causes this to vary
 				// between platforms/compilers
-				TEST_CHECK(active_time >= 10);
-				TEST_CHECK(active_time <= 14);
+				TEST_CHECK(active_time >= 6);
+				TEST_CHECK(active_time <= 9);
 			}
 
 			torrent_status st = handle.status();

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1673,7 +1673,18 @@ bool utp_socket_impl::send_pkt(int const flags)
 	}
 
 	if (!m_stalled)
+	{
 		++p->num_transmissions;
+		// Only reset the timeout for the initial packet
+		if (m_bytes_in_flight == 0)
+		{
+			m_timeout = now + milliseconds(packet_timeout());
+#if TORRENT_UTP_LOG
+			UTP_LOGV("%8p: updating timeout to: now + %d\n"
+			, static_cast<void*>(this), packet_timeout());
+#endif
+		}
+	}
 
 	// Any queued up deferred ack is now redundant
 	if (m_deferred_ack)
@@ -2463,12 +2474,6 @@ bool utp_socket_impl::incoming_packet(span<char const> b
 
 	++m_in_packets;
 
-	// this is a valid incoming packet, update the timeout timer
-	m_num_timeouts = 0;
-	m_timeout = receive_time + milliseconds(packet_timeout());
-	UTP_LOGV("%8p: updating timeout to: now + %d\n"
-		, static_cast<void*>(this), packet_timeout());
-
 	// the test for INT_MAX here is a work-around for a bug in uTorrent where
 	// it's sometimes sent as INT_MAX when it is in fact uninitialized
 	const std::uint32_t sample = ph->timestamp_difference_microseconds == INT_MAX
@@ -2578,6 +2583,13 @@ bool utp_socket_impl::incoming_packet(span<char const> b
 		ptr += len;
 		extension = next_extension;
 	}
+
+	// this is a valid incoming packet, update the timeout timer
+	// do this after processing sacks/acks as that can effect packet_timeout()
+	m_num_timeouts = 0;
+	m_timeout = receive_time + milliseconds(packet_timeout());
+	UTP_LOGV("%8p: updating timeout to: now + %d\n"
+		, static_cast<void*>(this), packet_timeout());
 
 	// the send operation in parse_sack() may have set the socket to an error
 	// state, in which case we shouldn't continue

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -3102,18 +3102,15 @@ void utp_socket_impl::do_ledbat(const int acked_bytes, const int delay
 		, scaled_gain / double(1 << 16), int(m_cwnd >> 16)
 		, int(m_slow_start));
 
-	// if scaled_gain + m_cwnd <= 0, set m_cwnd to 0
-	if (-scaled_gain >= m_cwnd)
-	{
-		m_cwnd = 0;
-	}
+	// don't drop below 1*MSS. This behavior is from rfc6817 (LEDBAT). This differs
+	// from BEP 29 which allows cwnd to drop to 0, however this way avoids needing
+	// to wait until the next timeout to resume sending.
+	if ((m_cwnd + scaled_gain) >> 16 < m_mtu)
+		m_cwnd = std::int64_t(m_mtu) * (1 << 16);
 	else
-	{
 		m_cwnd += scaled_gain;
-		TORRENT_ASSERT(m_cwnd > 0);
-	}
 
-	TORRENT_ASSERT(m_cwnd >= 0);
+	TORRENT_ASSERT((m_cwnd >> 16) >= m_mtu);
 
 	int const window_size_left = std::min(int(m_cwnd >> 16), int(m_adv_wnd)) - in_flight + acked_bytes;
 	if (window_size_left >= m_mtu)


### PR DESCRIPTION
Currently the time of the next uTP timeout is set on socket creation, when a packet is received, and every time the timeout itself happens. If a packet is sent just before the next timeout expires, which can happen on an otherwise idle connection with no regular incoming packets to reset it, it can be unnecessarily timed out and resent.

This patch fixes it by updating the next timeout when a packet is sent. It also moves updating the timeout in `incoming_packet()` to after sacks/acks have been read as this can effect the timeout duration.

The BEP has timeouts getting updated every time a packet is both sent and received:

> Every time a socket sends or receives a packet, it updates its timeout counter. If no packet has arrived within timeout number of milliseconds from the last timeout counter reset, the socket triggers a timeout.
