### PR TITLE
Color theme revamp

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -15,7 +15,7 @@
 /* STYLE */
 
 body {
-    margin: 0px;
+    margin: 0;
     font-size: 12pt;
 }
 
@@ -37,50 +37,62 @@ tt {
 h1 {
     font-size: 1.7em;
 }
+
 h2 {
     font-size: 1.5em;
 }
 
 @media (prefers-color-scheme: light) {
     tt {
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: rgb(0 0 0 / 5%);
     }
+
     table {
         border-color: #ccc;
     }
+
     th,
     td {
         border-color: #ddd;
     }
+
     th {
         border-bottom-color: black;
     }
+
     a.reference,
     a {
         color: #000070;
     }
+
     hr {
         border-color: #eee;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     tt {
-        background-color: rgba(255, 255, 255, 0.2);
+        background-color: rgb(255 255 255 / 20%);
     }
+
     table {
         border-color: #777;
     }
+
     th,
     td {
         border-color: #444;
     }
+
     th {
         border-bottom-color: white;
     }
+
     a.reference,
     a {
         color: #bbf;
     }
+
     hr {
         border-color: #777;
     }
@@ -139,36 +151,46 @@ p.first {
     #footer {
         color: #777;
     }
+
     #footer a {
         color: #555;
     }
+
     #footer a:hover {
         color: #000;
     }
+
     #gradient {
         background: linear-gradient(#aaa, #ddd);
     }
+
     #filler {
         background: linear-gradient(#ddd, #fff);
     }
 }
+
 @media (prefers-color-scheme: dark) {
     #footer {
         color: #888;
     }
+
     #footer a {
         color: #ccc;
     }
+
     #footer a:hover {
         color: #fff;
     }
+
     #gradient {
         background: #444;
     }
+
     #filler {
         background: linear-gradient(#444, black);
     }
 }
+
 #container {
     text-align: left;
     max-width: 60em;
@@ -187,11 +209,10 @@ p.first {
 }
 
 #footer {
-    margin-bottom: 0px;
+    margin-bottom: 0;
     margin-left: auto;
     margin-right: auto;
-    column-count: 3;
-    column-width: 7em;
+    columns: 7em 3;
     max-width: 40em;
 }
 
