### PR TITLE
expose i2p destination in `peer_info`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+	* add an i2p torrent state to control interactions with clear swarms
+	* fix i2p SAM protocol parsing of quoted messages
+	* expose i2p peer destination in peer_info
+	* fix i2p tracker announces
 	* fix issue with read_piece() stopping torrent on pieces not yet downloaded
 	* improve handling of allow_i2p_mixed setting to work for magnet links
 	* fix web seed request for renamed single-file torrents

--- a/bindings/python/src/peer_info.cpp
+++ b/bindings/python/src/peer_info.cpp
@@ -108,6 +108,9 @@ void bind_peer_info()
         .def_readonly("estimated_reciprocation_rate", &peer_info::estimated_reciprocation_rate)
 #endif
         .add_property("local_endpoint", get_local_endpoint)
+#if TORRENT_USE_I2P
+        .def("i2p_destination", &peer_info::i2p_destination)
+#endif
         ;
 
     // flags

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -330,6 +330,56 @@ int peer_index(lt::tcp::endpoint addr, std::vector<lt::peer_info> const& peers)
 	return int(i - peers.begin());
 }
 
+#if TORRENT_USE_I2P
+void base32encode_i2p(lt::sha256_hash const& s, std::string& out, int limit)
+{
+	static char const base32_table[] =
+	{
+		'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+		'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+		'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+		'y', 'z', '2', '3', '4', '5', '6', '7'
+	};
+
+	static std::array<int, 6> const input_output_mapping{{0, 2, 4, 5, 7, 8}};
+
+	std::array<std::uint8_t, 5> inbuf;
+	std::array<std::uint8_t, 8> outbuf;
+
+	TORRENT_ASSERT(s.size() % 5 );
+	for (auto i = s.begin(); i != s.end();)
+	{
+		int const available_input = std::min(int(inbuf.size()), int(s.end() - i));
+
+		// clear input buffer
+		inbuf.fill(0);
+
+		// read a chunk of input into inbuf
+		std::copy(i, i + available_input, inbuf.begin());
+		i += available_input;
+
+		// encode inbuf to outbuf
+		outbuf[0] = (inbuf[0] & 0xf8) >> 3;
+		outbuf[1] = (((inbuf[0] & 0x07) << 2) | ((inbuf[1] & 0xc0) >> 6)) & 0xff;
+		outbuf[2] = ((inbuf[1] & 0x3e) >> 1);
+		outbuf[3] = (((inbuf[1] & 0x01) << 4) | ((inbuf[2] & 0xf0) >> 4)) & 0xff;
+		outbuf[4] = (((inbuf[2] & 0x0f) << 1) | ((inbuf[3] & 0x80) >> 7)) & 0xff;
+		outbuf[5] = ((inbuf[3] & 0x7c) >> 2);
+		outbuf[6] = (((inbuf[3] & 0x03) << 3) | ((inbuf[4] & 0xe0) >> 5)) & 0xff;
+		outbuf[7] = inbuf[4] & 0x1f;
+
+		// write output
+		int const num_out = input_output_mapping[std::size_t(available_input)];
+		for (int j = 0; j < num_out; ++j)
+		{
+			out += base32_table[outbuf[std::size_t(j)]];
+			--limit;
+			if (limit <= 0) return;
+		}
+	}
+}
+#endif
+
 // returns the number of lines printed
 int print_peer_info(std::string& out
 	, std::vector<lt::peer_info> const& peers, int max_lines)
