### PR TITLE
use `$GITHUB_OUTPUT` instead of `echo ::set-output`

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -71,9 +71,9 @@ jobs:
     - id: set-matrix
       run: |
         if [ $GITHUB_EVENT_NAME == "pull_request" ]; then
-          echo ::set-output name=matrix::$(echo $MATRIX_PULL_REQUEST | jq -c)
+          echo "matrix=$(echo $MATRIX_PULL_REQUEST | jq -c)" >> "$GITHUB_OUTPUT"
         else
-          echo ::set-output name=matrix::$(echo $MATRIX_WORKFLOW_DISPATCH | jq -c)
+          echo "matrix=$(echo $MATRIX_WORKFLOW_DISPATCH | jq -c)" >> "$GITHUB_OUTPUT"
         fi
 
   build_wheels:


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This should be merged through to all branches