### PR TITLE
Resend uTP ACKs that fail to send due to stalling

### DIFF
--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -962,7 +962,10 @@ void utp_socket_impl::writable()
 	m_stalled = false;
 	if (should_delete()) return;
 
-	while(send_pkt());
+	// if the socket stalled while sending an ack then there will be a
+	// pending deferred ack. make sure it gets sent out
+	if (!m_deferred_ack || send_pkt(pkt_ack))
+		while(send_pkt());
 
 	maybe_trigger_send_callback();
 }
@@ -1686,17 +1689,19 @@ bool utp_socket_impl::send_pkt(int const flags)
 			, static_cast<void*>(this), packet_timeout());
 #endif
 		}
+		// Any queued up deferred ack is now redundant
+		if (m_deferred_ack)
+		{
+	#if TORRENT_UTP_LOG
+			UTP_LOGV("%8p: Cancelling redundant deferred ack\n"
+				, static_cast<void*>(this));
+	#endif
+			m_deferred_ack = false;
+		}
 	}
-
-	// Any queued up deferred ack is now redundant
-	if (m_deferred_ack)
-	{
-#if TORRENT_UTP_LOG
-		UTP_LOGV("%8p: Cancelling redundant deferred ack\n"
-			, static_cast<void*>(this));
-#endif
-		m_deferred_ack = false;
-	}
+	// If this is an ack then defer it to when the socket becomes writable again
+	else if (p->size == p->header_size && (flags & pkt_ack))
+		defer_ack();
 
 	// if we have payload, we need to save the packet until it's acked
 	// and progress m_seq_nr


### PR DESCRIPTION
Following #7107, uTP packets with payload that failed to send due to a stalled socket should now be sent once the socket becomes writable again. However, this doesn't apply to `ST_STATE` packets (ie payload-less ACKs), which would simply be lost. If another packet isn't sent out in time (updating our `ack_nr` at the other end) then this will be seen as loss and can trigger a needless resend by the other-end.

The idea behind this change is to note that an ack is still needed if the socket stalls while sending an empty payload ACK-only packet. Once the socket is writable again, the deferred ack is then sent out if its still needed.

I wonder if a simulation with a low enough `send_socket_buffer_size` might be able to trigger this and to confirm that this fix as well as #7107 work as intended.