@@ -363,13 +413,29 @@ int print_peer_info(std::string& out
 
 		if (print_ip)
 		{
-			std::snprintf(str, sizeof(str), "%-30s ", ::print_endpoint(i->ip).c_str());
-			out += str;
+#if TORRENT_USE_I2P
+			if (i->flags & peer_info::i2p_socket)
+			{
+				base32encode_i2p(i->i2p_destination(), out, 31);
+			}
+			else
+#endif
+			{
+				std::snprintf(str, sizeof(str), "%-30s ", ::print_endpoint(i->ip).c_str());
+				out += str;
+			}
 		}
 		if (print_local_ip)
 		{
-			std::snprintf(str, sizeof(str), "%-30s ", ::print_endpoint(i->local_endpoint).c_str());
-			out += str;
+#if TORRENT_USE_I2P
+			if (i->flags & peer_info::i2p_socket)
+				out += "                               ";
+			else
+#endif
+			{
+				std::snprintf(str, sizeof(str), "%-30s ", ::print_endpoint(i->local_endpoint).c_str());
+				out += str;
+			}
 		}
 
 		char temp[10];
@@ -650,7 +716,6 @@ void assign_setting(lt::settings_pack& settings, std::string const& key, char co
 				{"socks5_pw"_sv, settings_pack::socks5_pw},
 				{"http"_sv, settings_pack::http},
 				{"http_pw"_sv, settings_pack::http_pw},
-				{"i2p_proxy"_sv, settings_pack::i2p_proxy},
 			};
 
 			{

--- a/examples/torrent_view.cpp
+++ b/examples/torrent_view.cpp
@@ -75,6 +75,8 @@ std::string torrent_state(lt::torrent_status const& s)
 		else
 			ret += " [F]";
 	}
+	if (s.flags & lt::torrent_flags::i2p_torrent)
+		ret += " i2p";
 	char buf[10];
 	std::snprintf(buf, sizeof(buf), " (%.1f%%)", s.progress_ppm / 10000.0);
 	ret += buf;

--- a/fuzzers/src/base32encode.cpp
+++ b/fuzzers/src/base32encode.cpp
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-	lt::base32encode({reinterpret_cast<char const*>(data), size});
+	lt::base32encode_i2p({reinterpret_cast<char const*>(data), static_cast<int>(size)});
 	return 0;
 }
 

--- a/include/libtorrent/aux_/escape_string.hpp
+++ b/include/libtorrent/aux_/escape_string.hpp
@@ -41,23 +41,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/flags.hpp"
 #if TORRENT_USE_I2P
+#include <vector>
 #include "libtorrent/span.hpp"
 #endif
 
 namespace libtorrent {
-
-	// hidden
-	using encode_string_flags_t = flags::bitfield_flag<std::uint8_t, struct encode_string_flags_tag>;
-
-	namespace string
-	{
-		// use lower case alphabet used with i2p
-		constexpr encode_string_flags_t lowercase = 0_bit;
-		// don't insert padding
-		constexpr encode_string_flags_t no_padding = 1_bit;
-		// shortcut used for addresses as sha256 hashes
-		constexpr encode_string_flags_t i2p = lowercase | no_padding;
-	}
 
 	TORRENT_EXTRA_EXPORT std::string unescape_string(string_view s, error_code& ec);
 	// replaces all disallowed URL characters by their %-encoding
@@ -80,7 +68,8 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT std::string base64encode(std::string const& s);
 #if TORRENT_USE_I2P
 	// encodes a string using the base32 scheme
-	TORRENT_EXTRA_EXPORT std::string base32encode(span<char const> s, encode_string_flags_t flags = {});
+	TORRENT_EXTRA_EXPORT std::string base32encode_i2p(span<char const> s);
+	TORRENT_EXTRA_EXPORT std::vector<char> base64decode_i2p(string_view s);
 #endif
 	TORRENT_EXTRA_EXPORT std::string base32decode(string_view s);
 

--- a/include/libtorrent/aux_/escape_string.hpp
+++ b/include/libtorrent/aux_/escape_string.hpp
@@ -40,6 +40,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/flags.hpp"
+#if TORRENT_USE_I2P
+#include "libtorrent/span.hpp"
+#endif
 
 namespace libtorrent {
 
@@ -77,7 +80,7 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT std::string base64encode(std::string const& s);
 #if TORRENT_USE_I2P
 	// encodes a string using the base32 scheme
-	TORRENT_EXTRA_EXPORT std::string base32encode(string_view s, encode_string_flags_t flags = {});
+	TORRENT_EXTRA_EXPORT std::string base32encode(span<char const> s, encode_string_flags_t flags = {});
 #endif
 	TORRENT_EXTRA_EXPORT std::string base32decode(string_view s);
 

--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -443,7 +443,7 @@ private:
 
 	// send and receive buffer
 	aux::noexcept_movable<aux::vector<char>> m_buffer;
-	char const* m_id;
+	char const* m_id = nullptr;
 	std::string m_dest;
 	std::string m_name_lookup;
 
@@ -459,7 +459,7 @@ private:
 	command_t m_command;
 	state_t m_state;
 #if TORRENT_USE_ASSERTS
-	int m_magic;
+	int m_magic = 0x1337;
 #endif
 };
 

--- a/include/libtorrent/peer.hpp
+++ b/include/libtorrent/peer.hpp
@@ -65,6 +65,12 @@ namespace libtorrent {
 		std::uint16_t port;
 	};
 
+#if TORRENT_USE_I2P
+	struct i2p_peer_entry
+	{
+		sha256_hash destination;
+	};
+#endif
 }
 
 #endif // TORRENT_PEER_HPP_INCLUDED

