### PR TITLE
Make sure boost-system is found when using old versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -808,7 +808,7 @@ endif()
 find_public_dependency(Boost REQUIRED)
 target_link_libraries(torrent-rasterbar PUBLIC Boost::headers)
 if (Boost_MAJOR_VERSION LESS_EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
-	find_package(Boost REQUIRED COMPONENTS system)
+	find_public_dependency(Boost REQUIRED COMPONENTS system)
 	target_link_libraries(torrent-rasterbar PUBLIC Boost::system)
 endif()
 


### PR DESCRIPTION
When using older boost versions, boost-system is a 'PUBLIC' link target.
Make sure it's treated as a required build dependency.
(courtesy of Christophe Giboudeaux <christophe@krop.fr>)