### PR TITLE
improve compatibility with boost.variant visitor

### DIFF
--- a/src/socket_type.cpp
+++ b/src/socket_type.cpp
@@ -99,18 +99,18 @@ namespace aux {
 #endif
 
 	struct idx_visitor {
-		socket_type_t operator()(tcp::socket const&) { return socket_type_t::tcp; }
-		socket_type_t operator()(socks5_stream const&) { return socket_type_t::socks5; }
-		socket_type_t operator()(http_stream const&) { return socket_type_t::http; }
-		socket_type_t operator()(utp_stream const&) { return socket_type_t::utp; }
+		socket_type_t operator()(tcp::socket const&) const { return socket_type_t::tcp; }
+		socket_type_t operator()(socks5_stream const&) const { return socket_type_t::socks5; }
+		socket_type_t operator()(http_stream const&) const { return socket_type_t::http; }
+		socket_type_t operator()(utp_stream const&) const { return socket_type_t::utp; }
 #if TORRENT_USE_I2P
-		socket_type_t operator()(i2p_stream const&) { return socket_type_t::i2p; }
+		socket_type_t operator()(i2p_stream const&) const { return socket_type_t::i2p; }
 #endif
 #if TORRENT_USE_SSL
-		socket_type_t operator()(ssl_stream<tcp::socket> const&) { return socket_type_t::tcp_ssl; }
-		socket_type_t operator()(ssl_stream<socks5_stream> const&) { return socket_type_t::socks5_ssl; }
-		socket_type_t operator()(ssl_stream<http_stream> const&) { return socket_type_t::http_ssl; }
-		socket_type_t operator()(ssl_stream<utp_stream> const&) { return socket_type_t::utp_ssl; }
+		socket_type_t operator()(ssl_stream<tcp::socket> const&) const { return socket_type_t::tcp_ssl; }
+		socket_type_t operator()(ssl_stream<socks5_stream> const&) const { return socket_type_t::socks5_ssl; }
+		socket_type_t operator()(ssl_stream<http_stream> const&) const { return socket_type_t::http_ssl; }
+		socket_type_t operator()(ssl_stream<utp_stream> const&) const { return socket_type_t::utp_ssl; }
 #endif
 	};
 


### PR DESCRIPTION
courtesy of https://stackoverflow.com/questions/75853506/building-libtorrent-fails-with-compilation-erros-when-building-boost-library