--- a/include/libtorrent/peer_info.hpp
+++ b/include/libtorrent/peer_info.hpp
@@ -249,7 +249,7 @@ TORRENT_VERSION_NAMESPACE_2
 		int payload_up_speed;
 		int payload_down_speed;
 
-		// the peer's id as used in the bit torrent protocol. This id can be used
+		// the peer's id as used in the bittorrent protocol. This id can be used
 		// to extract 'fingerprints' from the peer. Sometimes it can tell you
 		// which client the peer is using. See identify_client()_
 		peer_id pid;
@@ -389,7 +389,8 @@ TORRENT_VERSION_NAMESPACE_2
 #endif
 
 		// the IP-address to this peer. The type is an asio endpoint. For
-		// more info, see the asio_ documentation.
+		// more info, see the asio_ documentation. This field is not valid for
+		// i2p peers. Instead use the i2p_destination() function.
 		//
 		// .. _asio: http://asio.sourceforge.net/asio-0.3.8/doc/asio/reference.html
 		tcp::endpoint ip;
@@ -397,6 +398,7 @@ TORRENT_VERSION_NAMESPACE_2
 		// the IP and port pair the socket is bound to locally. i.e. the IP
 		// address of the interface it's going out over. This may be useful for
 		// multi-homed clients with multiple interfaces to the internet.
+		// This field is not valid for i2p peers.
 		tcp::endpoint local_endpoint;
 
 		// The peer is not waiting for any external events to
@@ -422,6 +424,15 @@ TORRENT_VERSION_NAMESPACE_2
 		// class.
 		bandwidth_state_flags_t read_state;
 		bandwidth_state_flags_t write_state;
+
+#if TORRENT_USE_I2P
+		// If this peer is an i2p peer, this function returns the destination
+		// address of the peer
+		sha256_hash i2p_destination() const;
+
+		// internal
+		void set_i2p_destination(sha256_hash dest);
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 		TORRENT_DEPRECATED static constexpr bandwidth_state_flags_t bw_torrent = bw_limit;

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -165,6 +165,9 @@ enum class event_t : std::uint8_t
 		std::vector<peer_entry> peers;
 		std::vector<ipv4_peer_entry> peers4;
 		std::vector<ipv6_peer_entry> peers6;
