### PR TITLE
Add support for passing client_data_t to flush_cache

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -13,6 +13,7 @@ Copyright (c) 2019, ghbplayer
 Copyright (c) 2020, AllSeeingEyeTolledEweSew
 Copyright (c) 2020, Fonic
 Copyright (c) 2020, Viktor Elofsson
+Copyright (c) 2023, Joris Carrier
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -1891,11 +1892,16 @@ TORRENT_VERSION_NAMESPACE_3
 	struct TORRENT_EXPORT cache_flushed_alert final : torrent_alert
 	{
 		// internal
-		TORRENT_UNEXPORT cache_flushed_alert(aux::stack_allocator& alloc, torrent_handle const& h);
+		TORRENT_UNEXPORT cache_flushed_alert(aux::stack_allocator& alloc,
+			torrent_handle const& h, client_data_t userdata = {});
 
 		TORRENT_DEFINE_ALERT_PRIO(cache_flushed_alert, 58, alert_priority::high)
 
 		static constexpr alert_category_t static_category = alert_category::storage;
+
+		// '`userdata`` as set in torrent_handle::flush_cache on call.
+		// This can be used to associate the call with related data.
+		client_data_t userdata;
 	};
 
 #if TORRENT_ABI_VERSION == 1

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -12,6 +12,7 @@ Copyright (c) 2018, d-komarov
 Copyright (c) 2019, ghbplayer
 Copyright (c) 2020, Paul-Louis Ageneau
 Copyright (c) 2021, AdvenT
+Copyright (c) 2023, Joris Carrier
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -563,7 +564,7 @@ namespace libtorrent {
 		bool has_error() const { return !!m_error; }
 		error_code error() const { return m_error; }
 
-		void flush_cache();
+		void flush_cache(client_data_t userdata = {});
 		void pause(pause_flags_t flags = {});
 		void resume();
 
@@ -1307,7 +1308,7 @@ namespace libtorrent {
 		void on_file_renamed(std::string const& filename
 			, file_index_t file_idx
 			, storage_error const& error);
-		void on_cache_flushed(bool manually_triggered);
+		void on_cache_flushed(bool manually_triggered, client_data_t userdata = {});
 
 		// this is used when a torrent is being removed.It synchronizes with the
 		// disk thread

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -9,6 +9,7 @@ Copyright (c) 2017, 2020, AllSeeingEyeTolledEweSew
 Copyright (c) 2017, Falcosc
 Copyright (c) 2019, Andrei Kurushin
 Copyright (c) 2019, ghbplayer
+Copyright (c) 2023, Joris Carrier
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -652,13 +653,15 @@ namespace aux {
 
 		// Instructs libtorrent to flush all the disk caches for this torrent and
 		// close all file handles. This is done asynchronously and you will be
-		// notified that it's complete through cache_flushed_alert.
+		// notified that it's complete through cache_flushed_alert
+		// with custom data (client_data_t) to be associated with this operation.
 		//
 		// Note that by the time you get the alert, libtorrent may have cached
 		// more data for the torrent, but you are guaranteed that whatever cached
 		// data libtorrent had by the time you called
-		// ``torrent_handle::flush_cache()`` has been written to disk.
-		void flush_cache() const;
+		// ``torrent_handle::flush_cache(client_data_t)`` with the provided client_data_t
+		// has been written to disk.
+		void flush_cache(client_data_t userdata = {}) const;
 
 		// ``force_recheck`` puts the torrent back in a state where it assumes to
 		// have no resume data. All peers will be disconnected and the torrent

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -1561,8 +1561,9 @@ namespace {
 #endif // TORRENT_ABI_VERSION
 
 	cache_flushed_alert::cache_flushed_alert(aux::stack_allocator& alloc
-		, torrent_handle const& h)
-		: torrent_alert(alloc, h) {}
+		, torrent_handle const& h, client_data_t u)
+		: torrent_alert(alloc, h)
+		, userdata(u) {}
 
 #if TORRENT_ABI_VERSION == 1
 	anonymous_mode_alert::anonymous_mode_alert(aux::stack_allocator& alloc

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -8,6 +8,7 @@ Copyright (c) 2017, Falcosc
 Copyright (c) 2018, Steven Siloti
 Copyright (c) 2019, Andrei Kurushin
 Copyright (c) 2019, ghbplayer
+Copyright (c) 2023, Joris Carrier
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -356,9 +357,9 @@ namespace libtorrent {
 	{ async_call(&torrent::set_sequential_download, sd); }
 #endif
 
-	void torrent_handle::flush_cache() const
+	void torrent_handle::flush_cache(client_data_t userdata) const
 	{
-		async_call(&torrent::flush_cache);
+		async_call(&torrent::flush_cache, userdata);
 	}
 
 	void torrent_handle::set_ssl_certificate(


### PR DESCRIPTION
Allowing users to pass `client_data_t` as a parameter to the `torrent_handle::flush_cache` function.
This enhancement allows users to associate custom data with the flush_cache operation;
this association will be retrieved in cache_flushed_alert by the custom data provided.