### PR TITLE
Add macOS arm64 wheels build and tests to .cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,6 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 build_macos_arm64_task:
   name: Build macOS arm64 wheels.
-  trigger_type: manual
 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
@@ -63,7 +62,6 @@ build_macos_arm64_task:
 
 test_macos_arm64_task:
   name: Test macOS arm64.
-  trigger_type: manual
 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,6 +38,8 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 build_macos_arm64_task:
   name: Build macOS arm64 wheels.
+  trigger_type: manual
+
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 
@@ -61,6 +63,8 @@ build_macos_arm64_task:
 
 test_macos_arm64_task:
   name: Test macOS arm64.
+  trigger_type: manual
+
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,11 +34,10 @@ build_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 
   env:
-    PATH: /opt/homebrew/opt/python@3.9/bin:$PATH
+    PATH: /opt/homebrew/bin:$PATH
 
   install_pre_requirements_script:
     - brew install python@3.9
-    - ln -s python3 /opt/homebrew/opt/python@3.9/bin/python
   <<: *BUILD_AND_STORE_WHEELS
 
 test_macos_arm64_task:
@@ -47,11 +46,10 @@ test_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 
   env:
-    PATH: /opt/homebrew/opt/python@3.9/bin:$PATH
+    PATH: /opt/homebrew/bin:$PATH
 
   install_pre_requirements_script:
     - brew install python@3.9
-    - ln -s python3 /opt/homebrew/opt/python@3.9/bin/python
     - brew install boost-build boost openssl@1.1
     - echo "using darwin ;" >>~/user-config.jam
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     - echo $PATH
     - ls -l /opt/homebrew/bin
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.12.0
+    - $PYTHON -m pip install cibuildwheel==2.12.0
   run_cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:
@@ -39,6 +39,7 @@ build_macos_arm64_task:
   env:
     CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
+    PYTHON: python3.9
 
   install_pre_requirements_script:
     - brew install python@3.9
@@ -57,6 +58,7 @@ test_macos_arm64_task:
   env:
     CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
+    PYTHON: python3.9
 
   install_pre_requirements_script:
     - brew install python@3.9

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,3 +19,48 @@ task:
     cd test
     b2 -l250 warnings-as-errors=on warnings=all crypto=openssl stage_enum_if stage_dependencies include=/usr/local/include library-path=/usr/local/lib
     LD_LIBRARY_PATH=./dependencies ./enum_if
+
+build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  install_cibuildwheel_script:
+    - python -m pip install cibuildwheel==2.12.0
+  run_cibuildwheel_script:
+    - cibuildwheel
+  wheels_artifacts:
+    path: "wheelhouse/*"
+
+build_macos_arm64_task:
+  name: Build macOS arm64 wheels.
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
+
+  env:
+    PATH: /opt/homebrew/opt/python@3.9/bin:$PATH
+
+  install_pre_requirements_script:
+    - brew install python@3.9
+    - ln -s python3 /opt/homebrew/opt/python@3.9/bin/python
+  <<: *BUILD_AND_STORE_WHEELS
+
+test_macos_arm64_task:
+  name: Test macOS arm64.
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
+
+  env:
+    PATH: /opt/homebrew/opt/python@3.9/bin:$PATH
+
+  install_pre_requirements_script:
+    - brew install python@3.9
+    - ln -s python3 /opt/homebrew/opt/python@3.9/bin/python
+    - brew install boost-build boost openssl@1.1
+    - echo "using darwin ;" >>~/user-config.jam
+
+  test_script:
+    - cd test
+    - b2 crypto=built-in -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
+    - b2 deprecated-functions=off -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
+
+  test_flaky_script:
+    - cd test
+    - b2 crypto=built-in -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on
+    - b2 deprecated-functions=off -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,9 @@ task:
     LD_LIBRARY_PATH=./dependencies ./enum_if
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  debug_script:
+    - echo $PATH
+    - ls -l /opt/homebrew/bin
   install_cibuildwheel_script:
     - python -m pip install cibuildwheel==2.12.0
   run_cibuildwheel_script:
