### PR TITLE
(Backport) Treat CGNAT address range as local IPs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 	* back-port fix last_upload and last_download resume data fields to use posix time
+	* back-port treat CGNAT address range as local IPs
 
 1.2.19 released
 

--- a/src/broadcast_socket.cpp
+++ b/src/broadcast_socket.cpp
@@ -105,7 +105,9 @@ namespace libtorrent {
 			|| (ip & 0xfff00000) == 0xac100000 // 172.16.x.x
 			|| (ip & 0xffff0000) == 0xc0a80000 // 192.168.x.x
 			|| (ip & 0xffff0000) == 0xa9fe0000 // 169.254.x.x
-			|| (ip & 0xff000000) == 0x7f000000); // 127.x.x.x
+			|| (ip & 0xff000000) == 0x7f000000 // 127.x.x.x
+			|| (ip & 0xffc00000) == 0x64400000 // 100.64.0.0/10
+			);
 	}
 
 	// TODO: this function is pointless

--- a/test/test_enum_net.cpp
+++ b/test/test_enum_net.cpp
@@ -47,6 +47,10 @@ TORRENT_TEST(is_local)
 	TEST_CHECK(!ec);
 	TEST_CHECK(is_local(address::from_string("10.1.1.56", ec)));
 	TEST_CHECK(!ec);
+	TEST_CHECK(is_local(address::from_string("100.64.0.0", ec)));
+	TEST_CHECK(!ec);
+	TEST_CHECK(is_local(address::from_string("100.127.255.255", ec)));
+	TEST_CHECK(!ec);
 	TEST_CHECK(!is_local(address::from_string("14.14.251.63", ec)));
 	TEST_CHECK(!ec);
 }


### PR DESCRIPTION
This is backporting PR #7389 to RC_1_2 branch.

Related issue: https://github.com/qbittorrent/qBittorrent/issues/19673