### PR TITLE
Don't require dependencies to be static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,11 +544,6 @@ if(static_runtime)
 	set(OPENSSL_MSVC_STATIC_RT ON)
 endif()
 
-if (NOT BUILD_SHARED_LIBS)
-	set(Boost_USE_STATIC_LIBS ON)
-	set(OPENSSL_USE_STATIC_LIBS ON)
-endif()
-
 add_library(torrent-rasterbar
 	${sources}
 	${try_signal_sources}


### PR DESCRIPTION
when libtorrent itself is being built as a static library.