@@ -39,6 +42,11 @@ build_macos_arm64_task:
 
   install_pre_requirements_script:
     - brew install python@3.9
+
+  debug_script:
+    - echo $PATH
+    - ls -l /opt/homebrew/bin
+
   <<: *BUILD_AND_STORE_WHEELS
 
 test_macos_arm64_task:
@@ -49,10 +57,15 @@ test_macos_arm64_task:
   env:
     CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
+
   install_pre_requirements_script:
     - brew install python@3.9
     - brew install boost-build boost openssl@1.1
     - echo "using darwin ;" >>~/user-config.jam
+
+  debug_script:
+    - echo $PATH
+    - ls -l /opt/homebrew/bin
 
   test_script:
     - cd test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,13 @@ task:
     LD_LIBRARY_PATH=./dependencies ./enum_if
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  env:
+    CIBW_BUILD_VERBOSITY: 3
+    CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+      find . -name '*libtorrent-rasterbar*' -ls &&
+      REPAIR_LIBRARY_PATH=xxxx/lib &&
+      DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
+      DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
   debug_script:
     - echo $PATH
     - ls -l /opt/homebrew/bin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,6 +72,9 @@ test_macos_arm64_task:
     CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9
+    OPENSSL_OPTS: >
+      openssl-lib=/opt/homebrew/opt/openssl@1.1/lib
+      openssl-include=/opt/homebrew/opt/openssl@1.1/include
 
   install_pre_requirements_script:
     - brew install python@3.9
@@ -86,9 +89,11 @@ test_macos_arm64_task:
   test_script:
     - cd test
     - b2 crypto=built-in -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
-    - b2 deprecated-functions=off -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
+    - b2 $OPENSSL_OPTS crypto=openssl -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
+    - b2 $OPENSSL_OPTS deprecated-functions=off -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
 
   test_flaky_script:
     - cd test
     - b2 crypto=built-in -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on
-    - b2 deprecated-functions=off -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on
+    - b2 $OPENSSL_OPTS crypto=openssl -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on
+    - b2 $OPENSSL_OPTS deprecated-functions=off -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,6 +47,7 @@ build_macos_arm64_task:
   debug_script:
     - echo $PATH
     - ls -l /opt/homebrew/bin
+    - find /opt/homebrew -name '*openssl*' -ls
 
   <<: *BUILD_AND_STORE_WHEELS
 
@@ -68,6 +69,7 @@ test_macos_arm64_task:
   debug_script:
     - echo $PATH
     - ls -l /opt/homebrew/bin
+    - find /opt/homebrew -name '*openssl*' -ls
 
   test_script:
     - cd test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,7 @@ build_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 
   env:
+    CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
 
   install_pre_requirements_script:
@@ -46,8 +47,8 @@ test_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 
   env:
+    CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
-
   install_pre_requirements_script:
     - brew install python@3.9
     - brew install boost-build boost openssl@1.1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,13 +26,13 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
       delocate-listdeps {wheel} &&
       delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-  debug_script:
-    - echo $PATH
-    - ls -l /opt/homebrew/bin
+
   install_cibuildwheel_script:
     - $PYTHON -m pip install cibuildwheel==2.12.0
+
   run_cibuildwheel_script:
     - cibuildwheel
+
   wheels_artifacts:
     path: "wheelhouse/*"
 
@@ -43,7 +43,8 @@ build_macos_arm64_task:
 
   env:
     CIRRUS_CLONE_SUBMODULES: true
-    CIBW_SKIP: cp38-*
+    CIBW_SKIP: pp* cp38-* # cp38-* has problem with x86_64 / arm64 confusion
+    CIBW_BUILD: cp39-* cp310-* # cp311-* can be added after boost-python version >= 1.81
     CIBW_ARCH: arm64
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,10 +24,8 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   env:
     CIBW_BUILD_VERBOSITY: 3
     CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-      find . -name '*libtorrent-rasterbar*' -ls &&
-      REPAIR_LIBRARY_PATH=xxxx/lib &&
-      DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
-      DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+      delocate-listdeps {wheel} &&
+      delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
   debug_script:
     - echo $PATH
     - ls -l /opt/homebrew/bin
@@ -45,7 +43,8 @@ build_macos_arm64_task:
 
   env:
     CIRRUS_CLONE_SUBMODULES: true
-    CIBW_BUILD: cp39-*
+    CIBW_SKIP: cp38-*
+    CIBW_ARCH: arm64
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,6 +45,7 @@ build_macos_arm64_task:
 
   env:
     CIRRUS_CLONE_SUBMODULES: true
+    CIBW_BUILD: cp39-*
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9
 

--- a/Jamfile
+++ b/Jamfile
@@ -396,7 +396,7 @@ rule openssl-lib-path ( properties * )
 		# on macOS, default to pick up openssl from the homebrew installation
 		# brew install openssl
 		# homebrew on M1 Macs install to /opt/homebrew
-		OPENSSL_LIB = /opt/homebrew/opt/openssl/lib /usr/local/opt/openssl/lib ;
+		OPENSSL_LIB = /opt/homebrew/opt/openssl@1.1/lib /opt/homebrew/opt/openssl/lib /usr/local/opt/openssl/lib ;
 	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_LIB) = ""
 	{
@@ -423,7 +423,7 @@ rule openssl-include-path ( properties * )
 		# on macOS, default to pick up openssl from the homebrew installation
 		# brew install openssl
 		# homebrew on M1 Macs install to /opt/homebrew
-		OPENSSL_INCLUDE = /opt/homebrew/opt/openssl/include /usr/local/opt/openssl/include ;
+		OPENSSL_INCLUDE = /opt/homebrew/opt/openssl@1.1/include /opt/homebrew/opt/openssl/include /usr/local/opt/openssl/include ;
 	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_INCLUDE) = ""
 	{

--- a/Jamfile
+++ b/Jamfile
@@ -396,7 +396,7 @@ rule openssl-lib-path ( properties * )
 		# on macOS, default to pick up openssl from the homebrew installation
 		# brew install openssl
 		# homebrew on M1 Macs install to /opt/homebrew
-		OPENSSL_LIB = /opt/homebrew/opt/openssl@1.1/lib /opt/homebrew/opt/openssl/lib /usr/local/opt/openssl/lib ;
+		OPENSSL_LIB = /opt/homebrew/opt/openssl/lib /usr/local/opt/openssl/lib ;
 	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_LIB) = ""
 	{
@@ -423,7 +423,7 @@ rule openssl-include-path ( properties * )
 		# on macOS, default to pick up openssl from the homebrew installation
 		# brew install openssl
 		# homebrew on M1 Macs install to /opt/homebrew
-		OPENSSL_INCLUDE = /opt/homebrew/opt/openssl@1.1/include /opt/homebrew/opt/openssl/include /usr/local/opt/openssl/include ;
+		OPENSSL_INCLUDE = /opt/homebrew/opt/openssl/include /usr/local/opt/openssl/include ;
 	}
 	else if <target-os>windows in $(properties) && $(OPENSSL_INCLUDE) = ""
 	{


### PR DESCRIPTION
Fixes #7131

Does not have any automated pypi upload, but otherwise works for cp39 and cp310 wheels. The artifacts have to be downloaded from Cirrus-CI servers.

https://cirrus-ci.org/guide/writing-tasks/#latest-build-artifacts

```
Uploading 2 artifacts for /var/folders/76/zy5ktkns50v6gt5g8r0sf6sc0000gn/T/cirrus-ci-build/wheelhouse/*
Uploaded /var/folders/76/zy5ktkns50v6gt5g8r0sf6sc0000gn/T/cirrus-ci-build/wheelhouse/libtorrent-2.0.8-cp310-cp310-macosx_11_0_arm64.whl
Uploaded /var/folders/76/zy5ktkns50v6gt5g8r0sf6sc0000gn/T/cirrus-ci-build/wheelhouse/libtorrent-2.0.8-cp39-cp39-macosx_11_0_arm64.whl
```