### PR TITLE
minor accounting fix for utp packet pool

### DIFF
--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1896,7 +1896,12 @@ bool utp_socket_impl::send_pkt(int const flags)
 		TORRENT_ASSERT(payload_size == 0);
 		// If we're stalled we'll need to resend
 		if (m_stalled) p->need_resend = true;
-		m_outbuf.insert(m_seq_nr, std::move(p));
+		packet_ptr old = m_outbuf.insert(m_seq_nr, std::move(p));
+		if (old)
+		{
+			if (!old->need_resend) m_bytes_in_flight -= old->size - old->header_size;
+			release_packet(std::move(old));
+		}
 	}
 	else
 	{


### PR DESCRIPTION
this is not addressing a leak (`packet_ptr` is a `unique_ptr`), but allows the allocation to be returned to the pool