### PR TITLE
cmake: don't define _FILE_OFFSET_BITS on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,10 +595,16 @@ target_compile_definitions(torrent-rasterbar
 		BOOST_ASIO_NO_DEPRECATED
 	PRIVATE
 		TORRENT_BUILDING_LIBRARY
-		_FILE_OFFSET_BITS=64
 		BOOST_EXCEPTION_DISABLE
 		BOOST_ASIO_HAS_STD_CHRONO
 )
+
+if (NOT WIN32)
+	target_compile_definitions(torrent-rasterbar
+		PRIVATE
+			_FILE_OFFSET_BITS=64
+	)
+endif()
 
 target_link_libraries(torrent-rasterbar
 	PUBLIC


### PR DESCRIPTION
Completes 44da281de200ca97757e7e which removed it in various places, but missed the cmake config.

This fixes the build on Windows with mingw-w64.