### PR TITLE
Fix dht_announce_interval not being followed accurately in some cases

### DIFF
--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -6597,7 +6597,7 @@ namespace {
 		}
 
 		ADD_OUTSTANDING_ASYNC("session_impl::on_dht_announce");
-		int delay = std::max(m_settings.get_int(settings_pack::dht_announce_interval)
+		int delay = std::max(1000 * m_settings.get_int(settings_pack::dht_announce_interval)
 			/ std::max(int(m_torrents.size()), 1), 1);
 
 		if (!m_dht_torrents.empty())
@@ -6605,10 +6605,10 @@ namespace {
 			// we have prioritized torrents that need
 			// an initial DHT announce. Don't wait too long
 			// until we announce those.
-			delay = std::min(4, delay);
+			delay = std::min(4000, delay);
 		}
 
-		m_dht_announce_timer.expires_after(seconds(delay));
+		m_dht_announce_timer.expires_after(milliseconds(delay));
 		m_dht_announce_timer.async_wait([this](error_code const& e) {
 			wrap(&session_impl::on_dht_announce, e); });
 #endif


### PR DESCRIPTION
If I'm understanding the code correctly, announcing to the DHT seems to be done by cycling over all torrents with a delay of `dht_announce_interval / total-number-of-torrents` between each torrent - the idea being that announces are spread out evenly over the entire interval rather than everything being announced to the DHT all at once.

The delay between torrents seems to be calculated with a minimum of a single second and is rounded down. Depending on the total number of torrents, this might lead to the actual DHT announce interval being considerably shorter or longer than expected, especially with a larger number of torrents.

For example, the default `dht_announce_interval` of 900s with 451 torrents calculates a 1s delay, taking 451s to cycle through everything, or half as long as expected.

If there are more than `dht_announce_interval` torrents, the actual announce interval would be longer than expected. 1800 torrents would take 1800s to cycle through, twice as long as expected by default.

This change attempts to address this by calculating the delay between torrents using milliseconds instead of seconds, allowing sub-second delays when needed and preventing rounding issues.