### PR TITLE
rely on the openssl version already installed on the runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,14 +33,6 @@ jobs:
         with:
            submodules: true
 
-      - name: install openssl (64 bit)
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: 4
-          max_attempts: 3
-          command: choco install openssl --limitoutput --no-progress
-
       - name: install boost
         run: |
           git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.78.0 https://github.com/boostorg/boost.git
@@ -148,14 +140,6 @@ jobs:
           cd boost
           bootstrap.bat
 
-      - name: install openssl (64 bit)
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: 4
-          max_attempts: 3
-          command: choco install openssl --limitoutput --no-progress
-
       - name: boost headers
         run: |
           cd boost
@@ -198,14 +182,6 @@ jobs:
         uses: actions/checkout@v4
         with:
            submodules: true
-
-      - name: install openssl (64 bit)
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: 4
-          max_attempts: 3
-          command: choco install openssl --limitoutput --no-progress
 
       - name: install boost
         run: |


### PR DESCRIPTION
rather than installing openssl on windows