### PR TITLE
Remove redundant move in return statement

### DIFF
--- a/bindings/python/src/entry.cpp
+++ b/bindings/python/src/entry.cpp
@@ -20,7 +20,7 @@ struct entry_to_python
             result.append(*i);
         }
 
-        return std::move(result);
+        return result;
     }
 
     static object convert(entry::dictionary_type const& d)
@@ -30,7 +30,7 @@ struct entry_to_python
         for (entry::dictionary_type::const_iterator i(d.begin()), e(d.end()); i != e; ++i)
             result[bytes(i->first)] = i->second;
 
-        return std::move(result);
+        return result;
     }
 
     static object convert0(entry const& e)

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -2579,7 +2579,7 @@ namespace {
 		for (int i = 0; i < m_v6_num_peers; i++)
 			peers.push_back(aux::read_v6_endpoint<tcp::endpoint>(v6_ptr));
 
-		return std::move(peers);
+		return peers;
 	}
 
 	dht_direct_response_alert::dht_direct_response_alert(
@@ -2819,7 +2819,7 @@ namespace {
 			nodes.emplace_back(ih, aux::read_v6_endpoint<udp::endpoint>(v6_ptr));
 		}
 
-		return std::move(nodes);
+		return nodes;
 	}
 	}
 
@@ -2931,7 +2931,7 @@ namespace {
 		char const* ptr = m_alloc.get().ptr(m_samples_idx);
 		std::memcpy(samples.data(), ptr, samples.size() * 20);
 
-		return std::move(samples);
+		return samples;
 	}
 
 	int dht_sample_infohashes_alert::num_nodes() const

--- a/src/session_stats.cpp
+++ b/src/session_stats.cpp
@@ -584,7 +584,7 @@ namespace {
 			stats[i].type = metrics[i].value_index >= counters::num_stats_counters
 				? metric_type_t::gauge : metric_type_t::counter;
 		}
-		return std::move(stats);
+		return stats;
 	}
 
 	int find_metric_idx(string_view name)

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -484,7 +484,7 @@ namespace libtorrent {
 	{
 		aux::vector<std::int64_t, file_index_t> ret;
 		sync_call(&torrent::file_progress, std::ref(ret), flags);
-		return std::move(ret);
+		return ret;
 	}
 
 	void torrent_handle::post_file_progress(file_progress_flags_t const flags) const
@@ -542,7 +542,7 @@ namespace libtorrent {
 		aux::vector<download_priority_t, piece_index_t> ret;
 		auto retp = &ret;
 		sync_call(&torrent::piece_priorities, retp);
-		return std::move(ret);
+		return ret;
 	}
 
 #if TORRENT_ABI_VERSION == 1
@@ -598,7 +598,7 @@ namespace libtorrent {
 		aux::vector<download_priority_t, file_index_t> ret;
 		auto retp = &ret;
 		sync_call(&torrent::file_priorities, retp);
-		return std::move(ret);
+		return ret;
 	}
 
 #if TORRENT_ABI_VERSION == 1


### PR DESCRIPTION
This suppresses the following warning from gcc 13.2.1:
```
/home/user/libtorrent-rasterbar-2_0-git/src/libtorrent/bindings/python/src/entry.cpp:23:25: warning: redundant move in return statement [-Wredundant-move]
   23 |         return std::move(result);
      |                ~~~~~~~~~^~~~~~~~
```

Also refer to the manual:
https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/C_002b_002b-Dialect-Options.html#index-Wredundant-move