### PR TITLE
Fix for C bindings

### DIFF
--- a/bindings/c/library.cpp
+++ b/bindings/c/library.cpp
@@ -151,6 +151,7 @@ TORRENT_EXPORT void* session_create(int tag, ...)
 
 		tag = va_arg(lp, int);
 	}
+	va_end(lp);
 
 	if (listen_range.first != -1 && (listen_range.second == -1
 		|| listen_range.second < listen_range.first))
@@ -253,6 +254,7 @@ TORRENT_EXPORT int session_add_torrent(void* ses, int tag, ...)
 
 		tag = va_arg(lp, int);
 	}
+	va_end(lp);
 
 	if (!params.ti && torrent_data && torrent_size)
 		params.ti.reset(new (std::nothrow) torrent_info(torrent_data, torrent_size));
@@ -392,6 +394,7 @@ TORRENT_EXPORT int session_set_settings(void* ses, int tag, ...)
 
 		tag = va_arg(lp, int);
 	}
+	va_end(lp);
 	return 0;
 }
 
@@ -490,7 +493,7 @@ TORRENT_EXPORT int torrent_get_status(int tor, torrent_status* s, int struct_siz
 	s->state = (state_t)ts.state;
 	s->paused = ts.paused;
 	s->progress = ts.progress;
-	strncpy(s->error, ts.error.c_str(), 1025);
+	strncpy(s->error, ts.error.c_str(), 1024);
 	s->next_announce = lt::total_seconds(ts.next_announce);
 	s->announce_interval = lt::total_seconds(ts.announce_interval);
 	strncpy(s->current_tracker, ts.current_tracker.c_str(), 512);
@@ -574,6 +577,7 @@ TORRENT_EXPORT int torrent_set_settings(int tor, int tag, ...)
 
 		tag = va_arg(lp, int);
 	}
+	va_end(lp);
 	return 0;
 }
 

--- a/bindings/c/library.cpp
+++ b/bindings/c/library.cpp
@@ -493,10 +493,12 @@ TORRENT_EXPORT int torrent_get_status(int tor, torrent_status* s, int struct_siz
 	s->state = (state_t)ts.state;
 	s->paused = ts.paused;
 	s->progress = ts.progress;
-	strncpy(s->error, ts.error.c_str(), 1024);
+	strncpy(s->error, ts.error.c_str(), sizeof(s->error)-1);
+	s->error[sizeof(s->error)-1] = '\0';
 	s->next_announce = lt::total_seconds(ts.next_announce);
 	s->announce_interval = lt::total_seconds(ts.announce_interval);
-	strncpy(s->current_tracker, ts.current_tracker.c_str(), 512);
+	strncpy(s->current_tracker, ts.current_tracker.c_str(), sizeof(s->current_tracker)-1);
+	s->current_tracker[sizeof(s->current_tracker)-1] = '\0';
 	s->total_download = ts.total_download = ts.total_download = ts.total_download;
 	s->total_upload = ts.total_upload = ts.total_upload = ts.total_upload;
 	s->total_payload_download = ts.total_payload_download;


### PR DESCRIPTION
`torrent_status::error` is a 1024 bytes long. Still if `ts.error.size()` will be > 1024 then `\0` will not be added to the end of `error` field. Perhaps it should be added explicitly in any case as the last symbol of array (here and in other places too).

Also we should call [va_end](https://en.cppreference.com/w/c/variadic/va_end) for freeing resources.


Target branch is a RC_2_0 is correct?