### PR TITLE
Minor fixes

### DIFF
--- a/bindings/c/library.cpp
+++ b/bindings/c/library.cpp
@@ -259,7 +259,6 @@ TORRENT_EXPORT int session_add_torrent(void* ses, int tag, ...)
 	if (!params.ti && torrent_data && torrent_size)
 		params.ti.reset(new (std::nothrow) torrent_info(torrent_data, torrent_size));
 
-	std::vector<char> rd;
 	if (resume_data && resume_size)
 	{
 		params.resume_data.assign(resume_data, resume_data + resume_size);

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -484,7 +484,7 @@ struct peer_conn
 		unsigned int length = read_uint32(ptr);
 		if (length > sizeof(buffer))
 		{
-			std::fprintf(stderr, "len: %d\n", length);
+			std::fprintf(stderr, "len: %u\n", length);
 			close("ERROR RECEIVE MESSAGE PREFIX: packet too big", error_code());
 			return;
 		}

--- a/simulation/setup_swarm.cpp
+++ b/simulation/setup_swarm.cpp
@@ -347,7 +347,7 @@ void setup_swarm(int num_nodes
 #if DEBUG_SWARM != 0
 							"[%d] "
 #endif
-							"%4d.%03d: %-25s %s\n"
+							"%4u.%03u: %-25s %s\n"
 #if DEBUG_SWARM != 0
 							, i
 #endif

--- a/simulation/test_optimistic_unchoke.cpp
+++ b/simulation/test_optimistic_unchoke.cpp
@@ -134,7 +134,7 @@ TORRENT_TEST(optimistic_unchoke)
 					lt::time_duration d = lt::clock_type::now() - start_time;
 					std::uint32_t const millis = std::uint32_t(
 						lt::duration_cast<lt::milliseconds>(d).count());
-					printf("\x1b[35m%4d.%03d: [%d] %s (%d ms)\x1b[0m\n"
+					printf("\x1b[35m%4u.%03u: [%d] %s (%d ms)\x1b[0m\n"
 						, millis / 1000, millis % 1000, i, msg_str[msg]
 						, int(lt::duration_cast<lt::milliseconds>(cs.unchoke_duration).count()));
 				}

--- a/simulation/test_socks5.cpp
+++ b/simulation/test_socks5.cpp
@@ -255,7 +255,7 @@ void test_udp_tracker(std::uint32_t const flags, socks_flags_t const sflags)
 				}
 				else
 				{
-					std::printf("unsupported udp tracker action: %d\n", action);
+					std::printf("unsupported udp tracker action: %u\n", action);
 				}
 				return ret;
 			});

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -951,7 +951,7 @@ TORRENT_TEST(pex)
 						lt::duration_cast<lt::milliseconds>(d).count());
 
 					if (i == 0) {
-					std::printf("%4d.%03d: %-25s %s\n"
+					std::printf("%4u.%03u: %-25s %s\n"
 						, millis / 1000, millis % 1000
 						, a->what()
 						, a->message().c_str());

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -354,7 +354,7 @@ void on_alert_notify(lt::session* ses)
 			lt::time_duration d = a->timestamp().time_since_epoch();
 			std::uint32_t const millis = std::uint32_t(
 				lt::duration_cast<lt::milliseconds>(d).count());
-			std::printf("%4d.%03d: %s\n", millis / 1000, millis % 1000,
+			std::printf("%4u.%03u: %s\n", millis / 1000, millis % 1000,
 				a->message().c_str());
 		}
 	});
@@ -514,7 +514,7 @@ void test_udpv6_support(char const* listen_interfaces
 					lt::time_duration d = a->timestamp().time_since_epoch();
 					std::uint32_t const millis = std::uint32_t(
 						lt::duration_cast<lt::milliseconds>(d).count());
-					std::printf("%4d.%03d: %s\n", millis / 1000, millis % 1000,
+					std::printf("%4u.%03u: %s\n", millis / 1000, millis % 1000,
 						a->message().c_str());
 					if (auto tr = alert_cast<tracker_announce_alert>(a))
 					{

--- a/test/peer_server.cpp
+++ b/test/peer_server.cpp
@@ -119,7 +119,6 @@ struct peer_server
 			error_code ec;
 			tcp::endpoint from;
 			tcp::socket socket(m_ios);
-			std::condition_variable cond;
 			bool done = false;
 			m_acceptor.async_accept(socket, from, std::bind(&new_connection, _1, &ec, &done));
 			while (!done)

--- a/test/print_alerts.cpp
+++ b/test/print_alerts.cpp
@@ -63,7 +63,7 @@ void print_alerts(lt::session* ses, lt::time_point start_time)
 #endif
 		lt::time_duration d = a->timestamp() - start_time;
 		std::uint32_t millis = std::uint32_t(lt::duration_cast<lt::milliseconds>(d).count());
-		std::printf("%4d.%03d: %-25s %s\n", millis / 1000, millis % 1000
+		std::printf("%4u.%03u: %-25s %s\n", millis / 1000, millis % 1000
 			, a->what()
 			, a->message().c_str());
 	}

--- a/test/udp_tracker.cpp
+++ b/test/udp_tracker.cpp
@@ -160,7 +160,7 @@ struct udp_tracker
 				std::printf("%s: UDP scrape (ignored)\n", time_now_string().c_str());
 				break;
 			default:
-				std::printf("%s: UDP unknown message: %d\n", time_now_string().c_str()
+				std::printf("%s: UDP unknown message: %u\n", time_now_string().c_str()
 					, action);
 				break;
 		}


### PR DESCRIPTION
I guess I need some clarification for some other lines in code. Seems they should be changed, they looks suspicious a little bit

fuzzers/src/add_torrent.cpp:142, 146, 150: the same code in an 'if' and related 'else' branch
```
if (bits.read(1)) mask.set_bit(i); else mask.set_bit(i);
if (bits.read(1)) ret.have_pieces.set_bit(i); else ret.have_pieces.set_bit(i);
if (bits.read(1)) ret.verified_pieces.set_bit(i); else ret.verified_pieces.set_bit(i);
```

test/test_remap_files.cpp:112 the same expression on both sides of an operator &&
```
TEST_CHECK(st.state != torrent_status::checking_files
	&& st.state != torrent_status::checking_files);
```
