### PR TITLE
Fixes various typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -152,7 +152,7 @@
 
 2.0 released
 
-	* dropped depenency on iconv
+	* dropped dependency on iconv
 	* deprecate set_file_hash() in torrent creator, as it's superceded by v2 torrents
 	* deprecate mutable access to info_section in torrent_info
 	* removed deprecated lazy_entry/lazy_bdecode
@@ -270,7 +270,7 @@
 	* fix issue with moving the session object
 	* deprecate torrent_status::allocating. This state is no longer used
 	* fix bug creating torrents with symbolic links
-	* remove special case to save metadata in resume data unconditionally when added throught magnet link
+	* remove special case to save metadata in resume data unconditionally when added through magnet link
 	* fix bugs in mutable-torrent support (reusing identical files from different torrents)
 	* fix incorrectly inlined move-assignment of file_storage
 	* add session::paused flag, and the ability to construct a session in paused mode
@@ -324,7 +324,7 @@
 	* limit number of concurrent HTTP announces
 	* fix queue position for force_rechecking a torrent that is not auto-managed
 	* improve rate-based choker documentation, and minor tweak
-	* undeprecate upnp_ignore_nonrouters (but refering to devices on our subnet)
+	* undeprecate upnp_ignore_nonrouters (but referring to devices on our subnet)
 	* increase default tracker timeout
 	* retry failed socks5 server connections
 	* allow UPnP lease duration to be changed after device discovery
@@ -404,7 +404,7 @@
 1.2.1 release
 
 	* add dht_pkt_alert and alerts_dropped_alert to python bindings
-	* fix python bindins for block_uploaded_alert
+	* fix python bindings for block_uploaded_alert
 	* optimize resolving duplicate filenames in loading torrent files
 	* fix python binding of dht_settings
 	* tighten up various input validation checks
@@ -413,7 +413,7 @@
 	* fix python bindings for peer_info
 	* support creating symlinks, for torrents with symlinks in them
 	* fix error in seed_mode flag
-	* support magnet link parameters with number siffixes
+	* support magnet link parameters with number suffixes
 	* consistently use "lt" namespace in examples and documentation
 	* fix Mingw build to use native cryptoAPI
 	* uPnP/NAT-PMP errors no longer set the client's advertised listen port to zero
@@ -607,7 +607,7 @@
 
 	* fix infinite loop when parsing certain invalid magnet links
 	* fix parsing of torrents with certain invalid filenames
-	* fix leak of torrent_peer objecs (entries in peer_list)
+	* fix leak of torrent_peer objects (entries in peer_list)
 	* fix leak of peer_class objects (when setting per-torrent rate limits)
 	* expose peer_class API to python binding
 	* fix integer overflow in whole_pieces_threshold logic
@@ -642,7 +642,7 @@
 	* fix proxying of https connections
 	* fix race condition in disk I/O storage class
 	* fix http connection timeout on multi-homed hosts
-	* removed depdendency on boost::uintptr_t for better compatibility
+	* removed dependency on boost::uintptr_t for better compatibility
 	* fix memory leak in the disk cache
 	* fix double free in disk cache
 	* forward declaring libtorrent types is discouraged. a new fwd.hpp header is provided
@@ -928,7 +928,7 @@
 	* tweak flag_override_resume_data semantics to make more sense (breaks
 	  backwards compatibility of edge-cases)
 	* improve DHT bootstrapping and periodic refresh
-	* improve DHT maintanence performance (by pinging instead of full lookups)
+	* improve DHT maintenance performance (by pinging instead of full lookups)
 	* fix bug in DHT routing table node-id prefix optimization
 	* fix incorrect behavior of flag_use_resume_save_path
 	* fix protocol race-condition in super seeding mode
@@ -1111,7 +1111,7 @@
 	* fix piece-picker stat bug when only selecting some files for download
 	* fix bug in async_add_torrent when settings file_priorities
 	* fix boost-1.42 support for python bindings
-	* fix memory allocation issue (virtual addres space waste) on windows
+	* fix memory allocation issue (virtual address space waste) on windows
 
 0.16.11 release
 
@@ -1127,7 +1127,7 @@
 	* GCC 4.8 fix
 	* fix proxy failure semantics with regards to anonymous mode
 	* fix round-robin seed-unchoke algorithm
-	* add bootstrap.sh to generage configure script and run configure
+	* add bootstrap.sh to generate configure script and run configure
 	* fix bug in SOCK5 UDP support
 	* fix issue where torrents added by URL would not be started immediately
 
@@ -1304,7 +1304,7 @@
 	* support banning web seeds sending corrupt data
 	* don't let hung outgoing connection attempts block incoming connections
 	* improve SSL torrent support by using SNI and a single SSL listen socket
-	* improved peer exchange performance by sharing incoming connections which advertize listen port
+	* improved peer exchange performance by sharing incoming connections which advertise listen port
 	* deprecate set_ratio(), and per-peer rate limits
 	* add web seed support for torrents with pad files
 	* introduced a more scalable API for torrent status updates (post_torrent_updates()) and updated client_test to use it
@@ -1696,7 +1696,7 @@ release 0.14.9
 
 release 0.14.8
 
-	* ignore unkown metadata messages
+	* ignore unknown metadata messages
 	* fixed typo that would sometimes prevent queued torrents to be checked
 	* fixed bug in auto-manager where active_downloads and active_seeds would
 	  sometimes be used incorrectly
@@ -1723,7 +1723,7 @@ release 0.14.7
 	  ended with a /
 	* fixed bug in error handling when parsing torrent files
 	* fixed file checking bug when renaming a file before checking the torrent
-	* fixed race conditon when receiving metadata from swarm
+	* fixed race condition when receiving metadata from swarm
 	* fixed assert in ut_metadata plugin
 	* back-ported some fixes for building with no exceptions
 	* fixed create_torrent when passing in a path ending with /
@@ -1816,7 +1816,7 @@ release 0.14.3
 	* fixed issue where renamed files were sometimes not saved in resume data
 	* accepts tracker responses with no 'peers' field, as long as 'peers6'
 	  is present
-	* fixed CIDR-distance calculation in the precense of IPv6 peers
+	* fixed CIDR-distance calculation in the presence of IPv6 peers
 	* save partial resume data for torrents that are queued for checking
 	  or checking, to maintain stats and renamed files
 	* Don't try IPv6 on windows if it's not installed
