### PR TITLE
add test coverage for read_resume_data()

### DIFF
--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -135,11 +135,6 @@ namespace {
 				{
 					ec = err;
 				}
-				else if (((ret.info_hashes.has_v1() && ret.info_hashes.v1 != ret.ti->info_hashes().v1)
-					|| (ret.info_hashes.has_v2() && ret.info_hashes.v2 != ret.ti->info_hashes().v2)))
-				{
-					ec = errors::mismatching_info_hash;
-				}
 				else
 				{
 					// time_t might be 32 bit if we're unlucky, but there isn't
@@ -149,6 +144,10 @@ namespace {
 					ret.ti->internal_set_creator(rd.dict_find_string_value("created by", ""));
 					ret.ti->internal_set_comment(rd.dict_find_string_value("comment", ""));
 				}
+			}
+			else
+			{
+				ec = errors::mismatching_info_hash;
 			}
 		}
 


### PR DESCRIPTION
 when v1 or v2 hashes do not match the torrent metadata