### PR TITLE
GHA CI: Migrate to OpenSSL 3.x

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: install boost
         run: |
-          brew install boost-build boost openssl@1.1
+          brew install boost-build boost openssl@3
           echo "using darwin ;" >>~/user-config.jam
 
       - name: build and run tests
@@ -75,7 +75,7 @@ jobs:
 
       - name: install boost
         run: |
-          brew install boost-build boost openssl@1.1
+          brew install boost-build boost openssl@3
           echo "using darwin ;" >>~/user-config.jam
 
       - name: build and run simulations
@@ -109,7 +109,7 @@ jobs:
 
       - name: install boost
         run: |
-          brew install boost-build boost openssl@1.1
+          brew install boost-build boost openssl@3
           echo "using darwin ;" >>~/user-config.jam
 
       - name: build library

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
     - name: dependencies (MacOS)
       if: runner.os == 'macOS'
       run: |
-        brew install boost-build boost boost-python3 python@3.12 openssl@1.1 python-setuptools
+        brew install boost-build boost boost-python3 python@3.12 openssl@3 python-setuptools
         export PATH=$(brew --prefix)/opt/python@3.12/bin:$PATH
 
     - name: update package lists (linux)

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -76,7 +76,7 @@ Linux::
 
 Mac OS::
 
-	brew install boost-build boost openssl@1.1
+	brew install boost-build boost openssl@3
 	echo "using darwin ;" >>~/user-config.jam
 	b2 crypto=openssl cxxstd=14 release
 


### PR DESCRIPTION
Migrated macOS/python workflows to OpenSSL 3.x
* [OpenSSL 1.1.1 End Of Life](https://openssl-library.org/post/2023-09-11-eol-111/)

* DOCS: Changed macOS building instructions for OpenSSL to use v3.