@@ -206,13 +227,13 @@ p.first {
 table.docinfo {
     float: right;
     width: 200px;
-    margin-right: 0px;
+    margin-right: 0;
     margin-left: 20px;
     margin-bottom: 20px;
     border: none;
 }
 
-@media screen and (max-width: 499px) {
+@media screen and (width <= 499px) {
     table.docinfo {
         display: none;
     }
@@ -230,20 +251,21 @@ table.docinfo td {
 
 /* FRONT PAGE */
 
-@media screen and (min-width: 500px) {
+@media screen and (width >= 500px) {
     #librarySidebar {
         float: left;
         width: 13em;
     }
+
     #libraryBody {
         margin-left: 13em;
     }
 }
 
-@media screen and (max-width: 240px) {
+@media screen and (width <= 240px) {
     #librarySidebar ul {
         list-style-type: none;
-        padding-inline-start: 0px;
+        padding-inline-start: 0;
     }
 }
 
@@ -256,6 +278,7 @@ table.docinfo td {
         border-color: #eee;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     #libraryBody {
         border-color: #777;
@@ -276,7 +299,8 @@ table.docinfo td {
 .front-page-screenshot {
     float: right;
 }
-@media screen and (max-width: 890px) {
+
+@media screen and (width <= 890px) {
     .front-page-screenshot {
         display: none;
     }
@@ -286,7 +310,8 @@ table.docinfo td {
     float: right;
     clear: right;
 }
-@media screen and (max-width: 600px) {
+
+@media screen and (width <= 600px) {
     .front-page-qr {
         display: none;
     }
@@ -304,14 +329,15 @@ table.docinfo td {
         border-color: #999;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     div.main-toc {
         border-color: #888;
     }
 }
+
 div.main-toc {
-    column-count: 4;
-    column-width: 13em;
+    columns: 13em 4;
     border-style: solid;
     border-width: 1px;
     padding: 5px;
@@ -333,12 +359,14 @@ div.main-toc {
         border-color: #a1c5d6;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     #table-of-contents {
         background-color: black;
         border-color: #76c;
     }
 }
+
 #table-of-contents {
     margin-left: 20px;
     padding: 0.8em;
@@ -348,7 +376,7 @@ div.main-toc {
     z-index: 1;
 }
 
-@media screen and (min-width: 500px) {
+@media screen and (width >= 500px) {
     #table-of-contents {
         width: 15em;
         float: right;
@@ -371,10 +399,10 @@ div.main-toc {
     line-height: 1.5em;
 }
 
-@media screen and (max-width: 319px) {
+@media screen and (width <= 319px) {
     #table-of-contents ul {
         list-style-type: none;
-        padding-inline-start: 0px;
+        padding-inline-start: 0;
     }
 }
 
@@ -396,15 +424,17 @@ div.main-toc {
         border-color: #bbb;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     pre {
         background: #222;
         border-color: #666;
     }
 }
+
 pre {
     font-family: monospace;
-    padding: 5px 10px 5px 10px;
+    padding: 5px 10px;
     border-style: solid;
     border-width: 1px;
     margin: 1em 0;
@@ -420,30 +450,37 @@ pre {
     .string {
         color: #771;
     }
+
     .comment {
         font-style: italic;
         color: #559;
     }
+
     .preproc {
         font-style: italic;
         color: #959;
     }
+
     .number {
         color: #595;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     .string {
         color: #ff6;
     }
+
     .comment {
         font-style: italic;
         color: #99f;
     }
+
     .preproc {
         font-style: italic;
         color: #f7f;
     }
+
     .number {
         color: #7f7;
     }
@@ -458,17 +495,21 @@ pre {
         background: #f1fff5;
         border-color: #d1dfd5;
     }
+
     div.warning {
         background: #fffdca;
         border-color: #dddd80;
     }
+
     div.note .admonition-title {
         border-bottom-color: #d1dfd5;
     }
+
     div.warning .admonition-title {
         border-bottom-color: #dddd80;
     }
 }
+
 @media (prefers-color-scheme: dark) {
     div.warning,
     div.note,
@@ -476,17 +517,21 @@ pre {
         background: #0f3a0f;
         border-color: #5d9e5d;
     }
+
     div.warning {
         background: #666507;
         border-color: #dbd818;
     }
+
     div.warning .admonition-title {
         border-bottom-color: #dbd818;
     }
+
     div.note .admonition-title {
         border-bottom-color: #5d9e5d;
     }
 }
+
 div.warning,
 div.note,
 div.important {
@@ -494,7 +539,7 @@ div.important {
     margin: 1.5em auto;
     border-style: solid;
     border-width: 1px;
-    padding: 5px 10px 5px 10px;
+    padding: 5px 10px;
 }
 
 div.warning {
@@ -506,7 +551,7 @@ p.admonition-title {
     font-size: 128%;
     letter-spacing: 2px;
     text-transform: uppercase;
-    margin: 0 0 0.5em 0;
+    margin: 0 0 0.5em;
     border-bottom-style: solid;
     border-bottom-width: 1px;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -15,412 +15,498 @@
 /* STYLE */
 
 body {
-	margin: 0px;
-	font-size: 12pt;
+    margin: 0px;
+    font-size: 12pt;
 }
 
 dt {
-	margin-bottom: 0.3em;
-	font-style: italic;
-	font-weight: 600;
+    margin-bottom: 0.3em;
+    font-style: italic;
+    font-weight: 600;
 }
 
 dd {
-	margin-left: 2em;
-	margin-bottom: 1em;
+    margin-left: 2em;
+    margin-bottom: 1em;
 }
 
 tt {
-	font-family: monospace;
+    font-family: monospace;
 }
 
-h1 { font-size: 1.7em; }
-h2 { font-size: 1.5em; }
+h1 {
+    font-size: 1.7em;
+}
+h2 {
+    font-size: 1.5em;
+}
 
 @media (prefers-color-scheme: light) {
-tt { background-color: rgba(0, 0, 0, 0.05); }
-table { border-color: #ccc; }
-th, td { border-color: #ddd; }
-th { border-bottom-color: black; }
-a.reference, a { color: #000070; }
-hr { border-color: #eee; }
+    tt {
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+    table {
+        border-color: #ccc;
+    }
+    th,
+    td {
+        border-color: #ddd;
+    }
+    th {
+        border-bottom-color: black;
+    }
+    a.reference,
+    a {
+        color: #000070;
+    }
+    hr {
+        border-color: #eee;
+    }
 }
 @media (prefers-color-scheme: dark) {
-tt { background-color: rgba(255, 255, 255, 0.2); }
-table { border-color: #777; }
-th, td { border-color: #444; }
-th { border-bottom-color: white; }
-a.reference, a { color: #bbf; }
-hr { border-color: #777; }
+    tt {
+        background-color: rgba(255, 255, 255, 0.2);
+    }
+    table {
+        border-color: #777;
+    }
+    th,
+    td {
+        border-color: #444;
+    }
+    th {
+        border-bottom-color: white;
+    }
+    a.reference,
+    a {
+        color: #bbf;
+    }
+    hr {
+        border-color: #777;
+    }
 }
 
 hr {
-	border-bottom-width: 1px;
-	border-style: solid;
+    border-bottom-width: 1px;
+    border-style: solid;
 }
 
 table {
-	margin-bottom: 1em;
-	border-collapse: collapse;
-	border-style: solid;
+    margin-bottom: 1em;
+    border-collapse: collapse;
+    border-style: solid;
 }
 
-th, td { padding: 0.2em; }
+th,
+td {
+    padding: 0.2em;
+}
 
 th {
-	border-bottom-style: solid;
-	border-bottom-width: 1px;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
 }
 
 a {
-	text-decoration: none;
+    text-decoration: none;
 }
 
-a:hover
-{
-	text-decoration: underline;
+a:hover {
+    text-decoration: underline;
 }
 
 p.last {
-	margin-bottom: 0.3em;
+    margin-bottom: 0.3em;
 }
 
 p.first {
-	margin-top: 0.3em;
+    margin-top: 0.3em;
 }
 
 .align-right {
-	float: right;
+    float: right;
 }
 
 @media (prefers-color-scheme: dark) {
-.bw {
-	filter: invert(1);
-}
+    .bw {
+        filter: invert(1);
+    }
 }
 
 /* TEMPLATE */
 
 @media (prefers-color-scheme: light) {
-#footer {
-	color: #777;
-}
-#footer a { color: #555; }
-#footer a:hover { color: #000; }
-#gradient { background: linear-gradient(#aaa, #ddd); }
-#filler { background: linear-gradient(#ddd, #fff); }
+    #footer {
+        color: #777;
+    }
+    #footer a {
+        color: #555;
+    }
+    #footer a:hover {
+        color: #000;
+    }
+    #gradient {
+        background: linear-gradient(#aaa, #ddd);
+    }
+    #filler {
+        background: linear-gradient(#ddd, #fff);
+    }
 }
 @media (prefers-color-scheme: dark) {
-#footer {
-	color: #888;
-}
-#footer a { color: #ccc; }
-#footer a:hover { color: #fff; }
-#gradient { background: #444; }
-#filler { background: linear-gradient(#444, black); }
+    #footer {
+        color: #888;
+    }
+    #footer a {
+        color: #ccc;
+    }
+    #footer a:hover {
+        color: #fff;
+    }
+    #gradient {
+        background: #444;
+    }
+    #filler {
+        background: linear-gradient(#444, black);
+    }
 }
 #container {
-	text-align: left;
-	max-width: 60em;
-	margin: 5px auto;
-	position: relative;
-	padding: 3px;
+    text-align: left;
+    max-width: 60em;
+    margin: 5px auto;
+    position: relative;
+    padding: 3px;
 }
 
 #gradient {
-	height: 40px;
+    height: 40px;
 }
 
 #filler {
-	min-height: 400px;
-	height: 100%;
+    min-height: 400px;
+    height: 100%;
 }
 
 #footer {
-	margin-bottom: 0px;
-	margin-left: auto;
-	margin-right: auto;
-	column-count: 3;
-	column-width: 7em;
-	max-width: 40em;
+    margin-bottom: 0px;
+    margin-left: auto;
+    margin-right: auto;
+    column-count: 3;
+    column-width: 7em;
+    max-width: 40em;
 }
 
 #footer a {
-	text-decoration: none;
+    text-decoration: none;
 }
 
 #footer a:hover {
-	text-decoration: underline;
+    text-decoration: underline;
 }
 
 table.docinfo {
-	float: right;
-	width: 200px;
-	margin-right: 0px;
-	margin-left: 20px;
-	margin-bottom: 20px;
-	border: none;
+    float: right;
+    width: 200px;
+    margin-right: 0px;
+    margin-left: 20px;
+    margin-bottom: 20px;
+    border: none;
 }
 
 @media screen and (max-width: 499px) {
-table.docinfo {
-	display: none;
-}
+    table.docinfo {
+        display: none;
+    }
 }
 
 table.docinfo th {
-	text-align: right;
-	background-color: transparent;
-	border: none;
+    text-align: right;
+    background-color: transparent;
+    border: none;
 }
 
 table.docinfo td {
-	padding-left: 10px;
+    padding-left: 10px;
 }
-
 
 /* FRONT PAGE */
 
 @media screen and (min-width: 500px) {
-#librarySidebar {
-	float: left;
-	width: 13em;
-}
-#libraryBody {
-	margin-left: 13em;
-}
+    #librarySidebar {
+        float: left;
+        width: 13em;
+    }
+    #libraryBody {
+        margin-left: 13em;
+    }
 }
 
 @media screen and (max-width: 240px) {
-#librarySidebar ul {
-	list-style-type: none;
-	padding-inline-start: 0px;
-}
+    #librarySidebar ul {
+        list-style-type: none;
+        padding-inline-start: 0px;
+    }
 }
 
-#librarySidebar li { padding-bottom: 0.35em; }
+#librarySidebar li {
+    padding-bottom: 0.35em;
+}
 
 @media (prefers-color-scheme: light) {
-#libraryBody {
-	border-color: #eee;
-}
+    #libraryBody {
+        border-color: #eee;
+    }
 }
 @media (prefers-color-scheme: dark) {
-#libraryBody {
-	border-color: #777;
-}
+    #libraryBody {
+        border-color: #777;
+    }
 }
 
 #libraryBody {
