### PR TITLE
Make WebTorrent offer_id length consistent with the reference implementation

### DIFF
--- a/include/libtorrent/aux_/rtc_signaling.hpp
+++ b/include/libtorrent/aux_/rtc_signaling.hpp
@@ -47,7 +47,7 @@ namespace aux {
 
 struct rtc_stream_init;
 
-constexpr int RTC_OFFER_ID_LEN = 16;
+constexpr int RTC_OFFER_ID_LEN = 20;
 
 struct rtc_offer_id : std::vector<char>
 {


### PR DESCRIPTION
This PR changes the generated WebTorrent `offer_id` length from 16 to 20 bytes to be consistent with the reference implementation.

Fixes https://github.com/arvidn/libtorrent/issues/7238