### PR TITLE
torrent_status::num_pieces counts pieces passed hash check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2.0.11 not released
 
+	* torrent_status::num_pieces counts pieces passed hash check, as documented
+
 2.0.10 released
 
 	* allow on_unknown_torrent method in the absence of active torrents (new plugin feature added)

--- a/include/libtorrent/torrent_status.hpp
+++ b/include/libtorrent/torrent_status.hpp
@@ -357,6 +357,8 @@ TORRENT_VERSION_NAMESPACE_3
 		// ``std::accumulate(pieces->begin(), pieces->end())``. So you don't have
 		// to count yourself. This can be used to see if anything has updated
 		// since last time if you want to keep a graph of the pieces up to date.
+		// Note that these pieces have not necessarily been written to disk yet,
+		// and there is a risk the write to disk will fail.
 		int num_pieces = 0;
 
 		// the number of distributed copies of the torrent. Note that one copy

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -12008,7 +12008,24 @@ namespace {
 				st->pieces.resize(num_pieces, false);
 			}
 		}
-		st->num_pieces = num_have();
+		st->num_pieces = num_passed();
+#if TORRENT_USE_INVARIANT_CHECKS
+		{
+			// The documentation states that `num_pieces` is the count of number
+			// of bits set in `pieces`. Ensure that invariant holds.
+			int num_have_pieces = 0;
+			if (has_picker())
+			{
+				for (auto const i : m_torrent_file->piece_range())
+					if (m_picker->has_piece_passed(i)) ++num_have_pieces;
+			}
+			else if (m_have_all)
+			{
+				num_have_pieces = m_torrent_file->num_pieces();
+			}
+			TORRENT_ASSERT(num_have_pieces == st->num_pieces);
+		}
+#endif
 		st->num_seeds = num_seeds();
 		if ((flags & torrent_handle::query_distributed_copies) && m_picker.get())
 		{


### PR DESCRIPTION
To align with the documentation