### PR TITLE
assume copy_file_range() exists on linux (unless old glibc)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 
 2.0.11 not released
 
+	* assume copy_file_range() exists on linux (unless old glibc)
 	* fix issue where set_piece_deadline() did not correctly post read_piece_alert
 	* fix integer overflow in piece picker
 	* torrent_status::num_pieces counts pieces passed hash check, as documented

--- a/include/libtorrent/config.hpp
+++ b/include/libtorrent/config.hpp
@@ -186,7 +186,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #define TORRENT_HAVE_MMAP 1
 #endif
 
-#if defined __GLIBC__ && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 27))
+#if defined __GLIBC__ && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 27))
+#define TORRENT_HAS_COPY_FILE_RANGE 0
+#elif defined __ANDROID__
+#define TORRENT_HAS_COPY_FILE_RANGE 0
+#else
 #define TORRENT_HAS_COPY_FILE_RANGE 1
 #endif
 


### PR DESCRIPTION
related to https://github.com/arvidn/libtorrent/issues/7669