### PR TITLE
Add announce_port support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@
 	* fix integer overflow in piece picker
 	* torrent_status::num_pieces counts pieces passed hash check, as documented
 	* check settings_pack::max_out_request_queue before performance alert
+	* add announce_port setting to override the port announced to trackers
 
 2.0.10 released
 

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -507,6 +507,7 @@ namespace libtorrent {
 		// specified info-hash, advertising the specified port. If the port is
 		// left at its default, 0, the port will be implied by the DHT message's
 		// source port (which may improve connectivity through a NAT).
+		// ``dht_announce()`` is not affected by the ``announce_port`` override setting.
 		//
 		// Both these functions are exposed for advanced custom use of the DHT.
 		// All torrents eligible to be announce to the DHT will be automatically,

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -2068,6 +2068,20 @@ namespace aux {
 			i2p_inbound_length,
 			i2p_outbound_length,
 
+			// ``announce_port`` is the port passed along as the ``port`` parameter
+			// to remote trackers such as HTTP or DHT. This setting does not affect
+			// the effective listening port nor local service discovery announcements.
+			// If left as zero (default), the listening port value is used.
+			//
+			// .. note::
+			//    This setting is only meant for very special cases where a
+			//    seed's listening port differs from the external port. As an
+			//    example, if a local proxy is used and that the proxy supports
+			//    reverse tunnels through NAT-PMP, the tracker must connect to
+			//    the external NAT-PMP port (configured using ``announce_port``)
+			//    instead of the actual local listening port.
+			announce_port,
+
 			max_int_setting_internal
 		};
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1301,9 +1301,11 @@ namespace {
 #endif
 			req.ssl_ctx = &m_ssl_ctx;
 #endif
-
-		auto ls = req.outgoing_socket.get();
-		if (ls)
+		if (const auto announce_port = std::uint16_t(m_settings.get_int(settings_pack::announce_port)))
+		{
+			req.listen_port = announce_port;
+		}
+		else if (auto ls = req.outgoing_socket.get())
 		{
 			req.listen_port =
 #ifdef TORRENT_SSL_PEERS

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -401,7 +401,8 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(i2p_inbound_quantity, 3, nullptr),
 		SET(i2p_outbound_quantity, 3, nullptr),
 		SET(i2p_inbound_length, 3, nullptr),
-		SET(i2p_outbound_length, 3, nullptr)
+		SET(i2p_outbound_length, 3, nullptr),
+		SET(announce_port, 0, nullptr)
 	}});
 
 #undef SET

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2795,15 +2795,17 @@ bool is_downloading_state(int const st)
 		// If this is an SSL torrent the announce needs to specify an SSL
 		// listen port. DHT nodes only operate on non-SSL ports so SSL
 		// torrents cannot use implied_port.
-		// if we allow incoming uTP connections, set the implied_port
-		// argument in the announce, this will make the DHT node use
+		// if we allow incoming uTP connections and don't overwrite
+		// the announced port, set the implied_port argument
+		// in the announce, this will make the DHT node use
 		// our source port in the packet as our listen port, which is
 		// likely more accurate when behind a NAT
+		const auto announce_port = std::uint16_t(settings().get_int(settings_pack::announce_port));
 		if (is_ssl_torrent())
 		{
 			flags |= dht::announce::ssl_torrent;
 		}
-		else if (settings().get_bool(settings_pack::enable_incoming_utp))
+		else if (!announce_port && settings().get_bool(settings_pack::enable_incoming_utp))
 		{
 			flags |= dht::announce::implied_port;
 		}
@@ -2811,7 +2813,7 @@ bool is_downloading_state(int const st)
 		std::weak_ptr<torrent> self(shared_from_this());
 		m_torrent_file->info_hashes().for_each([&](sha1_hash const& ih, protocol_version v)
 		{
-			m_ses.dht()->announce(ih, 0, flags
+			m_ses.dht()->announce(ih, announce_port, flags
 				, std::bind(&torrent::on_dht_announce_response_disp, self, v, _1));
 		});
 	}


### PR DESCRIPTION
The `announce_port` setting permits to overwrite the port passed along to trackers as the `&port=` parameter. If left as the default, the listening port is used. This setting is only meant for very special cases where a seed's listening port differs from the effectively exposed port (e.g., through external NAT-PMP).

This PR would be complementary to the https://github.com/arvidn/libtorrent/pull/7726 `listen_on_proxy` setting.