### PR TITLE
Change the default to disable functions deprecated in 1.1 and earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,7 +713,9 @@ feature_option(python-install-system-dir "Install python bindings to the system 
 # these options require existing target
 feature_option(dht "enable support for Mainline DHT" ON)
 target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME deprecated-functions DEFAULT ON
-	DESCRIPTION "enable deprecated functions for backwards compatibility" DISABLED TORRENT_NO_DEPRECATE)
+	DESCRIPTION "enable deprecated functions for backwards compatibility"
+	ENABLED TORRENT_ABI_VERSION=2
+	DISABLED TORRENT_ABI_VERSION=100)
 feature_option(encryption "Enables encryption in libtorrent" ON)
 feature_option(exceptions "build with exception support" ON)
 feature_option(gnutls "build using GnuTLS instead of OpenSSL" OFF)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* default build to not include functions deprecated in libtorrent 1.1 and earlier
 	* add comment, created_by and creation_date to add_torrent_params
 	* move session_flags to session_params
 	* the entry class is now a standard variant type

--- a/Jamfile
+++ b/Jamfile
@@ -641,8 +641,19 @@ feature.compose <crypto>gcrypt : <define>TORRENT_USE_LIBGCRYPT ;
 
 feature openssl-version : 1.1 pre1.1 : composite propagated ;
 
-feature deprecated-functions : on off : composite propagated link-incompatible ;
-feature.compose <deprecated-functions>off : <define>TORRENT_NO_DEPRECATE ;
+# ABI version numbers
+# 1: libtorrent-1.1
+# 2: libtorrent-1.2 (default)
+# 3: libtorrent-2.0
+# 4: libtorrent-2.1
+# on: oldest supported version
+# off: most recent version
+feature deprecated-functions : 2 on off 1 3 4 : composite propagated link-incompatible ;
+feature.compose <deprecated-functions>off : <define>TORRENT_ABI_VERSION=100 ;
+feature.compose <deprecated-functions>1 : <define>TORRENT_ABI_VERSION=1 ;
+feature.compose <deprecated-functions>2 : <define>TORRENT_ABI_VERSION=2 ;
+feature.compose <deprecated-functions>3 : <define>TORRENT_ABI_VERSION=3 ;
+feature.compose <deprecated-functions>4 : <define>TORRENT_ABI_VERSION=4 ;
 
 feature boost-link : default static shared : propagated composite ;
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -709,8 +709,9 @@ own code that compiles and links with libtorrent.
 |                                        | checks. Useful for finding particular bugs      |
 |                                        | or for running before releases.                 |
 +----------------------------------------+-------------------------------------------------+
-| ``TORRENT_NO_DEPRECATE``               | This will exclude all deprecated functions from |
-|                                        | the header files and source files.              |
+| ``TORRENT_ABI_VERSION``                | The ABI version to support in the build.        |
+|                                        | A lower number means to support deprecated      |
+|                                        | functions, a higher number means newer versions |
 +----------------------------------------+-------------------------------------------------+
 | ``TORRENT_PRODUCTION_ASSERTS``         | Define to either 0 or 1. Enables assert logging |
 |                                        | in release builds.                              |

--- a/docs/tuning.rst
+++ b/docs/tuning.rst
@@ -167,7 +167,7 @@ in libtorrent. If these macros are used to strip down libtorrent, make sure the 
 macros are defined when building libtorrent as when linking against it. Some of
 these macros may affect ABI (although they are not intended to).
 
-One, probably, safe macro to define is ``TORRENT_NO_DEPRECATE`` which removes all
+One, probably, safe macro to define is ``TORRENT_ABI_VERSION=100`` which removes all
 deprecated functions and struct members. As long as no deprecated functions are
 relied upon, this should be a simple way to shave off some size from the executable.
 

--- a/docs/upgrade_to_2.1.rst
+++ b/docs/upgrade_to_2.1.rst
@@ -60,6 +60,12 @@ standard string_view
 libtorrent now uses ``std::string_view`` instead of ``boost::string_view`` or ``boost::string_ref```.
 This affects libtorrent's API to some extent.
 
+bump API version
+================
+
+By default, functions deprecated in libtorrent 1.1 and earlier are not included
+in the build now. To enable them, build with ``deprecated-functions=1``.
+
 entry as a variant
 ==================
 

--- a/include/libtorrent/aux_/export.hpp
+++ b/include/libtorrent/aux_/export.hpp
@@ -25,8 +25,9 @@ see LICENSE file.
 // 4: libtorrent-2.1
 
 #if !defined TORRENT_ABI_VERSION
+// Supporting TORRENT_NO_DEPRECATE is here for backwards compatibility
 # ifdef TORRENT_NO_DEPRECATE
-#  define TORRENT_ABI_VERSION 4
+#  define TORRENT_ABI_VERSION 100
 # else
 #  define TORRENT_ABI_VERSION 1
 # endif

--- a/include/libtorrent/hex.hpp
+++ b/include/libtorrent/hex.hpp
@@ -36,7 +36,7 @@ namespace aux {
 	// buffer [``in``, ``in`` + len) to hexadecimal and prints it to the buffer
 	// ``out``. The caller is responsible for making sure the buffer pointed to
 	// by ``out`` is large enough, i.e. has at least len * 2 bytes of space.
-	TORRENT_CONDITIONAL_EXPORT std::string to_hex(span<char const> s);
+	TORRENT_CONDITIONAL_EXPORT std::string to_hex(span<char const> in);
 	TORRENT_CONDITIONAL_EXPORT void to_hex(span<char const> in, char* out);
 	TORRENT_CONDITIONAL_EXPORT void to_hex(char const* in, int len, char* out);
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2213,7 +2213,7 @@ namespace {
 		, m_counters_idx(alloc.allocate(sizeof(std::int64_t)
 			* counters::num_counters + sizeof(std::int64_t) - 1))
 	{
-		std::int64_t* ptr = align_pointer<std::int64_t>(alloc.ptr(m_counters_idx));
+		auto* ptr = align_pointer<std::int64_t>(alloc.ptr(m_counters_idx));
 		for (int i = 0; i < counters::num_counters; ++i, ++ptr)
 			*ptr = cnt[i];
 	}


### PR DESCRIPTION
make TORRENT_ABI_VERSION the main macro to define which deprecated functions to enable.