### PR TITLE
skip some expensive invariant checks

### DIFF
--- a/include/libtorrent/aux_/torrent_list.hpp
+++ b/include/libtorrent/aux_/torrent_list.hpp
@@ -214,6 +214,12 @@ struct torrent_list
 #if TORRENT_USE_INVARIANT_CHECKS
 	void check_invariant() const
 	{
+#ifndef TORRENT_EXPENSIVE_INVARIANT_CHECKS
+		// if we have many torrents, this would be an expensive
+		// invariant check, so don't run it in that case (unless we
+		// enabled expensive invariant checks)
+		if (m_array.size() > 100) return;
+#endif
 		std::set<T*> all_torrents;
 		std::set<T*> all_indexed_torrents;
 #if !defined TORRENT_DISABLE_ENCRYPTION

--- a/src/file_progress.cpp
+++ b/src/file_progress.cpp
@@ -194,6 +194,13 @@ namespace libtorrent { namespace aux {
 			return;
 		}
 
+#ifndef TORRENT_EXPENSIVE_INVARIANT_CHECKS
+		// if we have many files, this would be an expensive
+		// invariant check, so don't run it unless we
+		// enabled expensive invariant checks
+		if (m_file_progress.size() > 900) return;
+#endif
+
 		file_index_t index(0);
 		std::int64_t total_on_disk = 0;
 		for (std::int64_t progress : m_file_progress)

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -7076,19 +7076,25 @@ namespace {
 			&& m_settings.get_int(settings_pack::choking_algorithm) == settings_pack::fixed_slots_choker)
 			TORRENT_ASSERT(m_stats_counters[counters::num_unchoke_slots] == std::numeric_limits<int>::max());
 
-		for (torrent_list_index_t l{}; l != m_torrent_lists.end_index(); ++l)
+#ifndef TORRENT_EXPENSIVE_INVARIANT_CHECKS
+		// this can get expensive when there are a lot of torrents
+		if (m_download_queue.size() < 500)
+#endif
 		{
-			std::vector<torrent*> const& list = m_torrent_lists[l];
-			for (auto const& i : list)
+			for (torrent_list_index_t l{}; l != m_torrent_lists.end_index(); ++l)
 			{
-				TORRENT_ASSERT(i->m_links[l].in_list());
-			}
+				std::vector<torrent*> const& list = m_torrent_lists[l];
+				for (auto const& i : list)
+				{
+					TORRENT_ASSERT(i->m_links[l].in_list());
+				}
 
-			queue_position_t idx{};
-			for (auto t : m_download_queue)
-			{
-				TORRENT_ASSERT(t->queue_position() == idx);
-				++idx;
+				queue_position_t idx{};
+				for (auto t : m_download_queue)
+				{
+					TORRENT_ASSERT(t->queue_position() == idx);
+					++idx;
+				}
 			}
 		}
 


### PR DESCRIPTION
unless the build-configuration is enabled to always perform them