### PR TITLE
fix peer_list to support incoming i2p connections

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -733,6 +733,7 @@ namespace aux {
 
 #if TORRENT_USE_I2P
 			char const* i2p_session() const override { return m_i2p_conn.session_id(); }
+			std::string const& local_i2p_endpoint() const override { return m_i2p_conn.local_endpoint(); }
 
 			void on_i2p_open(error_code const& ec);
 			void open_new_incoming_i2p_connection();

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -214,6 +214,7 @@ namespace aux {
 
 #if TORRENT_USE_I2P
 		virtual char const* i2p_session() const = 0;
+		virtual std::string const& local_i2p_endpoint() const = 0;
 #endif
 
 		virtual void prioritize_connections(std::weak_ptr<torrent> t) = 0;

--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -125,8 +125,10 @@ struct i2p_stream : proxy_base
 
 	void set_session_id(char const* id) { m_id = id; }
 
+	void set_local_i2p_endpoint(string_view d) { m_local = d.to_string(); }
+	std::string const& local_i2p_endpoint() const { return m_local; }
 	void set_destination(string_view d) { m_dest = d.to_string(); }
-	std::string const& destination() { return m_dest; }
+	std::string const& destination() const { return m_dest; }
 
 	template <class Handler>
 	void async_connect(endpoint_type const&, Handler h)
@@ -445,6 +447,7 @@ private:
 	aux::noexcept_movable<aux::vector<char>> m_buffer;
 	char const* m_id = nullptr;
 	std::string m_dest;
+	std::string m_local;
 	std::string m_name_lookup;
 
 	enum state_t : std::uint8_t
@@ -513,6 +516,7 @@ public:
 	}
 	void close(error_code&);
 
+	// TODO: make this a string_view
 	char const* session_id() const { return m_session_id.c_str(); }
 	std::string const& local_endpoint() const { return m_i2p_local_endpoint; }
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -492,6 +492,11 @@ namespace aux {
 		tcp::endpoint const& remote() const override { return m_remote; }
 		tcp::endpoint local_endpoint() const override { return m_local; }
 
+#if TORRENT_USE_I2P
+		std::string const& destination() const override;
+		std::string const& local_i2p_endpoint() const override;
+#endif
+
 		typed_bitfield<piece_index_t> const& get_bitfield() const;
 		std::vector<piece_index_t> const& allowed_fast();
 		std::vector<piece_index_t> const& suggested_pieces() const { return m_suggested_pieces; }

--- a/include/libtorrent/peer_connection_interface.hpp
+++ b/include/libtorrent/peer_connection_interface.hpp
@@ -55,6 +55,10 @@ namespace libtorrent {
 		static constexpr disconnect_severity_t failure{1};
 		static constexpr disconnect_severity_t peer_error{2};
 
+#if TORRENT_USE_I2P
+		virtual std::string const& destination() const = 0;
+		virtual std::string const& local_i2p_endpoint() const = 0;
+#endif
 		virtual tcp::endpoint const& remote() const = 0;
 		virtual tcp::endpoint local_endpoint() const = 0;
 		virtual void disconnect(error_code const& ec

--- a/include/libtorrent/torrent_peer.hpp
+++ b/include/libtorrent/torrent_peer.hpp
@@ -294,6 +294,19 @@ namespace libtorrent {
 			return lhs->address() < rhs->address();
 		}
 	};
+
+	inline bool torrent_peer_equal(torrent_peer const* lhs, torrent_peer const* rhs)
+	{
+#if TORRENT_USE_I2P
+		if (lhs->is_i2p_addr != rhs->is_i2p_addr)
+			return false;
+
+		if (lhs->is_i2p_addr)
+			return lhs->dest() == rhs->dest();
+#endif
+		return lhs->address() == rhs->address()
+			&& lhs->port == rhs->port;
+	}
 }
 
 #endif

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1184,6 +1184,22 @@ namespace libtorrent {
 		t->received_synack(ipv6);
 	}
 
+#if TORRENT_USE_I2P
+	std::string const& peer_connection::destination() const
+	{
+		static std::string const empty;
+		auto s = boost::get<i2p_stream>(&m_socket);
+		return s ? s->destination() : empty;
+	}
+
+	std::string const& peer_connection::local_i2p_endpoint() const
+	{
+		static std::string const empty;
+		auto s = boost::get<i2p_stream>(&m_socket);
+		return s ? s->local_i2p_endpoint() : empty;
+	}
+#endif
+
 	typed_bitfield<piece_index_t> const& peer_connection::get_bitfield() const
 	{
 		TORRENT_ASSERT(is_single_thread());

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -301,9 +301,10 @@ namespace libtorrent {
 		TORRENT_ASSERT(p->in_use);
 		TORRENT_ASSERT(m_locked_peer != p);
 
-		auto const addr = p->address();
-		auto const range = find_peers(addr);
-		auto const iter = std::find_if(range.first, range.second, match_peer_endpoint(addr, p->port));
+		auto const range = std::equal_range(m_peers.begin(), m_peers.end(), p, peer_address_compare{});
+		auto const iter = std::find_if(range.first, range.second, [&](torrent_peer const* needle) {
+			return torrent_peer_equal(needle, p);
+		});
 		if (iter == range.second) return;
 		erase_peer(iter, state);
 	}
@@ -613,8 +614,15 @@ namespace libtorrent {
 		iterator iter;
 		torrent_peer* i = nullptr;
 
+#if TORRENT_USE_I2P
+		std::string const i2p_dest = c.destination();
+#else
+		std::string const i2p_dest;
+#endif
+
 		bool found = false;
-		if (state->allow_multiple_connections_per_ip)
+		// this check doesn't support i2p peers
+		if (state->allow_multiple_connections_per_ip && i2p_dest.empty())
 		{
 			auto const& remote = c.remote();
 			auto const addr = remote.address();
@@ -629,15 +637,33 @@ namespace libtorrent {
 		}
 		else
 		{
-			iter = std::lower_bound(
-				m_peers.begin(), m_peers.end()
-				, c.remote().address(), peer_address_compare()
-			);
-
-			if (iter != m_peers.end() && (*iter)->address() == c.remote().address())
+#if TORRENT_USE_I2P
+			if (!i2p_dest.empty())
 			{
-				TORRENT_ASSERT((*iter)->in_use);
-				found = true;
+				iter = std::lower_bound(
+					m_peers.begin(), m_peers.end()
+					, i2p_dest, peer_address_compare()
+					);
+
+				if (iter != m_peers.end() && (*iter)->is_i2p_addr && (*iter)->dest() == i2p_dest)
+				{
+					TORRENT_ASSERT((*iter)->in_use);
+					found = true;
+				}
+			}
+			else
+#endif
+			{
+				iter = std::lower_bound(
+					m_peers.begin(), m_peers.end()
+					, c.remote().address(), peer_address_compare()
+					);
+
+				if (iter != m_peers.end() && (*iter)->address() == c.remote().address())
+				{
+					TORRENT_ASSERT((*iter)->in_use);
+					found = true;
+				}
 			}
 		}
 
@@ -658,9 +684,19 @@ namespace libtorrent {
 #ifndef TORRENT_DISABLE_LOGGING
 			if (i->connection != nullptr && c.should_log(peer_log_alert::info))
 			{
-				c.peer_log(peer_log_alert::info, "DUPLICATE PEER", "this: \"%s\" that: \"%s\""
-					, print_address(c.remote().address()).c_str()
-					, print_address(i->address()).c_str());
+#if TORRENT_USE_I2P
+				if (!i2p_dest.empty())
+				{
+					c.peer_log(peer_log_alert::info, "DUPLICATE PEER", "destination: \"%s\""
+						, i2p_dest.c_str());
+				}
+				else
+#endif
+				{
+					c.peer_log(peer_log_alert::info, "DUPLICATE PEER", "this: \"%s\" that: \"%s\""
+						, print_address(c.remote().address()).c_str()
+						, print_address(i->address()).c_str());
+				}
 			}
 #endif
 			if (i->banned)
@@ -671,9 +707,18 @@ namespace libtorrent {
 
 			if (i->connection != nullptr)
 			{
-				bool const self_connection =
-					i->connection->remote() == c.local_endpoint()
+				bool self_connection = false;
+#if TORRENT_USE_I2P
+				if (!i2p_dest.empty())
+				{
+					self_connection = i->connection->local_i2p_endpoint() == i2p_dest;
+				}
+				else
+#endif
+				{
+					self_connection = i->connection->remote() == c.local_endpoint()
 					|| i->connection->local_endpoint() == c.remote();
+				}
 
 				if (self_connection)
 				{
@@ -694,6 +739,42 @@ namespace libtorrent {
 					c.disconnect(errors::duplicate_peer_id, operation_t::bittorrent);
 					return false;
 				}
+#if TORRENT_USE_I2P
+				else if (!i2p_dest.empty())
+				{
+					// duplicate connection resolution for i2p connections is
+					// simple. The smaller address takes priority for making the
+					// outgoing connection
+
+					std::string const& other_dest = i->connection->destination();
+
+					// decide which peer connection to disconnect
+					// if the ports are equal, pick on at random
+					bool disconnect1 = c.is_outgoing() && i2p_dest > other_dest;
+
+#ifndef TORRENT_DISABLE_LOGGING
+					if (c.should_log(peer_log_alert::info))
+					{
+						c.peer_log(peer_log_alert::info, "DUPLICATE_PEER_RESOLUTION"
+							, "our: %s other: %s disconnecting: %s"
+							, i2p_dest.c_str(), other_dest.c_str(), disconnect1 ? "yes" : "no");
+						i->connection->peer_log(peer_log_alert::info, "DUPLICATE_PEER_RESOLUTION"
+							, "our: %s other: %s disconnecting: %s"
+							, other_dest.c_str(), i2p_dest.c_str(), disconnect1 ? "no" : "yes");
+					}
+#endif
+
+					if (disconnect1)
+					{
+						c.disconnect(errors::duplicate_peer_id, operation_t::bittorrent);
+						return false;
+					}
+					TORRENT_ASSERT(m_locked_peer == nullptr);
+					m_locked_peer = i;
+					i->connection->disconnect(errors::duplicate_peer_id, operation_t::bittorrent);
+					m_locked_peer = nullptr;
+				}
+#endif
 				else
 				{
 					// at this point, we need to disconnect either
@@ -769,24 +850,36 @@ namespace libtorrent {
 				);
 			}
 
-			bool const is_v6 = lt::aux::is_v6(c.remote());
-			torrent_peer* p = m_peer_allocator.allocate_peer_entry(
-				is_v6 ? torrent_peer_allocator_interface::ipv6_peer_type
-				: torrent_peer_allocator_interface::ipv4_peer_type);
-			if (p == nullptr) return false;
-
-			if (is_v6)
-				p = new (p) ipv6_peer(c.remote(), false, {});
+#if TORRENT_USE_I2P
+			if (!i2p_dest.empty())
+			{
+				i = add_i2p_peer(i2p_dest, peer_info::incoming, {}, state);
+				// we're about to attach the new connection to this torrent_peer
+				if (is_connect_candidate(*i))
+					update_connect_candidates(-1);
+			}
 			else
-				p = new (p) ipv4_peer(c.remote(), false, {});
+#endif
+			{
+				bool const is_v6 = lt::aux::is_v6(c.remote());
+				torrent_peer* p = m_peer_allocator.allocate_peer_entry(
+					is_v6 ? torrent_peer_allocator_interface::ipv6_peer_type
+					: torrent_peer_allocator_interface::ipv4_peer_type);
+				if (p == nullptr) return false;
 
-			iter = m_peers.insert(iter, p);
+				if (is_v6)
+					p = new (p) ipv6_peer(c.remote(), false, {});
+				else
+					p = new (p) ipv4_peer(c.remote(), false, {});
 
-			if (m_round_robin >= iter - m_peers.begin()) ++m_round_robin;
+				iter = m_peers.insert(iter, p);
 
-			i = *iter;
+				if (m_round_robin >= iter - m_peers.begin()) ++m_round_robin;
 
-			i->source = static_cast<std::uint8_t>(peer_info::incoming);
+				i = *iter;
+
+				i->source = static_cast<std::uint8_t>(peer_info::incoming);
+			}
 		}
 
 		TORRENT_ASSERT(i);
@@ -816,6 +909,10 @@ namespace libtorrent {
 		TORRENT_ASSERT(is_single_thread());
 
 		INVARIANT_CHECK;
+
+#if TORRENT_USE_I2P
+		if (p->is_i2p_addr) return true;
+#endif
 
 		if (p->port == port) return true;
 
@@ -857,13 +954,8 @@ namespace libtorrent {
 #if TORRENT_USE_ASSERTS
 		else
 		{
-#if TORRENT_USE_I2P
-			if (!p->is_i2p_addr)
-#endif
-			{
-				std::pair<iterator, iterator> range = find_peers(p->address());
-				TORRENT_ASSERT(std::distance(range.first, range.second) == 1);
-			}
+			std::pair<iterator, iterator> range = find_peers(p->address());
+			TORRENT_ASSERT(std::distance(range.first, range.second) == 1);
 		}
 #endif
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7516,9 +7516,11 @@ namespace {
 
 			aux::socket_type ret = instantiate_connection(m_ses.get_context()
 				, proxy, nullptr, nullptr, false, false);
-			boost::get<i2p_stream>(ret).set_destination(static_cast<i2p_peer*>(peerinfo)->dest());
-			boost::get<i2p_stream>(ret).set_command(i2p_stream::cmd_connect);
-			boost::get<i2p_stream>(ret).set_session_id(m_ses.i2p_session());
+			i2p_stream& str = boost::get<i2p_stream>(ret);
+			str.set_local_i2p_endpoint(m_ses.local_i2p_endpoint());
+			str.set_destination(static_cast<i2p_peer*>(peerinfo)->dest());
+			str.set_command(i2p_stream::cmd_connect);
+			str.set_session_id(m_ses.i2p_session());
 			return ret;
 		}
 		else

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 using namespace lt;
 
+#if 0
 struct mock_peer_connection final : peer_connection_interface
 {
 	tcp::endpoint const& remote() const override { return m_remote; }
@@ -66,6 +67,18 @@ struct mock_peer_connection final : peer_connection_interface
 	void peer_log(peer_log_alert::direction_t
 		, char const*, char const*, ...) const noexcept override TORRENT_FORMAT(4, 5) {}
 #endif
+#if TORRENT_USE_I2P
+	std::string const& destination() const override
+	{
+		static std::string const empty;
+		return empty;
+	}
+	std::string const& local_i2p_endpoint() const override
+	{
+		static std::string const empty;
+		return empty;
+	}
+#endif
 
 	torrent_peer* m_torrent_peer;
 	lt::stat m_stat;
@@ -73,7 +86,6 @@ struct mock_peer_connection final : peer_connection_interface
 	peer_id m_pid;
 };
 
-#if 0
 TORRENT_TEST(pick_piece_layer)
 {
 	file_storage fs;

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -58,18 +58,31 @@ struct mock_peer_connection
 	: peer_connection_interface
 	, std::enable_shared_from_this<mock_peer_connection>
 {
-	mock_peer_connection(mock_torrent* tor, bool out, tcp::endpoint const& remote)
+	mock_peer_connection(mock_torrent* tor, bool out)
 		: m_choked(false)
 		, m_outgoing(out)
 		, m_tp(nullptr)
-		, m_remote(remote)
-		, m_local(ep("127.0.0.1", 8080))
 		, m_our_id(nullptr)
 		, m_disconnect_called(false)
 		, m_torrent(*tor)
 	{
 		aux::random_bytes(m_id);
 	}
+
+	mock_peer_connection(mock_torrent* tor, bool out, tcp::endpoint const& remote)
+		: mock_peer_connection(tor, out)
+	{
+		m_remote = remote;
+		m_local = ep("127.0.0.1", 8080);
+	}
+
+#if TORRENT_USE_I2P
+	mock_peer_connection(mock_torrent* tor, bool out, std::string remote)
+		: mock_peer_connection(tor, out)
+	{
+		m_i2p_destination = std::move(remote);
+	}
+#endif
 
 	virtual ~mock_peer_connection() = default;
 
@@ -103,10 +116,25 @@ struct mock_peer_connection
 	torrent_peer* m_tp;
 	tcp::endpoint m_remote;
 	tcp::endpoint m_local;
+#if TORRENT_USE_I2P
+	std::string m_i2p_destination;
+	std::string m_local_i2p_endpoint;
+#endif
 	peer_id m_id;
 	peer_id m_our_id;
 	bool m_disconnect_called;
 	mock_torrent& m_torrent;
+
+#if TORRENT_USE_I2P
+	std::string const& destination() const override
+	{
+		return m_i2p_destination;
+	}
+	std::string const& local_i2p_endpoint() const override
+	{
+		return m_local_i2p_endpoint;
+	}
+#endif
 
 	void get_peer_info(peer_info&) const override {}
 	tcp::endpoint const& remote() const override { return m_remote; }
@@ -189,6 +217,21 @@ torrent_peer* add_peer(peer_list& p, torrent_state& st, tcp::endpoint const& ep)
 	st.erased.clear();
 	return peer;
 }
+
+#if TORRENT_USE_I2P
+torrent_peer* add_i2p_peer(peer_list& p, torrent_state& st, std::string const& destination)
+{
+	int cc = p.num_connect_candidates();
+	torrent_peer* peer = p.add_i2p_peer(destination, {}, {}, &st);
+	if (peer)
+	{
+		TEST_EQUAL(p.num_connect_candidates(), cc + 1);
+		TEST_EQUAL(peer->dest(), destination);
+	}
+	st.erased.clear();
+	return peer;
+}
+#endif
 
 void connect_peer(peer_list& p, mock_torrent& t, torrent_state& st)
 {
@@ -775,7 +818,7 @@ TORRENT_TEST(double_connection)
 
 	p.new_connection(*con1, 0, &st);
 
-	// and the incoming connection
+	// the seconds incoming connection
 	auto con2 = std::make_shared<mock_peer_connection>(&t, false, ep("10.0.0.2", 3561));
 	con2->set_local_ep(ep("10.0.0.1", 8080));
 
@@ -880,6 +923,126 @@ TORRENT_TEST(double_connection_win)
 	TEST_EQUAL(con_out->was_disconnected(), false);
 	TEST_EQUAL(con_in->was_disconnected(), true);
 }
+
+#if TORRENT_USE_I2P
+// test i2p self-connection
+TORRENT_TEST(self_connection_i2p)
+{
+	torrent_state st = init_state();
+	mock_torrent t(&st);
+	st.allow_multiple_connections_per_ip = false;
+	peer_list p(allocator);
+	t.m_p = &p;
+
+	// add and connect peer
+	torrent_peer* peer = add_i2p_peer(p, st, "foobar");
+	connect_peer(p, t, st);
+
+	auto con_out = shared_from_this(peer->connection);
+	con_out->m_i2p_destination = "foobar";
+	con_out->m_local_i2p_endpoint = "foobar";
+
+	auto con_in = std::make_shared<mock_peer_connection>(&t, false, "foobar");
+	con_in->m_local_i2p_endpoint = "foobar";
+
+	p.new_connection(*con_in, 0, &st);
+
+	// from the peer_list's point of view, this looks like we made one
+	// outgoing connection and received an incoming one. Since they share
+	// the exact same endpoints (IP ports) but just swapped source and
+	// destination, the peer list is supposed to figure out that we connected
+	// to ourself and disconnect it
+	TEST_EQUAL(con_out->was_disconnected(), true);
+	TEST_EQUAL(con_in->was_disconnected(), true);
+}
+
+// test double i2p connection (both incoming)
+TORRENT_TEST(double_connection_i2p)
+{
+	torrent_state st = init_state();
+	mock_torrent t(&st);
+	st.allow_multiple_connections_per_ip = false;
+	peer_list p(allocator);
+	t.m_p = &p;
+
+	// we are "foo" and the other peer is "bar"
+
+	// first incoming connection
+	auto con1 = std::make_shared<mock_peer_connection>(&t, false, "bar");
+	con1->m_local_i2p_endpoint = "foo";
+
+	p.new_connection(*con1, 0, &st);
+
+	// the second incoming connection
+	auto con2 = std::make_shared<mock_peer_connection>(&t, false, "bar");
+	con2->m_local_i2p_endpoint = "foo";
+
+	p.new_connection(*con2, 0, &st);
+
+	// the second incoming connection should be closed
+	TEST_EQUAL(con1->was_disconnected(), false);
+	TEST_EQUAL(con2->was_disconnected(), true);
+}
+
+// test double connection (we loose)
+TORRENT_TEST(double_connection_loose_i2p)
+{
+	torrent_state st = init_state();
+	mock_torrent t(&st);
+	st.allow_multiple_connections_per_ip = false;
+	peer_list p(allocator);
+	t.m_p = &p;
+
+	// we are "foo" and the other peer is "bar"
+
+	// our outgoing connection
+	torrent_peer* peer = add_i2p_peer(p, st, "bar");
+	connect_peer(p, t, st);
+
+	auto con_out = shared_from_this(peer->connection);
+	con_out->m_local_i2p_endpoint = "foo";
+
+	// and the incoming connection
+	auto con_in = std::make_shared<mock_peer_connection>(&t, false, "bar");
+	con_in->m_local_i2p_endpoint = "foo";
+
+	p.new_connection(*con_in, 0, &st);
+
+	// the rules are documented in peer_list.cpp
+	TEST_EQUAL(con_out->was_disconnected(), true);
+	TEST_EQUAL(con_in->was_disconnected(), false);
+}
+
+// test double connection (we win)
+TORRENT_TEST(double_connection_win_i2p)
+{
+	torrent_state st = init_state();
+	mock_torrent t(&st);
+	st.allow_multiple_connections_per_ip = false;
+	peer_list p(allocator);
+	t.m_p = &p;
+
+	// we are "bar" and the other peer is "foo"
+	// "bar" < "foo", so we gets to make the outgoing connection
+
+	// our outgoing connection
+	torrent_peer* peer = add_i2p_peer(p, st, "foo");
+	connect_peer(p, t, st);
+
+	auto con_out = shared_from_this(peer->connection);
+	con_out->m_local_i2p_endpoint = "bar";
+
+	//and the incoming connection
+	auto con_in = std::make_shared<mock_peer_connection>(&t, false, "foo");
+	con_in->m_local_i2p_endpoint = "bar";
+
+	p.new_connection(*con_in, 0, &st);
+
+	// the rules are documented in peer_list.cpp
+	TEST_EQUAL(con_out->was_disconnected(), true);
+	TEST_EQUAL(con_in->was_disconnected(), false);
+}
+#endif
 
 // test incoming connection when we are at the list size limit
 TORRENT_TEST(incoming_size_limit)


### PR DESCRIPTION
this fixes a few issues in the peer_list when putting i2p peers in it.
* incoming i2p connections did not work correctly
* detecting self connections did not work correctly
* resolving a double-connect (where two peers connect to each other at the same time), did not work correctly