### PR TITLE
check settings_pack::max_out_request_queue before alert outstanding_r…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 	* fix issue where set_piece_deadline() did not correctly post read_piece_alert
 	* fix integer overflow in piece picker
 	* torrent_status::num_pieces counts pieces passed hash check, as documented
+	* check settings_pack::max_out_request_queue before performance alert
 
 2.0.10 released
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5103,8 +5103,7 @@ namespace libtorrent {
 
 		update_desired_queue_size();
 
-		if (m_desired_queue_size == m_max_out_request_queue
-			&& m_desired_queue_size >= m_settings.get_int(settings_pack::max_out_request_queue)
+		if (m_desired_queue_size >= m_settings.get_int(settings_pack::max_out_request_queue)
 			&& t->alerts().should_post<performance_alert>())
 		{
 			t->alerts().emplace_alert<performance_alert>(t->get_handle()

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5104,6 +5104,7 @@ namespace libtorrent {
 		update_desired_queue_size();
 
 		if (m_desired_queue_size == m_max_out_request_queue
+			&& m_desired_queue_size >= m_settings.get_int(settings_pack::max_out_request_queue)
 			&& t->alerts().should_post<performance_alert>())
 		{
 			t->alerts().emplace_alert<performance_alert>(t->get_handle()


### PR DESCRIPTION
…equest_limit_reached

This should fix performance warning: max outstanding piece requests reached, outstanding_request_limit_reached