### PR TITLE
Updated numerous action revisions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
       delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
   install_cibuildwheel_script:
-    - $PYTHON -m pip install cibuildwheel==2.16.3
+    - $PYTHON -m pip install cibuildwheel==2.16.5
 
   run_cibuildwheel_script:
     - cibuildwheel

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,7 +22,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -6,7 +6,7 @@ name: cibuildwheel
 # sample.
 
 # The full list of cibuildwheel's build targets can be found here:
-# https://github.com/pypa/cibuildwheel/blob/v2.2.0a1/cibuildwheel/resources/build-platforms.toml
+# https://github.com/pypa/cibuildwheel/blob/v2.16.5/cibuildwheel/resources/build-platforms.toml
 
 # Notes on build targets we (don't) support:
 # - pypy: libtorrent doesn't build with pypy as of writing
@@ -91,20 +91,20 @@ jobs:
       CIBW_TEST_SKIP: "*-win32"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache-wheel
       with:
         path: wheelhouse
         key: wheel-${{ matrix.CIBW_BUILD }}-${{ matrix.CIBW_ARCHS }}-${{ github.sha }}
 
-    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-qemu-action@v3
       if: steps.cache-wheel.outputs.cache-hit != 'true' && runner.os == 'Linux'
 
-    - uses: pypa/cibuildwheel@v2.12.3
+    - uses: pypa/cibuildwheel@v2.16.5
       if: steps.cache-wheel.outputs.cache-hit != 'true'
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -43,7 +43,7 @@ jobs:
   '
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -57,6 +57,6 @@ jobs:
   '
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: update package lists
         continue-on-error: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,13 +15,13 @@ jobs:
       # TODO: matrix across python version and os
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
            submodules: recursive
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
            python-version: 3.8
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
    build:
       name: build
@@ -34,7 +34,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -87,7 +87,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -126,7 +126,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -159,7 +159,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -205,7 +205,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -248,7 +248,7 @@ jobs:
           b2 ${{ matrix.config }} -l500 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests
 
       - name: run tests (flaky)
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4
@@ -263,7 +263,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -305,7 +305,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -331,9 +331,9 @@ jobs:
       - name: build tarball
         run: AAFIGURE=~/.local/bin/aafigure RST2HTML=rst2html make dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: tarball
+          name: tarball-${{ matrix.os }}
           path: libtorrent-rasterbar-*.tar.gz
 
       - name: test-tarball (b2 install)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -41,7 +41,7 @@ jobs:
         run: (cd test; b2 ${{ matrix.config }} -l400 warnings-as-errors=on debug-iterators=on invariant-checks=full asserts=on deterministic-tests)
 
       - name: run tests (flaky)
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           retry_wait_seconds: 1
@@ -55,7 +55,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -87,7 +87,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -114,7 +114,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest, windows-latest ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -66,7 +66,7 @@ jobs:
 
     - name: install openssl (windows)
       if: runner.os == 'Windows'
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         shell: cmd
         timeout_minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,12 +29,12 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
       - name: install openssl (64 bit)
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4
@@ -82,7 +82,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -116,7 +116,7 @@ jobs:
           b2 --hash release address-model=64 link=static debug-iterators=off invariant-checks=on define=BOOST_ASIO_DISABLE_IOCP asserts=on testing.execute=off
 
       - name: run sims
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           max_attempts: 3
           timeout_minutes: 120
@@ -138,7 +138,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
@@ -149,7 +149,7 @@ jobs:
           bootstrap.bat
 
       - name: install openssl (64 bit)
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4
@@ -195,12 +195,12 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: true
 
       - name: install openssl (64 bit)
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           retry_wait_seconds: 4


### PR DESCRIPTION
Addresses some but not all github action warnings below. (Others require upstream changes)

Node.js 16 actions are deprecated.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

CodeQL Action v2 will be deprecated on December 5th, 2024.
https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/