### PR TITLE
Make anti-leech choker never increase score for dishonesty

### DIFF
--- a/src/choker.cpp
+++ b/src/choker.cpp
@@ -167,7 +167,10 @@ namespace {
 
 		std::int64_t const total_size = t->torrent_file().total_size();
 		if (total_size == 0) return 0;
-		std::int64_t const have_size = std::max(peer->statistics().total_payload_upload()
+		// Cap the given_size so that it never causes the score to increase
+		std::int64_t const given_size = std::min(peer->statistics().total_payload_upload()
+			, total_size / 2);
+		std::int64_t const have_size = std::max(given_size
 			, std::int64_t(t->torrent_file().piece_length()) * peer->num_have_pieces());
 		return int(std::abs((have_size - total_size / 2) * 2000 / total_size));
 	}


### PR DESCRIPTION
The current anti-leech choker takes the maximum of client-reported have and our own session uploaded size as the progress of the client.  This may paradoxically inflate the score of dishonest clients if we've been uploading to it for long enough, that our uploaded size exceeds 50% of the total size. (That could in turn happen if we had nobody else to upload to for a while. That in turn screws over some honest client that then appears in our peer list, until the dishonest peer disconnects.)

This commit caps "given_size" to 50% of total_size, so that we never cause an increase of the score by taking into account the "given".