### PR TITLE
Fix some issues finalizing uTP connections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* fix uTP streams timing out instead of closing cleanly
+
 2.0.8 released
 
 	* add write_torrent_file_buf() overload for generating .torrent files

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -877,7 +877,9 @@ private:
 	std::uint16_t m_ack_nr = 0;
 
 	// the sequence number of the next packet
-	// we'll send
+	// we'll send. when we're closing the connection
+	// this becomes the sequence number of the ST_FIN packet
+	// and will no longer increase
 	std::uint16_t m_seq_nr = 0;
 
 	// this is the sequence number of the packet that

--- a/simulation/test_utp.cpp
+++ b/simulation/test_utp.cpp
@@ -135,8 +135,7 @@ TORRENT_TEST(utp_pmtud)
 
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_loss"), 0);
 
-	// TODO: 3 This timeout happens at shutdown. It's not very clean
-	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 1);
+	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 0);
 
 	TEST_EQUAL(metric(cnt, "utp.utp_packets_in"), 593);
 	TEST_EQUAL(metric(cnt, "utp.utp_payload_pkts_in"), 66);
@@ -160,7 +159,7 @@ TORRENT_TEST(utp_plain)
 	std::vector<std::int64_t> cnt = utp_test(cfg);
 
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_loss"), 0);
-	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 1);
+	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_fast_retransmit"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_resend"), 0);
 
@@ -186,7 +185,7 @@ TORRENT_TEST(utp_buffer_bloat)
 	std::vector<std::int64_t> cnt = utp_test(cfg);
 
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_loss"), 0);
-	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 1);
+	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_fast_retransmit"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_resend"), 0);
 
@@ -244,7 +243,7 @@ TORRENT_TEST(utp_small_kernel_send_buf)
 	std::vector<std::int64_t> cnt = utp_test(cfg, 5000);
 
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_loss"), 0);
-	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 1);
+	TEST_EQUAL(metric(cnt, "utp.utp_timeout"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_fast_retransmit"), 0);
 	TEST_EQUAL(metric(cnt, "utp.utp_packet_resend"), 190);
 

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -978,9 +978,12 @@ void utp_socket_impl::writable()
 	m_stalled = false;
 	if (should_delete()) return;
 
+	// this handles the case where send_fin() was called while stalled
+	if (state() == state_t::fin_sent && m_outbuf.at(m_seq_nr) == nullptr)
+		send_pkt(pkt_fin);
 	// if the socket stalled while sending an ack then there will be a
 	// pending deferred ack. make sure it gets sent out
-	if (!m_deferred_ack || send_pkt(pkt_ack))
+	else if (!m_deferred_ack || send_pkt(pkt_ack))
 		while(send_pkt());
 
 	maybe_trigger_send_callback();

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -3023,6 +3023,10 @@ bool utp_socket_impl::incoming_packet(span<char const> b
 			// After that has happened we know the remote side has all our
 			// data, and we can gracefully shut down.
 
+			// we should still ack any incoming data to prevent potential
+			// timeouts/resends at the other end
+			if (ph->get_type() == ST_DATA) defer_ack();
+
 			if (consume_incoming_data(ph, ptr, payload_size, receive_time))
 			{
 				break;

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1409,7 +1409,10 @@ bool utp_socket_impl::send_pkt(int const flags)
 	// although, we may re-send packets, but those live in m_outbuf
 	TORRENT_ASSERT(state() != state_t::fin_sent || m_write_buffer_size == 0);
 
-	int payload_size = std::min(m_write_buffer_size
+	// If the connection is finalizing we no longer want to include any payload
+	bool const finalizing = state() == state_t::fin_sent || (flags & pkt_fin);
+
+	int payload_size = finalizing ? 0 : std::min(m_write_buffer_size
 		, effective_mtu - header_size);
 	TORRENT_ASSERT(payload_size >= 0);
 
@@ -1471,7 +1474,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 	// payload size being zero means we're just sending
 	// an force. For efficiency, pick up the nagle packet
 	// if there's room
-	if (!m_nagle_packet || (payload_size == 0 && force
+	if (!m_nagle_packet || finalizing || (payload_size == 0 && force
 		&& m_bytes_in_flight + m_nagle_packet->size
 		> std::min(int(m_cwnd >> 16), int(m_adv_wnd))))
 	{
@@ -1768,6 +1771,13 @@ bool utp_socket_impl::send_pkt(int const flags)
 		TORRENT_ASSERT(payload_size >= 0);
 		if (!m_stalled) m_bytes_in_flight += new_in_flight;
 	}
+	else if (flags & pkt_fin)
+	{
+		TORRENT_ASSERT(payload_size == 0);
+		// If we're stalled we'll need to resend
+		if (m_stalled) p->need_resend = true;
+		m_outbuf.insert(m_seq_nr, std::move(p));
+	}
 	else
 	{
 		TORRENT_ASSERT(h->seq_nr == m_seq_nr);
@@ -1985,7 +1995,10 @@ void utp_socket_impl::maybe_inc_acked_seq_nr()
 	// supposed to be in m_outbuf
 	// if the slot in m_outbuf is 0, it means the
 	// packet has been ACKed and removed from the send buffer
-	while (((m_acked_seq_nr + 1) & ACK_MASK) != m_seq_nr
+	// once we're in the fin_sent state m_acked_seq_nr can equal
+	// m_seq_nr, but shouldn't reach m_seq_nr + 1
+	while (((m_acked_seq_nr + 1) & ACK_MASK) !=
+		(state() == state_t::fin_sent ? ((m_seq_nr + 1) & ACK_MASK) : m_seq_nr)
 		&& m_outbuf.at((m_acked_seq_nr + 1) & ACK_MASK) == nullptr)
 	{
 		// increment the fast resend sequence number


### PR DESCRIPTION
This draft PR currently does the following:

* Prevents any more payload data being sent once we've either received or sent an `ST_FIN`. I've noticed in utp log files that it's currently possible for more payload data to be sent and for the sequence number to then exceed that of our sent `ST_FIN` packet. Ideally the other end would just discard such packets, by we probably shouldn't be sending them in the first place.

* Continue to ack incoming data packets after transitioning to the fin-sent state. The idea is to prevent the other side from potentially triggering timeouts/resends, especially if the fin packet itself needs resending.

* `m_seq_nr` is the next packet to be sent. Usually we don't allow `m_acked_seq_nr` to reach it as anything euqal to or above hasn't been sent yet. Once we've sent out the `ST_FIN` packet, `m_seq_nr` becomes the sequence number of the fin packet (it's not incremented when sending the fin), meaning we then need to allow `m_acked_seq_nr` to reach `m_seq_nr` in order to ack it. `maybe_inc_acked_seq_nr()` has been updated to allow this.

* Ensure that the fin packet is stored in `m_outbuf` so it can be resent if needed. Previously it was only stored if it happened to include payload (now it should never include payload). This is also needed for `maybe_inc_acked_seq_nr()` to correctly mark it as ack'd.

This appears to be enough to cleanly close connections that would previously have instead timed out. The results in the `test_utp.cpp` simulation no longer include unexpected timeouts.

* Handle calling `send_fin()` while the socket is stalled. It is re-called once the socket is writable again. If it re-stalls then it'll be in `m_sendbuf` and can be retried like any other packet. `send_fin()` progresses to the fin-sent state regardless, so other logic can still act as if it was sent.