### PR TITLE
Add option to install python .dist-info.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -702,6 +702,7 @@ feature_option(build_examples "build examples" OFF)
 feature_option(build_tools "build tools" OFF)
 feature_option(python-bindings "build python bindings" OFF)
 feature_option(python-egg-info "generate python egg info" OFF)
+feature_option(python-dist-info "generate python dist info" OFF)
 feature_option(python-install-system-dir "Install python bindings to the system installation directory rather than the CMake installation prefix" OFF)
 
 # these options require existing target

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -126,3 +126,22 @@ if (python-egg-info)
 
 	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent.egg-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
 endif()
+
+if (python-dist-info)
+	set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")
+	set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
+	set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
+	set(DEPS        python-libtorrent "${SETUP_PY}")
+
+	configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
+
+	add_custom_command(OUTPUT ${OUTPUT}
+		COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${Python3_EXECUTABLE} ${SETUP_PY} dist_info
+		COMMAND echo 'libtorrent' > "${CMAKE_CURRENT_BINARY_DIR}/libtorrent-${CMAKE_PROJECT_VERSION}.dist-info/top_level.txt"
+		COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
+		DEPENDS ${DEPS}
+	)
+
+	add_custom_target(python_bindings ALL DEPENDS ${OUTPUT})
+	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libtorrent-${CMAKE_PROJECT_VERSION}.dist-info" DESTINATION "${_PYTHON3_SITE_ARCH}")
+endif()


### PR DESCRIPTION
This is just to make the bindings more pip-friendly when building from source.