### PR TITLE
fix the compilation failure caused by the failure to find std::max

### DIFF
--- a/include/libtorrent/aux_/heterogeneous_queue.hpp
+++ b/include/libtorrent/aux_/heterogeneous_queue.hpp
@@ -39,6 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib> // for malloc
 #include <type_traits>
 #include <memory>
+#include <algorithm>
 
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/throw.hpp"


### PR DESCRIPTION
When I was using libtorrent 2.0.10 on Windows, I encountered a compilation error.

Here is my compilation environment:

Visual Studio 2019 16.4.12
CMake 3.28.0
Boost 1.82.0 (installed by vcpkg)
And so on.

The compilation error reported that it could not find std::max in libtorrent\include\libtorrent\aux_\heterogeneous_queue.h.

I believe this issue can be fixed with the patch I have discovered.