### PR TITLE
fix cancelling deferred ACK

### DIFF
--- a/include/libtorrent/aux_/utp_socket_manager.hpp
+++ b/include/libtorrent/aux_/utp_socket_manager.hpp
@@ -119,6 +119,7 @@ namespace aux {
 		int num_sockets() const { return int(m_utp_sockets.size()); }
 
 		void defer_ack(utp_socket_impl* s);
+		void cancel_deferred_ack(utp_socket_impl* s);
 		void subscribe_drained(utp_socket_impl* s);
 
 		void restrict_mtu(int const mtu)

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -624,7 +624,7 @@ struct utp_socket_impl
 	void update_mtu_limits();
 	void experienced_loss(std::uint32_t seq_nr, time_point now);
 
-	void send_ack();
+	void send_deferred_ack();
 	void socket_drained();
 
 	void set_userdata(utp_stream* s) { m_userdata = s; }

--- a/src/utp_socket_manager.cpp
+++ b/src/utp_socket_manager.cpp
@@ -161,9 +161,14 @@ namespace aux {
 			return m_last_socket->incoming_packet(p, ep, receive_time);
 		}
 
+		// we send the deferred ACK when the socket is drained as well,
+		// so as long as the incoming packets go to the last socket
+		// (m_last_socket) we can derfer the ACK more. However, if we
+		// receive a packet for another socket, we have to trigger the
+		// ACK in case the new socket also wants to defer an ACK.
 		if (m_deferred_ack)
 		{
-			m_deferred_ack->send_ack();
+			m_deferred_ack->send_deferred_ack();
 			m_deferred_ack = nullptr;
 		}
 
@@ -253,7 +258,7 @@ namespace aux {
 		{
 			utp_socket_impl* s = m_deferred_ack;
 			m_deferred_ack = nullptr;
-			s->send_ack();
+			s->send_deferred_ack();
 		}
 
 		if (!m_drained_event.empty())
@@ -270,6 +275,13 @@ namespace aux {
 		TORRENT_ASSERT(m_deferred_ack == nullptr || m_deferred_ack == s);
 		m_deferred_ack = s;
 	}
+
+	void utp_socket_manager::cancel_deferred_ack(utp_socket_impl* s)
+	{
+		if (m_deferred_ack == s)
+			m_deferred_ack = nullptr;
+	}
+
 
 	void utp_socket_manager::subscribe_drained(utp_socket_impl* s)
 	{


### PR DESCRIPTION
when cancelling a deferred ACK, also tell the socket manager about it (to prevent it from triggering it later). This is especially important when destructing, in case the socket manager still has a reference to the socket after it is destructed.

This could possibly fix this issue: https://github.com/qbittorrent/qBittorrent/issues/18157#issuecomment-1347030504