### PR TITLE
use move when draining torrent_info

### DIFF
--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -73,6 +73,13 @@ namespace aux {
 	TORRENT_EXTRA_EXPORT void sanitize_append_path_element(std::string& path
 		, string_view element);
 	TORRENT_EXTRA_EXPORT bool verify_encoding(std::string& target);
+
+	struct internal_drained_state
+	{
+		aux::vector<lt::announce_entry> urls;
+		std::vector<web_seed_entry> web_seeds;
+		std::vector<std::pair<std::string, int>> nodes;
+	};
 }
 
 	// the web_seed_entry holds information about a web seed (also known
@@ -341,7 +348,9 @@ TORRENT_VERSION_NAMESPACE_3
 		void set_web_seeds(std::vector<web_seed_entry> seeds);
 
 		// internal
-		void clear_web_seeds() { m_web_seeds.clear(); }
+		aux::internal_drained_state _internal_drain() {
+			return aux::internal_drained_state{std::move(m_urls), std::move(m_web_seeds), std::move(m_nodes)};
+		}
 
 		// ``total_size()`` returns the total number of bytes the torrent-file
 		// represents. Note that this is the number of pieces times the piece


### PR DESCRIPTION
when draining the torrent_info object (in load_torrent()), move the data structures instead of copying