### PR TITLE
announce port=1025 instead of port=1, when there is no listen port

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 	* fix issue where set_piece_deadline() did not correctly post read_piece_alert
 	* fix integer overflow in piece picker
 	* torrent_status::num_pieces counts pieces passed hash check, as documented
+	* announce port=1025 instead of port=1, when there is no listen port
 
 2.0.10 released
 

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -382,7 +382,7 @@ void test_ipv6_support(char const* listen_interfaces
 
 	// if we're not listening we'll just report port 0
 	std::string const expect_port = (listen_interfaces && listen_interfaces == ""_sv)
-		? "&port=1" : "&port=6881";
+		? "&port=1025" : "&port=6881";
 
 	http_v4.register_handler("/announce"
 	, [&v4_announces,expect_port](std::string method, std::string req

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1280,7 +1280,7 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 namespace {
 
 	std::uint16_t make_announce_port(std::uint16_t const p)
-	{ return p == 0 ? 1 : p; }
+	{ return p == 0 ? 1025 : p; }
 }
 
 	void session_impl::queue_tracker_request(tracker_request req


### PR DESCRIPTION
slight update from https://github.com/arvidn/libtorrent/pull/4400

this was causing issues with certain trackers which block advertised listen ports less than 1024 - https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/3329

this was causing bugs with using libtorrent based clients (such as qbittorrent) when using socks proxy, as seen in following issues
https://github.com/HDInnovations/UNIT3D-Community-Edition/issues/3428
https://github.com/HDInnovations/UNIT3D-Community-Edition/issues/3847

please let me know if there are any other follow on effects from this that might require changes