### PR TITLE
starting torrent: connect to peers found in params immediately

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -559,6 +559,11 @@ bool is_downloading_state(int const st)
 				add_peer(peer, peer_info::resume_data);
 			}
 
+			if (!p.peers.empty())
+			{
+				do_connect_boost();
+			}
+
 #ifndef TORRENT_DISABLE_LOGGING
 			if (should_log() && !p.peers.empty())
 			{


### PR DESCRIPTION
moving the code from add_torrent_fun to add_torrent is required because of the following code:

```c++
	torrent_handle session_impl::add_torrent(add_torrent_params&& params
		, error_code& ec)
	{
                // ...
		torrent_ptr->start();

#ifndef TORRENT_DISABLE_EXTENSIONS
		for (auto& ext : extensions)
		{
			std::shared_ptr<torrent_plugin> tp(ext(handle, userdata));
			if (tp) torrent_ptr->add_extension(std::move(tp));
		}

		add_extensions_to_torrent(torrent_ptr, userdata);
#endif
               // ...


```

without this the extensions don't have access to the connections made at the start of the torrent