### PR TITLE
try encode web seed redirect location

### DIFF
--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -666,6 +666,7 @@ void web_peer_connection::handle_redirect(int const bytes_left)
 		file_index_t const file_index = m_file_requests.front().file_index;
 
 		location = aux::resolve_redirect_location(m_url, location);
+		location = maybe_url_encode(location);
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, "LOCATION", "%s", location.c_str());
 #endif
@@ -735,6 +736,7 @@ void web_peer_connection::handle_redirect(int const bytes_left)
 	else
 	{
 		location = aux::resolve_redirect_location(m_url, location);
+		location = maybe_url_encode(location);
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, "LOCATION", "%s", location.c_str());
 #endif

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -666,6 +666,8 @@ void web_peer_connection::handle_redirect(int const bytes_left)
 		file_index_t const file_index = m_file_requests.front().file_index;
 
 		location = aux::resolve_redirect_location(m_url, location);
+
+		// work-around for buggy HTTP servers, that fail to encode the redirect URL
 		location = maybe_url_encode(location);
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, "LOCATION", "%s", location.c_str());
@@ -736,6 +738,8 @@ void web_peer_connection::handle_redirect(int const bytes_left)
 	else
 	{
 		location = aux::resolve_redirect_location(m_url, location);
+
+		// work-around for buggy HTTP servers, that fail to encode the redirect URL
 		location = maybe_url_encode(location);
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, "LOCATION", "%s", location.c_str());


### PR DESCRIPTION
web server may redirect with non encoded paths (like "Location: http://newserver.net/with space/file.bin" instead of  "Location: http://newserver.net/with%20space/file.bin")
let's try encode such values as curl or wget