### PR TITLE
Fix WebSocket tracker peer id changing in answer

### DIFF
--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -772,6 +772,9 @@ namespace libtorrent::aux {
 		// The key is passed to http trackers as ``&key=``.
 		std::uint32_t tracker_key() const;
 
+		// the peer id for tracker interaction only, generated when we add the torrent
+		peer_id const& pid() const { return m_peer_id; }
+
 		// if we need a connect boost, connect some peers
 		// immediately
 		void do_connect_boost();

--- a/src/rtc_signaling.cpp
+++ b/src/rtc_signaling.cpp
@@ -21,7 +21,6 @@ see LICENSE file.
 #include "libtorrent/aux_/rtc_signaling.hpp"
 #include "libtorrent/aux_/rtc_stream.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
-#include "libtorrent/aux_/generate_peer_id.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <rtc/rtc.hpp>
@@ -140,7 +139,7 @@ void rtc_signaling::generate_offers(int count, offers_handler handler)
 	while (count--)
 	{
 		rtc_offer_id offer_id = generate_offer_id();
-		peer_id pid = aux::generate_peer_id(m_torrent->settings());
+		peer_id pid = m_torrent->pid();
 
 		auto& conn = create_connection(offer_id, [weak_this = weak_from_this(), offer_id, pid]
 			(error_code const& ec, std::string sdp)
@@ -359,8 +358,7 @@ void rtc_signaling::on_generated_answer(error_code const& ec, rtc_answer answer,
 	debug_log("*** RTC signaling generated answer");
 #endif
 	TORRENT_ASSERT(offer.answer_callback);
-	peer_id pid = aux::generate_peer_id(m_torrent->settings());
-	offer.answer_callback(pid, answer);
+	offer.answer_callback(m_torrent->pid(), answer);
 }
 
 void rtc_signaling::on_data_channel(error_code const& ec


### PR DESCRIPTION
The `rtc_signaling` implementation currently generates a new `peer_id` for each offer and answer, following an early attempt to mimic the per-connection `peer_id` mechanism in libtorrent. However, this is not possible with the WebTorrent tracker protocol and as a result answers announces are wrongly sent with changing peer ids while offers batches are correctly sent with the peer id generated for the torrent. This causes incompatibility with trackers and possible connection issues.

This PR fixes the behavior by always using the `peer_id` generated for the torrent in  `rtc_signaling`.

Fixes https://github.com/arvidn/libtorrent/issues/7237