### PR TITLE
Update state when need to save resume data

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -581,7 +581,9 @@ namespace libtorrent {
 
 		void set_need_save_resume()
 		{
+			if (m_need_save_resume_data) return;
 			m_need_save_resume_data = true;
+			state_updated();
 		}
 
 		bool is_auto_managed() const { return m_auto_managed; }

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10038,8 +10038,7 @@ namespace {
 
 		// these counters are saved in the resume data, since they updated
 		// we need to save the resume data too
-		m_need_save_resume_data = true;
-		state_updated();
+		set_need_save_resume();
 
 		// if the rate is 0, there's no update because of network transfers
 		if (m_stat.low_pass_upload_rate() > 0 || m_stat.low_pass_download_rate() > 0)


### PR DESCRIPTION
In #7063 I incorrectly recognized the place where `m_need_save_resume_data` is being set, so now I have to fix it.