### PR TITLE
README: Remove LGTM badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,17 +18,11 @@
 .. image:: https://api.cirrus-ci.com/github/arvidn/libtorrent.svg?branch=RC_2_0
     :target: https://cirrus-ci.com/github/arvidn/libtorrent
 
-.. image:: https://img.shields.io/lgtm/alerts/g/arvidn/libtorrent.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/arvidn/libtorrent/alerts/
-
 .. image:: https://oss-fuzz-build-logs.storage.googleapis.com/badges/libtorrent.svg
     :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&q=proj%3Alibtorrent&can=1
 
 .. image:: https://codecov.io/github/arvidn/libtorrent/coverage.svg?branch=RC_2_0
     :target: https://codecov.io/github/arvidn/libtorrent?branch=RC_2_0&view=all#sort=missing&dir=desc
-
-.. image:: https://img.shields.io/lgtm/grade/cpp/g/arvidn/libtorrent.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/arvidn/libtorrent/context:cpp
 
 .. image:: https://www.openhub.net/p/rasterbar-libtorrent/widgets/project_thin_badge.gif
     :target: https://www.openhub.net/p/rasterbar-libtorrent


### PR DESCRIPTION
LGTM was sunset in December 2022 https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/