### PR TITLE
Clean up MSVC compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,14 +612,14 @@ if (WIN32)
 		)
 		target_compile_options(torrent-rasterbar
 			PRIVATE
+				# allow larger .obj files (with more sections)
+				/bigobj
 				# https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170
 				/permissive-
 				# https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
 				/utf-8
 				# https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
 				/Zc:__cplusplus
-				/MP # for multi-core compilation
-				/bigobj # increase the number of sections for obj files
 		)
 		set_target_properties(torrent-rasterbar PROPERTIES LINK_FLAGS_RELEASE "/OPT:ICF=5 /OPT:REF")
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,8 @@ if (WIN32)
 		)
 		target_compile_options(torrent-rasterbar
 			PRIVATE
+				# https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170
+				/permissive-
 				# https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
 				/utf-8
 				# https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/

--- a/Jamfile
+++ b/Jamfile
@@ -275,6 +275,8 @@ rule building ( properties * )
 	{
 		# allow larger .obj files (with more sections)
 		result += <cxxflags>/bigobj ;
+		# https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170
+		result += <cxxflags>/permissive- ;
 		# https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
 		result += <cxxflags>/utf-8 ;
 	}


### PR DESCRIPTION
* Specify standards conformance mode to MSVC
  https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170
* Remove unsuitable compiler flag
  Control of multi-core compilation should be set at the build tool (e.g. MSBuild, ninja, make) and not as a compiler flag.
  Also cmake already append it automatically:
  https://github.com/Kitware/CMake/blob/e75afeae5cc1b41e1fb97e1924e6dbcd1e39d91a/CompileFlags.cmake#L118-L134

This patch is for RC_1_2 and it should also be applied to RC_2_0 and master branch.