### PR TITLE
Send read_piece_alert after piece passes

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4412,10 +4412,6 @@ namespace {
 
 		inc_stats_counter(counters::num_piece_passed);
 
-#ifndef TORRENT_DISABLE_STREAMING
-		remove_time_critical_piece(index, true);
-#endif
-
 		if (settings().get_int(settings_pack::suggest_mode)
 			== settings_pack::suggest_read_cache)
 		{
@@ -4463,6 +4459,10 @@ namespace {
 		m_picker->piece_passed(index);
 		update_gauge();
 		we_have(index);
+
+#ifndef TORRENT_DISABLE_STREAMING
+		remove_time_critical_piece(index, true);
+#endif
 	}
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES


### PR DESCRIPTION
Fixes #7634. Per comment https://github.com/arvidn/libtorrent/issues/7634#issuecomment-1962734438 I've found that `lt::torrent::remove_time_critical_piece` gets called before the piece is set to having passed the check by `lt::torrent::we_have`, this change places the former to after the latter in `lt::torrent::piece_passed`.
