### PR TITLE
ignore peers with listen port 1

### DIFF
--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -1062,7 +1062,7 @@ namespace libtorrent {
 		auto const remote_address = remote.address();
 
 		// just ignore the obviously invalid entries
-		if (remote_address == address() || remote.port() == 0)
+		if (remote_address == address() || remote.port() == 0 || remote.port() == 1)
 			return nullptr;
 
 		// don't allow link-local IPv6 addresses since they


### PR DESCRIPTION
port 1 is used as a placeholder for announcing to trackers without the ability to accept incoming connections. When we see such peers, don't add them to the peer list