### PR TITLE
Various CI fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -352,5 +352,5 @@ jobs:
 
       - name: test-tarball (python bindings)
         run: |
-          cd libtorrent-rasterbar-*/
-          python3 bindings/python/setup.py build
+          cd libtorrent-rasterbar-*/bindings/python/
+          python3 setup.py build

--- a/Makefile
+++ b/Makefile
@@ -198,40 +198,42 @@ EXTRA_DIST = \
   $(DOCS_IMAGES)
 
 PYTHON_FILES= \
-  CMakeLists.txt            \
-  Jamfile                   \
-  client.py                 \
-  make_torrent.py           \
-  setup.py                  \
-  setup.py.cmake.in         \
-  simple_client.py          \
-  src/alert.cpp             \
-  src/boost_python.hpp      \
-  src/bytes.hpp             \
-  src/converters.cpp        \
-  src/create_torrent.cpp    \
-  src/file_storage.cpp      \
-  src/datetime.cpp          \
-  src/entry.cpp             \
-  src/error_code.cpp        \
-  src/fingerprint.cpp       \
-  src/gil.hpp               \
-  src/ip_filter.cpp         \
-  src/load_torrent.cpp      \
-  src/magnet_uri.cpp        \
-  src/module.cpp            \
-  src/optional.hpp          \
-  src/peer_info.cpp         \
-  src/session.cpp           \
-  src/session_settings.cpp  \
-  src/sha1_hash.cpp         \
-  src/sha256_hash.cpp       \
-  src/info_hash.cpp         \
-  src/string.cpp            \
-  src/torrent_handle.cpp    \
-  src/torrent_info.cpp      \
-  src/torrent_status.cpp    \
-  src/utility.cpp           \
+  CMakeLists.txt                        \
+  Jamfile                               \
+  client.py                             \
+  make_torrent.py                       \
+  setup.py                              \
+  setup.py.cmake.in                     \
+  simple_client.py                      \
+  install_data/libtorrent/__init__.pyi  \
+  install_data/libtorrent/py.typed      \
+  src/alert.cpp                         \
+  src/boost_python.hpp                  \
+  src/bytes.hpp                         \
+  src/converters.cpp                    \
+  src/create_torrent.cpp                \
+  src/file_storage.cpp                  \
+  src/datetime.cpp                      \
+  src/entry.cpp                         \
+  src/error_code.cpp                    \
+  src/fingerprint.cpp                   \
+  src/gil.hpp                           \
+  src/ip_filter.cpp                     \
+  src/load_torrent.cpp                  \
+  src/magnet_uri.cpp                    \
+  src/module.cpp                        \
+  src/optional.hpp                      \
+  src/peer_info.cpp                     \
+  src/session.cpp                       \
+  src/session_settings.cpp              \
+  src/sha1_hash.cpp                     \
+  src/sha256_hash.cpp                   \
+  src/info_hash.cpp                     \
+  src/string.cpp                        \
+  src/torrent_handle.cpp                \
+  src/torrent_info.cpp                  \
+  src/torrent_status.cpp                \
+  src/utility.cpp                       \
   src/version.cpp
 
 EXAMPLE_FILES= \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,6 +100,7 @@ build_script:
 
 test_script:
   - cd %ROOT_DIRECTORY%\test
+  - set PATH=%PATH%;c:\OpenSSL-v111-Win64\bin
   - if defined tests (
     appveyor-retry b2.exe -l500 --hash openssl-lib=%ssl_lib% openssl-include=%ssl_include% warnings=all warnings-as-errors=on %compiler% address-model=%model% picker-debugging=on invariant-checks=full variant=%variant% link=shared crypto=%crypto% webtorrent=%webtorrent% asserts=on export-extra=on windows-api=%api% windows-version=win10 deterministic-tests
     )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - if not defined ssl_include ( set ssl_include=c:\ )
   - if not defined ssl_root_dir ( set ssl_root_dir=c:\ )
   - cd %ROOT_DIRECTORY%
-  - set BOOST_ROOT=c:\Libraries\boost_1_77_0
+  - set BOOST_ROOT=c:\Libraries\boost_1_83_0
   - set BOOST_BUILD_PATH=%BOOST_ROOT%\tools\build
   - echo %BOOST_ROOT%
   - echo %BOOST_BUILD_PATH%

--- a/bindings/python/mypy-tox.ini
+++ b/bindings/python/mypy-tox.ini
@@ -1,5 +1,6 @@
 [mypy]
 ignore_missing_imports = True
+mypy_path = install_data
 
 [mypy-libtorrent]
 ignore_missing_imports = False

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -502,6 +503,15 @@ def find_all_files(path: str) -> Iterator[str]:
             yield os.path.join(dirpath, filename)
 
 
+# Our stubs end up in the "libtorrent" directory in the wheel.
+# Setuptools expects it to exist beforehand.
+if not os.path.exists("libtorrent"):
+    os.mkdir("libtorrent")
+try:
+    shutil.copytree("install_data/libtorrent", "libtorrent")
+except FileExistsError:
+    pass
+
 setuptools.setup(
     name="libtorrent",
     author="Arvid Norberg",
@@ -515,7 +525,6 @@ setuptools.setup(
         "build_ext": LibtorrentBuildExt,
     },
     distclass=B2Distribution,
-    data_files=[
-        ("libtorrent", list(find_all_files("install_data"))),
-    ],
+    packages=["libtorrent"],
+    package_data={"libtorrent": list(find_all_files("install_data"))},
 )

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -659,7 +659,7 @@ void wait_for_port(int const port)
 		}
 		s.connect(tcp::endpoint(make_address("127.0.0.1")
 			, std::uint16_t(port)), ec);
-		if (ec == boost::system::errc::connection_refused)
+		if (ec)
 		{
 			if (i == 100)
 			{


### PR DESCRIPTION
This PR targets `master` because that is where the issue of missing wheel types occurs (the original target of this PR).

There are a few layers of issues that have surfaced. This PR addresses the following:

- [x] `continuous-integration/appveyor/pr` cannot find boost (`c:\Libraries\boost_1_77_0` does not exist, only `boost_1_83_0`, `boost_1_84_0`, `boost_1_85_0` exist on the image). **Resolution**: switched to ~~`boost_1_85_0`~~ `boost_1_83_0` (see below).
- [x] `Cirrus CI / Build macOS arm64 wheels` cannot find types. **Resolution**: fixed in `mypy-tox.ini`.
- [x] types are not in the appropriate location in the built wheel. **Resolution**: fixed in `bindings/python/setup.py`.
- [x] `Test macOS arm64` "flaky test" `test_privacy` fails with `Cputime limit exceeded: 24`. Does not work with `boost_1_85_0`, `boost_1_84_0`. **Mitigation 1**: downgraded to `boost_1_83_0`. **Mitigation 2**: allow errors other than `connection_refused` when waiting for Python to start during testing. *Even so, this test is still unstable.* 
- [x]  `continuous-integration/appveyor/pr` fails with `EXIT STATUS: -1073741515` for `variant=release`.  **Resolution**: included the OpenSSL bin directory in the path.
- [x] `Tests (webtorrent=on deprecated-functions=off)` failing with `set but not used` errors. **Resolution: wont fix**. Bumping the version of `libdatachannel` to `0.19.0` should fix this error but it seems to cause other issues.
- [x] `build dist (ubuntu-22.04)` failing due to missing `install_data/libtorrent` in tarball. **Resolution**: added the typing files to the Makefile.