### PR TITLE
GHA CI: Updated numerous `actions`

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,7 +22,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
            submodules: true
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -71,9 +71,9 @@ jobs:
     - id: set-matrix
       run: |
         if [ $GITHUB_EVENT_NAME == "pull_request" ]; then
-          echo ::set-output name=matrix::$(echo $MATRIX_PULL_REQUEST | jq -c)
+          echo "matrix=$(echo $MATRIX_PULL_REQUEST | jq -c)" >> "$GITHUB_OUTPUT"
         else
-          echo ::set-output name=matrix::$(echo $MATRIX_WORKFLOW_DISPATCH | jq -c)
+          echo "matrix=$(echo $MATRIX_WORKFLOW_DISPATCH | jq -c)" >> "$GITHUB_OUTPUT"
         fi
 
   build_wheels:
@@ -90,23 +90,23 @@ jobs:
       CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache-wheel
       with:
         path: wheelhouse
         key: wheel-${{ matrix.CIBW_BUILD }}-${{ matrix.CIBW_ARCHS }}-${{ github.sha }}
 
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-qemu-action@v2
       if: steps.cache-wheel.outputs.cache-hit != 'true' && runner.os == 'Linux'
 
-    - uses: pypa/cibuildwheel@v2.9.0
+    - uses: pypa/cibuildwheel@v2.12.3
       if: steps.cache-wheel.outputs.cache-hit != 'true'
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         path: wheelhouse/*.whl
         name: wheels
@@ -117,7 +117,7 @@ jobs:
     if: needs.build_wheels.result == 'success' && github.event.inputs.publish == 'PUBLISH'
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: wheels
         path: wheelhouse
@@ -134,7 +134,7 @@ jobs:
     if: needs.build_wheels.result == 'success' && github.event.inputs.publish_test == 'PUBLISH_TEST'
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: wheels
         path: wheelhouse

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: update package lists
         continue-on-error: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,13 +15,13 @@ jobs:
       # TODO: matrix across python version and os
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
            submodules: recursive
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
            python-version: 3.8
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
 
    build:
       name: build
@@ -34,7 +34,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -82,7 +82,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -121,7 +121,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -154,7 +154,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -200,7 +200,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -238,7 +238,7 @@ jobs:
           b2 ${{ matrix.config }} -l500 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
 
       - name: run tests (flaky)
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4
@@ -253,7 +253,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -295,7 +295,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -321,7 +321,7 @@ jobs:
       - name: build tarball
         run: AAFIGURE=~/.local/bin/aafigure RST2HTML=rst2html make dist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: tarball
           path: libtorrent-rasterbar-*.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -41,7 +41,7 @@ jobs:
         run: (cd test; b2 ${{ matrix.config }} -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests)
 
       - name: run tests (flaky)
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
           retry_wait_seconds: 1
@@ -55,7 +55,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -87,7 +87,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -114,7 +114,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
            submodules: true
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest, windows-latest ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -66,7 +66,7 @@ jobs:
 
     - name: install openssl (windows)
       if: runner.os == 'Windows'
-      uses: nick-invision/retry@v2
+      uses: nick-fields/retry@v2
       with:
         shell: cmd
         timeout_minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,12 +29,12 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
       - name: install openssl (64 bit)
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4
@@ -82,7 +82,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -138,7 +138,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
            submodules: true
 
@@ -149,7 +149,7 @@ jobs:
           bootstrap.bat
 
       - name: install openssl (64 bit)
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4
@@ -195,12 +195,12 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
       - name: install openssl (64 bit)
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4


### PR DESCRIPTION
Resolves `Node.js 12 actions are deprecated.`  & `set-output commands are deprecated.` warnings.

For more information see:
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
____

Changed `nick-invision/retry` to `nick-fields/retry` action due to upstream change.

- https://github.com/nick-fields/retry#ownership