### PR TITLE
Update Cirrus CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1
+  image_family: freebsd-14-0
 
 task:
   install_script: |
@@ -28,7 +28,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
       delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
   install_cibuildwheel_script:
-    - $PYTHON -m pip install cibuildwheel==2.12.0
+    - $PYTHON -m pip install cibuildwheel==2.16.3
 
   run_cibuildwheel_script:
     - cibuildwheel
@@ -40,12 +40,12 @@ build_macos_arm64_task:
   name: Build macOS arm64 wheels.
 
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode
+    image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
 
   env:
     CIRRUS_CLONE_SUBMODULES: true
     CIBW_SKIP: pp* cp38-* # cp38-* has problem with x86_64 / arm64 confusion
-    CIBW_BUILD: cp39-* cp310-* cp311-*
+    CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
     CIBW_ARCH: arm64
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9
@@ -64,19 +64,19 @@ test_macos_arm64_task:
   name: Test macOS arm64.
 
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode
+    image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
 
   env:
     CIRRUS_CLONE_SUBMODULES: true
     PATH: /opt/homebrew/bin:$PATH
     PYTHON: python3.9
     OPENSSL_OPTS: >
-      openssl-lib=/opt/homebrew/opt/openssl@1.1/lib
-      openssl-include=/opt/homebrew/opt/openssl@1.1/include
+      openssl-lib=/opt/homebrew/opt/openssl@3.0/lib
+      openssl-include=/opt/homebrew/opt/openssl@3.0/include
 
   install_pre_requirements_script:
     - brew install python@3.9
-    - brew install boost-build boost openssl@1.1
+    - brew install boost-build boost openssl@3.0
     - echo "using darwin ;" >>~/user-config.jam
 
   debug_script:


### PR DESCRIPTION
* Bumped FreeBSD image to `14-0` (`12.x` - EOL)
* Bumped pypa/cibuildwheel: `v2.12.0` -> `v2.16.3` (python 3.12 support)
* Added python `3.12` build
* Use latest macOS/Xcode instance (Sonoma)
* Bumped OpenSSL to `3.0 LTS` as `1.1.1` is EOL