### PR TITLE
allow connections while checking resume data if no_verify_files flag is set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 
 2.0.11 not released
 
+	* allow boost connect while checking resume data if no_verify_files flag is set
 	* fix BEP-40 peer priority for IPv6
 	* limit piece size in torrent creator
 	* fix file pre-allocation when changing file priority (HanabishiRecca)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -20,6 +20,7 @@ Copyright (c) 2020, Paul-Louis Ageneau
 Copyright (c) 2021, AdvenT
 Copyright (c) 2021, Joris CARRIER
 Copyright (c) 2021, thrnz
+Copyright (c) 2024, Elyas EL IDRISSI
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -8160,8 +8161,11 @@ namespace {
 		// if we're paused, obviously we're not connecting to peers
 		if (is_paused() || m_abort || m_graceful_pause_mode) return false;
 
+		// if metadata are valid and we are either checking files or checking resume data without no_verify_files flag,
+		// we don't want peers
 		if ((m_state == torrent_status::checking_files
-			|| m_state == torrent_status::checking_resume_data)
+			|| (m_state == torrent_status::checking_resume_data
+				&& !(m_add_torrent_params && m_add_torrent_params->flags & torrent_flags::no_verify_files)))
 			&& valid_metadata())
 			return false;
 


### PR DESCRIPTION
When adding a torrent with peers, if metadata is already available and the torrent is in `checking_resume_data` state, `torrent::want_peers()` currently returns `false`. This behavior prevents `torrent::do_connect_boost()` from initiating connections, leading to delays.  

This modification addresses the issue by permitting peer connections in this scenario when `no_verify_files` flag is set.