### PR TITLE
fix gcc 13 build

### DIFF
--- a/include/libtorrent/aux_/numeric_cast.hpp
+++ b/include/libtorrent/aux_/numeric_cast.hpp
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef TORRENT_NUMERIC_CAST_HPP
 #define TORRENT_NUMERIC_CAST_HPP
 
+#include <cstdint>
 #include <type_traits>
 #include <limits>
 


### PR DESCRIPTION
    include/libtorrent/aux_/numeric_cast.hpp:52:33: error:
    'int64_t' is not a member of 'std'; did you mean 'int64_t'?

see: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes