### PR TITLE
add validation of enum settings when asserts are enabled

### DIFF
--- a/include/libtorrent/assert.hpp
+++ b/include/libtorrent/assert.hpp
@@ -85,6 +85,9 @@ extern TORRENT_EXPORT char const* libtorrent_assert_log;
 
 #ifndef TORRENT_USE_SYSTEM_ASSERTS
 
+#define TORRENT_ASSERT_PRECOND_MSG(x, msg) \
+	do { if (x) {} else libtorrent::assert_fail(#x, __LINE__, __FILE__, __func__, msg, 1); } TORRENT_WHILE_0
+
 #define TORRENT_ASSERT_PRECOND(x) \
 	do { if (x) {} else libtorrent::assert_fail(#x, __LINE__, __FILE__, __func__, nullptr, 1); } TORRENT_WHILE_0
 
@@ -110,6 +113,7 @@ extern TORRENT_EXPORT char const* libtorrent_assert_log;
 
 #else
 #include <cassert>
+#define TORRENT_ASSERT_PRECOND_MSG(x, msg) assert(x)
 #define TORRENT_ASSERT_PRECOND(x) assert(x)
 #define TORRENT_ASSERT(x) assert(x)
 #define TORRENT_ASSERT_VAL(x, y) assert(x)
@@ -119,6 +123,7 @@ extern TORRENT_EXPORT char const* libtorrent_assert_log;
 
 #else // TORRENT_USE_ASSERTS
 
+#define TORRENT_ASSERT_PRECOND_MSG(a, msg) do {} TORRENT_WHILE_0
 #define TORRENT_ASSERT_PRECOND(a) do {} TORRENT_WHILE_0
 #define TORRENT_ASSERT(a) do {} TORRENT_WHILE_0
 #define TORRENT_ASSERT_VAL(a, b) do {} TORRENT_WHILE_0

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -468,6 +468,10 @@ namespace aux {
 
 			void close_connection(peer_connection* p) noexcept override;
 
+#if !defined TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
+			void validate_setting(int const int_name, int const min, int const max);
+			void validate_settings();
+#endif
 			void apply_settings_pack(std::shared_ptr<settings_pack> pack) override;
 			void apply_settings_pack_impl(settings_pack const& pack);
 			session_settings const& settings() const override { return m_settings; }

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -270,11 +270,15 @@ namespace {
 				setup_receive();
 			}
 		}
-		else if (out_policy == settings_pack::pe_disabled)
+		else
 #endif
 		{
+#if !defined TORRENT_DISABLE_ENCRYPTION
+			TORRENT_ASSERT(out_policy == settings_pack::pe_disabled);
+#endif
 			write_handshake();
 
+			TORRENT_ASSERT(m_sent_handshake);
 			// start in the state where we are trying to read the
 			// handshake from the other side
 			m_recv_buffer.reset(20);
@@ -3273,6 +3277,8 @@ namespace {
 
 		if (m_state == state_t::read_protocol_identifier)
 		{
+			TORRENT_ASSERT(!m_outgoing || m_sent_handshake);
+
 			received_bytes(0, int(bytes_transferred));
 			bytes_transferred = 0;
 			TORRENT_ASSERT(m_recv_buffer.packet_size() == 20);
@@ -3359,6 +3365,7 @@ namespace {
 #endif
 			}
 
+			TORRENT_ASSERT(!m_outgoing || m_sent_handshake);
 			m_state = state_t::read_info_hash;
 			m_recv_buffer.reset(28);
 		}

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -567,6 +567,9 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 		, m_close_file_timer(m_io_context)
 		, m_paused(flags & session::paused)
 	{
+#if !defined TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
+		validate_settings();
+#endif
 	}
 
 	template <typename Fun, typename... Args>
@@ -1517,6 +1520,34 @@ namespace {
 	}
 }
 
+#if !defined TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
+	void session_impl::validate_setting(int const int_name, int const min, int const max)
+	{
+		int const val = m_settings.get_int(int_name);
+		TORRENT_ASSERT_PRECOND_MSG(val >= min, name_for_setting(int_name));
+		TORRENT_ASSERT_PRECOND_MSG(val <= max, name_for_setting(int_name));
+#ifndef TORRENT_DISABLE_LOGGING
+		if (val < min || val > max)
+			session_log("invalid %s setting: %d", name_for_setting(int_name), val);
+#endif
+	}
+
+	void session_impl::validate_settings()
+	{
+		validate_setting(settings_pack::out_enc_policy, 0, 2);
+		validate_setting(settings_pack::in_enc_policy, 0, 2);
+		validate_setting(settings_pack::allowed_enc_level, 1, 3);
+		validate_setting(settings_pack::mixed_mode_algorithm, 0, 1);
+		validate_setting(settings_pack::proxy_type, 0, 5);
+		validate_setting(settings_pack::disk_io_read_mode, 0, 3);
+		validate_setting(settings_pack::disk_io_write_mode, 0, 3);
+		validate_setting(settings_pack::choking_algorithm, 0, 3);
+		validate_setting(settings_pack::seed_choking_algorithm, 0, 3);
+		validate_setting(settings_pack::suggest_mode, 0, 1);
+		validate_setting(settings_pack::disk_write_mode, 0, 2);
+	}
+#endif
+
 	void session_impl::apply_settings_pack_impl(settings_pack const& pack)
 	{
 		bool const reopen_listen_port
@@ -1540,6 +1571,11 @@ namespace {
 #endif
 
 		apply_pack(&pack, m_settings, this);
+
+#if !defined TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
+		validate_settings();
+#endif
+
 		m_disk_thread->settings_updated();
 
 		if (!reopen_listen_port)

--- a/test/test_privacy.cpp
+++ b/test/test_privacy.cpp
@@ -339,10 +339,3 @@ TORRENT_TEST(http_pw_peer)
 {
 	test_proxy(settings_pack::http_pw, dont_proxy_peers | expect_peer_connection);
 }
-
-#if TORRENT_USE_I2P
-TORRENT_TEST(i2p)
-{
-	test_proxy(settings_pack::i2p_proxy, {});
-}
-#endif


### PR DESCRIPTION
When logging is enabled, print a session log if invalid values are set