### PR TITLE
Allow to compile RC_1_2 branch in C++20 mode

### DIFF
--- a/include/libtorrent/aux_/socket_type.hpp
+++ b/include/libtorrent/aux_/socket_type.hpp
@@ -224,20 +224,20 @@ namespace aux {
 		{ TORRENT_SOCKTYPE_FORWARD_RET(read_some(buffers, ec), 0) }
 
 		template <class Mutable_Buffers, class Handler>
-		void async_read_some(Mutable_Buffers const& buffers, Handler const& handler)
-		{ TORRENT_SOCKTYPE_FORWARD(async_read_some(buffers, handler)) }
+		void async_read_some(Mutable_Buffers const& buffers, Handler handler)
+		{ TORRENT_SOCKTYPE_FORWARD(async_read_some(buffers, std::move(handler))) }
 
 		template <class Const_Buffers>
 		std::size_t write_some(Const_Buffers const& buffers, error_code& ec)
 		{ TORRENT_SOCKTYPE_FORWARD_RET(write_some(buffers, ec), 0) }
 
 		template <class Const_Buffers, class Handler>
-		void async_write_some(Const_Buffers const& buffers, Handler const& handler)
-		{ TORRENT_SOCKTYPE_FORWARD(async_write_some(buffers, handler)) }
+		void async_write_some(Const_Buffers const& buffers, Handler handler)
+		{ TORRENT_SOCKTYPE_FORWARD(async_write_some(buffers, std::move(handler))) }
 
 		template <class Handler>
-		void async_connect(endpoint_type const& endpoint, Handler const& handler)
-		{ TORRENT_SOCKTYPE_FORWARD(async_connect(endpoint, handler)) }
+		void async_connect(endpoint_type const& endpoint, Handler handler)
+		{ TORRENT_SOCKTYPE_FORWARD(async_connect(endpoint, std::move(handler))) }
 
 #ifndef BOOST_NO_EXCEPTIONS
 		template <class IO_Control_Command>

--- a/include/libtorrent/proxy_base.hpp
+++ b/include/libtorrent/proxy_base.hpp
@@ -69,9 +69,9 @@ public:
 #endif
 
 	template <class Mutable_Buffers, class Handler>
-	void async_read_some(Mutable_Buffers const& buffers, Handler const& handler)
+	void async_read_some(Mutable_Buffers const& buffers, Handler handler)
 	{
-		m_sock.async_read_some(buffers, handler);
+		m_sock.async_read_some(buffers, std::move(handler));
 	}
 
 	template <class Mutable_Buffers>
@@ -119,9 +119,9 @@ public:
 	}
 
 	template <class Const_Buffers, class Handler>
-	void async_write_some(Const_Buffers const& buffers, Handler const& handler)
+	void async_write_some(Const_Buffers const& buffers, Handler handler)
 	{
-		m_sock.async_write_some(buffers, handler);
+		m_sock.async_write_some(buffers, std::move(handler));
 	}
 
 #ifndef BOOST_NO_EXCEPTIONS

--- a/include/libtorrent/ssl_stream.hpp
+++ b/include/libtorrent/ssl_stream.hpp
@@ -78,7 +78,7 @@ public:
 	using handler_type = std::function<void(error_code const&)>;
 
 	template <class Handler>
-	void async_connect(endpoint_type const& endpoint, Handler const& handler)
+	void async_connect(endpoint_type const& endpoint, Handler handler)
 	{
 		// the connect is split up in the following steps:
 		// 1. connect to peer
@@ -110,7 +110,7 @@ public:
 	}
 
 	template <class Handler>
-	void async_shutdown(Handler const& handler)
+	void async_shutdown(Handler handler)
 	{
 		error_code ec;
 		m_sock.next_layer().cancel(ec);
@@ -123,9 +123,9 @@ public:
 	}
 
 	template <class Mutable_Buffers, class Handler>
-	void async_read_some(Mutable_Buffers const& buffers, Handler const& handler)
+	void async_read_some(Mutable_Buffers const& buffers, Handler handler)
 	{
-		m_sock.async_read_some(buffers, handler);
+		m_sock.async_read_some(buffers, std::move(handler));
 	}
 
 	template <class Mutable_Buffers>
@@ -190,9 +190,9 @@ public:
 	{ return m_sock.next_layer().non_blocking(b, ec); }
 
 	template <class Const_Buffers, class Handler>
-	void async_write_some(Const_Buffers const& buffers, Handler const& handler)
+	void async_write_some(Const_Buffers const& buffers, Handler handler)
 	{
-		m_sock.async_write_some(buffers, handler);
+		m_sock.async_write_some(buffers, std::move(handler));
 	}
 
 	template <class Const_Buffers>

--- a/include/libtorrent/utp_stream.hpp
+++ b/include/libtorrent/utp_stream.hpp
@@ -297,31 +297,31 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 	io_service& get_io_service() { return m_io_service; }
 
 	template <class Handler>
