### PR TITLE
WIP: add future on asynchronous methods that trigger alerts (should I continue?) 

### DIFF
--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -79,6 +79,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <bitset>
 #include <cstdarg> // for va_list
 
+#include <boost/type_index.hpp>
+
 #if TORRENT_ABI_VERSION == 1
 #define PROGRESS_NOTIFICATION | alert::progress_notification
 #else
@@ -3114,6 +3116,27 @@ TORRENT_VERSION_NAMESPACE_3_END
 
 	// internal
 	TORRENT_EXTRA_EXPORT char const* performance_warning_str(performance_alert::performance_warning_t i);
+
+
+	template<typename T>
+	class alert_exception : public std::exception {
+	public:
+		alert_exception(const T* a) : m_alert(a) {}
+
+		const char* what() const noexcept override {
+			return m_alert->message().c_str();
+		}
+
+	private:
+		const T* m_alert;
+	};
+
+	template<typename T>
+	class alert_dont_post_exception: public std::exception {
+		const char* what() const noexcept override {
+			return std::string(boost::typeindex::type_id<T>().pretty_name() + " ignored").c_str();
+		}
+	};
 
 
 #undef TORRENT_DEFINE_ALERT_IMPL

--- a/include/libtorrent/aux_/alert_manager.hpp
+++ b/include/libtorrent/aux_/alert_manager.hpp
@@ -69,7 +69,7 @@ namespace aux {
 		~alert_manager();
 
 		template <class T, typename... Args>
-		void emplace_alert(Args&&... args) try
+		const T* emplace_alert(Args&&... args) try
 		{
 			std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
@@ -82,13 +82,15 @@ namespace aux {
 			{
 				// record that we dropped an alert of this type
 				m_dropped.set(T::alert_type);
-				return;
+				return nullptr;
 			}
 
 			T& alert = queue.emplace_back<T>(
 				m_allocations[m_generation], std::forward<Args>(args)...);
 
 			maybe_notify(&alert);
+
+			return &alert;
 		}
 		catch (std::bad_alloc const&)
 		{

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -48,6 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <set>
 #include <list>
+#include <future>
 #include <deque>
 #include <limits> // for numeric_limits
 #include <memory> // for unique_ptr
@@ -563,7 +564,8 @@ namespace libtorrent {
 		bool has_error() const { return !!m_error; }
 		error_code error() const { return m_error; }
 
-		void flush_cache();
+
+		void flush_cache(std::shared_ptr<std::promise<const cache_flushed_alert*>> promise = nullptr);
 		void pause(pause_flags_t flags = {});
 		void resume();
 
@@ -1307,7 +1309,8 @@ namespace libtorrent {
 		void on_file_renamed(std::string const& filename
 			, file_index_t file_idx
 			, storage_error const& error);
-		void on_cache_flushed(bool manually_triggered);
+
+		void on_cache_flushed(bool manually_triggered, std::shared_ptr<std::promise<const cache_flushed_alert*>> promise = nullptr);
 
 		// this is used when a torrent is being removed.It synchronizes with the
 		// disk thread

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -1165,7 +1165,7 @@ namespace libtorrent {
 		// RESOURCE MANAGEMENT
 
 		// flags are defined in storage.hpp
-		void move_storage(std::string const& save_path, move_flags_t flags);
+		void move_storage(std::string const& save_path, move_flags_t flags, std::shared_ptr<std::promise<const storage_moved_alert*>> promise = nullptr);
 
 		// renames the file with the given index to the new name
 		// the name may include a directory path
@@ -1308,7 +1308,7 @@ namespace libtorrent {
 		void on_files_deleted(storage_error const& error);
 		void on_torrent_paused();
 		void on_storage_moved(status_t status, std::string const& path
-			, storage_error const& error);
+			, storage_error const& error, std::shared_ptr<std::promise<const storage_moved_alert*>> promise = nullptr);
 		void on_file_renamed(std::string const& filename
 			, file_index_t file_idx
 			, storage_error const& error);

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -486,8 +486,11 @@ namespace libtorrent {
 			int blocks_left;
 			bool fail;
 			error_code error;
+			std::shared_ptr<std::promise<const read_piece_alert*>> promise;
 		};
-		void read_piece(piece_index_t);
+
+		void read_piece(piece_index_t const piece, std::shared_ptr<std::promise<const read_piece_alert*>> promise = nullptr);
+
 		void on_disk_read_complete(disk_buffer_holder, storage_error const&
 			, peer_request const&, std::shared_ptr<read_piece_struct>);
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -47,6 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <functional>
 #include <memory>
+#include <future>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #if TORRENT_ABI_VERSION == 1
@@ -80,6 +81,9 @@ namespace aux {
 #endif
 	struct torrent;
 	struct client_data_t;
+
+	struct cache_flushed_alert;
+	struct read_piece_alert;
 
 #ifndef BOOST_NO_EXCEPTIONS
 	[[noreturn]] void throw_invalid_handle();
@@ -310,6 +314,7 @@ namespace aux {
 		// Note that if you read multiple pieces, the read operations are not
 		// guaranteed to finish in the same order as you initiated them.
 		void read_piece(piece_index_t piece) const;
+		std::future<const read_piece_alert*> async_read_piece(piece_index_t piece);
 
 		// Returns true if this piece has been completely downloaded and written
 		// to disk, and false otherwise.
@@ -659,6 +664,7 @@ namespace aux {
 		// data libtorrent had by the time you called
 		// ``torrent_handle::flush_cache()`` has been written to disk.
 		void flush_cache() const;
+		std::future<const cache_flushed_alert*> async_flush_cache();
 
 		// ``force_recheck`` puts the torrent back in a state where it assumes to
 		// have no resume data. All peers will be disconnected and the torrent

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -84,6 +84,7 @@ namespace aux {
 
 	struct cache_flushed_alert;
 	struct read_piece_alert;
+	struct storage_moved_alert;
 
 #ifndef BOOST_NO_EXCEPTIONS
 	[[noreturn]] void throw_invalid_handle();
@@ -1334,6 +1335,9 @@ namespace aux {
 		void move_storage(std::string const& save_path
 			, move_flags_t flags = move_flags_t::always_replace_files
 			) const;
+
+		std::future<const storage_moved_alert*> async_move_storage(std::string const& save_path
+			, move_flags_t flags = move_flags_t::always_replace_files);
 
 #if TORRENT_ABI_VERSION == 1
 		// deprecated in 1.2

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -358,7 +358,14 @@ namespace libtorrent {
 
 	void torrent_handle::flush_cache() const
 	{
-		async_call(&torrent::flush_cache);
+		async_call(&torrent::flush_cache, nullptr);
+	}
+
+	std::future<const cache_flushed_alert*> torrent_handle::async_flush_cache()
+	{
+		auto promise = std::make_shared<std::promise<const cache_flushed_alert*>>();
+		async_call(&torrent::flush_cache, promise);
+		return promise->get_future();
 	}
 
 	void torrent_handle::set_ssl_certificate(

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -270,14 +270,22 @@ namespace libtorrent {
 
 	void torrent_handle::move_storage(std::string const& save_path, move_flags_t flags) const
 	{
-		async_call(&torrent::move_storage, save_path, flags);
+		async_call(&torrent::move_storage, save_path, flags, nullptr);
+	}
+
+	std::future<const storage_moved_alert*> torrent_handle::async_move_storage(std::string const& save_path
+		, move_flags_t flags)
+	{
+		auto promise = std::make_shared<std::promise<const storage_moved_alert*>>();
+		async_call(&torrent::move_storage, save_path, flags, promise);
+		return promise->get_future();
 	}
 
 #if TORRENT_ABI_VERSION == 1
 	void torrent_handle::move_storage(
 		std::string const& save_path, int const flags) const
 	{
-		async_call(&torrent::move_storage, save_path, static_cast<move_flags_t>(flags));
+		async_call(&torrent::move_storage, save_path, static_cast<move_flags_t>(flags), nullptr);
 	}
 #endif // TORRENT_ABI_VERSION
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -751,7 +751,14 @@ namespace libtorrent {
 
 	void torrent_handle::read_piece(piece_index_t piece) const
 	{
-		async_call(&torrent::read_piece, piece);
+		async_call(&torrent::read_piece, piece, nullptr);
+	}
+
+	std::future<const read_piece_alert*> torrent_handle::async_read_piece(piece_index_t piece)
+	{
+		auto promise = std::make_shared<std::promise<const read_piece_alert*>>();
+		async_call(&torrent::read_piece, piece, promise);
+		return promise->get_future();
 	}
 
 	bool torrent_handle::have_piece(piece_index_t piece) const


### PR DESCRIPTION
# requires that the lifetime of alerts be guaranteed after session::pop_alerts is called, if they are still referenced.

this pull request allows you to have a future on asynchronous methods that trigger alerts:

### torrent_handle:

- [ ] add_piece
- [x] read_piece
- [ ] post_peer_info
- [ ] post_status
- [ ] post_download_queue
- [ ] post_trackers
- [ ] set_metadata
- [x] flush_cache
- [ ] force_recheck
- [ ] save_resume_data
- [ ] post_piece_availability
- [ ] prioritize_files
- [ ] file_priority
- [ ] scrape_tracker
- [x] move_storage
- [ ] rename_file


### session_handle:

- [ ] post_torrent_updates
- [ ] post_session_stats
- [ ] post_dht_stats
- [ ] async_add_torrent
- [ ] dht_live_nodes
- [ ] dht_sample_infohashes
- [ ] dht_direct_request
- [ ] remove_torrent
