### PR TITLE
introduce new API for create_torrent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* introduced a new API for creating torrents, enabling file_storage optimizations
 	* default build to not include functions deprecated in libtorrent 1.1 and earlier
 	* add comment, created_by and creation_date to add_torrent_params
 	* move session_flags to session_params

--- a/bindings/python/install_data/libtorrent/__init__.pyi
+++ b/bindings/python/install_data/libtorrent/__init__.pyi
@@ -141,6 +141,12 @@ def set_piece_hashes(
 ) -> None: ...
 @overload
 def set_piece_hashes(_ct: create_torrent, _path: _PathLike) -> None: ...
+@overload
+def list_files(p: _PathLike, flags: int = ...) -> List[create_file_entry]: ...
+@overload
+def list_files(
+    p: _PathLike, cb: Callable[[str], bool], flags: int = ...
+) -> List[create_file_entry]: ...
 def socks_category() -> error_category: ...
 def system_category() -> error_category: ...
 def upnp_category() -> error_category: ...
@@ -407,6 +413,21 @@ class close_reason_t(int):
     upload_to_upload: close_reason_t
     values: Mapping[int, close_reason_t]
 
+class create_file_entry:
+    def __init__(
+        self,
+        filename: str,
+        size: int,
+        flags: int = ...,
+        mtime: int = ...,
+        symlink: str = ...,
+    ) -> None: ...
+    filename: str
+    size: int
+    flags: int
+    mtime: int
+    symlink: str
+
 class create_torrent:
     canonical_files: int
     merkle: int
@@ -415,6 +436,10 @@ class create_torrent:
     symlinks: int
     v1_only: int
     v2_only: int
+    @overload
+    def __init__(
+        self, files: List[create_file_entry], piece_size: int = ..., flags: int = ...
+    ) -> None: ...
     @overload
     def __init__(
         self, storage: file_storage, piece_size: int = ..., flags: int = ...

--- a/bindings/python/make_torrent.py
+++ b/bindings/python/make_torrent.py
@@ -12,19 +12,14 @@ if len(sys.argv) < 3:
 
 input = os.path.abspath(sys.argv[1])
 
-fs = libtorrent.file_storage()
-
-# def predicate(f):
-#   print f
-#   return True
-# libtorrent.add_files(fs, input, predicate)
+fs = []
 
 parent_input = os.path.split(input)[0]
 
 # if we have a single file, use it because os.walk does not work on a single files
 if os.path.isfile(input):
     size = os.path.getsize(input)
-    fs.add_file(input, size)
+    fs.append(libtorrent.create_file_entry(input, size))
 
 for root, dirs, files in os.walk(input):
     # skip directories starting with .
@@ -43,9 +38,9 @@ for root, dirs, files in os.walk(input):
         fname = os.path.join(root[len(parent_input) + 1 :], f)
         size = os.path.getsize(os.path.join(parent_input, fname))
         print("%10d kiB  %s" % (size / 1024, fname))
-        fs.add_file(fname, size)
+        fs.append(libtorrent.create_file_entry(fname, size))
 
-if fs.num_files() == 0:
+if len(fs) == 0:
     print("no files added")
     sys.exit(1)
 

--- a/bindings/python/src/converters.cpp
+++ b/bindings/python/src/converters.cpp
@@ -423,6 +423,7 @@ void bind_converters()
     to_python_converter<std::pair<std::string, std::string>, pair_to_tuple<std::string, std::string>>();
     to_python_converter<lt::piece_block, piece_block_to_tuple>();
 
+    to_python_converter<std::vector<lt::create_file_entry>, vector_to_list<std::vector<lt::create_file_entry>>>();
     to_python_converter<std::vector<lt::stats_metric>, vector_to_list<std::vector<lt::stats_metric>>>();
     to_python_converter<std::vector<lt::open_file_state>, vector_to_list<std::vector<lt::open_file_state>>>();
     to_python_converter<std::vector<lt::sha1_hash>, vector_to_list<std::vector<lt::sha1_hash>>>();
@@ -509,6 +510,7 @@ void bind_converters()
     list_to_vector<std::vector<std::pair<std::string, int>>>();
     list_to_vector<std::vector<std::pair<std::string, std::string>>>();
     list_to_vector<std::vector<lt::sha1_hash>>();
+    list_to_vector<std::vector<lt::create_file_entry>>();
 
     // work-around types
     list_to_vector<lt::aux::noexcept_movable<std::vector<int>>>();

--- a/bindings/python/src/file_storage.cpp
+++ b/bindings/python/src/file_storage.cpp
@@ -76,11 +76,21 @@ namespace
     { return FileIter(self, self.end_file()); }
 #endif // TORRENT_ABI_VERSION
 
+#if TORRENT_ABI_VERSION < 4
+    void add_files_no_callback(file_storage& fs, std::string const& file
+       , create_flags_t const flags)
+    {
+        python_deprecated("add_files is deprecated, use list_files() instead");
+        add_files(fs, file, flags);
+    }
+
     void add_files_callback(file_storage& fs, std::string const& file
        , boost::python::object cb, create_flags_t const flags)
     {
+        python_deprecated("add_files is deprecated, use list_files() instead");
         add_files(fs, file, [&](std::string const& i) { return cb(i); }, flags);
     }
+#endif
 
     void add_file0(file_storage& fs, string_view const file, std::int64_t size
        , file_flags_t const flags, std::time_t md, string_view const link)
@@ -175,8 +185,6 @@ namespace
 
 void bind_file_storage()
 {
-    void (*add_files0)(file_storage&, std::string const&, create_flags_t) = add_files;
-
 #if TORRENT_ABI_VERSION < 4
     sha1_hash (file_storage::*file_storage_hash)(file_index_t) const = &file_storage::hash;
 #endif
@@ -241,9 +249,11 @@ void bind_file_storage()
        s.attr("flag_symlink") = file_storage::flag_symlink;
     }
 
-    def("add_files", add_files0, (arg("fs"), arg("path"), arg("flags") = 0));
+#if TORRENT_ABI_VERSION < 4
+    def("add_files", add_files_no_callback, (arg("fs"), arg("path"), arg("flags") = 0));
     def("add_files", add_files_callback, (arg("fs"), arg("path")
         , arg("predicate"), arg("flags") = 0));
+#endif
 
 }
 

--- a/examples/make_torrent.cpp
+++ b/examples/make_torrent.cpp
@@ -207,7 +207,6 @@ int main(int argc_, char const* argv_[]) try
 		args = args.subspan(1);
 	}
 
-	lt::file_storage fs;
 #ifdef TORRENT_WINDOWS
 	if (full_path[1] != ':')
 #else
@@ -236,13 +235,14 @@ int main(int argc_, char const* argv_[]) try
 #endif
 	}
 
