### PR TITLE
I2p roundup

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -270,7 +270,7 @@ jobs:
 
       strategy:
          matrix:
-            os: [ubuntu-20.04, ubuntu-18.04]
+            os: [ubuntu-20.04, ubuntu-22.04]
 
       steps:
       - name: checkout

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest ]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2

--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -159,7 +159,7 @@ private:
 
 	state_t m_state;
 #if TORRENT_USE_ASSERTS
-	int m_magic;
+	int m_magic = 0x1337;
 #endif
 };
 

--- a/src/i2p_stream.cpp
+++ b/src/i2p_stream.cpp
@@ -221,11 +221,7 @@ namespace libtorrent {
 		, m_id(nullptr)
 		, m_command(cmd_create_session)
 		, m_state(read_hello_response)
-	{
-#if TORRENT_USE_ASSERTS
-		m_magic = 0x1337;
-#endif
-	}
+	{}
 
 #if TORRENT_USE_ASSERTS
 	i2p_stream::~i2p_stream()

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -991,7 +991,6 @@ namespace aux {
 			m_i2p_listen_socket->close(ec);
 			TORRENT_ASSERT(!ec);
 		}
-		m_i2p_listen_socket.reset();
 #endif
 
 #ifndef TORRENT_DISABLE_LOGGING
@@ -2207,6 +2206,7 @@ namespace {
 			m_i2p_conn.close(ec);
 			return;
 		}
+		TORRENT_ASSERT(!m_abort);
 		m_i2p_conn.open(m_settings.get_str(settings_pack::i2p_hostname)
 			, m_settings.get_int(settings_pack::i2p_port)
 			, std::bind(&session_impl::on_i2p_open, this, _1));
@@ -2262,6 +2262,7 @@ namespace {
 
 	void session_impl::open_new_incoming_i2p_connection()
 	{
+		if (m_abort) return;
 		if (!m_i2p_conn.is_open()) return;
 
 		if (m_i2p_listen_socket) return;
@@ -2301,8 +2302,9 @@ namespace {
 #endif
 			return;
 		}
-		open_new_incoming_i2p_connection();
 		incoming_connection(s);
+		m_i2p_listen_socket.reset();
+		open_new_incoming_i2p_connection();
 	}
 #endif
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -795,6 +795,13 @@ bool is_downloading_state(int const st)
 		if (!m_enable_dht) return false;
 		if (!m_ses.announce_dht()) return false;
 
+#if TORRENT_USE_I2P
+		// i2p torrents don't announced on the DHT
+		// unless we allow mixed swarms
+		if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+			return false;
+#endif
+
 		if (!m_ses.dht()) return false;
 		if (m_torrent_file->is_valid() && !m_files_checked) return false;
 		if (!m_announce_to_dht) return false;
@@ -2731,6 +2738,10 @@ bool is_downloading_state(int const st)
 #ifndef TORRENT_DISABLE_LOGGING
 			if (should_log())
 			{
+#if TORRENT_USE_I2P
+				if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+					debug_log("DHT: i2p torrent (and mixed peers not allowed)");
+#endif
 				if (!m_ses.announce_dht())
 					debug_log("DHT: no listen sockets");
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3245,9 +3245,16 @@ bool is_downloading_state(int const st)
 			&& m_apply_ip_filter)
 			req.filter = m_ip_filter;
 
+		auto& ae = m_trackers[idx];
+#if TORRENT_USE_I2P
+		if (is_i2p_url(ae.url))
+			req.kind |= tracker_request::i2p;
+		else if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+			return;
+#endif
 		req.info_hash = m_torrent_file->info_hash();
 		req.kind |= tracker_request::scrape_request;
-		req.url = m_trackers[idx].url;
+		req.url = ae.url;
 		req.private_torrent = m_torrent_file->priv();
 #if TORRENT_ABI_VERSION == 1
 		req.auth = tracker_login();

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3466,11 +3466,11 @@ bool is_downloading_state(int const st)
 				continue;
 
 #if TORRENT_USE_I2P
-			if (r.i2pconn && string_ends_with(i.hostname, ".i2p"))
+			if (r.i2pconn)
 			{
 				// this is an i2p name, we need to use the SAM connection
 				// to do the name lookup
-				if (string_ends_with(i.hostname, ".b32.i2p"))
+				if (string_ends_with(i.hostname, ".i2p"))
 				{
 					ADD_OUTSTANDING_ASYNC("torrent::on_i2p_resolve");
 					r.i2pconn->async_name_lookup(i.hostname.c_str()


### PR DESCRIPTION
this cherry-picks a few of the recent i2p fixes from RC_2_0 into RC_1_2. i2p is not recommended to be used in libtorrent-1.2.x still