### PR TITLE
Improve save resume if modified

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* improve save_resume behavior with only_if_modified flag
 	* fix issue with retrying trackers in tiers > 0
 	* fix last_upload and last_download resume data fields to use posix time
 	* improve error messages for no_connect_privileged_ports, by untangle it from the port filter

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -1111,7 +1111,7 @@ bool handle_alert(client_state_t& client_state, lt::alert* a)
 		// the alert handler for save_resume_data_alert
 		// will save it to disk
 		torrent_handle h = p->handle;
-		h.save_resume_data(torrent_handle::save_info_dict);
+		h.save_resume_data(torrent_handle::save_info_dict | torrent_handle::only_if_modified);
 		++num_outstanding_resume_data;
 		if (exit_on_finish) quit = true;
 	}

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -2148,7 +2148,7 @@ done:
 				std::vector<lt::open_file_state> file_status = h.file_status();
 				std::vector<lt::download_priority_t> file_prio = h.get_file_priorities();
 				auto f = file_status.begin();
-				std::shared_ptr<const lt::torrent_info> ti = h.torrent_file();
+				std::shared_ptr<const lt::torrent_info> ti = s.torrent_file.lock();
 
 				auto const& file_progress = client_state.file_progress;
 				int p = 0; // this is horizontal position

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -873,7 +873,7 @@ namespace libtorrent {
 
 		// called when we learn that we have a piece
 		// only once per piece
-		void we_have(piece_index_t index);
+		void we_have(piece_index_t index, bool loading_resume = false);
 
 		// process the v2 block hashes for a piece
 		boost::tribool on_blocks_hashed(piece_index_t piece
@@ -1670,7 +1670,11 @@ namespace libtorrent {
 		// the number of unchoked peers in this torrent
 		unsigned int m_num_uploads:24;
 
-		// 4 unused bits
+		// 3 unused bits
+
+		// set to false when saving resume data. Set to true
+		// whenever some statistics that's saved in the resume data is updated
+		bool m_counters_updated:1;
 
 		// when this is true, this torrent supports peer exchange
 		bool m_enable_pex:1;

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -683,10 +683,20 @@ namespace aux {
 		// if nothing significant has changed in the torrent since the last
 		// time resume data was saved, fail this attempt. Significant changes
 		// primarily include more data having been downloaded, file or piece
-		// priorities having changed etc. If the resume data doesn't need
-		// saving, a save_resume_data_failed_alert is posted with the error
+		// priorities, paused-state, transfer limit settings  having changed etc.
+		// Counters keeping statistics are notably *not* considered significant.
+		// Things like total_uploaded, total_downloaded, last_seen_complete,
+		// tracker scrape counters, are not considered significant enough
+		// changes for this flag to save the resume data.
+		// If the resume data doesn't need saving, a
+		// save_resume_data_failed_alert is posted with the error
 		// resume_data_not_modified.
 		static constexpr resume_data_flags_t only_if_modified = 2_bit;
+
+		// this flag amends the behavior of only_if_modified to include
+		// stats counter or scrape data updating to also count as an update, so
+		// it becomes more eager to save resume data.
+		static constexpr resume_data_flags_t save_counters = 3_bit;
 
 		// ``save_resume_data()`` asks libtorrent to generate fast-resume data for
 		// this torrent. The fast resume data (stored in an add_torrent_params

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -69,6 +69,7 @@ namespace libtorrent {
 	constexpr resume_data_flags_t torrent_handle::flush_disk_cache;
 	constexpr resume_data_flags_t torrent_handle::save_info_dict;
 	constexpr resume_data_flags_t torrent_handle::only_if_modified;
+	constexpr resume_data_flags_t torrent_handle::save_counters;
 	constexpr add_piece_flags_t torrent_handle::overwrite_existing;
 	constexpr pause_flags_t torrent_handle::graceful_pause;
 	constexpr pause_flags_t torrent_handle::clear_disk_cache;


### PR DESCRIPTION
The main cases this fixes are things like:
* saving resume data whenever a torrent finishes downloading. This is a reasonable thing to do, but is not reasonable if you just started and added an existing torrent (just loading its resume data) and it was finished. You'll still get this alert to indicate that it's finished. saving with `only_if_modified` still triggers saving in this case, but not with this patch.
* saving resume data on `add_torrent_alert`, since maybe a new torrent was just added and it should be saved in the resume data so it will be restored in the next session. However, it the torrent was added from existing resume data, and we just started up a new session, it does not make sense to re-save the resume data. Saving with `only_if_modified` will trigger saving currently, but not with this patch.

Other minor improvements are:
* if you set per-torrent upload rate, download rate, connections limit, upload slots limit to the *same* value as was already set, it's not considered a "modification" for need-save-resume data purposes.
* if a web seed redirects and adds a new ephemeral web seed, it's not considered a modification for need-save-resume data purposes (since ephemeral web seeds aren't saved in the resume data anyway)