### PR TITLE
settings_pack returns default values when queried for missing settings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* settings_pack now returns default values when queried for missing settings
 	* fix copy_file fall-back when SEEK_HOL/SEEK_DATA is not supported
 	* improve error reporting from file copy and move
 	* tweak pad file placement to match reference implementation (tail-padding)

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -127,6 +127,11 @@ namespace aux {
 	// ``set_int()``, ``set_bool()`` functions, to specify the setting to
 	// change.
 	//
+	// The ``settings_pack`` only stores values for settings that have been
+	// explicitly set on this object. However, it can still be queried for
+	// settings that have not been set and returns the default value for those
+	// settings.
+	//
 	// .. include:: settings-ref.rst
 	//
 	struct TORRENT_EXPORT settings_pack final : settings_interface
@@ -166,7 +171,8 @@ namespace aux {
 		// queries the current configuration option from the settings_pack.
 		// ``name`` is one of the enumeration values from string_types, int_types
 		// or bool_types. The enum value must match the type of the get_*
-		// function.
+		// function. If the specified setting field has not been set, the default
+		// value is returned.
 		std::string const& get_str(int name) const override;
 		int get_int(int name) const override;
 		bool get_bool(int name) const override;

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -773,7 +773,13 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		auto i = std::lower_bound(m_strings.begin(), m_strings.end(), v
 				, &compare_first<std::string>);
 		if (i != m_strings.end() && i->first == name) return i->second;
-		return empty;
+
+		if (str_settings[name & index_mask].default_value == nullptr)
+			return empty;
+
+		static std::string tmp;
+		tmp = str_settings[name & index_mask].default_value;
+		return tmp;
 	}
 
 	int settings_pack::get_int(int name) const
@@ -792,7 +798,8 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		auto i = std::lower_bound(m_ints.begin(), m_ints.end(), v
 				, &compare_first<int>);
 		if (i != m_ints.end() && i->first == name) return i->second;
-		return 0;
+
+		return int_settings[name & index_mask].default_value;
 	}
 
 	bool settings_pack::get_bool(int name) const
@@ -811,7 +818,8 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		auto i = std::lower_bound(m_bools.begin(), m_bools.end(), v
 			, &compare_first<bool>);
 		if (i != m_bools.end() && i->first == name) return i->second;
-		return false;
+
+		return bool_settings[name & index_mask].default_value;
 	}
 
 	void settings_pack::clear()

--- a/test/test_settings_pack.cpp
+++ b/test/test_settings_pack.cpp
@@ -167,19 +167,21 @@ TORRENT_TEST(clear_single_int)
 
 	sp.clear(settings_pack::max_out_request_queue);
 
-	TEST_EQUAL(sp.get_int(settings_pack::max_out_request_queue), 0);
+	// when cleared, we'll get the default value
+	TEST_EQUAL(sp.get_int(settings_pack::max_out_request_queue), 500);
 }
 
 TORRENT_TEST(clear_single_bool)
 {
 	settings_pack sp;
-	sp.set_bool(settings_pack::send_redundant_have, true);
+	sp.set_bool(settings_pack::send_redundant_have, false);
 
-	TEST_EQUAL(sp.get_bool(settings_pack::send_redundant_have), true);
+	TEST_EQUAL(sp.get_bool(settings_pack::send_redundant_have), false);
 
 	sp.clear(settings_pack::send_redundant_have);
 
-	TEST_EQUAL(sp.get_bool(settings_pack::send_redundant_have), false);
+	// when cleared, we'll get the default value
+	TEST_EQUAL(sp.get_bool(settings_pack::send_redundant_have), true);
 }
 
 TORRENT_TEST(clear_single_string)
@@ -191,7 +193,8 @@ TORRENT_TEST(clear_single_string)
 
 	sp.clear(settings_pack::user_agent);
 
-	TEST_EQUAL(sp.get_str(settings_pack::user_agent), std::string());
+	// when cleared, we'll get the default value
+	TEST_EQUAL(sp.get_str(settings_pack::user_agent), "libtorrent/2.0.7.0");
 }
 
 TORRENT_TEST(duplicates)


### PR DESCRIPTION
This is especially helpful in the way settings are used in set_piece_hashes(), which otherwise would use 0 and false for anything not specified in the settings_pack