-	border-left-style: solid;
-	border-left-width: 1px;
-	padding-left: 10px;
-	margin-right: 10px;
+    border-left-style: solid;
+    border-left-width: 1px;
+    padding-left: 10px;
+    margin-right: 10px;
 }
 
 .screenshot {
-	width: 100%;
+    width: 100%;
 }
 
 .front-page-screenshot {
-	float: right;
+    float: right;
 }
 @media screen and (max-width: 890px) {
-.front-page-screenshot {
-	display: none;
-}
+    .front-page-screenshot {
+        display: none;
+    }
 }
 
 .front-page-qr {
-	float: right;
-	clear: right;
+    float: right;
+    clear: right;
 }
 @media screen and (max-width: 600px) {
-.front-page-qr {
-	display: none;
-}
+    .front-page-qr {
+        display: none;
+    }
 }
 
 .report-issue {
-	float: right;
-	font-size: 90%;
+    float: right;
+    font-size: 90%;
 }
 
 /* REFERENCE MAIN TABLE OF CONTENT */
 
 @media (prefers-color-scheme: light) {
-div.main-toc { border-color: #999; }
+    div.main-toc {
+        border-color: #999;
+    }
 }
 @media (prefers-color-scheme: dark) {
-div.main-toc { border-color: #888; }
+    div.main-toc {
+        border-color: #888;
+    }
 }
 div.main-toc {
-	column-count: 4;
-	column-width: 13em;
-	border-style: solid;
-	border-width: 1px;
-	padding: 5px;
-	margin-bottom: 10px;
+    column-count: 4;
+    column-width: 13em;
+    border-style: solid;
+    border-width: 1px;
+    padding: 5px;
+    margin-bottom: 10px;
 }
 
-.rubric
-{
-	margin-top: 5px;
-	margin-bottom: 5px;
-	font-size: 120%;
-	font-weight: bold;
+.rubric {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    font-size: 120%;
+    font-weight: bold;
 }
-
 
 /* TABLE OF CONTENT */
 
 @media (prefers-color-scheme: light) {
-#table-of-contents {
-	background-color: white;
-	border-color: #a1c5d6;
-}
+    #table-of-contents {
+        background-color: white;
+        border-color: #a1c5d6;
+    }
 }
 @media (prefers-color-scheme: dark) {
-#table-of-contents {
-	background-color: black;
-	border-color: #76c;
+    #table-of-contents {
+        background-color: black;
+        border-color: #76c;
+    }
 }
