### PR TITLE
don't hint `POSIX_FADV_RANDOM`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 
 2.0.11 not released
 
+	* don't hint FADV_RANDOM on posix systems. May improve seeding performance
 	* allow boost connect while checking resume data if no_verify_files flag is set
 	* fix BEP-40 peer priority for IPv6
 	* limit piece size in torrent creator

--- a/include/libtorrent/aux_/open_mode.hpp
+++ b/include/libtorrent/aux_/open_mode.hpp
@@ -48,7 +48,7 @@ namespace aux {
 		constexpr open_mode_t no_cache = 1_bit;
 		constexpr open_mode_t truncate = 2_bit;
 		constexpr open_mode_t no_atime = 3_bit;
-		constexpr open_mode_t random_access = 4_bit;
+		constexpr open_mode_t sequential_access = 4_bit;
 		constexpr open_mode_t hidden = 5_bit;
 		constexpr open_mode_t sparse = 6_bit;
 		constexpr open_mode_t executable = 7_bit;

--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -107,8 +107,8 @@ namespace file_open_mode {
 	// this generally improves disk performance.
 	constexpr file_open_mode_t no_atime = 3_bit;
 
-	// open the file for random access. This disables read-ahead
-	// logic
+	// When this is not set, the kernel is hinted that access to this file will
+	// be made sequentially.
 	constexpr file_open_mode_t random_access = 5_bit;
 
 #if TORRENT_ABI_VERSION == 1

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -315,7 +315,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 	DWORD file_flags(open_mode_t const mode)
 	{
 		return ((mode & open_mode::no_cache) ? FILE_FLAG_WRITE_THROUGH : 0)
-			| ((mode & open_mode::random_access) ? 0 : FILE_FLAG_SEQUENTIAL_SCAN)
+			| ((mode & open_mode::sequential_access) ? FILE_FLAG_SEQUENTIAL_SCAN : 0)
 			;
 	}
 
@@ -349,7 +349,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 		// http://support.microsoft.com/kb/2549369
 		return ((mode & open_mode::hidden) ? FILE_ATTRIBUTE_HIDDEN : FILE_ATTRIBUTE_NORMAL)
 			| ((mode & open_mode::no_cache) ? FILE_FLAG_WRITE_THROUGH : 0)
-			| ((mode & open_mode::random_access) ? 0 : FILE_FLAG_SEQUENTIAL_SCAN)
+			| ((mode & open_mode::sequential_access) ? FILE_FLAG_SEQUENTIAL_SCAN : 0)
 			;
 	}
 
@@ -563,11 +563,11 @@ file_handle::file_handle(string_view name, std::int64_t const size
 	}
 #endif
 
-#if (TORRENT_HAS_FADVISE && defined POSIX_FADV_RANDOM)
-	if (mode & aux::open_mode::random_access)
+#if (TORRENT_HAS_FADVISE && defined POSIX_FADV_SEQUENTIAL)
+	if (mode & aux::open_mode::sequential_access)
 	{
 		// disable read-ahead
-		::posix_fadvise(m_fd, 0, 0, POSIX_FADV_RANDOM);
+		::posix_fadvise(m_fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 	}
 #endif
 }

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -187,7 +187,7 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode, std::int64_
 #if TORRENT_USE_MADVISE
 	if (file_size > 0)
 	{
-		int const advise = ((mode & open_mode::random_access) ? 0 : MADV_SEQUENTIAL)
+		int const advise = ((mode & open_mode::sequential_access) ? MADV_SEQUENTIAL : 0)
 #ifdef MADV_DONTDUMP
 		// on versions of linux that support it, ask for this region to not be
 		// included in coredumps (mostly to make the coredumps more manageable

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -142,7 +142,7 @@ namespace {
 	aux::open_mode_t file_mode_for_job(aux::mmap_disk_job* j)
 	{
 		aux::open_mode_t ret = aux::open_mode::read_only;
-		if (!(j->flags & disk_interface::sequential_access)) ret |= aux::open_mode::random_access;
+		if (j->flags & disk_interface::sequential_access) ret |= aux::open_mode::sequential_access;
 		return ret;
 	}
 


### PR DESCRIPTION
Normal piece sizes, of 2 or 4 MiB, probably warrants read-ahead. Some antecdotes suggests this improve read speed in some circumstances.

The use of the internal open mode flag `random_access` is really used to hint sequential access, for when checking files. This patch, therefore, renames the flag to `sequential_access` and makes it mean that instead.

This is an internal flag so doesn't affect the user facing API.