### PR TITLE
use madvise(MADV_RANDOM) when torrenting mmaped files to reduce disk readahead

### DIFF
--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -187,7 +187,7 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode, std::int64_
 #if TORRENT_USE_MADVISE
 	if (file_size > 0)
 	{
-		int const advise = ((mode & open_mode::random_access) ? 0 : MADV_SEQUENTIAL)
+		int const advise = ((mode & open_mode::random_access) ? MADV_RANDOM : MADV_SEQUENTIAL)
 #ifdef MADV_DONTDUMP
 		// on versions of linux that support it, ask for this region to not be
 		// included in coredumps (mostly to make the coredumps more manageable
@@ -200,8 +200,7 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode, std::int64_
 			| MADV_NOCORE
 #endif
 		;
-		if (advise != 0)
-			madvise(m_mapping, static_cast<std::size_t>(m_size), advise);
+		madvise(m_mapping, static_cast<std::size_t>(m_size), advise);
 	}
 #endif
 }


### PR DESCRIPTION
For #7405. When torrenting (random_access) files, reduce excessive disk IO readahead with mmaped files by using MADV_RANDOM and hence matching normal file access using POSIX_FADV_RANDOM.

Could cause more IO calls though as unfortunately there's no reduced read ahead option to madvise.