### PR TITLE
Bump boost version to enable Python 3.11 package builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,7 @@ build_macos_arm64_task:
   env:
     CIRRUS_CLONE_SUBMODULES: true
     CIBW_SKIP: pp* cp38-* # cp38-* has problem with x86_64 / arm64 confusion
-    CIBW_BUILD: cp39-* cp310-* # cp311-* can be added after boost-python version >= 1.81
+    CIBW_BUILD: cp39-* cp310-* cp311-*
     CIBW_ARCH: arm64
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires-python = ">=3.7"
 
 [tool.cibuildwheel]
-skip = "{pp*,cp311-*}"
+skip = "{pp*,}"
 
 [tool.cibuildwheel.macos]
 before-all = [
@@ -17,7 +17,7 @@ test-command = [
 [tool.cibuildwheel.macos.environment]
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
-BOOST_VERSION = "1.80.0"
+BOOST_VERSION = "1.81.0"
 MACOSX_DEPLOYMENT_TARGET = "10.9"  # required for full C++11 support
 PATH = "/tmp/boost:$PATH"
 
@@ -38,7 +38,7 @@ test-command = [
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
-BOOST_VERSION = "1.80.0"
+BOOST_VERSION = "1.81.0"
 PATH = "/usr/local/ccache/bin:/tmp/boost:$PATH"
 
 [[tool.cibuildwheel.overrides]]
@@ -57,7 +57,7 @@ test-command = [
 [tool.cibuildwheel.overrides.environment]  # sub-table of previous block!
 BOOST_BUILD_PATH = "/tmp/boost/tools/build"
 BOOST_ROOT = "/tmp/boost"
-BOOST_VERSION = "1.76.0"
+BOOST_VERSION = "1.81.0"
 PATH = "/usr/lib/ccache/bin:/tmp/boost:$PATH"
 
 [[tool.cibuildwheel.overrides]]
@@ -80,7 +80,7 @@ test-command = '''bash -c "cd '{project}/bindings/python' && python test.py"'''
 [tool.cibuildwheel.windows.environment]
 BOOST_BUILD_PATH = 'c:/boost/tools/build'
 BOOST_ROOT = 'c:/boost'
-BOOST_VERSION = "1.80.0"
+BOOST_VERSION = "1.81.0"
 PATH = 'c:/boost;$PATH'
 
 [tool.isort]


### PR DESCRIPTION
Python 3.11 is not compatible with Boost Python <= 1.80 due to error with Py_TPFLAGS_HAVE_GC enum.

Ref: https://github.com/boostorg/python/issues/400
Fixes: https://github.com/arvidn/libtorrent/issues/7265