### PR TITLE
Don't require dependencies to be static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,11 +501,6 @@ if(static_runtime)
 	set(OPENSSL_MSVC_STATIC_RT ON)
 endif()
 
-if (NOT BUILD_SHARED_LIBS)
-	set(Boost_USE_STATIC_LIBS ON)
-	set(OPENSSL_USE_STATIC_LIBS ON)
-endif()
-
 add_library(torrent-rasterbar
 	${sources}
 	${libtorrent_include_files}


### PR DESCRIPTION
Don't require dependencies to be static libraries when libtorrent itself is being built as a static library.

I'm building libtorrent as a static library in flatpak environment. The openssl is provided by underlying platform and it is a shared library. Without this change, libtorrent won't be able to find/link with openssl (shared) library. And there is no way to work around it except to edit CMakeLists.txt manually.

IMO there is no reason that the dependencies should be static libraries and the user should be able to freely choose the version (static or shared) as they wish. Users should take the responsibility and set the following variables if they want to link dependencies statically.
* https://cmake.org/cmake/help/latest/module/FindOpenSSL.html#hints :
  >OPENSSL_USE_STATIC_LIBS
      Set to TRUE to look for static libraries.
* https://cmake.org/cmake/help/latest/module/FindBoost.html#other-variables
  >Boost_USE_STATIC_LIBS
    Set to ON to force the use of the static libraries. Default is OFF.

Note that `RC_2_0` and `master` branch are also affected.