### PR TITLE
fix pre-allocation when changing priority

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 
 2.0.11 not released
 
+	* fix file pre-allocation when changing file priority (HanabishiRecca)
 	* fix uTP issue where closing the connection could corrupt the payload
 	* apply DSCP/TOS to sockets before initiating the TCP connection
 	* assume copy_file_range() exists on linux (unless old glibc)

--- a/include/libtorrent/aux_/posix_storage.hpp
+++ b/include/libtorrent/aux_/posix_storage.hpp
@@ -68,7 +68,8 @@ namespace aux {
 			, storage_error& error);
 
 		bool has_any_file(storage_error& error);
-		void set_file_priority(aux::vector<download_priority_t, file_index_t>& prio
+		void set_file_priority(settings_interface const&
+			, aux::vector<download_priority_t, file_index_t>& prio
 			, storage_error& ec);
 		bool verify_resume_data(add_torrent_params const& rd
 			, aux::vector<std::string, file_index_t> const& links

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -63,6 +63,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/drive_info.hpp"
 #include "libtorrent/stat_cache.hpp"
 #include "libtorrent/hex.hpp" // to_hex
+#include "libtorrent/aux_/scope_end.hpp"
 
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 
@@ -161,15 +162,22 @@ error_code translate_error(std::error_code const& err, bool const write)
 
 			download_priority_t const old_prio = m_file_priority[i];
 			download_priority_t new_prio = prio[i];
+
+			m_file_priority[i] = new_prio;
+
+			// in case there's an error, we make sure m_file_priority is only
+			// updated for the successful files. By leaving failed files as
+			// priority 0, we allow re-trying them.
+			auto restore_prio = aux::scope_end([&] {
+				m_file_priority[i] = old_prio;
+				prio = m_file_priority;
+			});
+
 			if (old_prio == dont_download && new_prio != dont_download)
 			{
 				// move stuff out of the part file
 				std::shared_ptr<aux::file_mapping> f = open_file(sett, i, aux::open_mode::write, ec);
-				if (ec)
-				{
-					prio = m_file_priority;
-					return;
-				}
+				if (ec) return;
 
 				if (m_part_file && use_partfile(i))
 				{
@@ -196,7 +204,6 @@ error_code translate_error(std::error_code const& err, bool const write)
 						{
 							ec.file(i);
 							ec.operation = operation_t::partfile_write;
-							prio = m_file_priority;
 							return;
 						}
 					}
@@ -228,7 +235,6 @@ error_code translate_error(std::error_code const& err, bool const write)
 				{
 					ec.file(i);
 					ec.operation = operation_t::file_stat;
-					prio = m_file_priority;
 					return;
 				}
 				use_partfile(i, !file_exists);
@@ -236,11 +242,7 @@ error_code translate_error(std::error_code const& err, bool const write)
 				auto f = open_file(sett, i, aux::open_mode::read_only, ec);
 				if (ec.ec != boost::system::errc::no_such_file_or_directory)
 				{
-					if (ec)
-					{
-						prio = m_file_priority;
-						return;
-					}
+					if (ec) return;
 
 					need_partfile();
 
@@ -249,7 +251,6 @@ error_code translate_error(std::error_code const& err, bool const write)
 					{
 						ec.file(i);
 						ec.operation = operation_t::partfile_read;
-						prio = m_file_priority;
 						return;
 					}
 					// remove the file
@@ -259,14 +260,13 @@ error_code translate_error(std::error_code const& err, bool const write)
 					{
 						ec.file(i);
 						ec.operation = operation_t::file_remove;
-						prio = m_file_priority;
 						return;
 					}
 				}
 */
 			}
 			ec.ec.clear();
-			m_file_priority[i] = new_prio;
+			restore_prio.disarm();
 
 			if (m_file_priority[i] == dont_download && use_partfile(i))
 			{

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -370,7 +370,6 @@ namespace libtorrent {
 				span<char> v = {buf.get(), block_to_copy};
 				auto bytes_read = aux::pread_all(file.fd(), v, slot_offset(slot) + piece_offset, ec);
 				v = v.first(static_cast<std::ptrdiff_t>(bytes_read));
-				TORRENT_ASSERT(!ec);
 				if (ec || v.empty()) return;
 
 				f(file_offset, {buf.get(), block_to_copy});

--- a/src/posix_disk_io.cpp
+++ b/src/posix_disk_io.cpp
@@ -358,7 +358,7 @@ namespace {
 		{
 			posix_storage* st = m_torrents[storage].get();
 			storage_error error;
-			st->set_file_priority(prio, error);
+			st->set_file_priority(m_settings, prio, error);
 			post(m_ios, [p = std::move(prio), h = std::move(handler), error] () mutable
 				{ h(error, std::move(p)); });
 		}

--- a/src/posix_part_file.cpp
+++ b/src/posix_part_file.cpp
@@ -406,7 +406,6 @@ namespace aux {
 				if (int(bytes_read) != block_to_copy)
 					ec.assign(errno, generic_category());
 
-				TORRENT_ASSERT(!ec);
 				if (ec) return;
 
 				f(file_offset, {buf.get(), block_to_copy});

--- a/src/posix_storage.cpp
+++ b/src/posix_storage.cpp
@@ -84,7 +84,8 @@ namespace aux {
 			, files().num_pieces(), files().piece_length());
 	}
 
-	void posix_storage::set_file_priority(aux::vector<download_priority_t, file_index_t>& prio
+	void posix_storage::set_file_priority(settings_interface const&
+		, aux::vector<download_priority_t, file_index_t>& prio
 		, storage_error& ec)
 	{
 		// extend our file priorities in case it's truncated


### PR DESCRIPTION
based on @HanabishiRecca 's research and fix. set m_file_priority early, to make open_file() work as expected. If there's a failure, restore it.

https://github.com/arvidn/libtorrent/pull/7733