-	lt::add_files(fs, full_path, file_filter, flags);
-	if (fs.num_files() == 0) {
+	std::vector<lt::create_file_entry> fs
+		= lt::list_files(full_path, file_filter, flags);
+	if (fs.empty()) {
 		std::cerr << "no files specified.\n";
 		return 1;
 	}
 
-	lt::create_torrent t(fs, piece_size, flags);
+	lt::create_torrent t(std::move(fs), piece_size, flags);
 	int tier = 0;
 	for (std::string const& tr : trackers) {
 		if (tr == "-") ++tier;

--- a/fuzzers/src/add_torrent.cpp
+++ b/fuzzers/src/add_torrent.cpp
@@ -61,13 +61,13 @@ extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 	g_params.disk_io_constructor = lt::disabled_disk_io_constructor;
 
 	// create a torrent
-	file_storage fs;
 	std::int64_t const total_size = std::int64_t(piece_size) * num_pieces;
-	fs.add_file("test_file", total_size);
 
 	g_tree.resize(num_nodes);
 
-	create_torrent t(fs, piece_size);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test_file", total_size);
+	create_torrent t(std::move(fs), piece_size);
 
 	std::vector<char> piece(piece_size, 0);
 	lt::span<char const> piece_span(piece);

--- a/fuzzers/src/peer_conn.cpp
+++ b/fuzzers/src/peer_conn.cpp
@@ -67,12 +67,11 @@ extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 	g_ses = std::unique_ptr<session>(new lt::session(pack));
 
 	// create a torrent
-	file_storage fs;
 	int const piece_size = 1024 * 1024;
 	std::int64_t const total_size = std::int64_t(piece_size) * 100;
-	fs.add_file("test_file", total_size);
-
-	create_torrent t(fs, piece_size);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test_file", total_size);
+	create_torrent t(std::move(fs), piece_size);
 
 	for (piece_index_t i : t.piece_range())
 		t.set_hash(i, sha1_hash("abababababababababab"));

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -460,9 +460,10 @@ TORRENT_VERSION_NAMESPACE_4
 		// swap all content of *this* with *ti*.
 		void swap(file_storage& ti) noexcept;
 
-		// arrange files and padding to match the canonical form required
-		// by BEP 52
+#if TORRENT_ABI_VERSION < 4
+		TORRENT_DEPRECATED
 		void canonicalize();
+#endif
 
 #if TORRENT_ABI_VERSION < 4
 		// The ``hash()`` is a SHA-1 hash of the file, or 0 if none was
@@ -634,10 +635,12 @@ TORRENT_VERSION_NAMESPACE_4
 		// internal
 		void remove_tail_padding();
 
+	private:
+
+#if TORRENT_ABI_VERSION < 4
 		// internal
 		void canonicalize_impl(bool backwards_compatible);
-
-	private:
+#endif
 
 		void add_file_borrow_impl(error_code& ec, string_view filename
 			, std::string const& path, std::int64_t const file_size

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -140,7 +140,10 @@ struct bitfield;
 struct client_data_t;
 
 // include/libtorrent/create_torrent.hpp
+TORRENT_VERSION_NAMESPACE_4
+struct create_file_entry;
 struct create_torrent;
+TORRENT_VERSION_NAMESPACE_4_END
 
 // include/libtorrent/disk_buffer_holder.hpp
 struct buffer_allocator_interface;

--- a/simulation/test_checking.cpp
+++ b/simulation/test_checking.cpp
@@ -131,11 +131,10 @@ std::shared_ptr<lt::torrent_info> create_multifile_torrent()
 	// the two first files are exactly the size of a piece
 	static std::array<const int, 8> const file_sizes{{ 0x40000, 0x40000, 4300, 0, 400, 4300, 6, 4}};
 
-	lt::file_storage fs;
-	create_random_files("test_torrent_dir", file_sizes, &fs);
+	auto fs = create_random_files("test_torrent_dir", file_sizes);
 	// the torrent needs to be v1 only because the zero_priority_missing_partfile
 	// test relies on non-aligned files
-	lt::create_torrent t(fs, 0x40000, lt::create_torrent::v1_only);
+	lt::create_torrent t(std::move(fs), 0x40000, lt::create_torrent::v1_only);
 
 	// calculate the hash for all pieces
 	set_piece_hashes(t, ".");

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -1218,9 +1218,9 @@ TORRENT_TEST(clear_error)
 
 std::shared_ptr<torrent_info> make_torrent(bool priv)
 {
-	file_storage fs;
-	fs.add_file("foobar", 13241);
-	lt::create_torrent ct(fs);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("foobar", 13241);
+	lt::create_torrent ct(std::move(fs));
 
 	ct.add_tracker("http://tracker.com:8080/announce");
 

--- a/simulation/transfer_sim.hpp
+++ b/simulation/transfer_sim.hpp
@@ -158,9 +158,13 @@ void run_test(
 			if (ti->v2())
 				TEST_EQUAL(ti->v2_piece_hashes_verified(), true);
 
-			auto downloaded = serialize(*ti);
-			auto added = serialize(*torrent);
-			TEST_CHECK(downloaded == added);
+#if TORRENT_ABI_VERSION < 4
+			{
+				auto downloaded = serialize(*ti);
+				auto added = serialize(*torrent);
+				TEST_CHECK(downloaded == added);
+			}
+#endif
 		}
 
 		test(ses);

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -1245,6 +1245,9 @@ namespace {
 		swap(ti.m_v2, m_v2);
 	}
 
+#if TORRENT_ABI_VERSION < 4
+	// using file_storage when creating torrents is deprecated. Use a vector of
+	// create_file_entry with create_torrent instead.
 	void file_storage::canonicalize()
 	{
 		canonicalize_impl(false);
@@ -1288,17 +1291,13 @@ namespace {
 		});
 
 		aux::vector<aux::file_entry, file_index_t> new_files;
-#if TORRENT_ABI_VERSION < 4
 		aux::vector<char const*, file_index_t> new_file_hashes;
-#endif
 		aux::vector<std::time_t, file_index_t> new_mtime;
 
 		// reserve enough space for the worst case after padding
 		new_files.reserve(new_order.size() * 2 - 1);
-#if TORRENT_ABI_VERSION < 4
 		if (!m_file_hashes.empty())
 			new_file_hashes.reserve(new_order.size() * 2 - 1);
-#endif
 		if (!m_mtime.empty())
 			new_mtime.reserve(new_order.size() * 2 - 1);
 
@@ -1323,10 +1322,8 @@ namespace {
 				pad.set_name(name);
 				pad.pad_file = true;
 
-#if TORRENT_ABI_VERSION < 4
 				if (!m_file_hashes.empty())
 					new_file_hashes.push_back(nullptr);
-#endif
 				if (!m_mtime.empty())
 					new_mtime.push_back(0);
 			}
@@ -1340,12 +1337,10 @@ namespace {
 			TORRENT_ASSERT(!m_files[i].pad_file);
 			new_files.emplace_back(std::move(m_files[i]));
 
-#if TORRENT_ABI_VERSION < 4
 			if (i < m_file_hashes.end_index())
 				new_file_hashes.push_back(m_file_hashes[i]);
 			else if (!m_file_hashes.empty())
 				new_file_hashes.push_back(nullptr);
-#endif
 
 			if (i < m_mtime.end_index())
 				new_mtime.push_back(m_mtime[i]);
@@ -1365,15 +1360,14 @@ namespace {
 		}
 
 		m_files = std::move(new_files);
-#if TORRENT_ABI_VERSION < 4
 		m_file_hashes = std::move(new_file_hashes);
-#endif
 		m_mtime = std::move(new_mtime);
 
 		m_total_size = off;
 		m_size_on_disk = on_disk;
 		TORRENT_ASSERT(m_total_size >= m_size_on_disk);
 	}
+#endif
 
 	void file_storage::sanitize_symlinks()
 	{

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -67,11 +67,8 @@ EXPORT void wait_for_seeding(lt::session& ses, char const* name);
 EXPORT std::vector<char> generate_piece(lt::piece_index_t idx, int piece_size = 0x4000);
 EXPORT lt::file_storage make_file_storage(lt::span<const int> file_sizes
 	, int const piece_size, std::string base_name = "test_dir-");
-EXPORT std::shared_ptr<lt::torrent_info> make_torrent(lt::span<const int> file_sizes
-	, int piece_size);
-EXPORT std::shared_ptr<lt::torrent_info> make_torrent(lt::file_storage& fs);
-EXPORT void create_random_files(std::string const& path, lt::span<const int> file_sizes
-	, lt::file_storage* fs = nullptr);
+EXPORT std::shared_ptr<lt::torrent_info> make_torrent(std::vector<lt::create_file_entry> files, int piece_size, lt::create_flags_t flags = {});
+EXPORT std::vector<lt::create_file_entry> create_random_files(std::string const& path, lt::span<const int> file_sizes);
 
 EXPORT std::shared_ptr<lt::torrent_info> create_torrent(std::ostream* file = nullptr
 	, char const* name = "temporary", int piece_size = 16 * 1024, int num_pieces = 13

--- a/test/test_apply_pad.cpp
+++ b/test/test_apply_pad.cpp
@@ -146,7 +146,7 @@ TORRENT_TEST(back_to_back_pads)
 
 TORRENT_TEST(large_pad_file)
 {
-	auto const fs = make_files({{0x4001, false}, {0x100003fff, true}}, 0x4000);
+	auto const fs = make_fs({{0x4001, false}, {0x100003fff, true}}, 0x4000);
 	piece_index_t expected_piece(fs.num_pieces() - 1);
 	int num_calls = 0;
 	aux::apply_pad_files(fs, [&](piece_index_t const piece, int const bytes)

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -84,7 +84,6 @@ void test_checking(int const flags)
 	if (ec) fprintf(stdout, "ERROR: creating directory test_torrent_dir: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
-	file_storage fs;
 	int const piece_size = (flags & single_file) ? 0x8000 : 0x4000;
 
 	auto const file_sizes = (flags & single_file)
@@ -92,9 +91,9 @@ void test_checking(int const flags)
 		: std::vector<int>{0, 5, 16 - 5, 16000, 17, 10, 8000, 8000, 1,1,1,1,1,100,1,1,1,1,100,1,1,1,1,1,1
 		,1,1,1,1,1,1,13,65000,34,75,2,30,400,50000,73000,900,43000,400,4300,6, 4 };
 
-	create_random_files("test_torrent_dir", file_sizes, &fs);
+	auto fs = create_random_files("test_torrent_dir", file_sizes);
 
-	lt::create_torrent t(fs, piece_size, (flags & v2) ? create_torrent::v2_only : create_torrent::v1_only);
+	lt::create_torrent t(std::move(fs), piece_size, (flags & v2) ? create_torrent::v2_only : create_torrent::v1_only);
 
 	// calculate the hash for all pieces
 	set_piece_hashes(t, ".", ec);
@@ -371,11 +370,10 @@ TORRENT_TEST(discrete_checking)
 	int const piece_size = 2 * megabyte;
 	static std::array<int const, 2> const file_sizes{{ 9 * megabyte, 3 * megabyte }};
 
-	file_storage fs;
-	create_random_files("test_torrent_dir", file_sizes, &fs);
-	TEST_EQUAL(fs.num_files(), 2);
+	auto fs = create_random_files("test_torrent_dir", file_sizes);
+	TEST_EQUAL(fs.size(), 2);
 
-	lt::create_torrent t(fs, piece_size);
+	lt::create_torrent t(std::move(fs), piece_size);
 	set_piece_hashes(t, ".", ec);
 	if (ec) printf("ERROR: set_piece_hashes: (%d) %s\n", ec.value(), ec.message().c_str());
 

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -22,6 +22,10 @@ see LICENSE file.
 #include "libtorrent/announce_entry.hpp"
 #include "libtorrent/units.hpp"
 #include "libtorrent/load_torrent.hpp" // for load_torrent_buffer
+#include "libtorrent/file_storage.hpp"
+#include "libtorrent/aux_/path.hpp"
+#include "libtorrent/units.hpp"
+#include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/write_resume_data.hpp" // for write_torrent_file
 
 #include <cstring>
@@ -31,6 +35,12 @@ see LICENSE file.
 
 using namespace std::literals::string_literals;
 
+namespace {
+constexpr lt::aux::path_index_t operator""_path(unsigned long long i)
+{ return lt::aux::path_index_t(static_cast<std::uint32_t>(i)); }
+}
+
+#if TORRENT_ABI_VERSION < 4
 // make sure creating a torrent from an existing handle preserves the
 // info-dictionary verbatim, so as to not alter the info-hash
 TORRENT_TEST(create_verbatim_torrent)
@@ -56,6 +66,7 @@ TORRENT_TEST(create_verbatim_torrent)
 	// torrent, since create_torrent may have added items next to the info dict
 	TEST_CHECK(memcmp(dest_info, test_torrent + 1, sizeof(test_torrent)-3) == 0);
 }
+#endif
 
 TORRENT_TEST(auto_piece_size)
 {
@@ -78,10 +89,20 @@ TORRENT_TEST(auto_piece_size)
 
 	for (auto const& t : samples)
 	{
-		lt::file_storage fs;
-		fs.add_file("a", t.first);
-		lt::create_torrent ct(fs, 0);
-		TEST_CHECK(ct.piece_length() == static_cast<int>(t.second));
+#if TORRENT_ABI_VERSION < 4
+		{
+			lt::file_storage fs;
+			fs.add_file("a", t.first);
+			lt::create_torrent ct(fs, 0);
+			TEST_CHECK(ct.piece_length() == static_cast<int>(t.second));
+		}
+#endif
+		{
+			std::vector<lt::create_file_entry> files;
+			files.emplace_back("a", t.first);
+			lt::create_torrent ct(std::move(files), 0);
+			TEST_CHECK(ct.piece_length() == static_cast<int>(t.second));
+		}
 	}
 }
 
@@ -89,9 +110,17 @@ namespace {
 int test_piece_size(int const piece_size, lt::create_flags_t const f = {})
 {
 	std::int64_t const MiB = 1024 * 1024;
-	lt::file_storage fs;
-	fs.add_file("a", 100 * MiB);
-	lt::create_torrent ct(fs, piece_size, f);
+	std::vector<lt::create_file_entry> files;
+	files.emplace_back("a", 100 * MiB);
+	lt::create_torrent ct(std::move(files), piece_size, f);
+#if TORRENT_ABI_VERSION < 4
+	{
+		lt::file_storage fs;
+		fs.add_file("a", 100 * MiB);
+		lt::create_torrent ct2(fs, piece_size, f);
+		TEST_EQUAL(ct2.piece_length(), ct.piece_length());
+	}
+#endif
 	return ct.piece_length();
 }
 }
@@ -115,6 +144,7 @@ TORRENT_TEST(piece_size_quanta)
 	TEST_THROW(test_piece_size(47 * 1024));
 }
 
+#if TORRENT_ABI_VERSION < 4
 TORRENT_TEST(create_torrent_round_trip)
 {
 	char const test_torrent[] = "d8:announce26:udp://testurl.com/announce7:comment22:this is a test comment13:creation datei1337e4:infod6:lengthi12345e4:name6:foobar12:piece lengthi65536e6:pieces20:ababababababababababee";
@@ -136,6 +166,7 @@ TORRENT_TEST(create_torrent_round_trip)
 	TEST_CHECK(info1.info_hashes() == info2.info_hashes());
 	TEST_CHECK(info2.hash_for_piece(0_piece) == info1.hash_for_piece(0_piece));
 }
+#endif
 
 namespace {
 
@@ -151,6 +182,7 @@ void test_round_trip_torrent(std::string const& name)
 
 	lt::bdecode_node in_torrent = lt::bdecode(v2_buffer);
 
+#if TORRENT_ABI_VERSION < 4
 	{
 		lt::torrent_info info1(v2_buffer, lt::from_span);
 		lt::create_torrent t(info1);
@@ -170,6 +202,7 @@ void test_round_trip_torrent(std::string const& name)
 		auto out_piece_layers = out_torrent.dict_find("piece layers").data_section();
 		TEST_CHECK(out_piece_layers == in_piece_layers);
 	}
+#endif
 
 	auto atp = lt::load_torrent_buffer(v2_buffer);
 	std::vector<char> out_buffer;
@@ -212,27 +245,27 @@ TORRENT_TEST(create_torrent_round_trip_empty_file)
 // a file and directory with the same name is not allowed
 TORRENT_TEST(v2_path_conflict)
 {
-	lt::file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
 	for (int i = 0; i < 2; ++i)
 	{
 		switch (i)
 		{
 		case 0:
-			fs.add_file("test/A/tmp", 0x4000);
-			fs.add_file("test/a", 0x4000);
-			fs.add_file("test/A", 0x4000);
-			fs.add_file("test/filler", 0x4000);
+			fs.emplace_back("test/A/tmp", 0x4000);
+			fs.emplace_back("test/a", 0x4000);
+			fs.emplace_back("test/A", 0x4000);
+			fs.emplace_back("test/filler", 0x4000);
 			break;
 		case 1:
-			fs.add_file("test/long/path/name/that/collides", 0x4000);
-			fs.add_file("test/long/path", 0x4000);
-			fs.add_file("test/filler-1", 0x4000);
-			fs.add_file("test/filler-2", 0x4000);
+			fs.emplace_back("test/long/path/name/that/collides", 0x4000);
+			fs.emplace_back("test/long/path", 0x4000);
+			fs.emplace_back("test/filler-1", 0x4000);
+			fs.emplace_back("test/filler-2", 0x4000);
 			break;
 		}
 
-		lt::create_torrent t(fs, 0x4000);
+		lt::create_torrent t(std::move(fs), 0x4000);
 		lt::sha256_hash const dummy("01234567890123456789012345678901");
 		lt::piece_index_t::diff_type zero(0);
 		t.set_hash2(0_file, zero, dummy);
@@ -246,10 +279,10 @@ TORRENT_TEST(v2_path_conflict)
 
 TORRENT_TEST(v2_only)
 {
-	lt::file_storage fs;
-	fs.add_file("test/A", 0x8002);
-	fs.add_file("test/B", 0x4002);
-	lt::create_torrent t(fs, 0x4000, lt::create_torrent::v2_only);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/A", 0x8002);
+	fs.emplace_back("test/B", 0x4002);
+	lt::create_torrent t(std::move(fs), 0x4000, lt::create_torrent::v2_only);
 
 	using p = lt::piece_index_t::diff_type;
 	t.set_hash2(0_file, p(0), lt::sha256_hash::max());
@@ -270,19 +303,21 @@ TORRENT_TEST(v2_only)
 	TEST_EQUAL(info.files().file_name(2_file), "B");
 	TEST_EQUAL(info.name(), "test");
 
+#if TORRENT_ABI_VERSION < 4
 	lt::create_torrent t2(info);
 	std::vector<char> buffer2;
 	lt::bencode(std::back_inserter(buffer2), t2.generate());
 	TEST_CHECK(buffer2 == t2.generate_buf());
 
 	TEST_CHECK(buffer == buffer2);
+#endif
 }
 
 TORRENT_TEST(v2_only_set_hash)
 {
-	lt::file_storage fs;
-	fs.add_file("test/A", 0x8002);
-	lt::create_torrent t(fs, 0x4000, lt::create_torrent::v2_only);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/A", 0x8002);
+	lt::create_torrent t(std::move(fs), 0x4000, lt::create_torrent::v2_only);
 
 	TEST_THROW(t.set_hash(0_piece, lt::sha1_hash::max()));
 }
@@ -315,38 +350,54 @@ TORRENT_TEST(create_torrent_symlink)
 	check(::symlink("a/b/c/file-1", "test-torrent/a/b/c/test-link-3"));
 	check(::symlink("../../../d/file-2", "test-torrent/a/b/c/test-link-4"));
 
-	lt::file_storage fs;
-	lt::add_files(fs, "test-torrent"
-		, [](std::string n){ std::cout << n << '\n'; return true; }, lt::create_torrent::symlinks);
+	auto check = [](lt::create_torrent& t) {
+		lt::set_piece_hashes(t, ".", [] (lt::piece_index_t) {});
 
-	lt::create_torrent t(fs, 16 * 1024, lt::create_torrent::symlinks);
-	lt::set_piece_hashes(t, ".", [] (lt::piece_index_t) {});
+		std::vector<char> torrent;
+		lt::bencode(back_inserter(torrent), t.generate());
 
-	std::vector<char> torrent;
-	lt::bencode(back_inserter(torrent), t.generate());
-	TEST_CHECK(torrent == t.generate_buf());
+		TEST_CHECK(torrent == t.generate_buf());
+		lt::torrent_info ti(torrent, lt::from_span);
 
-	lt::torrent_info ti(torrent, lt::from_span);
+		int found = 0;
+		for (auto i : ti.files().file_range())
+		{
+			auto const filename = ti.files().file_path(i);
 
-	int found = 0;
-	for (auto i : ti.files().file_range())
+			if (filename == "test-torrent/d/test-link-1"
+				|| filename == "test-torrent/test-link-2"
+				|| filename == "test-torrent/a/b/c/test-link-3")
+			{
+				TEST_EQUAL(ti.files().symlink(i), "test-torrent/a/b/c/file-1");
+				++found;
+			}
+			else if (filename == "test-torrent/a/b/c/test-link-4")
+			{
+				TEST_EQUAL(ti.files().symlink(i), "test-torrent/d/file-2");
+				++found;
+			}
+		}
+		TEST_EQUAL(found, 4);
+	};
+
+#if TORRENT_ABI_VERSION < 4
 	{
-		auto const filename = ti.files().file_path(i);
+		lt::file_storage fs;
+		lt::add_files(fs, "test-torrent"
+			, [](std::string n){ std::cout << n << '\n'; return true; }, lt::create_torrent::symlinks);
 
-		if (filename == "test-torrent/d/test-link-1"
-			|| filename == "test-torrent/test-link-2"
-			|| filename == "test-torrent/a/b/c/test-link-3")
-		{
-			TEST_EQUAL(ti.files().symlink(i), "test-torrent/a/b/c/file-1");
-			++found;
-		}
-		else if (filename == "test-torrent/a/b/c/test-link-4")
-		{
-			TEST_EQUAL(ti.files().symlink(i), "test-torrent/d/file-2");
-			++found;
-		}
+		lt::create_torrent t(fs, 16 * 1024, lt::create_torrent::symlinks);
+		check(t);
 	}
-	TEST_EQUAL(found, 4);
+#endif
+
+	{
+		auto files = lt::list_files("test-torrent"
+			, [](std::string n){ std::cout << n << '\n'; return true; }, lt::create_torrent::symlinks);
+
+		lt::create_torrent t(std::move(files), 16 * 1024, lt::create_torrent::symlinks);
+		check(t);
+	}
 }
 
 #endif
@@ -359,26 +410,42 @@ TORRENT_TEST(v2_attributes)
 	check(::truncate("file-1", 1000));
 	check(::chmod("file-1", S_IWUSR | S_IRUSR | S_IXUSR));
 
-	lt::file_storage fs;
-	lt::add_files(fs, "file-1", [](std::string){ return true; }, {});
+	auto check = [](lt::create_torrent& t) {
+		lt::set_piece_hashes(t, ".", [] (lt::piece_index_t) {});
 
-	lt::create_torrent t(fs, 16 * 1024, {});
-	lt::set_piece_hashes(t, ".", [] (lt::piece_index_t) {});
+		lt::entry e = t.generate();
 
-	lt::entry e = t.generate();
+		std::cout << e.to_string() << '\n';
 
-	std::cout << e.to_string() << '\n';
+		TEST_EQUAL(e["info"]["attr"].string(), "x");
+		TEST_EQUAL(e["info"]["file tree"]["file-1"][""]["attr"].string(), "x");
+	};
 
-	TEST_EQUAL(e["info"]["attr"].string(), "x");
-	TEST_EQUAL(e["info"]["file tree"]["file-1"][""]["attr"].string(), "x");
+#if TORRENT_ABI_VERSION < 4
+	{
+		lt::file_storage fs;
+		lt::add_files(fs, "file-1");
+
+		lt::create_torrent t(fs, 16 * 1024, {});
+		check(t);
+	}
+#endif
+
+	{
+		auto files = lt::list_files("file-1");
+
+		lt::create_torrent t(std::move(files), 16 * 1024, {});
+		check(t);
+	}
+
 }
 #endif
 
 TORRENT_TEST(v1_only_set_hash2)
 {
-	lt::file_storage fs;
-	fs.add_file("test/A", 0x8002);
-	lt::create_torrent t(fs, 0x4000, lt::create_torrent::v1_only);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/A", 0x8002);
+	lt::create_torrent t(std::move(fs), 0x4000, lt::create_torrent::v1_only);
 
 	using p = lt::piece_index_t::diff_type;
 	TEST_THROW(t.set_hash2(0_file, p(0), lt::sha256_hash::max()));
@@ -388,10 +455,10 @@ TORRENT_TEST(v1_only_set_hash2)
 // torrent is implicitly v2-only
 TORRENT_TEST(implicit_v2_only)
 {
-	lt::file_storage fs;
-	fs.add_file("test/A", 0x8002);
-	fs.add_file("test/B", 0x4002);
-	lt::create_torrent t(fs, 0x4000);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/A", 0x8002);
+	fs.emplace_back("test/B", 0x4002);
+	lt::create_torrent t(std::move(fs), 0x4000);
 
 	using p = lt::piece_index_t::diff_type;
 	t.set_hash2(0_file, p(0), lt::sha256_hash::max());
@@ -417,10 +484,10 @@ TORRENT_TEST(implicit_v2_only)
 // torrent is implicitly v1-only
 TORRENT_TEST(implicit_v1_only)
 {
-	lt::file_storage fs;
-	fs.add_file("test/A", 0x8002);
-	fs.add_file("test/B", 0x4002);
-	lt::create_torrent t(fs, 0x4000);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/A", 0x8002);
+	fs.emplace_back("test/B", 0x4002);
+	lt::create_torrent t(std::move(fs), 0x4000);
 
 	for (lt::piece_index_t i : t.piece_range())
 		t.set_hash(i, lt::sha1_hash::max());
@@ -442,9 +509,9 @@ namespace {
 template <typename Fun>
 lt::torrent_info test_field(Fun f)
 {
-	lt::file_storage fs;
-	fs.add_file("A", 0x4000);
-	lt::create_torrent t(fs, 0x4000);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("A", 0x4000);
+	lt::create_torrent t(std::move(fs), 0x4000);
 	for (lt::piece_index_t i : t.piece_range())
 		t.set_hash(i, lt::sha1_hash::max());
 
@@ -516,11 +583,11 @@ TORRENT_TEST(priv)
 
 TORRENT_TEST(piece_layer)
 {
-	lt::file_storage fs;
-	fs.add_file("test/large", 0x8000);
-	fs.add_file("test/small-1", 0x4000);
-	fs.add_file("test/small-2", 0x3fff);
-	lt::create_torrent t(fs, 0x4000);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/large", 0x8000);
+	fs.emplace_back("test/small-1", 0x4000);
+	fs.emplace_back("test/small-2", 0x3fff);
+	lt::create_torrent t(std::move(fs), 0x4000);
 
 	using p = lt::piece_index_t::diff_type;
 	t.set_hash2(0_file, p(0), lt::sha256_hash::max());
@@ -540,11 +607,11 @@ TORRENT_TEST(piece_layer)
 
 TORRENT_TEST(pieces_root_empty_file)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-empty", 0);
-	fs.add_file("test/2-small", 0x3fff);
-	fs.add_file("test/3-empty", 0);
-	lt::create_torrent t(fs, 0x4000);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-empty", 0);
+	fs.emplace_back("test/2-small", 0x3fff);
+	fs.emplace_back("test/3-empty", 0);
+	lt::create_torrent t(std::move(fs), 0x4000);
 
 	using p = lt::piece_index_t::diff_type;
 	t.set_hash2(1_file, p(0), lt::sha256_hash::max());
@@ -564,17 +631,17 @@ TORRENT_TEST(pieces_root_empty_file)
 
 namespace {
 
-std::string test_create_torrent(lt::file_storage& fs, int const piece_size
+std::string test_create_torrent(std::vector<lt::create_file_entry> fs, int const piece_size
 	, lt::create_flags_t const flags)
 {
-	lt::create_torrent ct(fs, piece_size, flags);
+	lt::create_torrent ct(std::move(fs), piece_size, flags);
 	ct.set_creation_date(1337);
 	if (!(flags & lt::create_torrent::v2_only))
 		for (lt::piece_index_t i : ct.piece_range())
 			ct.set_hash(i, lt::sha1_hash::max());
 	if (!(flags & lt::create_torrent::v1_only))
 		for (auto const f : ct.file_range())
-			if (!fs.pad_file_at(f))
+			if (!(ct.file_at(f).flags & lt::file_storage::flag_pad_file))
 				for (auto const p : ct.file_piece_range(f))
 					ct.set_hash2(f, p, lt::sha256_hash::max());
 	auto e = ct.generate();
@@ -590,10 +657,10 @@ std::string test_create_torrent(lt::file_storage& fs, int const piece_size
 
 TORRENT_TEST(v1_tail_padding)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files)
 		, "d13:creation datei1337e4:infod5:filesl"
 		"d6:lengthi16383e4:pathl7:1-smallee"
 		"d4:attr1:p6:lengthi1e4:pathl4:.pad1:1ee"
@@ -612,11 +679,11 @@ TORRENT_TEST(v1_tail_padding)
 // padding goes before empty files, not after
 TORRENT_TEST(v1_empty_file_placement)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-empty", 0);
-	fs.add_file("test/3-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-empty", 0);
+	fs.emplace_back("test/3-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files)
 		, "d13:creation datei1337e4:infod5:filesl"
 		"d6:lengthi16383e4:pathl7:1-smallee"
 		"d4:attr1:p6:lengthi1e4:pathl4:.pad1:1ee"
@@ -637,10 +704,10 @@ TORRENT_TEST(v1_empty_file_placement)
 // files in the canonical order
 TORRENT_TEST(v1_file_sorting)
 {
-	lt::file_storage fs;
-	fs.add_file("test/2-small", 0x3fff);
-	fs.add_file("test/1-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/2-small", 0x3fff);
+	fs.emplace_back("test/1-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files)
 		, "d13:creation datei1337e4:infod5:filesl"
 		"d6:lengthi16383e4:pathl7:1-smallee"
 		"d4:attr1:p6:lengthi1e4:pathl4:.pad1:1ee"
@@ -659,10 +726,10 @@ TORRENT_TEST(v1_file_sorting)
 // This is a backwards compatibility feature
 TORRENT_TEST(v1_no_tail_padding)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files_no_tail_padding)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files_no_tail_padding)
 		, "d13:creation datei1337e4:infod5:filesl"
 		"d6:lengthi16383e4:pathl7:1-smallee"
 		"d4:attr1:p6:lengthi1e4:pathl4:.pad1:1ee"
@@ -680,11 +747,11 @@ TORRENT_TEST(v1_no_tail_padding)
 // padding goes after empty files in backwards compatibility mode
 TORRENT_TEST(v1_empty_file_placement_backwards_compatibility)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-empty", 0);
-	fs.add_file("test/3-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files_no_tail_padding)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-empty", 0);
+	fs.emplace_back("test/3-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v1_only | lt::create_torrent::canonical_files_no_tail_padding)
 		, "d13:creation datei1337e4:infod5:filesl"
 		"d6:lengthi16383e4:pathl7:1-smallee"
 		"d6:lengthi0e4:pathl7:2-emptyee"
@@ -704,10 +771,10 @@ TORRENT_TEST(v1_empty_file_placement_backwards_compatibility)
 // padding)
 TORRENT_TEST(v1_no_padding)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v1_only)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v1_only)
 		, "d13:creation datei1337e4:infod5:filesl"
 		"d6:lengthi16383e4:pathl7:1-smallee"
 		"d6:lengthi16383e4:pathl7:2-smallee"
@@ -723,10 +790,10 @@ TORRENT_TEST(v1_no_padding)
 
 TORRENT_TEST(hybrid)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, {})
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, {})
 		, "d13:creation datei1337e4:infod"
 		"9:file tree"
 		"d7:1-smalld0:d6:lengthi16383e11:pieces root32:"
@@ -758,9 +825,9 @@ TORRENT_TEST(hybrid)
 
 TORRENT_TEST(hybrid_single_file)
 {
-	lt::file_storage fs;
-	fs.add_file("1-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, {})
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("1-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, {})
 		, "d13:creation datei1337e4:infod"
 		"9:file tree"
 		"d7:1-smalld0:d6:lengthi16383e11:pieces root32:"
@@ -781,9 +848,9 @@ TORRENT_TEST(hybrid_single_file)
 
 TORRENT_TEST(hybrid_single_file_with_directory)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, {})
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, {})
 		, "d13:creation datei1337e4:infod"
 		"9:file tree"
 		"d7:1-smalld0:d6:lengthi16383e11:pieces root32:"
@@ -807,10 +874,10 @@ TORRENT_TEST(hybrid_single_file_with_directory)
 // this is a backwards compatibility feature
 TORRENT_TEST(hybrid_no_tail_padding)
 {
-	lt::file_storage fs;
-	fs.add_file("test/1-small", 0x3fff);
-	fs.add_file("test/2-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::canonical_files_no_tail_padding)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/1-small", 0x3fff);
+	fs.emplace_back("test/2-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::canonical_files_no_tail_padding)
 		, "d13:creation datei1337e4:infod"
 		"9:file tree"
 		"d7:1-smalld0:d6:lengthi16383e11:pieces root32:"
@@ -841,10 +908,10 @@ TORRENT_TEST(hybrid_no_tail_padding)
 
 TORRENT_TEST(v2_only_file_sorting)
 {
-	lt::file_storage fs;
-	fs.add_file("test/2-small", 0x3fff);
-	fs.add_file("test/1-small", 0x3fff);
-	TEST_EQUAL(test_create_torrent(fs, 0x4000, lt::create_torrent::v2_only)
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test/2-small", 0x3fff);
+	fs.emplace_back("test/1-small", 0x3fff);
+	TEST_EQUAL(test_create_torrent(std::move(fs), 0x4000, lt::create_torrent::v2_only)
 		, "d13:creation datei1337e4:infod"
 		"9:file tree"
 		"d7:1-smalld0:d6:lengthi16383e11:pieces root32:"
@@ -861,4 +928,296 @@ TORRENT_TEST(v2_only_file_sorting)
 		"e"
 		"12:piece layersde"
 		"e");
+}
+
+namespace {
+std::shared_ptr<lt::torrent_info>
+make_load_torrent(std::vector<lt::create_file_entry> files, int const piece_size)
+{
+	lt::create_torrent ct(std::move(files), piece_size);
+	for (lt::piece_index_t i : ct.piece_range())
+		ct.set_hash(i, lt::sha1_hash::max());
+	auto e = ct.generate();
+	std::vector<char> buf;
+	lt::bencode(std::back_inserter(buf), e);
+	auto atp = lt::load_torrent_buffer(buf);
+	return atp.ti;
+}
+}
+
+// make sure we fill in padding with small files
+TORRENT_TEST(canonicalize_pad)
+{
+	std::vector<lt::create_file_entry> files;
+	files.emplace_back("s/2", 0x7000);
+	files.emplace_back("s/1", 1);
+	files.emplace_back("s/3", 0x7001);
+
+	auto ti = make_load_torrent(files, 0x4000);
+	lt::file_storage const& fs = ti->files();
+
+	TEST_EQUAL(fs.num_files(), 6);
+
+	TEST_EQUAL(fs.file_size(0_file), 1);
+	TEST_EQUAL(fs.file_name(0_file), "1");
+	TEST_EQUAL(fs.pad_file_at(0_file), false);
+
+	TEST_EQUAL(fs.file_size(1_file), 0x4000 - 1);
+	TEST_EQUAL(fs.pad_file_at(1_file), true);
+
+	TEST_EQUAL(fs.file_size(2_file), 0x7000);
+	TEST_EQUAL(fs.file_name(2_file), "2");
+	TEST_EQUAL(fs.pad_file_at(2_file), false);
+
+	TEST_EQUAL(fs.file_size(3_file), 0x8000 - 0x7000);
+	TEST_EQUAL(fs.pad_file_at(3_file), true);
+
+	TEST_EQUAL(fs.file_size(4_file), 0x7001);
+	TEST_EQUAL(fs.file_name(4_file), "3");
+	TEST_EQUAL(fs.pad_file_at(4_file), false);
+	TEST_EQUAL(fs.size_on_disk(), 0x7000 + 1 + 0x7001);
+
+	TEST_EQUAL(fs.file_size(5_file), 0x8000 - 0x7001);
+	TEST_EQUAL(fs.pad_file_at(5_file), true);
+}
+
+// make sure canonicalize sorts by path correctly
+TORRENT_TEST(canonicalize_path)
+{
+	std::vector<lt::create_file_entry> files;
+	files.emplace_back("b/2/a", 0x4000);
+	files.emplace_back("b/1/a", 0x4000);
+	files.emplace_back("b/3/a", 0x4000);
+	files.emplace_back("b/11", 0x4000);
+
+	auto ti = make_load_torrent(files, 0x4000);
+	lt::file_storage const& fs = ti->files();
+
+	TEST_EQUAL(fs.num_files(), 4);
+
+	using lt::combine_path;
+
+	TEST_EQUAL(fs.file_path(0_file), combine_path("b", combine_path("1", "a")));
+	TEST_EQUAL(fs.file_path(1_file), combine_path("b", "11"));
+	TEST_EQUAL(fs.file_path(2_file), combine_path("b", combine_path("2", "a")));
+	TEST_EQUAL(fs.file_path(3_file), combine_path("b", combine_path("3", "a")));
+}
+
+TORRENT_TEST(file_num_blocks)
+{
+	std::vector<lt::create_file_entry> files;
+	files.emplace_back("test/0", 0x5000);
+	files.emplace_back("test/1", 0x2000);
+	files.emplace_back("test/2", 0x8000);
+	files.emplace_back("test/3", 0x8001);
+	files.emplace_back("test/4", 1);
+	files.emplace_back("test/5", 0);
+
+	auto ti = make_load_torrent(files, 0x8000);
+	lt::file_storage const& fs = ti->files();
+
+	// generally the number of blocks in a file is:
+	// (file_size + lt::default_block_size - 1) / lt::default_block_size
+
+	TEST_EQUAL(fs.file_num_blocks(0_file), 2);
+	// pad file at index 1
+	TEST_CHECK(fs.pad_file_at(1_file));
+	TEST_EQUAL(fs.file_num_blocks(2_file), 1);
+	// pad file at index 3
+	TEST_CHECK(fs.pad_file_at(3_file));
+	TEST_EQUAL(fs.file_num_blocks(4_file), 2);
+	TEST_EQUAL(fs.file_num_blocks(5_file), 3);
+	// pad file at index 6
+	TEST_CHECK(fs.pad_file_at(6_file));
+	TEST_EQUAL(fs.file_num_blocks(7_file), 1);
+	// pad file at index 8
+	TEST_CHECK(fs.pad_file_at(8_file));
+	TEST_EQUAL(fs.file_num_blocks(9_file), 0);
+}
+
+TORRENT_TEST(file_num_pieces)
+{
+	std::vector<lt::create_file_entry> files;
+	files.emplace_back("test/0", 0x5000);
+	files.emplace_back("test/1", 0x2000);
+	files.emplace_back("test/2", 0x8000);
+	files.emplace_back("test/3", 0x8001);
+	files.emplace_back("test/4", 1);
+	files.emplace_back("test/5", 0);
+
+	auto ti = make_load_torrent(files, 0x8000);
+	lt::file_storage const& fs = ti->files();
+
+	// generally the number of blocks in a file is:
+	// (file_size + lt::default_block_size - 1) / lt::default_block_size
+
+	TEST_EQUAL(fs.file_num_pieces(0_file), 1);
+	// pad file at index 1
+	TEST_CHECK(fs.pad_file_at(1_file));
+	TEST_EQUAL(fs.file_num_pieces(2_file), 1);
+	// pad file at index 3
+	TEST_CHECK(fs.pad_file_at(3_file));
+	TEST_EQUAL(fs.file_num_pieces(4_file), 1);
+	TEST_EQUAL(fs.file_num_pieces(5_file), 2);
+	// pad file at index 6
+	TEST_CHECK(fs.pad_file_at(6_file));
+	TEST_EQUAL(fs.file_num_pieces(7_file), 1);
+	// pad file at index 8
+	TEST_CHECK(fs.pad_file_at(8_file));
+	TEST_EQUAL(fs.file_num_pieces(9_file), 0);
+}
+
+TORRENT_TEST(coalesce_path)
+{
+	using lt::combine_path;
+
+	std::vector<lt::create_file_entry> files;
+	files.emplace_back("test/a", 10000);
+	files.emplace_back("test/b", 20000);
+	files.emplace_back("test/c/a", 30000);
+	files.emplace_back("test/c/b", 40000);
+	auto ti = make_load_torrent(files, 0x4000);
+	lt::file_storage const& fs = ti->files();
+
+	// pad files should be created, to make sure the pad files also share the
+	// same path entries
+
+	TEST_EQUAL(fs.paths().size(), 3);
+	TEST_EQUAL(fs.paths()[0_path], "");
+	TEST_EQUAL(fs.paths()[1_path], ".pad");
+	TEST_EQUAL(fs.paths()[2_path], "c");
+}
+
+using cfv = lt::aux::vector<lt::create_file_entry, lt::file_index_t>;
+
+#if defined(TORRENT_WINDOWS) || defined(TORRENT_OS2)
+#define SEPARATOR "\\"
+#else
+#define SEPARATOR "/"
+#endif
+
+TORRENT_TEST(canonalize_aligned)
+{
+	cfv files;
+	files.emplace_back("test/1-small", 0x4000);
+	files.emplace_back("test/2-small", 0x4000);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x4000, false);
+
+	TEST_EQUAL(new_files.size(), 2);
+	TEST_EQUAL(new_files[0_file].filename, "test/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test/2-small");
+	TEST_EQUAL(total, 0x8000);
+}
+
+TORRENT_TEST(canonalize_order)
+{
+	cfv files;
+	files.emplace_back("test/2-small", 0x4000);
+	files.emplace_back("test/1-small", 0x4000);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x4000, false);
+
+	TEST_EQUAL(new_files.size(), 2);
+	TEST_EQUAL(new_files[0_file].filename, "test/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test/2-small");
+	TEST_EQUAL(total, 0x8000);
+}
+
+TORRENT_TEST(canonalize_tail_padding)
+{
+	cfv files;
+	files.emplace_back("test/1-small", 0x4000);
+	files.emplace_back("test/2-small", 0x4000);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x8000, false);
+
+	TEST_EQUAL(new_files.size(), 4);
+	TEST_EQUAL(new_files[0_file].filename, "test/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test" SEPARATOR ".pad" SEPARATOR "16384");
+	TEST_EQUAL(new_files[2_file].filename, "test/2-small");
+	TEST_EQUAL(new_files[3_file].filename, "test" SEPARATOR ".pad" SEPARATOR "16384");
+	TEST_EQUAL(total, 0x10000);
+}
+
+TORRENT_TEST(canonalize_empty_file)
+{
+	cfv files;
+	files.emplace_back("test/1-small", 0x4000);
+	files.emplace_back("test/2-empty", 0);
+	files.emplace_back("test/3-small", 0x4000);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x8000, false);
+
+	TEST_EQUAL(new_files.size(), 5);
+	TEST_EQUAL(new_files[0_file].filename, "test/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test" SEPARATOR ".pad" SEPARATOR "16384");
+	TEST_EQUAL(new_files[2_file].filename, "test/2-empty");
+	TEST_EQUAL(new_files[3_file].filename, "test/3-small");
+	TEST_EQUAL(new_files[4_file].filename, "test" SEPARATOR ".pad" SEPARATOR "16384");
+	TEST_EQUAL(total, 0x10000);
+}
+
+TORRENT_TEST(canonalize_single_file)
+{
+	cfv files;
+	files.emplace_back("test/1-small", 0x4000);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x8000, false);
+
+	TEST_EQUAL(new_files.size(), 1);
+	TEST_EQUAL(new_files[0_file].filename, "test/1-small");
+	TEST_EQUAL(total, 0x4000);
+}
+
+// this is a backwards compatibility feature
+TORRENT_TEST(canonalize_no_tail_padding)
+{
+	cfv files;
+	files.emplace_back("test/1-small", 0x4000);
+	files.emplace_back("test/2-small", 0x4000);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x8000, true);
+
+	TEST_EQUAL(new_files.size(), 3);
+	TEST_EQUAL(new_files[0_file].filename, "test/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test" SEPARATOR ".pad" SEPARATOR "16384");
+	TEST_EQUAL(new_files[2_file].filename, "test/2-small");
+	TEST_EQUAL(total, 0xc000);
+}
+
+TORRENT_TEST(canonalize_tree)
+{
+	cfv files;
+	files.emplace_back("test/2/2-small", 0x3fff);
+	files.emplace_back("test/2/1-small", 0x3fff);
+	files.emplace_back("test/1/2-small", 0x3fff);
+	files.emplace_back("test/1/1-small", 0x3fff);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x4000, false);
+
+	TEST_EQUAL(new_files.size(), 8);
+	TEST_EQUAL(new_files[0_file].filename, "test/1/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(new_files[2_file].filename, "test/1/2-small");
+	TEST_EQUAL(new_files[3_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(new_files[4_file].filename, "test/2/1-small");
+	TEST_EQUAL(new_files[5_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(new_files[6_file].filename, "test/2/2-small");
+	TEST_EQUAL(new_files[7_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(total, 0x10000);
+}
+
+// this is a backwards compatibility feature
+TORRENT_TEST(canonalize_tree_no_tail_padding)
+{
+	cfv files;
+	files.emplace_back("test/2/2-small", 0x3fff);
+	files.emplace_back("test/2/1-small", 0x3fff);
+	files.emplace_back("test/1/2-small", 0x3fff);
+	files.emplace_back("test/1/1-small", 0x3fff);
+	auto const [new_files, total] = lt::aux::canonicalize(std::move(files), 0x4000, true);
+
+	TEST_EQUAL(new_files.size(), 7);
+	TEST_EQUAL(new_files[0_file].filename, "test/1/1-small");
+	TEST_EQUAL(new_files[1_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(new_files[2_file].filename, "test/1/2-small");
+	TEST_EQUAL(new_files[3_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(new_files[4_file].filename, "test/2/1-small");
+	TEST_EQUAL(new_files[5_file].filename, "test" SEPARATOR ".pad" SEPARATOR "1");
+	TEST_EQUAL(new_files[6_file].filename, "test/2/2-small");
+	TEST_EQUAL(total, 0x10000 - 1);
 }

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -59,11 +59,14 @@ void setup_test_storage(file_storage& st)
 	TEST_EQUAL(st.num_pieces(), (100000 + 0x3fff) / 0x4000);
 }
 
+#if TORRENT_ABI_VERSION < 4
 constexpr aux::path_index_t operator""_path(unsigned long long i)
 { return aux::path_index_t(static_cast<std::uint32_t>(i)); }
+#endif
 
 } // anonymous namespace
 
+#if TORRENT_ABI_VERSION < 4
 TORRENT_TEST(coalesce_path)
 {
 	file_storage st;
@@ -94,6 +97,7 @@ TORRENT_TEST(coalesce_path)
 	TEST_EQUAL(st.paths()[1_path], "c");
 	TEST_EQUAL(st.paths()[2_path], ".pad");
 }
+#endif
 
 TORRENT_TEST(rename_file)
 {
@@ -266,6 +270,7 @@ TORRENT_TEST(file_path_hash)
 	TEST_EQUAL(file_hash0, file_hash1);
 }
 
+#if TORRENT_ABI_VERSION < 4
 // make sure every file is tail padded
 TORRENT_TEST(canonicalize_pad)
 {
@@ -323,6 +328,7 @@ TORRENT_TEST(canonicalize_path)
 	TEST_EQUAL(fs.file_path(2_file), combine_path("b", combine_path("2", "a")));
 	TEST_EQUAL(fs.file_path(3_file), combine_path("b", combine_path("3", "a")));
 }
+#endif
 
 TORRENT_TEST(piece_range_exclusive)
 {
@@ -956,6 +962,7 @@ TORRENT_TEST(piece_size2)
 	TEST_EQUAL(fs.piece_size2(5_piece), 1);
 }
 
+#if TORRENT_ABI_VERSION < 4
 TORRENT_TEST(file_num_blocks)
 {
 	file_storage fs;
@@ -1019,6 +1026,7 @@ TORRENT_TEST(file_num_pieces)
 	TEST_CHECK(fs.pad_file_at(8_file));
 	TEST_EQUAL(fs.file_num_pieces(file_index_t{9}), 0);
 }
+#endif
 
 namespace {
 int first_piece_node(int piece_size, int file_size)

--- a/test/test_read_piece.cpp
+++ b/test/test_read_piece.cpp
@@ -49,15 +49,14 @@ void test_read_piece(int flags)
 	if (ec) std::printf("ERROR: creating directory test_torrent: (%d) %s\n"
 		, ec.value(), ec.message().c_str());
 
-	file_storage fs;
 	int piece_size = 0x4000;
 
 	static std::array<const int, 2> const file_sizes{{ 100000, 10000 }};
 
 	create_random_files(combine_path("tmp1_read_piece", "test_torrent"), file_sizes);
 
-	add_files(fs, combine_path("tmp1_read_piece", "test_torrent"));
-	lt::create_torrent t(fs, piece_size);
+	auto fs = list_files(combine_path("tmp1_read_piece", "test_torrent"));
+	lt::create_torrent t(std::move(fs), piece_size);
 
 	// calculate the hash for all pieces
 	set_piece_hashes(t, "tmp1_read_piece", ec);

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -167,11 +167,11 @@ TORRENT_TEST(read_resume_mismatching_torrent)
 namespace {
 std::shared_ptr<torrent_info> generate_torrent()
 {
-	file_storage fs;
-	fs.add_file("test_resume/tmp1", 128 * 1024 * 8);
-	fs.add_file("test_resume/tmp2", 128 * 1024);
-	fs.add_file("test_resume/tmp3", 128 * 1024);
-	lt::create_torrent t(fs, 128 * 1024);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test_resume/tmp1", 128 * 1024 * 8);
+	fs.emplace_back("test_resume/tmp2", 128 * 1024);
+	fs.emplace_back("test_resume/tmp3", 128 * 1024);
+	lt::create_torrent t(std::move(fs), 128 * 1024);
 
 	t.add_tracker("http://torrent_file_tracker.com/announce");
 	t.add_url_seed("http://torrent_file_url_seed.com/");

--- a/test/test_remap_files.cpp
+++ b/test/test_remap_files.cpp
@@ -44,9 +44,9 @@ void test_remap_files(storage_mode_t storage_mode = storage_mode_sparse)
 
 	// create a torrent with 2 files, remap them into 3 files and make sure
 	// the file priorities don't break things
-	static std::array<const int, 2> const file_sizes{ {0x8000 * 2, 0x8000} };
 	int const piece_size = 0x8000;
-	auto t = make_torrent(file_sizes, piece_size);
+	auto orig_files = make_files({{0x8000 * 2, false}, {0x8000, false}});
+	auto t = make_torrent(std::move(orig_files), piece_size);
 
 	static std::array<const int, 2> const remap_file_sizes
 		{{0x8000, 0x8000 * 2}};

--- a/test/test_resolve_links.cpp
+++ b/test/test_resolve_links.cpp
@@ -126,16 +126,16 @@ TORRENT_TEST(resolve_links)
 // since the zero-hash piece is in the second place
 TORRENT_TEST(range_lookup_duplicated_files)
 {
-	file_storage fs1;
-	file_storage fs2;
+	std::vector<lt::create_file_entry> fs1;
+	std::vector<lt::create_file_entry> fs2;
 
-	fs1.add_file("test_resolve_links_dir/tmp1", 1024);
-	fs1.add_file("test_resolve_links_dir/tmp2", 1024);
-	fs2.add_file("test_resolve_links_dir/tmp1", 1024);
-	fs2.add_file("test_resolve_links_dir/tmp2", 1024);
+	fs1.emplace_back("test_resolve_links_dir/tmp1", 1024);
+	fs1.emplace_back("test_resolve_links_dir/tmp2", 1024);
+	fs2.emplace_back("test_resolve_links_dir/tmp1", 1024);
+	fs2.emplace_back("test_resolve_links_dir/tmp2", 1024);
 
-	lt::create_torrent t1(fs1, 1024, lt::create_torrent::v1_only);
-	lt::create_torrent t2(fs2, 1024, lt::create_torrent::v1_only);
+	lt::create_torrent t1(std::move(fs1), 1024, lt::create_torrent::v1_only);
+	lt::create_torrent t2(std::move(fs2), 1024, lt::create_torrent::v1_only);
 
 	t1.set_hash(0_piece, sha1_hash::max());
 	t1.set_hash(1_piece, sha1_hash::max());

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -1744,13 +1744,13 @@ TORRENT_TEST(resume_data_have_pieces)
 		return;
 	}
 
-	file_storage fs;
-	fs.add_file("tmp1", 128 * 1024 * 8);
-	lt::create_torrent t(fs, 128 * 1024);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("tmp1", 128 * 1024 * 8);
+	lt::create_torrent t(std::move(fs), 128 * 1024);
 
 	TEST_CHECK(t.num_pieces() > 0);
 
-	std::vector<char> piece_data(std::size_t(fs.piece_length()), 0);
+	std::vector<char> piece_data(std::size_t(t.piece_length()), 0);
 	aux::random_bytes(piece_data);
 
 	sha1_hash const ph = lt::hasher(piece_data).final();

--- a/test/test_similar_torrent.cpp
+++ b/test/test_similar_torrent.cpp
@@ -63,10 +63,10 @@ std::array<bool, 2> test(
 	}
 
 	auto t1 = [&] {
-		lt::file_storage fs;
-		fs.add_file(ec, "test-torrent-1/A", std::int64_t(A.size()));
-		fs.add_file(ec, "test-torrent-1/B", std::int64_t(B.size()));
-		lt::create_torrent t(fs, 0, cflags1);
+		std::vector<lt::create_file_entry> fs;
+		fs.emplace_back("test-torrent-1/A", std::int64_t(A.size()));
+		fs.emplace_back("test-torrent-1/B", std::int64_t(B.size()));
+		lt::create_torrent t(std::move(fs), 0, cflags1);
 		lt::set_piece_hashes(t, ".");
 		if (sflags & st::collection)
 			t.add_collection("test collection");
@@ -101,10 +101,10 @@ std::array<bool, 2> test(
 	}
 
 	auto t2 = [&] {
-		lt::file_storage fs;
-		fs.add_file(ec, "test-torrent-2/A", std::int64_t(A.size()));
-		fs.add_file(ec, "test-torrent-2/B", std::int64_t(B.size()));
-		lt::create_torrent t(fs, 0, cflags2);
+		std::vector<lt::create_file_entry> fs;
+		fs.emplace_back("test-torrent-2/A", std::int64_t(A.size()));
+		fs.emplace_back("test-torrent-2/B", std::int64_t(B.size()));
+		lt::create_torrent t(std::move(fs), 0, cflags2);
 		lt::set_piece_hashes(t, ".");
 		if (sflags & st::collection)
 			t.add_collection("test collection");

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -204,14 +204,14 @@ TORRENT_TEST(large_piece_size)
 
 TORRENT_TEST(total_wanted)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
-	fs.add_file("test_torrent_dir4/tmp1", default_block_size);
-	fs.add_file("test_torrent_dir4/tmp2", default_block_size);
-	fs.add_file("test_torrent_dir4/tmp3", default_block_size);
-	fs.add_file("test_torrent_dir4/tmp4", default_block_size);
+	fs.emplace_back("test_torrent_dir4/tmp1", default_block_size);
+	fs.emplace_back("test_torrent_dir4/tmp2", default_block_size);
+	fs.emplace_back("test_torrent_dir4/tmp3", default_block_size);
+	fs.emplace_back("test_torrent_dir4/tmp4", default_block_size);
 
-	lt::create_torrent t(fs, default_block_size);
+	lt::create_torrent t(std::move(fs), default_block_size);
 	t.set_hash(0_piece, sha1_hash::max());
 	t.set_hash(1_piece, sha1_hash::max());
 	t.set_hash(2_piece, sha1_hash::max());
@@ -248,11 +248,11 @@ TORRENT_TEST(total_wanted)
 
 TORRENT_TEST(added_peers)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
-	fs.add_file("test_torrent_dir4/tmp1", 1024);
+	fs.emplace_back("test_torrent_dir4/tmp1", 1024);
 
-	lt::create_torrent t(fs, 1024);
+	lt::create_torrent t(std::move(fs), 1024);
 	t.set_hash(0_piece, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
@@ -285,9 +285,9 @@ TORRENT_TEST(added_peers)
 
 TORRENT_TEST(mismatching_info_hash)
 {
-	file_storage fs;
-	fs.add_file("test_torrent_dir4/tmp1", 1024);
-	lt::create_torrent t(fs, 1024);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test_torrent_dir4/tmp1", 1024);
+	lt::create_torrent t(std::move(fs), 1024);
 	t.set_hash(0_piece, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
@@ -307,9 +307,9 @@ TORRENT_TEST(mismatching_info_hash)
 
 TORRENT_TEST(exceed_file_prio)
 {
-	file_storage fs;
-	fs.add_file("test_torrent_dir4/tmp1", 1024);
-	lt::create_torrent t(fs, 1024);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test_torrent_dir4/tmp1", 1024);
+	lt::create_torrent t(std::move(fs), 1024, create_torrent::v1_only);
 	t.set_hash(0_piece, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
@@ -325,9 +325,9 @@ TORRENT_TEST(exceed_file_prio)
 
 TORRENT_TEST(exceed_piece_prio)
 {
-	file_storage fs;
-	fs.add_file("test_torrent_dir4/tmp1", 1024);
-	lt::create_torrent t(fs, 1024);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("test_torrent_dir4/tmp1", 1024);
+	lt::create_torrent t(std::move(fs), 1024);
 	t.set_hash(0_piece, sha1_hash::max());
 	std::vector<char> tmp;
 	bencode(std::back_inserter(tmp), t.generate());
@@ -362,12 +362,12 @@ TORRENT_TEST(torrent)
 		remove("test_torrent_dir2/tmp1");
 		remove("test_torrent_dir2/tmp2");
 		remove("test_torrent_dir2/tmp3");
-		file_storage fs;
+		std::vector<lt::create_file_entry> fs;
 		std::int64_t file_size = 256 * 1024;
-		fs.add_file("test_torrent_dir2/tmp1", file_size);
-		fs.add_file("test_torrent_dir2/tmp2", file_size);
-		fs.add_file("test_torrent_dir2/tmp3", file_size);
-		lt::create_torrent t(fs, 128 * 1024);
+		fs.emplace_back("test_torrent_dir2/tmp1", file_size);
+		fs.emplace_back("test_torrent_dir2/tmp2", file_size);
+		fs.emplace_back("test_torrent_dir2/tmp3", file_size);
+		lt::create_torrent t(std::move(fs), 128 * 1024);
 		t.add_tracker("http://non-existing.com/announce");
 
 		std::vector<char> piece(128 * 1024);
@@ -391,10 +391,10 @@ TORRENT_TEST(torrent)
 	}
 */
 	{
-		file_storage fs;
+		std::vector<lt::create_file_entry> fs;
 
-		fs.add_file("test_torrent_dir2/tmp1", default_block_size);
-		lt::create_torrent t(fs, default_block_size);
+		fs.emplace_back("test_torrent_dir2/tmp1", default_block_size);
+		lt::create_torrent t(std::move(fs), default_block_size);
 
 		std::vector<char> piece(default_block_size);
 		for (int i = 0; i < int(piece.size()); ++i)
@@ -434,10 +434,10 @@ struct plugin_creator
 
 TORRENT_TEST(duplicate_is_not_error)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
-	fs.add_file("test_torrent_dir2/tmp1", 1024);
-	lt::create_torrent t(fs, 128 * 1024);
+	fs.emplace_back("test_torrent_dir2/tmp1", 1024);
+	lt::create_torrent t(std::move(fs), 128 * 1024);
 
 	std::vector<char> piece(128 * 1024);
 	for (int i = 0; i < int(piece.size()); ++i)
@@ -475,34 +475,26 @@ TORRENT_TEST(duplicate_is_not_error)
 
 TORRENT_TEST(torrent_total_size_zero)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
-	fs.add_file("test_torrent_dir2/tmp1", 0);
-	TEST_CHECK(fs.num_files() == 1);
-	TEST_CHECK(fs.total_size() == 0);
+	fs.emplace_back("test_torrent_dir2/tmp1", 0);
+	TEST_CHECK(fs.size() == 1);
 
-	error_code ec;
-	lt::create_torrent t1(fs);
-	set_piece_hashes(t1, ".", ec);
-	TEST_CHECK(ec);
+	TEST_THROW(lt::create_torrent t1(fs));
 
-	fs.add_file("test_torrent_dir2/tmp2", 0);
-	TEST_CHECK(fs.num_files() == 2);
-	TEST_CHECK(fs.total_size() == 0);
+	fs.emplace_back("test_torrent_dir2/tmp2", 0);
+	TEST_CHECK(fs.size() == 2);
 
-	ec.clear();
-	lt::create_torrent t2(fs);
-	set_piece_hashes(t2, ".", ec);
-	TEST_CHECK(ec);
+	TEST_THROW(lt::create_torrent t2(fs));
 }
 
 TORRENT_TEST(rename_file)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
-	fs.add_file("test3/tmp1", 20);
-	fs.add_file("test3/tmp2", 20);
-	lt::create_torrent t(fs, 128 * 1024, lt::create_torrent::v1_only);
+	fs.emplace_back("test3/tmp1", 20);
+	fs.emplace_back("test3/tmp2", 20);
+	lt::create_torrent t(std::move(fs), 128 * 1024, lt::create_torrent::v1_only);
 	t.set_hash(0_piece, sha1_hash::max());
 
 	std::vector<char> tmp;
@@ -537,11 +529,11 @@ void test_queue(add_torrent_params const& atp)
 	std::vector<torrent_handle> torrents;
 	for(int i = 0; i < 6; i++)
 	{
-		file_storage fs;
+		std::vector<lt::create_file_entry> fs;
 		std::stringstream file_path;
 		file_path << "test_torrent_dir4/queue" << i;
-		fs.add_file(file_path.str(), 1024);
-		lt::create_torrent t(fs, 128 * 1024);
+		fs.emplace_back(file_path.str(), 1024);
+		lt::create_torrent t(std::move(fs), 128 * 1024);
 		t.set_hash(0_piece, sha1_hash::max());
 
 		std::vector<char> buf;
@@ -687,10 +679,8 @@ TORRENT_TEST(test_have_piece_out_of_range)
 	add_torrent_params p;
 	static std::array<const int, 2> const file_sizes{{100000, 100000}};
 	int const piece_size = 0x8000;
-	lt::file_storage fs;
-	fs.set_piece_length(piece_size);
-	create_random_files(".", file_sizes, &fs);
-	p.ti = make_torrent(fs);
+	auto files = create_random_files(".", file_sizes);
+	p.ti = make_torrent(std::move(files), piece_size);
 
 	p.save_path = ".";
 	p.flags |= torrent_flags::seed_mode;
@@ -723,9 +713,8 @@ TORRENT_TEST(test_read_piece_out_of_range)
 	lt::session ses(settings());
 
 	add_torrent_params p;
-	static std::array<const int, 2> const file_sizes{{100000, 100000}};
 	int const piece_size = 0x8000;
-	p.ti = make_torrent(file_sizes, piece_size);
+	p.ti = make_torrent(make_files({{100000, false}, {100000, false}}), piece_size);
 	p.save_path = "save_path";
 	p.flags |= torrent_flags::seed_mode;
 	torrent_handle h = ses.add_torrent(std::move(p));
@@ -819,9 +808,9 @@ TORRENT_TEST(symlinks_restore)
 
 TORRENT_TEST(redundant_add_piece)
 {
-	file_storage fs;
-	fs.add_file("tmp1", 128 * 1024 * 8);
-	lt::create_torrent t(fs, 128 * 1024);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back("tmp1", 128 * 1024 * 8);
+	lt::create_torrent t(std::move(fs), 128 * 1024);
 
 	TEST_CHECK(t.num_pieces() > 0);
 

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -33,11 +33,11 @@ using namespace lt;
 #ifndef TORRENT_DISABLE_MUTABLE_TORRENTS
 TORRENT_TEST(mutable_torrents)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 
-	fs.add_file("test/temporary.txt", 0x4000);
+	fs.emplace_back("test/temporary.txt", 0x4000);
 
-	lt::create_torrent t(fs, 0x4000);
+	lt::create_torrent t(std::move(fs), 0x4000);
 
 	// calculate the hash for all pieces
 	for (auto const i : t.piece_range())
@@ -81,7 +81,7 @@ struct test_torrent_t
 
 using namespace lt;
 
-#ifdef TORRENT_WINDOWS
+#if defined(TORRENT_WINDOWS) || defined(TORRENT_OS2)
 #define SEPARATOR "\\"
 #else
 #define SEPARATOR "/"
@@ -1177,14 +1177,14 @@ std::vector<lt::aux::vector<file_t, lt::file_index_t>> const test_cases
 
 void test_resolve_duplicates(aux::vector<file_t, file_index_t> const& test)
 {
-	file_storage fs;
-	for (auto const& f : test) fs.add_file(f.filename, f.size, f.flags);
+	std::vector<lt::create_file_entry> fs;
+	for (auto const& f : test) fs.emplace_back(f.filename, f.size, f.flags);
 
 	// This test creates torrents with duplicate (identical) filenames, which
 	// isn't supported by v2 torrents, so we can only test this with v1 torrents
-	lt::create_torrent t(fs, 0x4000, create_torrent::v1_only);
+	lt::create_torrent t(std::move(fs), 0x4000, create_torrent::v1_only);
 
-	for (auto const i : fs.piece_range())
+	for (auto const i : t.piece_range())
 		t.set_hash(i, sha1_hash::max());
 
 	std::vector<char> tmp;
@@ -1318,6 +1318,7 @@ TORRENT_TEST(copy_ptr)
 	TEST_EQUAL(b->val, 4);
 }
 
+#if TORRENT_ABI_VERSION < 4
 TORRENT_TEST(torrent_info_with_hashes_roundtrip)
 {
 	std::string const root_dir = parent_path(current_working_directory());
@@ -1363,6 +1364,7 @@ TORRENT_TEST(torrent_info_with_hashes_roundtrip)
 
 	TEST_EQUAL(out_buffer, data);
 }
+#endif
 
 TORRENT_TEST(write_torrent_file_session_roundtrip)
 {

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -97,6 +97,7 @@ bool exists(std::string const& f)
 	return lt::exists(f, ec);
 }
 
+#if TORRENT_ABI_VERSION < 4
 std::vector<char> serialize(lt::torrent_info const& ti)
 {
 	lt::create_torrent ct(ti);
@@ -106,20 +107,18 @@ std::vector<char> serialize(lt::torrent_info const& ti)
 	bencode(std::back_inserter(out_buffer), e);
 	return out_buffer;
 }
+#endif
 
-lt::file_storage make_files(std::vector<file_ent> const files, int const piece_size)
+std::vector<lt::create_file_entry> make_files(std::vector<file_ent> const files)
 {
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 	int i = 0;
 	for (auto const& e : files)
 	{
 		char filename[200];
 		std::snprintf(filename, sizeof(filename), "t/test%d", int(i++));
-		fs.add_file(filename, e.size, e.pad ? file_storage::flag_pad_file : file_flags_t{});
+		fs.emplace_back(filename, e.size, e.pad ? file_storage::flag_pad_file : file_flags_t{});
 	}
-
-	fs.set_piece_length(piece_size);
-	fs.set_num_pieces(aux::calc_num_pieces(fs));
 
 	return fs;
 }

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -39,7 +39,9 @@ constexpr inline lt::file_index_t operator "" _file(unsigned long long const p)
 constexpr inline lt::piece_index_t operator "" _piece(unsigned long long const p)
 { return lt::piece_index_t(static_cast<int>(p)); }
 
+#if TORRENT_ABI_VERSION < 4
 EXPORT std::vector<char> serialize(lt::torrent_info const& ti);
+#endif
 
 EXPORT lt::aux::vector<lt::sha256_hash> build_tree(int const size);
 
@@ -60,7 +62,7 @@ struct file_ent
 	bool pad;
 };
 
-EXPORT lt::file_storage make_files(std::vector<file_ent> files, int piece_size);
+EXPORT std::vector<lt::create_file_entry> make_files(std::vector<file_ent> files);
 
 #endif
 

--- a/test/test_web_seed_redirect.cpp
+++ b/test/test_web_seed_redirect.cpp
@@ -28,20 +28,20 @@ TORRENT_TEST(web_seed_redirect)
 
 	error_code ec;
 
-	file_storage fs;
+	std::vector<lt::create_file_entry> fs;
 	int piece_size = 0x4000;
 
 	std::array<char, 16000> random_data;
 	aux::random_bytes(random_data);
 
 	ofstream("test_file").write(random_data.data(), random_data.size());
-	fs.add_file("test_file", 16000);
+	fs.emplace_back("test_file", 16000);
 
 	int port = start_web_server();
 
 	// generate a torrent with pad files to make sure they
 	// are not requested web seeds
-	lt::create_torrent t(fs, piece_size);
+	lt::create_torrent t(std::move(fs), piece_size);
 
 	char tmp[512];
 	std::snprintf(tmp, sizeof(tmp), "http://127.0.0.1:%d/redirect", port);

--- a/tools/checking_benchmark.cpp
+++ b/tools/checking_benchmark.cpp
@@ -68,14 +68,14 @@ void generate_block_fill(lt::span<char> buf, std::uint64_t& state)
 std::vector<char> generate_torrent(int num_pieces, std::string save_path
 	, lt::create_flags_t const flags)
 {
-	lt::file_storage fs;
 	// 1 MiB piece size
 	const int piece_size = 1024 * 1024;
 	const std::int64_t total_size = std::int64_t(piece_size) * num_pieces + 2356;
 
 	std::string const filename = "test_checking_file";
 
-	fs.add_file(filename, total_size);
+	std::vector<lt::create_file_entry> fs;
+	fs.emplace_back(filename, total_size);
 
 	std::string const filepath = save_path + "/" + filename;
 
@@ -107,7 +107,7 @@ std::vector<char> generate_torrent(int num_pieces, std::string save_path
 		std::cout << '\n';
 	}
 
-	lt::create_torrent t(fs, piece_size, flags);
+	lt::create_torrent t(std::move(fs), piece_size, flags);
 
 	std::cout << "hashing torrent\n";
 	lt::set_piece_hashes(t, save_path);


### PR DESCRIPTION
to phase out the use of file_storage for creating torrents. Having a double-use for it complicates things