+#if TORRENT_USE_I2P
+		std::vector<i2p_peer_entry> i2p_peers;
+#endif
 		// our external IP address (if the tracker responded with ti, otherwise
 		// INADDR_ANY)
 		address external_ip;

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -489,8 +489,22 @@ namespace {
 		{
 			p.flags |= peer_info::i2p_socket;
 			auto const* pi = peer_info_struct();
-			sha256_hash const b32_hash = hasher256(pi->dest()).final();
-			p.set_i2p_destination(b32_hash);
+			if (pi != nullptr)
+			{
+				try
+				{
+					sha256_hash const b32_addr = hasher256(base64decode_i2p(pi->dest())).final();
+					p.set_i2p_destination(b32_addr);
+				}
+				catch (lt::system_error const&)
+				{
+					p.set_i2p_destination(sha256_hash());
+				}
+			}
+			else
+			{
+				p.set_i2p_destination(sha256_hash());
+			}
 		}
 #endif
 		if (is_utp(get_socket())) p.flags |= peer_info::utp_socket;

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -485,7 +485,13 @@ namespace {
 		if (support_extensions()) p.flags |= peer_info::supports_extensions;
 		if (is_outgoing()) p.flags |= peer_info::local_connection;
 #if TORRENT_USE_I2P
-		if (is_i2p(get_socket())) p.flags |= peer_info::i2p_socket;
+		if (is_i2p(get_socket()))
+		{
+			p.flags |= peer_info::i2p_socket;
+			auto const* pi = peer_info_struct();
+			sha256_hash const b32_hash = hasher256(pi->dest()).final();
+			p.set_i2p_destination(b32_hash);
+		}
 #endif
 		if (is_utp(get_socket())) p.flags |= peer_info::utp_socket;
 		if (is_ssl(get_socket())) p.flags |= peer_info::ssl_socket;

--- a/src/escape_string.cpp
+++ b/src/escape_string.cpp
@@ -297,7 +297,7 @@ namespace libtorrent {
 	}
 
 #if TORRENT_USE_I2P
-	std::string base32encode(string_view s, encode_string_flags_t const flags)
+	std::string base32encode(span<char const> s, encode_string_flags_t const flags)
 	{
 		static char const base32_table_canonical[] =
 		{

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -587,11 +587,9 @@ namespace libtorrent {
 				for (int i = 0; i < len; i += 32)
 				{
 					if (len - i < 32) break;
-					peer_entry p;
-					p.hostname = base32encode(std::string(peers + i, 32), string::i2p);
-					p.hostname += ".b32.i2p";
-					p.port = 6881;
-					resp.peers.push_back(p);
+					i2p_peer_entry p;
+					std::memcpy(p.destination.data(), peers + i, 32);
+					resp.i2p_peers.push_back(p);
 				}
 			}
 			else

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -214,7 +214,9 @@ namespace libtorrent {
 			}
 		}
 
-		if (!tracker_req().outgoing_socket)
+		// i2p trackers don't use our outgoing sockets, they use the SAM
+		// connection
+		if (!i2p && !tracker_req().outgoing_socket)
 		{
 			fail(errors::invalid_listen_socket, operation_t::get_interface
 				, "outgoing socket was closed");
@@ -247,7 +249,12 @@ namespace libtorrent {
 			: settings.get_str(settings_pack::user_agent);
 
 		auto const ls = bind_socket();
-		bind_info_t bi{ls.device(), ls.get_local_endpoint().address()};
+		bind_info_t bi = [&ls](){
+			if (ls.get() == nullptr)
+				return bind_info_t{};
+			else
+				return bind_info_t{ls.device(), ls.get_local_endpoint().address()};
+		}();
 
 		// when sending stopped requests, prefer the cached DNS entry
 		// to avoid being blocked for slow or failing responses. Chances
@@ -302,9 +309,12 @@ namespace libtorrent {
 		// be all of them, in which case we should not announce this listen socket
 		// to this tracker
 		auto const ls = bind_socket();
-		endpoints.erase(std::remove_if(endpoints.begin(), endpoints.end()
-			, [&](tcp::endpoint const& ep) { return !ls.can_route(ep.address()); })
-			, endpoints.end());
+		if (ls.get() != nullptr)
+		{
+			endpoints.erase(std::remove_if(endpoints.begin(), endpoints.end()
+				, [&](tcp::endpoint const& ep) { return !ls.can_route(ep.address()); })
+				, endpoints.end());
+		}
 
 		if (endpoints.empty())
 		{

--- a/src/i2p_stream.cpp
+++ b/src/i2p_stream.cpp
@@ -117,14 +117,9 @@ namespace libtorrent {
 
 	i2p_stream::i2p_stream(io_context& io_context)
 		: proxy_base(io_context)
-		, m_id(nullptr)
 		, m_command(cmd_create_session)
 		, m_state(read_hello_response)
-	{
-#if TORRENT_USE_ASSERTS
-		m_magic = 0x1337;
-#endif
-	}
+	{}
 
 #if TORRENT_USE_ASSERTS
 	i2p_stream::~i2p_stream()

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2230,7 +2230,7 @@ namespace libtorrent {
 			m_have_piece = bits;
 			m_num_pieces = bits.count();
 			t->set_seed(m_peer_info, m_num_pieces == bits.size());
-			TORRENT_ASSERT(is_seed() == (m_num_pieces == bits.size()));
+			TORRENT_ASSERT(!t->valid_metadata() || (is_seed() == (m_num_pieces == bits.size())));
 
 #if TORRENT_USE_INVARIANT_CHECKS
 			if (t && t->has_picker())

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1334,8 +1334,8 @@ namespace libtorrent {
 		}
 
 #if TORRENT_USE_I2P
-		auto* i2ps = boost::get<i2p_stream>(&m_socket);
-		if (!i2ps && t->torrent_file().is_i2p()
+		if (!aux::is_i2p(m_socket)
+			&& t->is_i2p()
 			&& !m_settings.get_bool(settings_pack::allow_i2p_mixed))
 		{
 			// the torrent is an i2p torrent, the peer is a regular peer

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -4553,7 +4553,6 @@ namespace libtorrent {
 		p.payload_down_speed = statistics().download_payload_rate();
 		p.payload_up_speed = statistics().upload_payload_rate();
 		p.pid = pid();
-		p.ip = remote();
 		p.pending_disk_bytes = m_outstanding_writing_bytes;
 		p.pending_disk_read_bytes = m_reading_bytes;
 		p.send_quota = m_quota[upload_channel];
@@ -4613,6 +4612,15 @@ namespace libtorrent {
 		p.flags = {};
 		get_specific_peer_info(p);
 
+#if TORRENT_USE_I2P
+		if (!(p.flags & peer_info::i2p_socket))
+#endif
+		{
+			p.ip = remote();
+			error_code ec;
+			p.local_endpoint = get_socket().local_endpoint(ec);
+		}
+
 		if (m_snubbed) p.flags |= peer_info::snubbed;
 		if (upload_only()) p.flags |= peer_info::upload_only;
 		if (m_endgame_mode) p.flags |= peer_info::endgame_mode;
@@ -4663,8 +4671,6 @@ namespace libtorrent {
 			p.progress_ppm = int(std::int64_t(p.pieces.count()) * 1000000 / p.pieces.size());
 		}
 
-		error_code ec;
-		p.local_endpoint = get_socket().local_endpoint(ec);
 	}
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING

--- a/src/peer_info.cpp
+++ b/src/peer_info.cpp
@@ -86,4 +86,27 @@ namespace libtorrent {
 	constexpr connection_type_t peer_info::standard_bittorrent;
 	constexpr connection_type_t peer_info::web_seed;
 	constexpr connection_type_t peer_info::http_seed;
+
+#if TORRENT_USE_I2P
+	sha256_hash peer_info::i2p_destination() const
+	{
+		sha256_hash ret;
+		if (!(flags & i2p_socket)) return ret;
+
+		char const* destination = reinterpret_cast<char const*>(&ip);
+		static_assert(sizeof(tcp::endpoint) * 2 >= sizeof(sha256_hash), "tcp::endpoint is smaller than expected");
+
+		std::memcpy(ret.data(), destination, ret.size());
+		return ret;
+	}
+
+	void peer_info::set_i2p_destination(sha256_hash dest)
+	{
+		flags |= i2p_socket;
+		char* destination = reinterpret_cast<char*>(&ip);
+		static_assert(sizeof(tcp::endpoint) * 2 >= sizeof(sha256_hash), "tcp::endpoint is smaller than expected");
+
+		std::memcpy(destination, dest.data(), dest.size());
+	}
+#endif
 }

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -259,6 +259,9 @@ namespace {
 #ifndef TORRENT_DISABLE_SUPERSEEDING
 		apply_flag(ret.flags, rd, "super_seeding", torrent_flags::super_seeding);
 #endif
+#if TORRENT_USE_I2P
+		apply_flag(ret.flags, rd, "i2p", torrent_flags::i2p_torrent);
+#endif
 		apply_flag(ret.flags, rd, "sequential_download", torrent_flags::sequential_download);
 		apply_flag(ret.flags, rd, "stop_when_ready", torrent_flags::stop_when_ready);
 		apply_flag(ret.flags, rd, "disable_dht", torrent_flags::disable_dht);
@@ -330,6 +333,9 @@ namespace {
 				{
 					ret.trackers.push_back(tier_list.list_string_value_at(j).to_string());
 					ret.tracker_tiers.push_back(tier);
+#if TORRENT_USE_I2P
+					if (is_i2p_url(ret.trackers.back())) ret.flags |= torrent_flags::i2p_torrent;
+#endif
 				}
 				++tier;
 			}

--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -141,10 +141,6 @@ namespace libtorrent {
 		// the number of blocks we want, but it will try to make the picked
 		// blocks be from whole pieces, possibly by returning more blocks
 		// than we requested.
-#if TORRENT_USE_ASSERTS
-		error_code ec;
-		TORRENT_ASSERT(c.remote() == c.get_socket().remote_endpoint(ec) || ec);
-#endif
 
 		aux::session_interface& ses = t.session();
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1300,18 +1300,21 @@ namespace {
 			req.ssl_ctx = &m_ssl_ctx;
 #endif
 
-		TORRENT_ASSERT(req.outgoing_socket);
-			auto ls = req.outgoing_socket.get();
-
-		req.listen_port =
-#if TORRENT_USE_I2P
-			(req.kind == tracker_request::i2p) ? 1 :
-#endif
+		auto ls = req.outgoing_socket.get();
+		if (ls)
+		{
+			req.listen_port =
 #ifdef TORRENT_SSL_PEERS
 			// SSL torrents use the SSL listen port
 			use_ssl ? make_announce_port(ssl_listen_port(ls)) :
 #endif
 			make_announce_port(listen_port(ls));
+		}
+		else
+		{
+			TORRENT_ASSERT(req.kind == tracker_request::i2p);
+			req.listen_port = 1;
+		}
 		m_tracker_manager.queue_request(get_context(), std::move(req), m_settings, c);
 	}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1096,7 +1096,6 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 			m_i2p_listen_socket->close(ec);
 			TORRENT_ASSERT(!ec);
 		}
-		m_i2p_listen_socket.reset();
 #endif
 
 #ifndef TORRENT_DISABLE_LOGGING
@@ -2368,6 +2367,7 @@ namespace {
 			m_i2p_conn.close(ec);
 			return;
 		}
+		TORRENT_ASSERT(!m_abort);
 		m_i2p_conn.open(m_settings.get_str(settings_pack::i2p_hostname)
 			, m_settings.get_int(settings_pack::i2p_port)
 			, std::bind(&session_impl::on_i2p_open, this, _1));
@@ -2412,6 +2412,7 @@ namespace {
 
 	void session_impl::open_new_incoming_i2p_connection()
 	{
+		if (m_abort) return;
 		if (!m_i2p_conn.is_open()) return;
 
 		if (m_i2p_listen_socket) return;
@@ -2446,9 +2447,9 @@ namespace {
 #endif
 			return;
 		}
-		open_new_incoming_i2p_connection();
 		incoming_connection(std::move(*m_i2p_listen_socket));
 		m_i2p_listen_socket.reset();
+		open_new_incoming_i2p_connection();
 	}
 #endif
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3521,11 +3521,11 @@ namespace {
 				continue;
 
 #if TORRENT_USE_I2P
-			if (r.i2pconn && string_ends_with(i.hostname, ".i2p"))
+			if (r.i2pconn)
 			{
 				// this is an i2p name, we need to use the SAM connection
 				// to do the name lookup
-				if (string_ends_with(i.hostname, ".b32.i2p"))
+				if (string_ends_with(i.hostname, ".i2p"))
 				{
 					ADD_OUTSTANDING_ASYNC("torrent::on_i2p_resolve");
 					r.i2pconn->async_name_lookup(i.hostname.c_str()

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3557,7 +3557,7 @@ namespace {
 			{
 				torrent_state st = get_peer_list_state();
 				peer_entry p;
-				std::string destination = base32encode(i.destination, string::i2p);
+				std::string destination = base32encode_i2p(i.destination);
 				destination += ".b32.i2p";
 
 				ADD_OUTSTANDING_ASYNC("torrent::on_i2p_resolve");

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -686,6 +686,13 @@ bool is_downloading_state(int const st)
 		if (!m_enable_dht) return false;
 		if (!m_ses.announce_dht()) return false;
 
+#if TORRENT_USE_I2P
+		// i2p torrents don't announced on the DHT
+		// unless we allow mixed swarms
+		if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+			return false;
+#endif
+
 		if (!m_ses.dht()) return false;
 		if (m_torrent_file->is_valid() && !m_files_checked) return false;
 		if (!m_announce_to_dht) return false;
@@ -2722,6 +2729,10 @@ bool is_downloading_state(int const st)
 #ifndef TORRENT_DISABLE_LOGGING
 			if (should_log())
 			{
+#if TORRENT_USE_I2P
+				if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+					debug_log("DHT: i2p torrent (and mixed peers not allowed)");
+#endif
 				if (!m_ses.announce_dht())
 					debug_log("DHT: no listen sockets");
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3299,6 +3299,13 @@ namespace {
 
 		req.kind |= tracker_request::scrape_request;
 		auto& ae = m_trackers[idx];
+
+#if TORRENT_USE_I2P
+		if (is_i2p_url(ae.url))
+			req.kind |= tracker_request::i2p;
+		else if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+			return;
+#endif
 		refresh_endpoint_list(m_ses, ae.url, is_ssl_torrent(), bool(m_complete_sent), ae.endpoints);
 		req.url = ae.url;
 		req.private_torrent = m_torrent_file->priv();

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -108,6 +108,9 @@ namespace {
 #ifndef TORRENT_DISABLE_SUPERSEEDING
 		ret["super_seeding"] = bool(atp.flags & torrent_flags::super_seeding);
 #endif
+#if TORRENT_USE_I2P
+		ret["i2p"] = bool(atp.flags & torrent_flags::i2p_torrent);
+#endif
 		ret["sequential_download"] = bool(atp.flags & torrent_flags::sequential_download);
 		ret["stop_when_ready"] = bool(atp.flags & torrent_flags::stop_when_ready);
 		ret["disable_dht"] = bool(atp.flags & torrent_flags::disable_dht);

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -965,6 +965,72 @@ TORRENT_TEST(new_peer_size_limit)
 		, 5);
 }
 
+TORRENT_TEST(peer_info_comparison)
+{
+	peer_address_compare cmp;
+	ipv4_peer const ip_low(ep("1.1.1.1", 6888), true, {});
+	ipv4_peer const ip_high(ep("100.1.1.1", 6888), true, {});
+	TEST_CHECK(cmp(&ip_low, &ip_high));
+	TEST_CHECK(!cmp(&ip_high, &ip_low));
+	TEST_CHECK(!cmp(&ip_high, &ip_high));
+	TEST_CHECK(!cmp(&ip_low, &ip_low));
+
+	TEST_CHECK(!cmp(&ip_low, addr("1.1.1.1")));
+	TEST_CHECK(cmp(&ip_low, addr("1.1.1.2")));
+	TEST_CHECK(cmp(&ip_low, addr("100.1.1.1")));
+
+	TEST_CHECK(!cmp(addr("1.1.1.1"), &ip_low));
+	TEST_CHECK(cmp(addr("1.1.1.0"), &ip_low));
+	TEST_CHECK(!cmp( addr("100.1.1.1"), &ip_low));
+
+#if TORRENT_USE_I2P
+	i2p_peer const i2p_low("aaaaaa", true, {});
+	i2p_peer const i2p_high("zzzzzz", true, {});
+
+	// noremal IPs always sort before i2p addresses
+	TEST_CHECK(cmp(&ip_low, &i2p_high));
+	TEST_CHECK(cmp(&ip_low, &i2p_low));
+	TEST_CHECK(cmp(&ip_high, &i2p_high));
+	TEST_CHECK(cmp(&ip_high, &i2p_low));
+
+	// i2p addresses always sort after noremal IPs
+	TEST_CHECK(!cmp(&i2p_high, &ip_low));
+	TEST_CHECK(!cmp(&i2p_low, &ip_low));
+	TEST_CHECK(!cmp(&i2p_high, &ip_high));
+	TEST_CHECK(!cmp(&i2p_low, &ip_high));
+
+	// noremal IPs always sort before i2p addresses
+	TEST_CHECK(cmp(addr4("1.1.1.1"), &i2p_high));
+	TEST_CHECK(cmp(addr4("1.1.1.1"), &i2p_low));
+	TEST_CHECK(cmp(addr4("100.1.1.1"), &i2p_high));
+	TEST_CHECK(cmp(addr4("100.1.1.1"), &i2p_low));
+
+	// i2p addresses always sort after noremal IPs
+	TEST_CHECK(!cmp(&i2p_high, addr4("1.1.1.1")));
+	TEST_CHECK(!cmp(&i2p_low, addr4("1.1.1.1")));
+	TEST_CHECK(!cmp(&i2p_high, addr4("100.1.1.1")));
+	TEST_CHECK(!cmp(&i2p_low, addr4("100.1.1.1")));
+
+	// internal i2p sorting
+	TEST_CHECK(cmp(&i2p_low, &i2p_high));
+	TEST_CHECK(!cmp(&i2p_high, &i2p_low));
+	TEST_CHECK(!cmp(&i2p_high, &i2p_high));
+	TEST_CHECK(!cmp(&i2p_low, &i2p_low));
+
+	TEST_CHECK(cmp(&i2p_low, "zzzzzz"));
+	TEST_CHECK(!cmp(&i2p_high, "aaaaaa"));
+	TEST_CHECK(!cmp(&i2p_high, "zzzzzz"));
+	TEST_CHECK(!cmp(&i2p_low, "aaaaaa"));
+	TEST_CHECK(cmp(&i2p_low, "aaaaab"));
+
+	TEST_CHECK(cmp("aaaaaa", &i2p_high));
+	TEST_CHECK(!cmp("zzzzzz", &i2p_low));
+	TEST_CHECK(!cmp("zzzzzz", &i2p_high));
+	TEST_CHECK(cmp("zzzzzy", &i2p_high));
+	TEST_CHECK(!cmp("aaaaaa", &i2p_low));
+#endif
+}
+
 // TODO: test erasing peers
 // TODO: test update_peer_port with allow_multiple_connections_per_ip and without
 // TODO: test add i2p peers

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -1031,6 +1031,18 @@ TORRENT_TEST(peer_info_comparison)
 #endif
 }
 
+#if TORRENT_USE_I2P
+TORRENT_TEST(peer_info_set_i2p_destination)
+{
+	peer_info p;
+	TORRENT_ASSERT(!(p.flags & peer_info::i2p_socket));
+	p.set_i2p_destination(sha256_hash("................................"));
+
+	TORRENT_ASSERT(p.i2p_destination() == sha256_hash("................................"));
+	TORRENT_ASSERT(p.flags & peer_info::i2p_socket);
+}
+#endif
+
 // TODO: test erasing peers
 // TODO: test update_peer_port with allow_multiple_connections_per_ip and without
 // TODO: test add i2p peers

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -66,6 +66,7 @@ TORRENT_TEST(read_resume)
 	rd["max_connections"] = 1345;
 	rd["max_uploads"] = 1346;
 	rd["seed_mode"] = 0;
+	rd["i2p"] = 0;
 	rd["super_seeding"] = 0;
 	rd["added_time"] = 1347;
 	rd["completed_time"] = 1348;
@@ -100,6 +101,7 @@ TORRENT_TEST(read_resume)
 		| torrent_flags::super_seeding
 		| torrent_flags::auto_managed
 		| torrent_flags::paused
+		| torrent_flags::i2p_torrent
 		| torrent_flags::sequential_download;
 
 	TEST_CHECK(!(atp.flags & flags_mask));
@@ -379,6 +381,9 @@ TORRENT_TEST(round_trip_flags)
 		torrent_flags::disable_dht,
 		torrent_flags::disable_lsd,
 		torrent_flags::disable_pex,
+#if TORRENT_USE_I2P
+		torrent_flags::i2p_torrent,
+#endif
 	};
 
 	for (auto const& f : flags)

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -75,7 +75,8 @@ torrent_flags_t const flags_mask
 	| torrent_flags::super_seeding
 	| torrent_flags::share_mode
 	| torrent_flags::upload_mode
-	| torrent_flags::apply_ip_filter;
+	| torrent_flags::apply_ip_filter
+	| torrent_flags::i2p_torrent;
 
 std::vector<char> generate_resume_data(torrent_info* ti
 	, char const* file_priorities = "")
@@ -97,6 +98,7 @@ std::vector<char> generate_resume_data(torrent_info* ti
 	rd["max_connections"] = 1345;
 	rd["max_uploads"] = 1346;
 	rd["seed_mode"] = 0;
+	rd["i2p"] = 0;
 	rd["super_seeding"] = 0;
 	rd["added_time"] = 1347;
 	rd["completed_time"] = 1348;

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -228,18 +228,18 @@ TORRENT_TEST(base32)
 	// base32 test vectors from http://www.faqs.org/rfcs/rfc4648.html
 
 #if TORRENT_USE_I2P
-	TEST_CHECK(base32encode("") == "");
-	TEST_CHECK(base32encode("f") == "MY======");
-	TEST_CHECK(base32encode("fo") == "MZXQ====");
-	TEST_CHECK(base32encode("foo") == "MZXW6===");
-	TEST_CHECK(base32encode("foob") == "MZXW6YQ=");
-	TEST_CHECK(base32encode("fooba") == "MZXW6YTB");
-	TEST_CHECK(base32encode("foobar") == "MZXW6YTBOI======");
+	TEST_CHECK(base32encode(""_sv) == "");
+	TEST_CHECK(base32encode("f"_sv) == "MY======");
+	TEST_CHECK(base32encode("fo"_sv) == "MZXQ====");
+	TEST_CHECK(base32encode("foo"_sv) == "MZXW6===");
+	TEST_CHECK(base32encode("foob"_sv) == "MZXW6YQ=");
+	TEST_CHECK(base32encode("fooba"_sv) == "MZXW6YTB");
+	TEST_CHECK(base32encode("foobar"_sv) == "MZXW6YTBOI======");
 
 	// base32 for i2p
-	TEST_CHECK(base32encode("fo", string::no_padding) == "MZXQ");
-	TEST_CHECK(base32encode("foob", string::i2p) == "mzxw6yq");
-	TEST_CHECK(base32encode("foobar", string::lowercase) == "mzxw6ytboi======");
+	TEST_CHECK(base32encode("fo"_sv, string::no_padding) == "MZXQ");
+	TEST_CHECK(base32encode("foob"_sv, string::i2p) == "mzxw6yq");
+	TEST_CHECK(base32encode("foobar"_sv, string::lowercase) == "mzxw6ytboi======");
 
 	std::string test;
 	for (int i = 0; i < 255; ++i)

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -168,7 +168,7 @@ TORRENT_TEST(parse_i2p_peers)
 		, ec, tracker_request::i2p, sha1_hash());
 
 	TEST_EQUAL(ec, error_code());
-	TEST_EQUAL(resp.peers.size(), 11);
+	TEST_EQUAL(resp.i2p_peers.size(), 11);
 
 	if (resp.peers.size() == 11)
 	{


### PR DESCRIPTION
The main feature is to add a function `i2p_destination()` to `peer_info`, which returns the base32 address (in binary form, i.e. `sha256(base64(destination))`) for i2p peers.

There's a number of other commits that fix and improve other aspects of i2p support as well