-	void async_connect(endpoint_type const& endpoint, Handler const& handler)
+	void async_connect(endpoint_type const& endpoint, Handler handler)
 	{
 		if (m_impl == nullptr)
 		{
-			m_io_service.post(std::bind<void>(handler, boost::asio::error::not_connected));
+			m_io_service.post(std::bind<void>(std::move(handler), boost::asio::error::not_connected));
 			return;
 		}
 
-		m_connect_handler = handler;
+		m_connect_handler = std::move(handler);
 		do_connect(endpoint);
 	}
 
 	template <class Mutable_Buffers, class Handler>
-	void async_read_some(Mutable_Buffers const& buffers, Handler const& handler)
+	void async_read_some(Mutable_Buffers const& buffers, Handler handler)
 	{
 		if (m_impl == nullptr)
 		{
-			m_io_service.post(std::bind<void>(handler, boost::asio::error::not_connected, std::size_t(0)));
+			m_io_service.post(std::bind<void>(std::move(handler), boost::asio::error::not_connected, std::size_t(0)));
 			return;
 		}
 
 		TORRENT_ASSERT(!m_read_handler);
 		if (m_read_handler)
 		{
-			m_io_service.post(std::bind<void>(handler, boost::asio::error::operation_not_supported, std::size_t(0)));
+			m_io_service.post(std::bind<void>(std::move(handler), boost::asio::error::operation_not_supported, std::size_t(0)));
 			return;
 		}
 		int bytes_added = 0;
@@ -344,20 +344,20 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 		{
 			// if we're reading 0 bytes, post handler immediately
 			// asio's SSL layer depends on this behavior
-			m_io_service.post(std::bind<void>(handler, error_code(), std::size_t(0)));
+			m_io_service.post(std::bind<void>(std::move(handler), error_code(), std::size_t(0)));
 			return;
 		}
 
-		m_read_handler = handler;
+		m_read_handler = std::move(handler);
 		issue_read();
 	}
 
 	template <class Handler>
-	void async_read_some(null_buffers const&, Handler const& handler)
+	void async_read_some(null_buffers const&, Handler handler)
 	{
 		if (m_impl == nullptr)
 		{
-			m_io_service.post(std::bind<void>(handler, boost::asio::error::not_connected, std::size_t(0)));
+			m_io_service.post(std::bind<void>(std::move(handler), boost::asio::error::not_connected, std::size_t(0)));
 			return;
 		}
 
@@ -365,10 +365,10 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 		if (m_read_handler)
 		{
 			TORRENT_ASSERT_FAIL(); // we should never do this!
-			m_io_service.post(std::bind<void>(handler, boost::asio::error::operation_not_supported, std::size_t(0)));
+			m_io_service.post(std::bind<void>(std::move(handler), boost::asio::error::operation_not_supported, std::size_t(0)));
 			return;
 		}
-		m_read_handler = handler;
+		m_read_handler = std::move(handler);
 		issue_read();
 	}
 
@@ -450,11 +450,11 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 #endif
 
 	template <class Const_Buffers, class Handler>
-	void async_write_some(Const_Buffers const& buffers, Handler const& handler)
+	void async_write_some(Const_Buffers const& buffers, Handler handler)
 	{
 		if (m_impl == nullptr)
 		{
-			m_io_service.post(std::bind<void>(handler
+			m_io_service.post(std::bind<void>(std::move(handler)
 				, boost::asio::error::not_connected, std::size_t(0)));
 			return;
 		}
@@ -462,7 +462,7 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 		TORRENT_ASSERT(!m_write_handler);
 		if (m_write_handler)
 		{
-			m_io_service.post(std::bind<void>(handler
+			m_io_service.post(std::bind<void>(std::move(handler)
 				, boost::asio::error::operation_not_supported, std::size_t(0)));
 			return;
 		}
@@ -470,7 +470,7 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 		if (check_fin_sent(m_impl))
 		{
 			// we can't send more data after closing the socket
-			m_io_service.post(std::bind<void>(handler
+			m_io_service.post(std::bind<void>(std::move(handler)
 				, boost::asio::error::broken_pipe, std::size_t(0)));
 			return;
 		}
@@ -495,10 +495,10 @@ struct TORRENT_EXTRA_EXPORT utp_stream
 		{
 			// if we're writing 0 bytes, post handler immediately
 			// asio's SSL layer depends on this behavior
-			m_io_service.post(std::bind<void>(handler, error_code(), std::size_t(0)));
+			m_io_service.post(std::bind<void>(std::move(handler), error_code(), std::size_t(0)));
 			return;
 		}
-		m_write_handler = handler;
+		m_write_handler = std::move(handler);
 		issue_write();
 	}
 


### PR DESCRIPTION
Previously boost 1.81 reported some errors about parameters should be movable.
Inspired by: 417405fc892903c8f850ca88d02bc045e56d2e19

I suppose this might be breaking ABI. Anyway I'll leave it to arvidn to decide.