### PR TITLE
fix pre-commit flake8 hook (`RC_2_0`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
             tools/update_copyright.py
           )$
 - repo: https://github.com/myint/autoflake
-  rev: v1.5.3
+  rev: v1.7.6
   hooks:
     - id: autoflake
       args: [--in-place, --remove-unused-variables, --remove-all-unused-imports, --remove-duplicate-keys]
@@ -86,7 +86,7 @@ repos:
                tools/libtorrent_lldb.py
           )
 - repo: https://github.com/python/black
-  rev: 22.8.0
+  rev: 22.10.0
   hooks:
     - id: black
       # Avoiding PR bloat
@@ -132,7 +132,7 @@ repos:
       name: black (pyi)
       types: [pyi]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.971
+  rev: v0.982
   hooks:
     - id: mypy
       # Avoiding PR bloat
@@ -171,7 +171,7 @@ repos:
               tools/update_copyright.py
           )$
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 5.0.4
   hooks:
   - id: flake8
     exclude: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,7 +170,7 @@ repos:
               tools/run_benchmark.py|
               tools/update_copyright.py
           )$
-- repo: https://gitlab.com/pycqa/flake8.git
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
Looks like flake8 abandoned their gitlab mirror. All new development is on github.

The old version was using some deprecated APIs of a middleware project, which caused failures like this https://github.com/arvidn/libtorrent/actions/runs/3263737743/jobs/5363268167

This switches to the github mirror of the flake8 pre-commit hook.

I also ran `pre-commit autoupdate` for good measure