-}
 #table-of-contents {
-	margin-left: 20px;
-	padding: 0.8em;
-	border-style: solid;
-	border-width: 1px;
-	position: relative;
-	z-index: 1;
+    margin-left: 20px;
+    padding: 0.8em;
+    border-style: solid;
+    border-width: 1px;
+    position: relative;
+    z-index: 1;
 }
 
 @media screen and (min-width: 500px) {
-#table-of-contents {
-	width: 15em;
-	float: right;
-	clear: right;
-}
+    #table-of-contents {
+        width: 15em;
+        float: right;
+        clear: right;
+    }
 }
 
 #table-of-contents p {
-	font-size: 140%;
-	font-weight: bold;
-	padding-bottom: 0.5em;
-	margin: 0;
+    font-size: 140%;
+    font-weight: bold;
+    padding-bottom: 0.5em;
+    margin: 0;
 }
 
 #table-of-contents ul {
-	margin: 0;
-	padding: 0 0 0 0.8em;
-	list-style: square;
-	text-align: left;
-	line-height: 1.5em;
+    margin: 0;
+    padding: 0 0 0 0.8em;
+    list-style: square;
+    text-align: left;
+    line-height: 1.5em;
 }
 
 @media screen and (max-width: 319px) {
-#table-of-contents ul {
-	list-style-type: none;
-	padding-inline-start: 0px;
-}
+    #table-of-contents ul {
+        list-style-type: none;
+        padding-inline-start: 0px;
+    }
 }
 
 #table-of-contents a.reference {
