### PR TITLE
Don't use visibility("hidden") on Windows

### DIFF
--- a/include/libtorrent/aux_/export.hpp
+++ b/include/libtorrent/aux_/export.hpp
@@ -100,7 +100,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #if !defined TORRENT_EXPORT_EXTRA \
-  && ((defined __GNUC__ && __GNUC__ >= 4) || defined __clang__)
+  && ((defined __GNUC__ && __GNUC__ >= 4) || defined __clang__) && !defined _WIN32
 # define TORRENT_UNEXPORT __attribute__((visibility("hidden")))
 #else
 # define TORRENT_UNEXPORT


### PR DESCRIPTION
clang v16 (in combination with mingw-w64) has gotten stricter and now fails with:

"error: hidden visibility cannot be applied to 'dllexport' declaration"

Since "visibility" isn't used on Windows anyway, just skip it there.