@@ -1841,7 +1841,7 @@ release 0.14.2
 	  tracker urls
 	* fixed bug where the files requested from web seeds would be the
 	  renamed file names instead of the original file names in the torrent.
-	* documentation fix of queing section
+	* documentation fix of queueing section
 	* fixed potential issue in udp_socket (affected udp tracker support)
 	* made name, comment and created by also be subject to utf-8 error
 	  correction (filenames already were)
@@ -1855,7 +1855,7 @@ release 0.14.2
 	* fixed race condition when saving DHT state
 	* fixed bugs related to lexical_cast being locale dependent
 	* added support for SunPro C++ compiler
-	* fixed bug where messeges sometimes could be encrypted in the
+	* fixed bug where messages sometimes could be encrypted in the
 	  wrong order, for encrypted connections.
 	* fixed race condition where torrents could get stuck waiting to
 	  get checked
@@ -1876,7 +1876,7 @@ release 0.14.1
 	  sometimes quit when an error occurred
 	* fixed DHT bug
 	* fixed potential shutdown crash in disk_io_thread
-	* fixed usage of deprecated boost.filsystem functions
+	* fixed usage of deprecated boost.filesystem functions
 	* fixed http_connection unit test
 	* fixed bug in DHT when a DHT state was loaded
 	* made rate limiter change in 0.14 optional (to take estimated
@@ -1947,7 +1947,7 @@ release 0.14
 	* Disk cache support.
 	* New, more memory efficient, piece picker with sequential download
 	  support (instead of the more complicated sequential download threshold).
-	* Auto Upload slots. Automtically opens up more slots if
+	* Auto Upload slots. Automatically opens up more slots if
 	  upload limit is not met.
 	* Improved NAT-PMP support by querying the default gateway
 	* Improved UPnP support by ignoring routers not on the clients subnet.
@@ -2058,7 +2058,7 @@ release 0.12
 	* fixed bug in DHT code which would send incorrect announce messages.
 	* fixed bug where the http header parser was case sensitive to the header
 	  names.
-	* Implemented an optmization which frees the piece_picker once a torrent
+	* Implemented an optimization which frees the piece_picker once a torrent
 	  turns into a seed.
 	* Added support for uT peer exchange extension, implemented by Massaroddel.
 	* Modified the quota management to offer better bandwidth balancing
@@ -2088,9 +2088,9 @@ release 0.11
 	* fixed bug with file_progress() with files = 0 bytes
 	* fixed a race condition bug in udp_tracker_connection that could
 	  cause a crash.
-	* fixed bug occuring when increasing the sequenced download threshold
+	* fixed bug occurring when increasing the sequenced download threshold
 	  with max availability lower than previous threshold.
-	* fixed an integer overflow bug occuring when built with gcc 4.1.x
+	* fixed an integer overflow bug occurring when built with gcc 4.1.x
 	* fixed crasing bug when closing while checking a torrent
 	* fixed bug causing a crash with a torrent with piece length 0
 	* added an extension to the DHT network protocol to support the
@@ -2156,7 +2156,7 @@ release 0.10
 
 release 0.9.1
 
-	* made the session disable file name checks within the boost.filsystem library
+	* made the session disable file name checks within the boost.filesystem library
 	* fixed race condition in the sockets
 	* strings that are invalid utf-8 strings are now decoded with the
 	  local codepage on windows

--- a/bindings/python/src/error_code.cpp
+++ b/bindings/python/src/error_code.cpp
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace boost
 {
-	// this fixe mysterious link error on msvc
+	// this fixes mysterious link error on msvc
 	template <>
 	inline boost::system::error_category const volatile*
 	get_pointer(class boost::system::error_category const volatile* p)

--- a/bindings/python/src/gil.hpp
+++ b/bindings/python/src/gil.hpp
@@ -80,7 +80,7 @@ struct visitor : boost::python::def_visitor<visitor<F>>
     F fn;
 };
 
-// Member function adaptor that releases and aqcuires the GIL
+// Member function adaptor that releases and acquires the GIL
 // around the function call.
 template <class F>
 visitor<F> allow_threads(F fn)

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -208,7 +208,7 @@ class test_torrent_handle(unittest.TestCase):
         self.assertEqual(new_trackers[1]['fail_limit'], 2)
 
     def test_pickle_trackers(self):
-        """Test lt objects convertors are working and trackers can be pickled"""
+        """Test lt objects converters are working and trackers can be pickled"""
         self.setup()
         tracker = lt.announce_entry('udp://tracker1.com')
         tracker.tier = 0

--- a/docs/tuning.rst
+++ b/docs/tuning.rst
@@ -48,7 +48,7 @@ session_stats_header_alert that will be posted on startup containing the column 
 for all metrics. Logging this line will greatly simplify interpreting the output,
 and is required for the script to work out-of-the-box.
 
-The python scrip in ``tools/parse_session_stats.py`` can parse the resulting
+The python script in ``tools/parse_session_stats.py`` can parse the resulting
 file and produce graphs of relevant stats. It requires gnuplot_.
 
 .. _gnuplot: http://www.gnuplot.info
@@ -332,7 +332,7 @@ contributions
 =============
 
 If you have added instrumentation for some part of libtorrent that is not
-covered here, or if you have improved any of the parser scrips, please consider
+covered here, or if you have improved any of the parser scripts, please consider
 contributing it back to the project.
 
 If you have run tests and found that some algorithm or default value in

--- a/docs/upgrade_to_1.2.rst
+++ b/docs/upgrade_to_1.2.rst
@@ -124,7 +124,7 @@ For example, the following expressions are deprecated::
 
 	atp.flags = 0;
 
-Insted say::
+Instead say::
 
 	if (!(atp.flags & torrent_flags::paused))
 

--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -81,7 +81,7 @@ void generate_block(span<std::uint32_t> buffer, piece_index_t const piece
 // in order to circumvent the restricton of only
 // one connection per IP that most clients implement
 // all sockets created by this tester are bound to
-// uniqe local IPs in the range (127.0.0.1 - 127.255.255.255)
+// unique local IPs in the range (127.0.0.1 - 127.255.255.255)
 // it's only enabled if the target is also on the loopback
 int local_if_counter = 0;
 bool local_bind = false;

--- a/examples/torrent_view.cpp
+++ b/examples/torrent_view.cpp
@@ -443,8 +443,8 @@ void torrent_view::print_torrent(lt::torrent_status const& s, bool selected)
 	std::array<char, 512> str;
 	lt::span<char> dest(str);
 
-	// the active torrent is highligted in the list
-	// this inverses the forground and background colors
+	// the active torrent is highlighted in the list
+	// this inverses the foreground and background colors
 	char const* selection = "";
 	if (selected)
 		selection = "\x1b[1m\x1b[44m";

--- a/include/libtorrent/aux_/io.hpp
+++ b/include/libtorrent/aux_/io.hpp
@@ -46,7 +46,7 @@ namespace libtorrent { namespace aux {
 
 	// reads an integer from a byte stream
 	// in big endian byte order and converts
-	// it to native endianess
+	// it to native endianness
 	template <class T, class Byte>
 	inline typename std::enable_if<sizeof(Byte)==1, T>::type
 	read_impl(span<Byte>& view, type<T>)

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -152,7 +152,7 @@ namespace libtorrent {
 	// layer that can be verified, and the root_index is the node that needs to
 	// be known in (tree) to do so. The num_valid_leafs specifies how many of
 	// the leafs that are actually *supposed* to be non-zero. Any leafs beyond
-	// thses are padding and expected to be zero.
+	// these are padding and expected to be zero.
 	// The caller must validate the hash at root_index.
 	TORRENT_EXTRA_EXPORT
 	std::tuple<int, int, int> merkle_find_known_subtree(span<sha256_hash const> const tree

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -176,7 +176,7 @@ private:
 	aux::vector<sha256_hash> m_tree;
 
 	// when the full tree is allocated, this has one bit for each block hash. a
-	// 1 means we have verified the block hash to be corret, otherwise the block
+	// 1 means we have verified the block hash to be correct, otherwise the block
 	// hash may represent what's on disk, but we haven't been able to verify it
 	// yet
 	bitfield m_block_verified;

--- a/include/libtorrent/aux_/resolver.hpp
+++ b/include/libtorrent/aux_/resolver.hpp
@@ -99,7 +99,7 @@ private:
 	time_duration m_timeout;
 
 	// the callbacks to call when a host resolution completes. This allows to
-	// attach more callbacks if the same host is looked up mutliple times
+	// attach more callbacks if the same host is looked up multiple times
 	std::multimap<std::string, resolver_interface::callback_t> m_callbacks;
 };
 

--- a/include/libtorrent/aux_/resolver_interface.hpp
+++ b/include/libtorrent/aux_/resolver_interface.hpp
@@ -53,7 +53,7 @@ struct TORRENT_EXTRA_EXPORT resolver_interface
 	using callback_t = std::function<void(error_code const&, std::vector<address> const&)>;
 
 	// this flag will make async_resolve() only use the cache and fail if we
-	// don't have a cache entry, regardless of how old it is. This is usefull
+	// don't have a cache entry, regardless of how old it is. This is useful
 	// when completing the lookup quickly is more important than accuracy,
 	// like on shutdown
 	static constexpr resolver_flags cache_only = 0_bit;

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -246,7 +246,7 @@ namespace aux {
 		}
 
 		// 0 is natpmp 1 is upnp
-		// the order of these arrays determines the priorty in
+		// the order of these arrays determines the priority in
 		// which their ports will be announced to peers
 		aux::array<listen_port_mapping, 2, portmap_transport> tcp_port_mapping;
 		aux::array<listen_port_mapping, 2, portmap_transport> udp_port_mapping;

--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -527,7 +527,7 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 	}
 
 #if BOOST_VERSION >= 106600
-	// Compatiblity with the async_wait method introduced in boost 1.66
+	// Compatibility with the async_wait method introduced in boost 1.66
 
 	enum wait_type { wait_read, wait_write, wait_error };
 

--- a/include/libtorrent/io.hpp
+++ b/include/libtorrent/io.hpp
@@ -49,7 +49,7 @@ namespace aux {
 
 	// reads an integer from a byte stream
 	// in big endian byte order and converts
-	// it to native endianess
+	// it to native endianness
 	template <class T, class InIt>
 	inline T read_impl(InIt& start, type<T>)
 	{

--- a/include/libtorrent/kademlia/refresh.hpp
+++ b/include/libtorrent/kademlia/refresh.hpp
@@ -61,7 +61,7 @@ protected:
 
 };
 
-} // namesapce dht
+} // namespace dht
 } // namespace libtorrent
 
 #endif // REFRESH_050324_HPP

--- a/include/libtorrent/mmap_storage.hpp
+++ b/include/libtorrent/mmap_storage.hpp
@@ -218,7 +218,7 @@ namespace aux {
 		// serialized on a per-file basis. See github issue #3842 for details.
 
 		// This array stores a mutex for each file in the storage object
-		// It must be aquired before calling CreateFileMapping or UnmapViewOfFile
+		// It must be acquired before calling CreateFileMapping or UnmapViewOfFile
 		mutable std::shared_ptr<std::mutex> m_file_open_unmap_lock;
 #endif
 

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -659,7 +659,7 @@ namespace aux {
 		// returns the block currently being
 		// downloaded. And the progress of that
 		// block. If the peer isn't downloading
-		// a piece for the moment, implementors
+		// a piece for the moment, implementers
 		// must return an object with the piece_index
 		// value invalid (the default constructor).
 		virtual piece_block_progress downloading_piece_progress() const;

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -807,8 +807,8 @@ namespace libtorrent {
 		// blocks covered by the pad bytes are not picked by the piece picker
 		std::unordered_map<piece_index_t, int> m_pads_in_piece;
 
-		// when the adjecent_piece affinity is enabled, this contains the most
-		// recent "extents" of adjecent pieces that have been requested from
+		// when the adjacent_piece affinity is enabled, this contains the most
+		// recent "extents" of adjacent pieces that have been requested from
 		// this is mutable because it's updated by functions to pick pieces, which
 		// are const. That's an efficient place to update it, since it's being
 		// traversed already.

--- a/include/libtorrent/proxy_base.hpp
+++ b/include/libtorrent/proxy_base.hpp
@@ -125,7 +125,7 @@ struct proxy_base
 	}
 
 #if BOOST_VERSION >= 106600 && !defined TORRENT_BUILD_SIMULATOR
-	// Compatiblity with the async_wait method introduced in boost 1.66
+	// Compatibility with the async_wait method introduced in boost 1.66
 
 	static constexpr auto wait_read = tcp::socket::wait_read;
 	static constexpr auto wait_write = tcp::socket::wait_write;

--- a/include/libtorrent/socks5_stream.hpp
+++ b/include/libtorrent/socks5_stream.hpp
@@ -127,7 +127,7 @@ public:
 
 	void set_dst_name(std::string const& host)
 	{
-		// if this assert trips, set_dst_name() is called wth an IP address rather
+		// if this assert trips, set_dst_name() is called with an IP address rather
 		// than a hostname. Instead, resolve the IP into an address and pass it to
 		// async_connect instead
 		TORRENT_ASSERT(!aux::is_ip_address(host));

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1023,7 +1023,7 @@ namespace libtorrent {
 		// piece_failed is called when a piece fails the hash check
 		// for failures detected with v2 hashes the failing blocks(s)
 		// are specified in blocks
-		// *blocks must be sorted in acending order*
+		// *blocks must be sorted in ascending order*
 		void piece_failed(piece_index_t index, std::vector<int> blocks = std::vector<int>());
 
 		// the peers in "peers" participated in sending a bad piece. If
@@ -1436,7 +1436,7 @@ namespace libtorrent {
 		// peers. This vector is ordered, to make lookups fast.
 
 		// TODO: 3 factor out predictive pieces and all operations on it into a
-		// separate class (to use as memeber here instead)
+		// separate class (to use as member here instead)
 		std::vector<piece_index_t> m_predictive_pieces;
 #endif
 

--- a/simulation/disk_io.hpp
+++ b/simulation/disk_io.hpp
@@ -100,7 +100,7 @@ struct test_disk
 	std::unique_ptr<lt::disk_interface> operator()(
 		lt::io_context& ioc, lt::settings_interface const&, lt::counters&);
 
-	// seek time in fron of every read and write
+	// seek time in front of every read and write
 	lt::time_duration seek_time = lt::milliseconds(10);
 
 	// hash time per block

--- a/simulation/test_file_pool.cpp
+++ b/simulation/test_file_pool.cpp
@@ -77,7 +77,7 @@ TORRENT_TEST(close_file_interval)
 			}
 			else if (ticks > 21)
 			{
-				// the close file timer shuold have kicked in at 20 seconds
+				// the close file timer should have kicked in at 20 seconds
 				// and closed the file
 				TEST_EQUAL(file_status.size(), 0);
 			}

--- a/simulation/test_http_connection.cpp
+++ b/simulation/test_http_connection.cpp
@@ -274,7 +274,7 @@ void run_suite(lt::aux::proxy_settings ps)
 	{
 		// this hostname will resolve to multiple IPs, all but one that we cannot
 		// connect to and the second one where we'll get the test file response. Make
-		// sure the http_connection correcly tries the second IP if the first one
+		// sure the http_connection correctly tries the second IP if the first one
 		// fails.
 		run_test(ps, "http://try-next.com:8080/test_file", 1337, 200
 			, error_condition(), { 1, 1, 1});

--- a/simulation/test_socks5.cpp
+++ b/simulation/test_socks5.cpp
@@ -299,7 +299,7 @@ TORRENT_TEST(socks5_udp_retry)
 	lt::session_proxy zombie;
 
 	sim::asio::io_context proxy_ios{sim, addr("50.50.50.50") };
-	// close UDP associate connectons prematurely
+	// close UDP associate connections prematurely
 	sim::socks_server socks5(proxy_ios, 5555, 5, socks_flag::disconnect_udp_associate);
 
 	lt::settings_pack pack = settings();

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -478,7 +478,7 @@ struct nat_config : sim::default_config
 
 	sim::route outgoing_route(lt::address ip) override
 	{
-		// This is extremely simplistic. It will simply alter the percieved source
+		// This is extremely simplistic. It will simply alter the perceived source
 		// IP of the connecting client.
 		sim::route r;
 		if (ip == addr("50.0.0.1")) r.append(m_nat_hop);

--- a/simulation/test_timeout.cpp
+++ b/simulation/test_timeout.cpp
@@ -241,7 +241,7 @@ disconnects_t test_no_interest_timeout(int const num_peers
 }
 
 // if a peer is not interested in us, and we're not interested in it for long
-// enoguh, we disconenct it, but only if we are close to peer connection capacity
+// enough, we disconnect it, but only if we are close to peer connection capacity
 TORRENT_TEST(no_interest_timeout)
 {
 	// with 10 peers, we're close enough to the connection limit to enable

--- a/simulation/test_torrent_status.cpp
+++ b/simulation/test_torrent_status.cpp
@@ -128,7 +128,7 @@ TORRENT_TEST(status_timers_last_upload)
 				TEST_CHECK(!handle.is_valid());
 				handle = ta->handle;
 				torrent_status st = handle.status();
-				// test last upload and download state before wo go throgh
+				// test last upload and download state before we go through
 				// torrent states
 				TEST_CHECK(st.last_upload == time_point(seconds(0)));
 				TEST_CHECK(st.last_download == time_point(seconds(0)));
@@ -174,7 +174,7 @@ TORRENT_TEST(status_timers_time_shift_with_active_torrent)
 				TEST_CHECK(!handle.is_valid());
 				handle = ta->handle;
 				torrent_status st = handle.status();
-				// test last upload and download state before wo go throgh
+				// test last upload and download state before we go through
 				// torrent states
 				TEST_CHECK(st.last_download == time_point(seconds(0)));
 				TEST_CHECK(st.last_upload == time_point(seconds(0)));
@@ -201,9 +201,9 @@ TORRENT_TEST(status_timers_time_shift_with_active_torrent)
 					break;
 				case 64000:
 					// resume just before we hit the time shift handling
-					// this is needed to test what happend if we want to
+					// this is needed to test what happens if we want to
 					// shift more time then we have active time because
-					// we shift 4 hours and have less then 1 hours active time
+					// we shift 4 hours and have less then 1 hour active time
 					handle.resume();
 					tick_is_in_active_range = true;
 					// don't check every tick
@@ -253,7 +253,7 @@ TORRENT_TEST(finish_time_shift_active)
 				TEST_CHECK(!handle.is_valid());
 				handle = ta->handle;
 				torrent_status st = handle.status();
-				// test last upload and download state before wo go throgh
+				// test last upload and download state before we go through
 				// torrent states
 				TEST_CHECK(st.last_download == time_point(seconds(0)));
 				TEST_CHECK(st.last_upload == time_point(seconds(0)));
@@ -325,7 +325,7 @@ TORRENT_TEST(finish_time_shift_paused)
 				TEST_CHECK(!handle.is_valid());
 				handle = ta->handle;
 				torrent_status st = handle.status();
-				// test last upload and download state before wo go throgh
+				// test last upload and download state before we go through
 				// torrent states
 				TEST_CHECK(st.last_upload == time_point(seconds(0)));
 				TEST_CHECK(st.last_download == time_point(seconds(0)));

--- a/simulation/test_utp.cpp
+++ b/simulation/test_utp.cpp
@@ -110,7 +110,7 @@ std::vector<std::int64_t> utp_test(sim::configuration& cfg, int send_buffer_size
 }
 
 // TODO: 3 simulate non-congestive packet loss
-// TODO: 3 simulate unpredictible latencies
+// TODO: 3 simulate unpredictable latencies
 // TODO: 3 simulate proper (taildrop) queues (perhaps even RED and BLUE)
 
 // The counters checked by these tests are proxies for the expected behavior. If

--- a/src/bdecode.cpp
+++ b/src/bdecode.cpp
@@ -150,7 +150,7 @@ namespace aux {
 
 
 
-	// reads the string between start and end, or up to the first occurrance of
+	// reads the string between start and end, or up to the first occurrence of
 	// 'delimiter', whichever comes first. This string is interpreted as an
 	// integer which is assigned to 'val'. If there's a non-delimiter and
 	// non-digit in the range, a parse error is reported in 'ec'. If the value

--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -70,7 +70,7 @@ namespace {
 		int const cmp = compare_peers(lhs, rhs);
 		if (cmp != 0) return cmp > 0;
 
-		// when seeding, rotate which peer is unchoked in a round-robin fasion
+		// when seeding, rotate which peer is unchoked in a round-robin fashion
 
 		// the amount uploaded since unchoked (not just in the last round)
 		std::int64_t const u1 = lhs->uploaded_since_unchoked();

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -299,7 +299,7 @@ namespace {
 		if (::send(sock, request_msg, request_msg->nlmsg_len, 0) < 0)
 			return -1;
 
-		// get the socket's port ID so that we can verify it in the repsonse
+		// get the socket's port ID so that we can verify it in the response
 		sockaddr_nl sock_addr;
 		socklen_t sock_addr_len = sizeof(sock_addr);
 		if (::getsockname(sock, reinterpret_cast<sockaddr*>(&sock_addr), &sock_addr_len) < 0)

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -1226,7 +1226,7 @@ namespace {
 		TORRENT_ASSERT(piece_length() >= 16 * 1024);
 
 		// use this vector to track the new ordering of files
-		// this allows the use of STL algorthims despite them
+		// this allows the use of STL algorithms despite them
 		// not supporting a custom swap functor
 		aux::vector<file_index_t, file_index_t> new_order(end_file());
 		for (auto i : file_range())
@@ -1246,7 +1246,7 @@ namespace {
 		std::sort(new_order.begin(), new_order.end()
 			, [this](file_index_t l, file_index_t r)
 		{
-			// assuming m_paths are unqiue!
+			// assuming m_paths are unique!
 			auto const& lf = m_files[l];
 			auto const& rf = m_files[r];
 			if (lf.path_index != rf.path_index)

--- a/src/file_view_pool.cpp
+++ b/src/file_view_pool.cpp
@@ -277,7 +277,7 @@ namespace libtorrent { namespace aux {
 		}
 		catch (storage_error& se)
 		{
-			// opening the file failed. If it was becase the directory was
+			// opening the file failed. If it was because the directory was
 			// missing, create it and try again. Otherwise, propagate the
 			// error
 			if (!(m & open_mode::write)

--- a/src/gzip.cpp
+++ b/src/gzip.cpp
@@ -128,7 +128,7 @@ namespace {
 		int const method = buffer[2];
 		int const flags = buffer[3];
 
-		// check for reserved flag and make sure it's compressed with the correct metod
+		// check for reserved flag and make sure it's compressed with the correct method
 		// we only support deflate
 		if (method != 8 || (flags & FRESERVED) != 0) return -1;
 

--- a/src/ip_notifier.cpp
+++ b/src/ip_notifier.cpp
@@ -172,7 +172,7 @@ private:
 		int family;
 		std::array<char, 16> data;
 	};
-	// maps if_index to the most recently advertized local address
+	// maps if_index to the most recently advertised local address
 	// this is used to filter duplicate updates
 	std::unordered_map<std::uint32_t, local_address> m_state;
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -159,7 +159,7 @@ namespace {
 			TORRENT_ASSERT(first_piece < int(mask.size()));
 			TORRENT_ASSERT(end_piece <= int(mask.size()));
 
-			// if the mask convers all pieces, and nothing below that layer, go
+			// if the mask covers all pieces, and nothing below that layer, go
 			// straight to piece_layer mode and validate
 			if (std::all_of(mask.begin() + first_piece, mask.begin() + end_piece, identity())
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -1021,7 +1021,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 		// TODO: Perhaps the job queue could be traversed and all jobs for this
 		// piece could be cancelled. If there are no threads currently writing
-		// to this piece, we could skip the fence alltogether
+		// to this piece, we could skip the fence altogether
 		add_fence_job(j);
 	}
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5523,7 +5523,7 @@ namespace libtorrent {
 		{
 		case set_block_hash_result::block_hash_failed:
 			// If the hash failed immediately at the leaf layer it means that
-			// the chuck hash is known so this peer definately sent bad data.
+			// the chuck hash is known so this peer definitely sent bad data.
 			t->piece_failed(r.piece, std::vector<int>{r.start / default_block_size});
 			TORRENT_ASSERT(m_disconnecting);
 			return;

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -466,7 +466,7 @@ namespace libtorrent {
 
 		const bool was_conn_cand = is_connect_candidate(*p);
 		p->connection = c;
-		// now that we're connected, no need to assume ther peer is a seed
+		// now that we're connected, no need to assume the peer is a seed
 		// anymore. We'll soon know.
 		p->maybe_upload_only = false;
 		if (was_conn_cand) update_connect_candidates(-1);

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -3113,7 +3113,7 @@ get_out:
 	void piece_picker::record_downloading_piece(piece_index_t const p)
 	{
 		// if a single piece is large enough, don't bother with the affinity of
-		// adjecent pieces.
+		// adjacent pieces.
 		if (blocks_per_piece() >= max_piece_affinity_extent) return;
 
 		piece_extent_t const this_extent = extent_for(p);
@@ -3137,7 +3137,7 @@ get_out:
 
 			// if at least one piece in this extent has a different priority than
 			// the one we just started downloading, don't create an affinity for
-			// adjecent pieces. This probably means the pieces belong to different
+			// adjacent pieces. This probably means the pieces belong to different
 			// files, or that some other mechanism determining the priority should
 			// take precedence.
 			if (piece_priority(piece) != this_prio) return;
@@ -3153,7 +3153,7 @@ get_out:
 
 		// limit the number of extent affinities active at any given time to limit
 		// the cost of checking them. Also, don't replace them, commit to
-		// finishing them before starting another extent. This is analoguous to
+		// finishing them before starting another extent. This is analogous to
 		// limiting the number of partial pieces.
 	}
 
@@ -3191,12 +3191,12 @@ get_out:
 			if (prio >= 0 && !m_dirty) update(prio, p.index);
 
 			// if the piece extent affinity is enabled, (maybe) record downloading a
-			// block from this piece to make other peers prefer adjecent pieces
+			// block from this piece to make other peers prefer adjacent pieces
 			// if reverse is set, don't encourage other peers to pick nearby
 			// pieces, as that's assumed to be low priority.
 			// if time critical mode is enabled, we're likely to either download
 			// adjacent pieces anyway, but more importantly, we don't want to
-			// create artificially higher priority for adjecent pieces if they
+			// create artificially higher priority for adjacent pieces if they
 			// aren't important or urgent
 			if (options & piece_extent_affinity)
 				record_downloading_piece(block.piece_index);

--- a/src/puff.cpp
+++ b/src/puff.cpp
@@ -628,7 +628,7 @@ local int fixed(struct state *s)
  *   are themselves compressed using Huffman codes and run-length encoding.  In
  *   the list of code lengths, a 0 symbol means no code, a 1..15 symbol means
  *   that length, and the symbols 16, 17, and 18 are run-length instructions.
- *   Each of 16, 17, and 18 are follwed by extra bits to define the length of
+ *   Each of 16, 17, and 18 are followed by extra bits to define the length of
  *   the run.  16 copies the last length 3 to 6 times.  17 represents 3 to 10
  *   zero lengths, and 18 represents 11 to 138 zero lengths.  Unused symbols
  *   are common, hence the special coding for zero lengths.

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2613,7 +2613,7 @@ namespace {
 				span<char const> const buf = packet.data;
 				if (!packet.hostname.empty())
 				{
-					// only the tracker manager supports receiveing UDP packets
+					// only the tracker manager supports receiving UDP packets
 					// from hostnames. If it won't handle it, no one else will
 					// either
 					m_tracker_manager.incoming_packet(packet.hostname, buf);
@@ -3736,7 +3736,7 @@ namespace {
 					// has reached its local limit
 					for (auto const& t : m_torrents)
 					{
-						// ths disconnect logic is disabled for torrents with
+						// this disconnect logic is disabled for torrents with
 						// too low connection limit
 						int const max = std::min(t->max_connections()
 							, std::numeric_limits<int>::max() / 100);

--- a/src/session_stats.cpp
+++ b/src/session_stats.cpp
@@ -520,7 +520,7 @@ namespace {
 		// the buffer sizes accepted by
 		// socket send and receive calls respectively.
 		// The larger the buffers are, the more efficient,
-		// because it reqire fewer system calls per byte.
+		// because it require fewer system calls per byte.
 		// The size is 1 << n, where n is the number
 		// at the end of the counter name. i.e.
 		// 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,

--- a/src/sha1.cpp
+++ b/src/sha1.cpp
@@ -205,8 +205,8 @@ void SHA1_update(sha1_ctx* context, u8 const* data, size_t len)
 #elif BOOST_ENDIAN_LITTLE_BYTE
 	internal_update<little_endian_blk0>(context, data, len);
 #else
-	// select different functions depending on endianess
-	// and figure out the endianess runtime
+	// select different functions depending on endianness
+	// and figure out the endianness runtime
 	if (is_big_endian())
 		internal_update<big_endian_blk0>(context, data, len);
 	else
@@ -307,9 +307,9 @@ By Arvid Norberg <arvidn@sourceforge.net>
 2- uses C99 types with size guarantees
    from boost
 3- if none of BOOST_BIG_ENDIAN or BOOST_LITTLE_ENDIAN
-   are defined, endianess is determined
+   are defined, endianness is determined
    at runtime. templates are used to duplicate
-   the transform function for each endianess
+   the transform function for each endianness
 4- using anonymous namespace to avoid external
    linkage on internal functions
 5- using standard C++ includes

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -39,7 +39,7 @@ namespace libtorrent { namespace aux {
 	time_point time_now() { return clock_type::now(); }
 	time_point32 time_now32() { return time_point_cast<seconds32>(clock_type::now()); }
 
-	// for simplying implementation
+	// for simplifying implementation
 	using std::chrono::system_clock;
 
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -7205,7 +7205,7 @@ namespace {
 			ret.verified_leaf_hashes.reserve(num_files);
 			for (auto const& t : m_merkle_trees)
 			{
-				// use stuctured binding in C++17
+				// use structured binding in C++17
 				aux::vector<bool> mask;
 				std::vector<sha256_hash> sparse_tree;
 				std::tie(sparse_tree, mask) = t.build_sparse_vector();
@@ -9088,7 +9088,7 @@ namespace {
 	void torrent::set_max_uploads(int limit, bool const state_update)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		// TODO: perhaps 0 should actially mean 0
+		// TODO: perhaps 0 should actually mean 0
 		if (limit <= 0) limit = (1 << 24) - 1;
 		if (int(m_max_uploads) == limit) return;
 		if (state_update) state_updated();
@@ -9105,7 +9105,7 @@ namespace {
 	void torrent::set_max_connections(int limit, bool const state_update)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		// TODO: perhaps 0 should actially mean 0
+		// TODO: perhaps 0 should actually mean 0
 		if (limit <= 0) limit = (1 << 24) - 1;
 		if (int(m_max_connections) == limit) return;
 		if (state_update) state_updated();

--- a/src/ut_metadata.cpp
+++ b/src/ut_metadata.cpp
@@ -76,7 +76,7 @@ namespace {
 		send_buffer_limit = 0x4000 * 10,
 
 		// this is the max number of requests we'll queue
-		// up. If we get more requests tha this, we'll
+		// up. If we get more requests than this, we'll
 		// start rejecting them, claiming we don't have
 		// metadata. If the torrent is greater than 16 MiB,
 		// we may hit this case (and the client requesting

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -259,7 +259,7 @@ void utp_socket_impl::update_mtu_limits()
 		m_mtu_ceiling = m_mtu_floor;
 
 		// the path MTU may have changed. Perform another search
-		// dont' start all the way from start, just half way down.
+		// don't start all the way from start, just half way down.
 		m_mtu_floor = ((TORRENT_INET_MIN_MTU - TORRENT_IPV4_HEADER - TORRENT_UDP_HEADER) + m_mtu_ceiling) / 2;
 
 		UTP_LOGV("%8p: reducing MTU floor\n", static_cast<void*>(this));
@@ -2324,7 +2324,7 @@ bool utp_socket_impl::consume_incoming_data(
 		// number of queued up bytes, waiting for the upper layer,
 		// exceeds the advertised receive window, start ignoring
 		// more data packets
-		UTP_LOG("%8p: ERROR: our advertized window is not honored. "
+		UTP_LOG("%8p: ERROR: our advertised window is not honored. "
 			"recv_buf: %d buffered_in: %d max_size: %d\n"
 			, static_cast<void*>(this), m_receive_buffer_size, m_buffered_incoming_bytes, m_receive_buffer_capacity);
 		return false;
@@ -3304,7 +3304,7 @@ void utp_socket_impl::do_ledbat(const int acked_bytes, const int delay
 	{
 		m_slow_start = false;
 		m_ssthres = (m_cwnd >> 16);
-		UTP_LOGV("%8p: cwnd > advertized wnd (%u) slow_start -> 0\n"
+		UTP_LOGV("%8p: cwnd > advertised wnd (%u) slow_start -> 0\n"
 			, static_cast<void*>(this), m_adv_wnd);
 	}
 */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR) # Configurable policies: <= CMP0097
 
-# Our tests contain printf formating checks therefore we disable GCC format string errors:
+# Our tests contain printf formatting checks therefore we disable GCC format string errors:
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	check_cxx_compiler_flag("-Wno-error=format-truncation" _WNO_ERROR_FORMAT_TRUNCATION)
 	if (_WNO_ERROR_FORMAT_TRUNCATION)

--- a/test/http_proxy.py
+++ b/test/http_proxy.py
@@ -44,7 +44,7 @@ def read_to_end_of_chunks(file_like):
     """Reads a chunked-encoded stream from a file-like object.
 
     This will read up to the end of the chunked encoding, including chunk
-    delimeters, trailers, and the terminal empty line.
+    delimiters, trailers, and the terminal empty line.
 
     The stream will be returned as an iterator of bytes objects. The split
     between bytes objects is arbitrary.

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -53,7 +53,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <csignal>
 
 #ifdef _WIN32
-#include "libtorrent/aux_/windows.hpp" // fot SetErrorMode
+#include "libtorrent/aux_/windows.hpp" // for SetErrorMode
 #include <io.h> // for _dup and _dup2
 #include <process.h> // for _getpid
 #include <crtdbg.h>

--- a/test/test_bdecode.cpp
+++ b/test/test_bdecode.cpp
@@ -1201,7 +1201,7 @@ TORRENT_TEST(non_owning_refs)
 }
 
 // test that a partial parse can be still be printed up to the
-// point where it faild
+// point where it failed
 TORRENT_TEST(partial_parse)
 {
 	char b[] = "d1:ai1e1:b3:foo1:cli1ei2ee1:dd1:xi1-eee";

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -305,7 +305,7 @@ void send_dht_request(node& node, char const* msg, udp::endpoint const& ep
 	{
 		if (i == g_sent_packets.end())
 		{
-			TEST_ERROR("not response from DHT node");
+			TEST_ERROR("no response from DHT node");
 			return;
 		}
 
@@ -3215,7 +3215,7 @@ TORRENT_TEST(read_only_node)
 	sett.set_bool(settings_pack::dht_read_only, false);
 
 	send_dht_request(node, "get", source, &response);
-	// sender should be added to repacement bucket
+	// sender should be added to replacement bucket
 	TEST_EQUAL(std::get<1>(node.size()), 1);
 
 	g_sent_packets.clear();

--- a/test/test_http_parser.cpp
+++ b/test/test_http_parser.cpp
@@ -749,7 +749,7 @@ TORRENT_TEST(missing_chunked_header)
 		"\r\n"
 		"\n";
 
-	// make the inpout not be null terminated. If the parser reads off the end,
+	// make the input not be null terminated. If the parser reads off the end,
 	// address sanitizer will trigger
 	char chunked_input[sizeof(input)-1];
 	std::memcpy(chunked_input, input, sizeof(chunked_input));

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -388,7 +388,7 @@ TORRENT_TEST(update_peer_port)
 }
 
 // test incoming connection
-// and update_peer_port, causing collission
+// and update_peer_port, causing collision
 TORRENT_TEST(update_peer_port_collide)
 {
 	torrent_state st = init_state();

--- a/test/test_piece_picker.cpp
+++ b/test/test_piece_picker.cpp
@@ -437,7 +437,7 @@ TORRENT_TEST(get_downloaders)
 	}
 
 	// if we ask for downloaders for a piece that's not
-	// curently being downloaded, we get zeroes back
+	// currently being downloaded, we get zeroes back
 	{
 		std::vector<torrent_peer*> d = p->get_downloaders(1_piece);
 
@@ -1281,7 +1281,7 @@ TORRENT_TEST(picking_downloading_blocks)
 	// don't pick both busy pieces, if there are already other blocks picked
 	TEST_EQUAL(picked.size(), 7 * blocks_per_piece - 2);
 
-	// make sure we still pick from a partial piece even when prefering whole pieces
+	// make sure we still pick from a partial piece even when preferring whole pieces
 	picked.clear();
 	p->pick_pieces(string2vec(" *     "), picked, 1, blocks_per_piece, nullptr
 		, piece_picker::rarest_first
@@ -1575,7 +1575,7 @@ TORRENT_TEST(bitfield_optimization)
 
 TORRENT_TEST(seed_optimization)
 {
-	// test seed optimizaton
+	// test seed optimization
 	auto p = setup_picker("0000000000000000", "                ", "", "");
 
 	// make sure it's not dirty
@@ -2717,7 +2717,7 @@ TORRENT_TEST(piece_extent_affinity_large_pieces)
 TORRENT_TEST(piece_extent_affinity_active_limit)
 {
 	// an extent is two pieces wide, 6 extents total.
-	// make ure we limit the number of extents to 5
+	// make sure we limit the number of extents to 5
 	int const blocks = 128;
 	auto const have_none = "            ";
 

--- a/test/test_privacy.cpp
+++ b/test/test_privacy.cpp
@@ -115,7 +115,7 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, flags_t flags)
 	sett.set_bool(settings_pack::enable_outgoing_utp, false);
 
 	// in non-anonymous mode we circumvent/ignore the proxy if it fails
-	// wheras in anonymous mode, we just fail
+	// whereas in anonymous mode, we just fail
 	sett.set_str(settings_pack::proxy_hostname, "non-existing.com");
 	sett.set_int(settings_pack::proxy_type, proxy_type);
 	sett.set_bool(settings_pack::proxy_peer_connections, !(flags & dont_proxy_peers));

--- a/test/test_remap_files.cpp
+++ b/test/test_remap_files.cpp
@@ -173,7 +173,7 @@ void test_remap_files(storage_mode_t storage_mode = storage_mode_sparse)
 	TEST_CHECK(all_of(files));
 	TEST_CHECK(all_of(passed));
 
-	// just because we can read them back throught libtorrent, doesn't mean the
+	// just because we can read them back through libtorrent, doesn't mean the
 	// files have hit disk yet (because of the cache). Retry a few times to try
 	// to pick up the files
 	for (auto i = 0_file; i < file_index_t(int(remap_file_sizes.size())); ++i)

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -1756,7 +1756,7 @@ TORRENT_TEST(unfinished_pieces_check_all)
 
 TORRENT_TEST(unfinished_pieces_finished)
 {
-	// make sure that a piece that isn't maked as "have", but whose blocks are
+	// make sure that a piece that isn't marked as "have", but whose blocks are
 	// all downloaded gets checked and turn into "have".
 	test_unfinished_pieces([](torrent_info const& ti, add_torrent_params& atp)
 	{
@@ -1767,7 +1767,7 @@ TORRENT_TEST(unfinished_pieces_finished)
 
 TORRENT_TEST(unfinished_pieces_all_finished)
 {
-	// make sure that a piece that isn't maked as "have", but whose blocks are
+	// make sure that a piece that isn't marked as "have", but whose blocks are
 	// all downloaded gets checked and turn into "have".
 	test_unfinished_pieces([](torrent_info const& ti, add_torrent_params& atp)
 	{

--- a/test/test_similar_torrent.cpp
+++ b/test/test_similar_torrent.cpp
@@ -285,7 +285,7 @@ TORRENT_TEST(shared_files_seed_mode_v1)
 
 TORRENT_TEST(shared_files_seed_mode_v1_no_files)
 {
-	// no files on disk, just an (incorrect) promise of beeing in seed mode
+	// no files on disk, just an (incorrect) promise of being in seed mode
 	// creating the hard links will fail
 	TEST_CHECK(test(st::no_files | st::seed_mode, v1 | canon, v1 | canon) == bools({false, false}));
 }

--- a/test/test_ssl.cpp
+++ b/test/test_ssl.cpp
@@ -306,8 +306,8 @@ void test_ssl(int const test_idx, bool const use_utp)
 	}
 
 	std::string const now = time_now_string();
-	std::printf("%s: EXPECT: %s\n", now.c_str(), test.expected_to_complete ? "SUCCEESS" : "FAILURE");
-	std::printf("%s: RESULT: %s\n", now.c_str(), tor2.status().is_seeding ? "SUCCEESS" : "FAILURE");
+	std::printf("%s: EXPECT: %s\n", now.c_str(), test.expected_to_complete ? "SUCCESS" : "FAILURE");
+	std::printf("%s: RESULT: %s\n", now.c_str(), tor2.status().is_seeding ? "SUCCESS" : "FAILURE");
 	TEST_EQUAL(tor2.status().is_seeding, test.expected_to_complete);
 
 	// this allows shutting down the sessions in parallel

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -852,7 +852,7 @@ void test_fastresume(bool const test_deprecated)
 		p.storage_mode = storage_mode_sparse;
 		torrent_handle h = ses.add_torrent(std::move(p), ec);
 
-		std::printf("expecting fastresume to be rejected becase the files were removed");
+		std::printf("expecting fastresume to be rejected because the files were removed");
 		alert const* a = wait_for_alert(ses, fastresume_rejected_alert::alert_type
 			, "ses");
 		// we expect the fast resume to be rejected because the files were removed
@@ -1323,7 +1323,7 @@ TORRENT_TEST(readwrite_zero_size_files)
 template <typename StorageType>
 void test_move_storage_to_self()
 {
-	// call move_storage with the path to the exising storage. should be a no-op
+	// call move_storage with the path to the existing storage. should be a no-op
 	std::string const save_path = current_working_directory();
 	std::string const test_path = complete("temp_storage");
 	delete_dirs(test_path);

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -224,7 +224,7 @@ std::string to_str(std::vector<char> const& v)
 	return std::string(v.begin(), v.end());
 }
 
-// convert the standard base64 alphabet to the i2p aphabet
+// convert the standard base64 alphabet to the i2p alphabet
 std::string transcode_alphabet(std::string in)
 {
 	std::string ret;

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -1132,7 +1132,7 @@ std::vector<lt::aux::vector<file_t, lt::file_index_t>> const test_cases
 		{"test/temporary.txt", 0x4000, {}, "test/temporary.txt"},
 		{"test/Temporary.txt", 0x4000, {}, "test/Temporary.1.txt"},
 		{"test/TeMPorArY.txT", 0x4000, {}, "test/TeMPorArY.2.txT"},
-		// a file with the same name in a seprate directory is fine
+		// a file with the same name in a separate directory is fine
 		{"test/test/TEMPORARY.TXT", 0x4000, {}, "test/test/TEMPORARY.TXT"},
 	},
 	{

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -644,7 +644,7 @@ TORRENT_TEST(tracker_proxy)
 namespace {
 void test_stop_tracker_timeout(int const timeout)
 {
-	// trick the min interval so that the stopped anounce is permitted immediately
+	// trick the min interval so that the stopped announce is permitted immediately
 	// after the initial announce
 	int port = start_web_server(false, false, true, -1);
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pem,*.torrent,./docs/hunspell,./src/puff.cpp" -L bu,fo,folx,ihs,ot,readd,requestor,te`