### PR TITLE
Allow loading .torrent files with 1 GB piece size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1012,6 +1012,7 @@ TEST_TORRENTS = \
   invalid_pieces.torrent \
   invalid_symlink.torrent \
   large.torrent \
+  large_piece_size.torrent \
   long_name.torrent \
   many_pieces.torrent \
   missing_path_list.torrent \

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1162,12 +1162,12 @@ namespace {
 
 		// extract piece length
 		std::int64_t const piece_length = info.dict_find_int_value("piece length", -1);
-		// limit the piece length at INT_MAX / 2 to get a bit of headroom. We
+		// limit the piece length at (INT_MAX / 2 + 1) to get a bit of headroom. We
 		// commonly compute the number of blocks per pieces by adding
 		// block_size - 1 before dividing by block_size. That would overflow with
 		// a piece size of INT_MAX. This limit is still an unreasonably large
 		// piece size anyway.
-		if (piece_length <= 0 || piece_length > std::numeric_limits<int>::max() / 2)
+		if (piece_length <= 0 || piece_length > (std::numeric_limits<int>::max() / 2 + 1))
 		{
 			ec = errors::torrent_missing_piece_length;
 			return false;

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -398,6 +398,10 @@ static test_torrent_t const test_torrents[] =
 			TEST_CHECK((ti->nodes() == std::vector<np>{np("127.0.0.1", 6881), np("192.168.1.1", 6881)}));
 		}
 	},
+	{ "large_piece_size.torrent", [](torrent_info const* ti) {
+			TEST_EQUAL(ti->piece_length(), (1024 * 1024 * 1024));
+		}
+	},
 };
 
 struct test_failing_torrent_t
@@ -980,7 +984,7 @@ void sanity_check(std::shared_ptr<torrent_info> const& ti)
 	// for it, it's still no good.
 	piece_picker pp(ti->total_size(), ti->piece_length());
 
-	TEST_CHECK(ti->piece_length() < std::numeric_limits<int>::max() / 2);
+	TEST_CHECK(ti->piece_length() <= (std::numeric_limits<int>::max() / 2 + 1));
 	TEST_EQUAL(ti->v1(), ti->info_hashes().has_v1());
 	TEST_EQUAL(ti->v2(), ti->info_hashes().has_v2());
 }

--- a/test/test_torrents/large_piece_size.torrent
+++ b/test/test_torrents/large_piece_size.torrent
@@ -1,0 +1,1 @@
+d10:created by10:libtorrent13:creation datei1359599503e4:infod6:lengthi425e4:name4:temp12:piece lengthi1073741824e6:pieces20:‚ž¼Œ&¾ÇJW›}ÜA4u,·¼‘‡ee


### PR DESCRIPTION
Previously the limit was 1073741823, however 1 GB = 1073741824 which is off by one (at least for x64 systems).
The reason to allow 1 GB piece size is because this is the maximum size that could be created by libtorrent. And it doesn't make sense if one can create it but cannot load it successfully.

~~RC_1_2 is not affected.~~ RC_1_2 can load it but it still has the piece picker problem.