### PR TITLE
make i2p session options configurable

### DIFF
--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -101,6 +101,22 @@ namespace libtorrent {
 	{ return i2p_category(); }
 #endif
 
+struct i2p_session_options
+{
+	i2p_session_options(int inbound_quantity = 3,
+		int outbound_quantity = 3, int inbound_length = 3, int outbound_length = 3)
+		: m_inbound_quantity(inbound_quantity)
+		, m_outbound_quantity(outbound_quantity)
+		, m_inbound_length(inbound_length)
+		, m_outbound_length(outbound_length)
+	{}
+
+	int m_inbound_quantity;
+	int m_outbound_quantity;
+	int m_inbound_length;
+	int m_outbound_length;
+};
+
 struct i2p_stream : proxy_base
 {
 	explicit i2p_stream(io_context& io_context);
@@ -122,6 +138,11 @@ struct i2p_stream : proxy_base
 	};
 
 	void set_command(command_t c) { m_command = c; }
+
+	void set_session_options(const i2p_session_options& session_options)
+	{
+		m_session_options = session_options;
+	}
 
 	void set_session_id(char const* id) { m_id = id; }
 
@@ -435,7 +456,9 @@ private:
 		char cmd[400];
 		int size = std::snprintf(cmd, sizeof(cmd),
 			"SESSION CREATE STYLE=STREAM ID=%s DESTINATION=TRANSIENT SIGNATURE_TYPE=7 "
-			"inbound.quantity=3 outbound.quantity=3 inbound.length=3 outbound.length=3\n", m_id);
+			"inbound.quantity=%d outbound.quantity=%d inbound.length=%d outbound.length=%d\n",
+			m_id, m_session_options.m_inbound_quantity, m_session_options.m_outbound_quantity,
+			m_session_options.m_inbound_length, m_session_options.m_outbound_length);
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, std::size_t(size)), wrap_allocator(
 			[this](error_code const& ec, std::size_t, Handler hn) {
@@ -449,6 +472,8 @@ private:
 	std::string m_dest;
 	std::string m_local;
 	std::string m_name_lookup;
+
+	i2p_session_options m_session_options;
 
 	enum state_t : std::uint8_t
 	{
@@ -483,7 +508,8 @@ public:
 			&& m_state != sam_connecting;
 	}
 	template <typename Handler>
-	void open(std::string const& hostname, int port, Handler handler)
+	void open(std::string const& hostname, int port,
+		const i2p_session_options& session_options, Handler handler)
 	{
 		// we already seem to have a session to this SAM router
 		if (m_hostname == hostname
@@ -507,6 +533,7 @@ public:
 		m_sam_socket->set_proxy(m_hostname, m_port);
 		m_sam_socket->set_command(i2p_stream::cmd_create_session);
 		m_sam_socket->set_session_id(m_session_id.c_str());
+		m_sam_socket->set_session_options(session_options);
 
 		ADD_OUTSTANDING_ASYNC("i2p_stream::on_sam_connect");
 		m_sam_socket->async_connect(tcp::endpoint(), wrap_allocator(

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -2056,6 +2056,18 @@ namespace aux {
 			// operations. This file size limit is specified in 16 kiB blocks.
 			mmap_file_size_cutoff,
 
+			// quantity of I2P inbound tunnels [1..16]
+			i2p_inbound_quantity,
+
+			// quantity of I2P outbound tunnels [1..16]
+			i2p_outbound_quantity,
+
+			// amount of hops for I2P inbound tunnels [0..7]
+			i2p_inbound_length,
+
+			// amount of hops for I2P outbound tunnels [0..7]
+			i2p_outbound_length,
+
 			max_int_setting_internal
 		};
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2368,8 +2368,15 @@ namespace {
 			return;
 		}
 		TORRENT_ASSERT(!m_abort);
+		i2p_session_options session_options(
+			m_settings.get_int(settings_pack::i2p_inbound_quantity)
+			, m_settings.get_int(settings_pack::i2p_outbound_quantity)
+			, m_settings.get_int(settings_pack::i2p_inbound_length)
+			, m_settings.get_int(settings_pack::i2p_outbound_length)
+		);
 		m_i2p_conn.open(m_settings.get_str(settings_pack::i2p_hostname)
 			, m_settings.get_int(settings_pack::i2p_port)
+			, session_options
 			, std::bind(&session_impl::on_i2p_open, this, _1));
 #endif
 	}

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -398,6 +398,10 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(metadata_token_limit, 2500000, nullptr),
 		SET(disk_write_mode, settings_pack::mmap_write_mode_t::auto_mmap_write, nullptr),
 		SET(mmap_file_size_cutoff, 40, nullptr),
+		SET(i2p_inbound_quantity, 3, nullptr),
+		SET(i2p_outbound_quantity, 3, nullptr),
+		SET(i2p_inbound_length, 3, nullptr),
+		SET(i2p_outbound_length, 3, nullptr)
 	}});
 
 #undef SET


### PR DESCRIPTION
Implements #7354.

> 1. adding settings to a settings_pack enum has to be at the end, otherwise some settings will change value and that's incompatible with the existing ABI.

Ok, I made this change.

> 2. I think it would be good to omit options that haven't been set explicitly, when building the SESSION CREATE string. I'd like libtorrent to defer default values to the i2p router as much as possible.

Options are set explicitly intentionally.
It is needed for consistent behaviour among two I2P implementations (i2pd and Java I2P).

> 3. it might be worth exploring putting these settings in their own class, to be able to pass them as one bundle to open(). m_inbound_quantity, m_outbound_quantity, m_inbound_length, m_outbound_length

I don't have strong opinion on this.
But I made such change. Technically it should work, but I know little about style traditions in this project, so I'm not sure if my changes aesthetically good.