### PR TITLE
support old building on older versions of MacOS

### DIFF
--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -127,7 +127,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_USE_EXECINFO 1
 #endif
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+// this is used for the ip_change_notifier on macOS, which isn't supported on
+// 10.6 and earlier
 #define TORRENT_USE_SYSTEMCONFIGURATION 1
+#endif
 
 #if TARGET_OS_IPHONE
 #define TORRENT_USE_SC_NETWORK_REACHABILITY 1


### PR DESCRIPTION
by disabling ip_change_notifier support.

The two configuration macros used for macOS and iOS were also made orthogonal to simplify the `ip_notifier.cpp` code a bit, as well as the configuration logic to still allow the iOS configuration to take effect, even though it probably doesn't defined the `MAC_OS_` macros.