-	border: none;
-	font-weight: bold;
+    border: none;
+    font-weight: bold;
 }
 
 #table-of-contents li li a.reference {
-	font-weight: normal;
-	padding: 0;
+    font-weight: normal;
+    padding: 0;
 }
-
 
 /* CODE BLOCKS */
 
 @media (prefers-color-scheme: light) {
-pre {
-	background: #f6f6f6;
-	border-color: #bbb;
-}
+    pre {
+        background: #f6f6f6;
+        border-color: #bbb;
+    }
 }
 @media (prefers-color-scheme: dark) {
+    pre {
+        background: #222;
+        border-color: #666;
+    }
+}
 pre {
-	background: #222;
-	border-color: #666;
+    font-family: monospace;
+    padding: 5px 10px 5px 10px;
+    border-style: solid;
+    border-width: 1px;
+    margin: 1em 0;
 }
-}
-pre {
-	font-family: monospace;
-	padding: 5px 10px 5px 10px;
-	border-style: solid;
-	border-width: 1px;
-	margin: 1em 0;
-}
-
 
 /* SYNTAX HIGHLIGHTING */
 
-.keyword { font-weight: bold }
+.keyword {
+    font-weight: bold;
+}
 
 @media (prefers-color-scheme: light) {
-.string { color: #771; }
-.comment { font-style: italic; color: #559; }
-.preproc { font-style: italic; color: #959; }
-.number { color: #595; }
+    .string {
+        color: #771;
+    }
+    .comment {
+        font-style: italic;
+        color: #559;
+    }
+    .preproc {
+        font-style: italic;
+        color: #959;
+    }
+    .number {
+        color: #595;
+    }
 }
 @media (prefers-color-scheme: dark) {
-.string { color: #ff6; }
-.comment { font-style: italic; color: #99f; }
-.preproc { font-style: italic; color: #f7f; }
-.number { color: #7f7; }
+    .string {
+        color: #ff6;
+    }
+    .comment {
+        font-style: italic;
+        color: #99f;
+    }
+    .preproc {
+        font-style: italic;
+        color: #f7f;
+    }
+    .number {
+        color: #7f7;
+    }
 }
 
 /* ALERT BOXES */
 
 @media (prefers-color-scheme: light) {
-div.warning, div.note, div.important {
-	background: #f1fff5;
-	border-color: #d1dfd5;
-}
-div.warning {
-	background: #fffdca;
-	border-color: #dddd80;
-}
-div.note .admonition-title { border-bottom-color: #d1dfd5; }
-div.warning .admonition-title { border-bottom-color: #dddd80; }
+    div.warning,
+    div.note,
+    div.important {
+        background: #f1fff5;
+        border-color: #d1dfd5;
+    }
+    div.warning {
+        background: #fffdca;
+        border-color: #dddd80;
+    }
+    div.note .admonition-title {
+        border-bottom-color: #d1dfd5;
+    }
+    div.warning .admonition-title {
+        border-bottom-color: #dddd80;
+    }
 }
 @media (prefers-color-scheme: dark) {
-div.warning, div.note, div.important {
-	background: #0f3a0f;
-	border-color: #5d9e5d;
+    div.warning,
+    div.note,
+    div.important {
+        background: #0f3a0f;
+        border-color: #5d9e5d;
+    }
+    div.warning {
+        background: #666507;
+        border-color: #dbd818;
+    }
+    div.warning .admonition-title {
+        border-bottom-color: #dbd818;
+    }
+    div.note .admonition-title {
+        border-bottom-color: #5d9e5d;
+    }
 }
-div.warning {
-	background: #666507;
-	border-color: #dbd818;
-}
-div.warning .admonition-title { border-bottom-color: #dbd818; }
-div.note .admonition-title { border-bottom-color: #5d9e5d; }
-}
-div.warning, div.note, div.important {
-	width: 80%;
-	margin: 1.5em auto;
-	border-style: solid;
-	border-width: 1px;
-	padding: 5px 10px 5px 10px;
+div.warning,
+div.note,
+div.important {
+    width: 80%;
+    margin: 1.5em auto;
+    border-style: solid;
+    border-width: 1px;
+    padding: 5px 10px 5px 10px;
 }
 
 div.warning {
-	border-style: solid;
-	border-width: 1px;
+    border-style: solid;
+    border-width: 1px;
 }
 
 p.admonition-title {
-	font-size: 128%;
-	letter-spacing: 2px;
-	text-transform: uppercase;
-	margin: 0 0 0.5em 0;
-	border-bottom-style: solid;
-	border-bottom-width: 1px;
+    font-size: 128%;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin: 0 0 0.5em 0;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
 }
-

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,29 @@
+:root {
+    /* Nord Color Theme: https://www.nordtheme.com/
+       Details about the palette and use cause of each color: https://www.nordtheme.com/docs/colors-and-palettes */
+
+    /* Polar Night  */
+    --nord0: #2e3440;
+    --nord1: #3b4252;
+    --nord2: #434c5e;
+    --nord3: #4c566a;
+    /* Snow Storm */
+    --nord4: #d8dee9;
+    --nord5: #e5e9f0;
+    --nord6: #eceff4;
+    /* Frost */
+    --nord7: #8fbcbb;
+    --nord8: #88c0d0;
+    --nord9: #81a1c1;
+    --nord10: #5e81ac;
+    /* Aurora */
+    --nord11: #bf616a;
+    --nord12: #d08770;
+    --nord13: #ebcb8b;
+    --nord14: #a3be8c;
+    --nord15: #b48ead;
+}
+
 @media (prefers-color-scheme: light) {
     body {
         background-color: white;
@@ -7,8 +33,8 @@
 
 @media (prefers-color-scheme: dark) {
     body {
-        background-color: black;
-        color: #ddd;
+        background-color: var(--nord0);
+        color: var(--nord6);
     }
 }
 
@@ -72,29 +98,29 @@ h2 {
 
 @media (prefers-color-scheme: dark) {
     tt {
-        background-color: rgb(255 255 255 / 20%);
+        background-color: var(--nord3);
     }
 
     table {
-        border-color: #777;
+        border-color: var(--nord7);
     }
 
     th,
     td {
-        border-color: #444;
+        border-color: var(--nord2);
     }
 
     th {
-        border-bottom-color: white;
+        border-bottom-color: var(--nord7);
     }
 
     a.reference,
     a {
-        color: #bbf;
+        color: var(--nord8);
     }
 
     hr {
-        border-color: #777;
+        border-color: var(--nord7);
     }
 }
 
@@ -171,23 +197,23 @@ p.first {
 
 @media (prefers-color-scheme: dark) {
     #footer {
-        color: #888;
+        color: var(--nord5);
     }
 
     #footer a {
-        color: #ccc;
+        color: var(--nord9);
     }
 
     #footer a:hover {
-        color: #fff;
+        color: var(--nord8);
     }
 
     #gradient {
-        background: #444;
+        background: var(--nord1);
     }
 
     #filler {
-        background: linear-gradient(#444, black);
+        background: linear-gradient(var(--nord1), var(--nord0));
     }
 }
 
@@ -281,7 +307,7 @@ table.docinfo td {
 
 @media (prefers-color-scheme: dark) {
     #libraryBody {
-        border-color: #777;
+        border-color: var(--nord7);
     }
 }
 
@@ -332,7 +358,7 @@ table.docinfo td {
 
 @media (prefers-color-scheme: dark) {
     div.main-toc {
-        border-color: #888;
+        border-color: var(--nord3);
     }
 }
 
@@ -362,8 +388,8 @@ div.main-toc {
 
 @media (prefers-color-scheme: dark) {
     #table-of-contents {
-        background-color: black;
-        border-color: #76c;
+        background-color: var(--nord1);
+        border-color: var(--nord10);
     }
 }
 
@@ -427,8 +453,8 @@ div.main-toc {
 
 @media (prefers-color-scheme: dark) {
     pre {
-        background: #222;
-        border-color: #666;
+        background: var(--nord2);
+        border-color: var(--nord1);
     }
 }
 
@@ -468,21 +494,21 @@ pre {
 
 @media (prefers-color-scheme: dark) {
     .string {
-        color: #ff6;
+        color: var(--nord14);
     }
 
     .comment {
         font-style: italic;
-        color: #99f;
+        color: var(--nord10);
     }
 
     .preproc {
         font-style: italic;
-        color: #f7f;
+        color: var(--nord10);
     }
 
     .number {
-        color: #7f7;
+        color: var(--nord15);
     }
 }
 
@@ -511,7 +537,6 @@ pre {
 }
 
 @media (prefers-color-scheme: dark) {
-    div.warning,
     div.note,
     div.important {
         background: #0f3a0f;


### PR DESCRIPTION
The current dark theme makes the online documentation a pain to read.
I took the liberty of implementing the color palette from the [Nord Theme](https://www.nordtheme.com/docs/colors-and-palettes).
I am not sure that I got it right, but IMO it is more readable now than it was before. (I am a noob on the topic of colors)

I didn't touch the colors for the `NOTE` and `WARNING` alert boxes, because I don't have any idea on how the make them work correctly with Nord's color palette.

**BEFORE**
![Screenshot 2023-11-21 at 02-26-02 libtorrent](https://github.com/arvidn/libtorrent/assets/273315/787fa13e-596c-4767-b90b-b58108cbaa56)
**AFTER**
![Screenshot 2023-11-21 at 02-24-58 libtorrent](https://github.com/arvidn/libtorrent/assets/273315/5ed67a54-2cdc-4b28-9846-4678359dc064)
