### PR TITLE
Update libdatachannel to v0.21.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -839,8 +839,7 @@ if (webtorrent)
 		target_compile_options(datachannel-static PRIVATE
 			-Wno-pedantic
 			-Wno-unused-parameter
-			-Wno-unused-variable
-			-Wno-format-nonliteral)
+			-Wno-unused-variable)
 	endif()
 endif()
 


### PR DESCRIPTION
This PR updates the libdatachannel submodule to v0.21.2. Main changes are related to media transport and MbedTLS support (which are not used here), but there are also a bunch of enhancements and fixes related to data channels.

Fixes https://github.com/arvidn/libtorrent/issues/7692