### PR TITLE
make file_pool_impl have the open_unmap_lock mutex type configurable

### DIFF
--- a/include/libtorrent/aux_/file_pool.hpp
+++ b/include/libtorrent/aux_/file_pool.hpp
@@ -19,12 +19,17 @@ namespace libtorrent::aux {
 
 	struct file_pool_entry
 	{
+#if TORRENT_HAVE_MAP_VIEW_OF_FILE
+		using mutex_type = int*;
+		using lock_type = int;
+#endif
+
 		file_pool_entry(file_id k
 			, string_view name
 			, open_mode_t const m
 			, std::int64_t const size
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-			, std::shared_ptr<std::mutex>
+			, mutex_type
 #endif
 			)
 			: key(k)

--- a/include/libtorrent/aux_/file_pool_impl.hpp
+++ b/include/libtorrent/aux_/file_pool_impl.hpp
@@ -73,7 +73,7 @@ namespace libtorrent::aux {
 		FileHandle open_file(storage_index_t st, std::string const& p
 			, file_index_t file_index, file_storage const& fs, open_mode_t m
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-			, std::shared_ptr<std::mutex> open_unmap_lock
+			, typename FileEntry::mutex_type open_unmap_lock
 #endif
 			);
 
@@ -151,7 +151,7 @@ namespace libtorrent::aux {
 			, file_index_t file_index, file_storage const& fs
 			, open_mode_t m, file_id file_key
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-			, std::shared_ptr<std::mutex> open_unmap_lock
+			, typename FileEntry::mutex_type open_unmap_lock
 #endif
 			);
 

--- a/include/libtorrent/aux_/file_view_pool.hpp
+++ b/include/libtorrent/aux_/file_view_pool.hpp
@@ -23,12 +23,15 @@ namespace libtorrent::aux {
 
 	struct file_view_entry
 	{
+		using mutex_type = std::shared_ptr<std::mutex>;
+		using lock_type = std::unique_lock<std::mutex>;
+
 		file_view_entry(file_id k
 			, string_view name
 			, open_mode_t const m
 			, std::int64_t const size
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-			, std::shared_ptr<std::mutex> open_unmap_lock
+			, mutex_type open_unmap_lock
 #endif
 			)
 			: key(k)

--- a/src/file_pool_impl.cpp
+++ b/src/file_pool_impl.cpp
@@ -40,7 +40,7 @@ namespace libtorrent::aux {
 		, file_index_t const file_index, file_storage const& fs
 		, open_mode_t const m
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-		, std::shared_ptr<std::mutex> open_unmap_lock
+		, typename FileEntry::mutex_type open_unmap_lock
 #endif
 		)
 	{
@@ -232,13 +232,14 @@ namespace libtorrent::aux {
 		, file_index_t const file_index, file_storage const& fs
 		, open_mode_t const m, file_id const file_key
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-		, std::shared_ptr<std::mutex> open_unmap_lock
+		, typename FileEntry::mutex_type open_unmap_lock
 #endif
 		)
 	{
 		std::string const file_path = fs.file_path(file_index, p);
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
-		std::unique_lock<std::mutex> lou(*open_unmap_lock);
+		typename FileEntry::lock_type lou(*open_unmap_lock);
+		TORRENT_UNUSED(lou);
 #endif
 		try
 		{


### PR DESCRIPTION
by its template parameter. This prepares for instantiations that don't need a mutex.