### PR TITLE
hidden dllexport

### DIFF
--- a/include/libtorrent/aux_/export.hpp
+++ b/include/libtorrent/aux_/export.hpp
@@ -99,8 +99,11 @@ POSSIBILITY OF SUCH DAMAGE.
 # endif
 #endif
 
+// clang on windows complain if you mark a symbol with visibility hidden that's
+// already being exported with dllexport. It seems dllexport doesn't support
+// omitting some members of an exported class
 #if !defined TORRENT_EXPORT_EXTRA \
-  && ((defined __GNUC__ && __GNUC__ >= 4) || defined __clang__)
+  && ((defined __GNUC__ && __GNUC__ >= 4) || defined __clang__) && !defined _WIN32
 # define TORRENT_UNEXPORT __attribute__((visibility("hidden")))
 #else
 # define TORRENT_UNEXPORT


### PR DESCRIPTION
clang v16 (in combination with mingw-w64) has gotten stricter and now fails with: hidden visibility cannot be applied to 'dllexport' declaration.

original PR: https://github.com/arvidn/libtorrent/pull/7456