### PR TITLE
Fix triggering loss for uTP packets that were never sent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* uTP performance, fix packet loss when sending is stalled
 	* fix trackers being stuck after session pause/resume
 	* fix bug in hash_picker with empty files
 	* uTP performance, prevent premature timeouts/resends

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -933,6 +933,8 @@ void utp_socket_impl::send_syn()
 
 	if (!m_stalled)
 		++p->num_transmissions;
+	else
+		p->need_resend = true;
 
 	TORRENT_ASSERT(!m_outbuf.at(m_seq_nr));
 	TORRENT_ASSERT(h->seq_nr == m_seq_nr);
@@ -1711,6 +1713,10 @@ bool utp_socket_impl::send_pkt(int const flags)
 		TORRENT_ASSERT(p->mtu_probe == (m_seq_nr == m_mtu_seq)
 			|| m_seq_nr == 0);
 
+		// If we're stalled we'll need to resend
+		if (m_stalled)
+			p->need_resend = true;
+
 		// If this packet is undersized then note the sequenece number so we
 		// never have more than one undersized packet in flight at once
 		if (int(p->size) < std::min(int(p->allocated), effective_mtu))
@@ -1878,6 +1884,8 @@ bool utp_socket_impl::resend_packet(packet* p, bool fast_resend)
 
 	if (!m_stalled)
 		++p->num_transmissions;
+	else
+		p->need_resend = true;
 
 	return !m_stalled;
 }


### PR DESCRIPTION
https://github.com/arvidn/libtorrent/blob/8786d17e59c90aee2cb66db891d3a16c7f369ad7/include/libtorrent/aux_/utp_stream.hpp#L964-L969

A uTP packet that fails to send due to a 'stall' isn't marked as `need_resend`. The send is only retried once the packet has timed out or is picked up by a SACK, causing it to trigger loss and the `cwnd` to be halved despite never having been sent yet. This also means packets with a higher `seq_nr` may be sent out first if the socket becomes writable before the unsent packet has timed out/been picked up by SACK.

From this utp log note that 6542-6544 stall while 6545-6594 were sent as normal as the socket became writable again. 6542-6544 were only sent once they are noticed as missing from a SACK, and are then treated as lost packets:

```
[000026139017] 0000028257BE58C0: sending packet seq_nr:6542 ack_nr:27277 type:ST_DATA id:15964 target:193.176.124.10:37495 size:1457 error:The operation completed successfully send_buffer_size:16315 cwnd:82107 adv_wnd:78873 in-flight:76161 mtu:1457 timestamp:3248500762 time_diff:3078327667 mtu_probe:0 extension:0
[000026139091] 0000028257BE58C0: socket stalled
...
[000026139136] 0000028257BE58C0: sending packet seq_nr:6543 ack_nr:27277 type:ST_DATA id:15964 target:193.176.124.10:37495 size:1457 error:The operation completed successfully send_buffer_size:14878 cwnd:82107 adv_wnd:81747 in-flight:74724 mtu:1457 timestamp:3248500879 time_diff:3078328093 mtu_probe:0 extension:0
[000026139142] 0000028257BE58C0: socket stalled
...
[000026139221] 0000028257BE58C0: sending packet seq_nr:6544 ack_nr:27277 type:ST_DATA id:15964 target:193.176.124.10:37495 size:1457 error:The operation completed successfully send_buffer_size:13454 cwnd:82107 adv_wnd:81747 in-flight:76161 mtu:1457 timestamp:3248500967 time_diff:3078328093 mtu_probe:0 extension:0
[000026139228] 0000028257BE58C0: socket stalled
...
[000026139382] 0000028257BE58C0: sending packet seq_nr:6545 ack_nr:27277 type:ST_DATA id:15964 target:193.176.124.10:37495 size:1457 error:The operation completed successfully send_buffer_size:93989 cwnd:82107 adv_wnd:81747 in-flight:77598 mtu:1457 timestamp:3248501126 time_diff:3078328093 mtu_probe:0 extension:0
...
[000026763903] 0000028257BE58C0: got SACK first:6543 00111111111111111111111111111100 our_seq_nr:6594
...
[000026763376] 0000028257BE58C0: Packet 6542 lost. (1 duplicate acks, trigger fast-resend)
[000026763379] 0000028257BE58C0: cwnd cut:41053 packets_in_flight:52 loss_seq_nr:6645
[000026763381] 0000028257BE58C0: experienced loss, slow_start -> 0 ssthres:41053
...
[000026763553] 0000028257BE58C0: Packet 6543 lost. (1 duplicate acks, trigger fast-resend)
---
[000026763922] 0000028257BE58C0: Packet 6544 lost. (1 duplicate acks, trigger fast-resend)
```

This suggested change marks such packets as `need_resend` when the stall happens, meaning they will be sent the next time send_pkt() is called once the socket is writable again. This should prevent packets that weren't sent from being 'lost' and needlessly halving the `cwnd`, and also sending packets out of order.

I've marked this as a draft for the time being as I'm not yet sure that I'm not missing/misunderstanding something.