### PR TITLE
`piece_picker` updates

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -856,6 +856,7 @@ namespace libtorrent {
 #endif
 
 		// returns true if we have downloaded the given piece
+		// but not necessarily flushed it to disk
 		bool have_piece(piece_index_t index) const
 		{
 			if (!valid_metadata()) return false;
@@ -870,15 +871,6 @@ namespace libtorrent {
 			if (index < piece_index_t{0} || index >= m_torrent_file->end_piece()) return false;
 			if (!has_picker()) return m_have_all;
 			return m_picker->have_piece(index);
-		}
-
-		// returns true if we have downloaded the given piece
-		bool has_piece_passed(piece_index_t index) const
-		{
-			if (!valid_metadata()) return false;
-			if (index < piece_index_t(0) || index >= torrent_file().end_piece()) return false;
-			if (!has_picker()) return m_have_all;
-			return m_picker->has_piece_passed(index);
 		}
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
@@ -903,21 +895,14 @@ namespace libtorrent {
 
 	public:
 
+		// the number of pieces that have passed
+		// hash check, but aren't necessarily
+		// flushed to disk yet
 		int num_have() const
 		{
 			// pretend we have every piece when in seed mode
 			if (m_seed_mode) return m_torrent_file->num_pieces();
 			if (has_picker()) return m_picker->have().num_pieces;
-			if (m_have_all) return m_torrent_file->num_pieces();
-			return 0;
-		}
-
-		// the number of pieces that have passed
-		// hash check, but aren't necessarily
-		// flushed to disk yet
-		int num_passed() const
-		{
-			if (has_picker()) return m_picker->num_passed();
 			if (m_have_all) return m_torrent_file->num_pieces();
 			return 0;
 		}

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -542,7 +542,7 @@ namespace libtorrent {
 			{
 				if (m_have_piece[j]
 					&& t->piece_priority(j) > dont_download
-					&& !p.has_piece_passed(j))
+					&& !p.have_piece(j))
 				{
 					interested = true;
 #ifndef TORRENT_DISABLE_LOGGING
@@ -2084,7 +2084,7 @@ namespace libtorrent {
 		// it's important to update whether we're interested in this peer before
 		// calling disconnect_if_redundant, otherwise we may disconnect even if
 		// we are interested
-		if (!t->has_piece_passed(index)
+		if (!t->have_piece(index)
 			&& !t->is_upload_only()
 			&& !is_interesting()
 			&& (!t->has_picker() || t->picker().piece_priority(index) != dont_download))
@@ -2418,7 +2418,7 @@ namespace libtorrent {
 					, valid_piece_index
 						? t->torrent_file().piece_size(r.piece) : -1
 					, t->torrent_file().num_pieces()
-					, valid_piece_index ? t->has_piece_passed(r.piece) : 0
+					, valid_piece_index ? t->have_piece(r.piece) : 0
 					, static_cast<int>(m_superseed_piece[0])
 					, static_cast<int>(m_superseed_piece[1]));
 			}
@@ -2433,7 +2433,7 @@ namespace libtorrent {
 				bool const peer_interested = bool(m_peer_interested);
 				t->alerts().emplace_alert<invalid_request_alert>(
 					t->get_handle(), m_remote, m_peer_id, r
-					, t->has_piece_passed(r.piece), peer_interested, true);
+					, t->user_have_piece(r.piece), peer_interested, true);
 			}
 			return;
 		}
@@ -2502,7 +2502,7 @@ namespace libtorrent {
 			{
 				t->alerts().emplace_alert<invalid_request_alert>(
 					t->get_handle(), m_remote, m_peer_id, r
-					, t->has_piece_passed(r.piece)
+					, t->user_have_piece(r.piece)
 					, false, false);
 			}
 
@@ -2515,7 +2515,7 @@ namespace libtorrent {
 		// is not choked
 		if (r.piece < piece_index_t(0)
 			|| r.piece >= t->torrent_file().end_piece()
-			|| (!t->has_piece_passed(r.piece)
+			|| (!t->user_have_piece(r.piece)
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 				&& !t->is_predictive_piece(r.piece)
 #endif
@@ -2537,7 +2537,7 @@ namespace libtorrent {
 					, valid_piece_index
 						? t->torrent_file().piece_size(r.piece) : -1
 					, ti.num_pieces()
-					, t->has_piece_passed(r.piece)
+					, t->user_have_piece(r.piece)
 					, t->block_size());
 			}
 #endif
@@ -2553,7 +2553,7 @@ namespace libtorrent {
 				bool const peer_interested = bool(m_peer_interested);
 				t->alerts().emplace_alert<invalid_request_alert>(
 					t->get_handle(), m_remote, m_peer_id, r
-					, t->has_piece_passed(r.piece), peer_interested, false);
+					, t->user_have_piece(r.piece), peer_interested, false);
 			}
 
 			// every ten invalid request, remind the peer that it's choked
@@ -3516,7 +3516,7 @@ namespace libtorrent {
 		// to download it, request it
 		if (index < m_have_piece.end_index()
 			&& m_have_piece[index]
-			&& !t->has_piece_passed(index)
+			&& !t->have_piece(index)
 			&& t->valid_metadata()
 			&& t->has_picker()
 			&& t->picker().piece_priority(index) > dont_download)
@@ -4001,7 +4001,7 @@ namespace libtorrent {
 		{
 			std::shared_ptr<torrent> t = m_torrent.lock();
 			TORRENT_ASSERT(t);
-			TORRENT_ASSERT(t->has_piece_passed(piece));
+			TORRENT_ASSERT(t->have_piece(piece));
 			TORRENT_ASSERT(piece < t->torrent_file().end_piece());
 		}
 #endif
@@ -5354,7 +5354,7 @@ namespace libtorrent {
 				continue;
 			}
 
-			if (!t->has_piece_passed(r.piece) && !seed_mode)
+			if (!t->have_piece(r.piece) && !seed_mode)
 			{
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 				// we don't have this piece yet, but we anticipate to have

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -197,7 +197,6 @@ namespace libtorrent {
 		m_have_pad_bytes = 0;
 		m_filtered_pad_bytes += m_have_filtered_pad_bytes;
 		m_have_filtered_pad_bytes = 0;
-		m_num_passed = 0;
 		m_dirty = true;
 		for (auto& m : m_piece_map)
 		{
@@ -633,31 +632,42 @@ namespace libtorrent {
 		{
 			piece_pos const& p = *i;
 
+			int const pad_bytes = pad_bytes_in_piece(piece);
 			if (p.filtered())
 			{
-				if (p.index != piece_pos::we_have_index)
+				if (p.downloading())
 				{
-					++num_filtered;
-					num_filtered_pad_bytes += pad_bytes_in_piece(piece);
+					auto dl = find_dl_piece(p.download_queue(), piece);
+					if (dl->passed_hash_check)
+					{
+						++num_have_filtered;
+						num_have_filtered_pad_bytes += pad_bytes;
+					}
+					else
+					{
+						++num_filtered;
+						num_filtered_pad_bytes += pad_bytes;
+					}
+				}
+				else if (p.have())
+				{
+					++num_have_filtered;
+					num_have_filtered_pad_bytes += pad_bytes;
 				}
 				else
 				{
-					++num_have_filtered;
-					num_have_filtered_pad_bytes += pad_bytes_in_piece(piece);
+					++num_filtered;
+					num_filtered_pad_bytes += pad_bytes;
 				}
 			}
 
 #ifdef TORRENT_DEBUG_REFCOUNTS
 			TORRENT_ASSERT(int(p.have_peers.size()) == p.peer_count + m_seeds);
 #endif
-			if (p.index == piece_pos::we_have_index)
+			if (p.have())
 			{
 				++num_have;
-				num_have_pad_bytes += pad_bytes_in_piece(piece);
-			}
-
-			if (p.index == piece_pos::we_have_index)
-			{
+				num_have_pad_bytes += pad_bytes;
 				TORRENT_ASSERT(t == nullptr || t->have_piece(piece));
 				TORRENT_ASSERT(p.downloading() == false);
 			}
@@ -669,6 +679,12 @@ namespace libtorrent {
 
 			if (p.downloading())
 			{
+				auto dl = find_dl_piece(p.download_queue(), piece);
+				if (dl->passed_hash_check)
+				{
+					++num_have;
+					num_have_pad_bytes += pad_bytes;
+				}
 				if (p.reverse())
 					TORRENT_ASSERT(prio == -1 || (prio % piece_picker::prio_factor == 2));
 				else
@@ -1615,11 +1631,12 @@ namespace libtorrent {
 
 		TORRENT_ASSERT(!i->passed_hash_check);
 		i->passed_hash_check = true;
-		++m_num_passed;
+
+		account_have(index);
 
 		if (i->finished < blocks_in_piece(index)) return;
 
-		we_have(index);
+		piece_flushed(index);
 	}
 
 	void piece_picker::we_dont_have(piece_index_t const index)
@@ -1632,7 +1649,8 @@ namespace libtorrent {
 			<< index << ")" << std::endl;
 #endif
 
-		if (!p.have())
+		bool have_piece = p.have();
+		if (!have_piece)
 		{
 			// even though we don't have the piece, it
 			// might still have passed hash check
@@ -1640,29 +1658,14 @@ namespace libtorrent {
 			if (download_state == piece_pos::piece_open) return;
 
 			auto const i = find_dl_piece(download_state, index);
-			if (i->passed_hash_check)
-			{
-				i->passed_hash_check = false;
-				TORRENT_ASSERT(m_num_passed > 0);
-				--m_num_passed;
-			}
+			have_piece = i->passed_hash_check;
 			erase_download_piece(i);
-			return;
 		}
 
-		TORRENT_ASSERT(m_num_passed > 0);
-		--m_num_passed;
-		if (p.filtered())
-		{
-			m_filtered_pad_bytes += pad_bytes_in_piece(index);
-			++m_num_filtered;
+		if (have_piece)
+			account_lost(index);
 
-			TORRENT_ASSERT(m_have_filtered_pad_bytes >= pad_bytes_in_piece(index));
-			m_have_filtered_pad_bytes -= pad_bytes_in_piece(index);
-			TORRENT_ASSERT(m_num_have_filtered > 0);
-			--m_num_have_filtered;
-		}
-		else
+		if (!p.filtered())
 		{
 			// update cursors
 			if (index < m_cursor) m_cursor = index;
@@ -1674,9 +1677,6 @@ namespace libtorrent {
 			}
 		}
 
-		--m_num_have;
-		m_have_pad_bytes -= pad_bytes_in_piece(index);
-		TORRENT_ASSERT(m_have_pad_bytes >= 0);
 		p.set_not_have();
 
 		if (m_dirty) return;
@@ -1687,13 +1687,11 @@ namespace libtorrent {
 	// downloaded a piece, and that no further attempts
 	// to pick that piece should be made. The piece will
 	// be removed from the available piece list.
-	void piece_picker::we_have(piece_index_t const index)
+	void piece_picker::piece_flushed(piece_index_t const index)
 	{
-#ifdef TORRENT_EXPENSIVE_INVARIANT_CHECKS
 		INVARIANT_CHECK;
-#endif
 #ifdef TORRENT_PICKER_LOG
-		std::cerr << "[" << this << "] " << "piece_picker::we_have("
+		std::cerr << "[" << this << "] " << "piece_picker::piece_flushed("
 			<< index << ")" << std::endl;
 #endif
 		piece_pos& p = m_piece_map[index];
@@ -1704,31 +1702,27 @@ namespace libtorrent {
 		if (p.have()) return;
 
 		auto const state = p.download_queue();
-		if (state != piece_pos::piece_open)
+		bool passed_hash_check = false;
+		if (p.downloading())
 		{
 			auto const i = find_dl_piece(state, index);
 			TORRENT_ASSERT(i != m_downloads[state].end());
 			TORRENT_ASSERT(i->hashing == 0);
-			// decrement num_passed here to compensate
-			// for the unconditional increment further down
-			if (i->passed_hash_check) --m_num_passed;
+			passed_hash_check = i->passed_hash_check;
+			TORRENT_ASSERT(i->locked == false);
+			if (i->locked) return;
 			erase_download_piece(i);
 		}
 
-		if (p.filtered())
+		if (!passed_hash_check)
 		{
-			TORRENT_ASSERT(m_filtered_pad_bytes >= pad_bytes_in_piece(index));
-			m_filtered_pad_bytes -= pad_bytes_in_piece(index);
-			TORRENT_ASSERT(m_num_filtered > 0);
-			--m_num_filtered;
-
-			m_have_filtered_pad_bytes += pad_bytes_in_piece(index);
-			++m_num_have_filtered;
+			// if we go straight from open to flushed, we need to make sure we
+			// maintain the accounting as-if we had downloaded it and checked
+			// the hash first. e.g. when we load resume data, we set up the
+			// piece states to indicate they're already on disk
+			account_have(index);
 		}
-		++m_num_have;
-		++m_num_passed;
-		m_have_pad_bytes += pad_bytes_in_piece(index);
-		TORRENT_ASSERT(m_have_pad_bytes <= num_pad_bytes());
+
 		p.set_have();
 		if (m_cursor == prev(m_reverse_cursor)
 			&& m_cursor == index)
@@ -1783,7 +1777,6 @@ namespace libtorrent {
 		m_filtered_pad_bytes = 0;
 		m_cursor = m_piece_map.end_index();
 		m_reverse_cursor = piece_index_t{0};
-		m_num_passed = num_pieces();
 		m_num_have = num_pieces();
 
 		for (auto& queue : m_downloads) queue.clear();
@@ -2538,12 +2531,13 @@ get_out:
 		return ret;
 	}
 
-	// have piece means that the piece passed hash check
-	// AND has been successfully written to disk
-	bool piece_picker::have_piece(piece_index_t const index) const
+	bool piece_picker::is_piece_flushed(piece_index_t const index) const
 	{
+		TORRENT_ASSERT(index < m_piece_map.end_index());
+		TORRENT_ASSERT(index >= piece_index_t(0));
+
 		piece_pos const& p = m_piece_map[index];
-		return p.index == piece_pos::we_have_index;
+		return p.have();
 	}
 
 	int piece_picker::blocks_in_piece(piece_index_t const index) const
@@ -2912,13 +2906,13 @@ get_out:
 		return i->hashing > 0;
 	}
 
-	bool piece_picker::has_piece_passed(piece_index_t const index) const
+	bool piece_picker::have_piece(piece_index_t const index) const
 	{
 		TORRENT_ASSERT(index < m_piece_map.end_index());
 		TORRENT_ASSERT(index >= piece_index_t(0));
 
 		piece_pos const& p = m_piece_map[index];
-		if (p.index == piece_pos::we_have_index) return true;
+		if (p.have()) return true;
 
 		auto const state = p.download_queue();
 		if (state == piece_pos::piece_open)
@@ -3474,8 +3468,7 @@ get_out:
 			// but it seems reasonable to not break the
 			// accounting over it.
 			i->passed_hash_check = false;
-			TORRENT_ASSERT(m_num_passed > 0);
-			--m_num_passed;
+			account_lost(piece);
 		}
 
 		// prevent this piece from being picked until it's restored
@@ -3483,7 +3476,7 @@ get_out:
 	}
 
 	// TODO: 2 it would be nice if this could be folded into lock_piece()
-	// the main distinction is that this also maintains the m_num_passed
+	// the main distinction is that this also maintains the m_num_have
 	// counter and the passed_hash_check member
 	// Is there ever a case where we call write failed without also locking
 	// the piece? Perhaps write_failed() should imply locking it.
@@ -3526,8 +3519,7 @@ get_out:
 			// some of the blocks to disk, which means we
 			// can't consider the piece complete
 			i->passed_hash_check = false;
-			TORRENT_ASSERT(m_num_passed > 0);
-			--m_num_passed;
+			account_lost(block.piece_index);
 		}
 
 		// prevent this hash job from actually completing
@@ -3697,7 +3689,7 @@ get_out:
 				return;
 
 			if (i->passed_hash_check && i->hashing == 0)
-				we_have(i->index);
+				piece_flushed(i->index);
 		}
 
 #if TORRENT_USE_INVARIANT_CHECKS
@@ -3715,6 +3707,8 @@ get_out:
 		TORRENT_ASSERT(bytes <= piece_size(piece));
 
 		m_num_pad_bytes += bytes;
+		// We don't support *changing* the number of pad bytes in a piece
+		TORRENT_ASSERT(m_pads_in_piece.count(piece) == 0);
 		m_pads_in_piece[piece] = bytes;
 
 		piece_pos& p = m_piece_map[piece];
@@ -3734,7 +3728,7 @@ get_out:
 		if (piece_size(piece) == bytes)
 		{
 			// the entire piece is a pad file
-			we_have(piece);
+			piece_flushed(piece);
 		}
 	}
 
@@ -3931,4 +3925,44 @@ get_out:
 		return ret;
 	}
 
+	void piece_picker::account_have(piece_index_t const index)
+	{
+		++m_num_have;
+		piece_pos& p = m_piece_map[index];
+		TORRENT_ASSERT(!p.have());
+		int const pad_bytes = pad_bytes_in_piece(index);
+		if (p.filtered())
+		{
+			TORRENT_ASSERT(m_filtered_pad_bytes >= pad_bytes);
+			m_filtered_pad_bytes -= pad_bytes;
+			TORRENT_ASSERT(m_num_filtered > 0);
+			--m_num_filtered;
+
+			m_have_filtered_pad_bytes += pad_bytes;
+			++m_num_have_filtered;
+		}
+		m_have_pad_bytes += pad_bytes;
+		TORRENT_ASSERT(m_have_pad_bytes <= num_pad_bytes());
+	}
+
+	void piece_picker::account_lost(piece_index_t const index)
+	{
+		TORRENT_ASSERT(m_num_have > 0);
+		--m_num_have;
+		piece_pos& p = m_piece_map[index];
+		int const pad_bytes = pad_bytes_in_piece(index);
+		if (p.filtered())
+		{
+			m_filtered_pad_bytes += pad_bytes;
+			TORRENT_ASSERT(m_filtered_pad_bytes <= num_pad_bytes());
+			++m_num_filtered;
+
+			TORRENT_ASSERT(m_have_filtered_pad_bytes >= pad_bytes);
+			m_have_filtered_pad_bytes -= pad_bytes;
+			TORRENT_ASSERT(m_num_have_filtered > 0);
+			--m_num_have_filtered;
+		}
+		TORRENT_ASSERT(m_have_pad_bytes >= pad_bytes);
+		m_have_pad_bytes -= pad_bytes;
+	}
 }

--- a/test/test_file_progress.cpp
+++ b/test/test_file_progress.cpp
@@ -58,7 +58,7 @@ TORRENT_TEST(init)
 	for (auto const idx : fs.piece_range())
 	{
 		piece_picker picker(fs.total_size(), fs.piece_length());
-		picker.we_have(idx);
+		picker.piece_flushed(idx);
 
 		aux::file_progress fp;
 		fp.init(picker, fs);
@@ -90,7 +90,7 @@ TORRENT_TEST(init2)
 	for (auto const idx : fs.piece_range())
 	{
 		piece_picker picker(fs.total_size(), fs.piece_length());
-		picker.we_have(idx);
+		picker.piece_flushed(idx);
 
 		aux::vector<std::int64_t, file_index_t> vec;
 		aux::file_progress fp;

--- a/test/test_piece_picker.cpp
+++ b/test/test_piece_picker.cpp
@@ -197,7 +197,7 @@ std::shared_ptr<piece_picker> setup_picker(
 	for (auto i = 0_piece; i < piece_index_t(num_pieces); ++i)
 	{
 		if (!have[i]) continue;
-		p->we_have(i);
+		p->piece_flushed(i);
 		for (int j = 0; j < blocks_per_piece; ++j)
 			TEST_CHECK(p->is_finished(piece_block(i, j)));
 	}
@@ -579,12 +579,12 @@ TORRENT_TEST(we_dont_have)
 {
 	// make sure we_dont_have works
 	auto p = setup_picker("1111111", "*******", "0100000", "");
-	TEST_CHECK(p->have_piece(1_piece));
-	TEST_CHECK(p->have_piece(2_piece));
+	TEST_CHECK(p->is_piece_flushed(1_piece));
+	TEST_CHECK(p->is_piece_flushed(2_piece));
 	p->we_dont_have(1_piece);
 	p->we_dont_have(2_piece);
-	TEST_CHECK(!p->have_piece(1_piece));
-	TEST_CHECK(!p->have_piece(2_piece));
+	TEST_CHECK(!p->is_piece_flushed(1_piece));
+	TEST_CHECK(!p->is_piece_flushed(2_piece));
 	auto picked = pick_pieces(p, "*** ** ", 1, 0, nullptr, options, empty_vector);
 	TEST_CHECK(int(picked.size()) > 0);
 	TEST_CHECK(picked.front().piece_index == 1_piece);
@@ -639,7 +639,7 @@ TORRENT_TEST(resize)
 	TEST_EQUAL(p->have().num_pieces, 0);
 	TEST_EQUAL(p->have().pad_bytes, 0);
 
-	p->we_have(0_piece);
+	p->piece_flushed(0_piece);
 
 	TEST_EQUAL(p->want().num_pieces, 6);
 	TEST_EQUAL(p->want().pad_bytes, 20);
@@ -855,13 +855,13 @@ TORRENT_TEST(priority_sequential_download)
 
 TORRENT_TEST(cursors_sweep_up_we_have)
 {
-	// sweep up, we_have()
+	// sweep up, piece_flushed()
 	auto p = setup_picker("7654321", "       ", "", "");
 	for (auto i = 0_piece; i < 7_piece; ++i)
 	{
 		TEST_EQUAL(p->cursor(), i);
 		TEST_EQUAL(p->reverse_cursor(), 7_piece);
-		p->we_have(i);
+		p->piece_flushed(i);
 	}
 	TEST_CHECK(p->is_finished());
 	TEST_CHECK(p->is_seeding());
@@ -887,13 +887,13 @@ TORRENT_TEST(cursors_sweep_up_set_piece_priority)
 
 TORRENT_TEST(cursors_sweep_down_we_have)
 {
-	// sweep down, we_have()
+	// sweep down, piece_flushed()
 	auto p = setup_picker("7654321", "       ", "", "");
 	for (auto i = 6_piece; i >= 0_piece; --i)
 	{
 		TEST_EQUAL(p->cursor(), 0_piece);
 		TEST_EQUAL(p->reverse_cursor(), next(i));
-		p->we_have(i);
+		p->piece_flushed(i);
 	}
 	TEST_CHECK(p->is_finished());
 	TEST_CHECK(p->is_seeding());
@@ -937,15 +937,15 @@ TORRENT_TEST(cursors_sweep_in_set_priority)
 
 TORRENT_TEST(cursors_sweep_in_we_have)
 {
-	// sweep in, we_have()
+	// sweep in, piece_flushed()
 	auto p = setup_picker("7654321", "       ", "", "");
 	for (piece_index_t left(0), right(6); left <= 3_piece
 		&& right >= 3_piece; ++left, --right)
 	{
 		TEST_EQUAL(p->cursor(), left);
 		TEST_EQUAL(p->reverse_cursor(), next(right));
-		p->we_have(left);
-		p->we_have(right);
+		p->piece_flushed(left);
+		p->piece_flushed(right);
 	}
 	TEST_CHECK(p->is_finished());
 	TEST_CHECK(p->is_seeding());
@@ -1019,21 +1019,21 @@ TORRENT_TEST(cursors)
 	auto p = setup_picker("7654321", "       ", "", "");
 	TEST_EQUAL(p->cursor(), 0_piece);
 	TEST_EQUAL(p->reverse_cursor(), 7_piece);
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	TEST_EQUAL(p->cursor(), 0_piece);
 	TEST_EQUAL(p->reverse_cursor(), 7_piece);
-	p->we_have(0_piece);
+	p->piece_flushed(0_piece);
 	TEST_EQUAL(p->cursor(), 2_piece);
 	TEST_EQUAL(p->reverse_cursor(), 7_piece);
-	p->we_have(5_piece);
+	p->piece_flushed(5_piece);
 	TEST_EQUAL(p->cursor(), 2_piece);
 	TEST_EQUAL(p->reverse_cursor(), 7_piece);
-	p->we_have(6_piece);
+	p->piece_flushed(6_piece);
 	TEST_EQUAL(p->cursor(), 2_piece);
 	TEST_EQUAL(p->reverse_cursor(), 5_piece);
-	p->we_have(4_piece);
-	p->we_have(3_piece);
-	p->we_have(2_piece);
+	p->piece_flushed(4_piece);
+	p->piece_flushed(3_piece);
+	p->piece_flushed(2_piece);
 	TEST_EQUAL(p->cursor(), 7_piece);
 	TEST_EQUAL(p->reverse_cursor(), 0_piece);
 
@@ -1072,7 +1072,7 @@ TORRENT_TEST(piece_priorities)
 	TEST_EQUAL(p->want().num_pieces, 6);
 	TEST_EQUAL(p->have_want().num_pieces, 0);
 	p->mark_as_finished({0_piece, 0}, nullptr);
-	p->we_have(0_piece);
+	p->piece_flushed(0_piece);
 	TEST_EQUAL(p->want().num_pieces, 6);
 	TEST_EQUAL(p->have_want().num_pieces, 0);
 	TEST_EQUAL(p->have().num_pieces, 1);
@@ -1088,7 +1088,7 @@ TORRENT_TEST(piece_priorities)
 		TEST_CHECK(picked[std::size_t(i)] == piece_block(piece_index_t(i / blocks_per_piece), i % blocks_per_piece));
 
 	// test changing priority on a piece we have
-	p->we_have(0_piece);
+	p->piece_flushed(0_piece);
 	p->set_piece_priority(0_piece, dont_download);
 	p->set_piece_priority(0_piece, low_priority);
 	p->set_piece_priority(0_piece, dont_download);
@@ -1238,7 +1238,7 @@ TORRENT_TEST(random_pick)
 	for (int i = 0; i < 7; ++i)
 	{
 		piece_index_t const piece = test_pick(p, {});
-		p->we_have(piece);
+		p->piece_flushed(piece);
 		random_pieces.insert(piece);
 	}
 	TEST_CHECK(random_pieces.size() == 7);
@@ -1694,49 +1694,50 @@ TORRENT_TEST(piece_passed)
 {
 	auto p = setup_picker("1111111", "*      ", "", "0300000");
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
-	TEST_EQUAL(p->num_passed(), 1);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
 	TEST_EQUAL(p->have().num_pieces, 1);
 
 	p->piece_passed(1_piece);
-	TEST_EQUAL(p->num_passed(), 2);
-	TEST_EQUAL(p->have().num_pieces, 1);
+	TEST_EQUAL(p->num_have(), 2);
+	TEST_EQUAL(p->have().num_pieces, 2);
 
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	TEST_EQUAL(p->have().num_pieces, 2);
 
 	p->mark_as_finished({2_piece, 0}, &tmp1);
 	p->piece_passed(2_piece);
-	TEST_EQUAL(p->num_passed(), 3);
-	// just because the hash check passed doesn't mean
-	// we "have" the piece. We need to write it to disk first
-	TEST_EQUAL(p->have().num_pieces, 2);
+	TEST_EQUAL(p->num_have(), 3);
+	// since the hash check passed we "have" the piece.
+	TEST_EQUAL(p->have().num_pieces, 3);
+	TEST_EQUAL(p->is_piece_flushed(0_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(2_piece), false);
 
 	// piece 2 already passed the hash check, as soon as we've
 	// written all the blocks to disk, we should have that piece too
 	p->mark_as_finished({2_piece, 1}, &tmp1);
 	p->mark_as_finished({2_piece, 2}, &tmp1);
 	p->mark_as_finished({2_piece, 3}, &tmp1);
-	TEST_EQUAL(p->have().num_pieces, 3);
-	TEST_EQUAL(p->have_piece(2_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(2_piece), true);
 }
 
 TORRENT_TEST(piece_passed_causing_we_have)
 {
 	auto p = setup_picker("1111111", "*      ", "", "0700000");
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
-	TEST_EQUAL(p->num_passed(), 1);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
 	TEST_EQUAL(p->have().num_pieces, 1);
 
 	p->mark_as_finished({1_piece, 3}, &tmp1);
-	TEST_EQUAL(p->num_passed(), 1);
+	TEST_EQUAL(p->num_have(), 1);
 	TEST_EQUAL(p->have().num_pieces, 1);
 
 	p->piece_passed(1_piece);
-	TEST_EQUAL(p->num_passed(), 2);
+	TEST_EQUAL(p->num_have(), 2);
 	TEST_EQUAL(p->have().num_pieces, 2);
 }
 
@@ -1760,38 +1761,38 @@ TORRENT_TEST(break_one_seed)
 TORRENT_TEST(we_dont_have2)
 {
 	auto p = setup_picker("1111111", "* *    ", "1101111", "");
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
-	TEST_EQUAL(p->has_piece_passed(2_piece), true);
-	TEST_EQUAL(p->num_passed(), 2);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->have_piece(2_piece), true);
+	TEST_EQUAL(p->num_have(), 2);
 	TEST_EQUAL(p->have().num_pieces, 2);
 	TEST_EQUAL(p->have_want().num_pieces, 1);
 	TEST_EQUAL(p->want().num_pieces, 6);
 
 	p->we_dont_have(0_piece);
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), false);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
-	TEST_EQUAL(p->has_piece_passed(2_piece), true);
-	TEST_EQUAL(p->num_passed(), 1);
+	TEST_EQUAL(p->have_piece(0_piece), false);
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->have_piece(2_piece), true);
+	TEST_EQUAL(p->num_have(), 1);
 	TEST_EQUAL(p->have().num_pieces, 1);
 	TEST_EQUAL(p->have_want().num_pieces, 0);
 
 	p = setup_picker("1111111", "* *    ", "1101111", "");
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
-	TEST_EQUAL(p->has_piece_passed(2_piece), true);
-	TEST_EQUAL(p->num_passed(), 2);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->have_piece(2_piece), true);
+	TEST_EQUAL(p->num_have(), 2);
 	TEST_EQUAL(p->have().num_pieces, 2);
 	TEST_EQUAL(p->have_want().num_pieces, 1);
 	TEST_EQUAL(p->want().num_pieces, 6);
 
 	p->we_dont_have(2_piece);
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
-	TEST_EQUAL(p->has_piece_passed(2_piece), false);
-	TEST_EQUAL(p->num_passed(), 1);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->have_piece(2_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
 	TEST_EQUAL(p->have().num_pieces, 1);
 	TEST_EQUAL(p->have_want().num_pieces, 1);
 	TEST_EQUAL(p->want().num_pieces, 6);
@@ -1801,44 +1802,44 @@ TORRENT_TEST(dont_have_but_passed_hash_check)
 {
 	auto p = setup_picker("1111111", "* *    ", "1101111", "0200000");
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
 	TEST_EQUAL(p->have_piece(0_piece), true);
 	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->is_piece_flushed(0_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
 
 	p->piece_passed(1_piece);
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), true);
-	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
 
 	p->we_dont_have(1_piece);
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
+	TEST_EQUAL(p->have_piece(0_piece), true);
 	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
 }
 
 TORRENT_TEST(write_failed)
 {
 	auto p = setup_picker("1111111", "* *    ", "1101111", "0200000");
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
+	TEST_EQUAL(p->have_piece(0_piece), true);
 	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
 
 	p->piece_passed(1_piece);
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), true);
-	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->have_piece(0_piece), true);
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
 
 	p->mark_as_writing({1_piece, 0}, &tmp1);
 	p->write_failed({1_piece, 0});
 
-	TEST_EQUAL(p->has_piece_passed(0_piece), true);
-	TEST_EQUAL(p->has_piece_passed(1_piece), false);
+	TEST_EQUAL(p->have_piece(0_piece), true);
 	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
 
 	// make sure write_failed() and lock_piece() actually
 	// locks the piece, and that it won't be picked.
@@ -2164,7 +2165,7 @@ TORRENT_TEST(num_pad_bytes_want_filter)
 TORRENT_TEST(num_pad_bytes_want_have)
 {
 	auto p = setup_picker("111", "   ", "444", "");
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	TEST_CHECK((p->want() == piece_count{3, 0, true}));
 	TEST_CHECK((p->have_want() == piece_count{1, 0, false}));
 	TEST_CHECK((p->have() == piece_count{1, 0, false}));
@@ -2193,7 +2194,7 @@ TORRENT_TEST(num_pad_bytes_we_have)
 	p->set_pad_bytes(1_piece, 2);
 	p->set_pad_bytes(0_piece, 0x4000);
 
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	TEST_CHECK((p->want() == piece_count{3, 0x4003, true}));
 	TEST_CHECK((p->have_want() == piece_count{1, 2, false}));
 	TEST_CHECK((p->have() == piece_count{1, 2, false}));
@@ -2208,7 +2209,7 @@ TORRENT_TEST(num_pad_bytes_dont_want_have)
 	p->set_pad_bytes(0_piece, 0x4000);
 
 	p->set_piece_priority(1_piece, dont_download);
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	TEST_CHECK((p->want() == piece_count{2, 0x4001, true}));
 	TEST_CHECK((p->have_want() == piece_count{0, 0, false}));
 	TEST_CHECK((p->have() == piece_count{1, 2, false}));
@@ -2222,7 +2223,7 @@ TORRENT_TEST(num_pad_bytes_have_dont_want)
 	p->set_pad_bytes(1_piece, 2);
 	p->set_pad_bytes(0_piece, 0x4000);
 
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	p->set_piece_priority(1_piece, dont_download);
 	TEST_CHECK((p->want() == piece_count{2, 0x4001, true}));
 	TEST_CHECK((p->have_want() == piece_count{0, 0, false}));
@@ -2233,7 +2234,7 @@ TORRENT_TEST(num_pad_bytes_have_dont_want)
 TORRENT_TEST(have_dont_want_pad_bytes)
 {
 	auto p = setup_picker("111", "   ", "444", "");
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	p->set_piece_priority(1_piece, dont_download);
 	p->set_pad_bytes(2_piece, 1);
 	p->set_pad_bytes(1_piece, 2);
@@ -2250,38 +2251,38 @@ TORRENT_TEST(pad_bytes_have)
 	{
 		auto p = setup_picker("1111111", "       ", "4444444", "");
 		p->set_pad_bytes(2_piece, 10);
-		TEST_CHECK(!p->have_piece(0_piece));
-		TEST_CHECK(!p->have_piece(1_piece));
-		TEST_CHECK(!p->have_piece(2_piece));
-		TEST_CHECK(!p->have_piece(3_piece));
+		TEST_CHECK(!p->is_piece_flushed(0_piece));
+		TEST_CHECK(!p->is_piece_flushed(1_piece));
+		TEST_CHECK(!p->is_piece_flushed(2_piece));
+		TEST_CHECK(!p->is_piece_flushed(3_piece));
 	}
 
 	{
 		auto p = setup_picker("1111111", "       ", "4444444", "");
 		p->set_pad_bytes(2_piece, default_block_size);
-		TEST_CHECK(!p->have_piece(0_piece));
-		TEST_CHECK(!p->have_piece(1_piece));
-		TEST_CHECK(!p->have_piece(2_piece));
-		TEST_CHECK(!p->have_piece(3_piece));
+		TEST_CHECK(!p->is_piece_flushed(0_piece));
+		TEST_CHECK(!p->is_piece_flushed(1_piece));
+		TEST_CHECK(!p->is_piece_flushed(2_piece));
+		TEST_CHECK(!p->is_piece_flushed(3_piece));
 	}
 
 	{
 		auto p = setup_picker("1111111", "       ", "4444444", "");
 		p->set_pad_bytes(2_piece, blocks_per_piece * default_block_size);
-		TEST_CHECK(!p->have_piece(0_piece));
-		TEST_CHECK(!p->have_piece(1_piece));
-		TEST_CHECK(p->have_piece(2_piece));
-		TEST_CHECK(!p->have_piece(3_piece));
+		TEST_CHECK(!p->is_piece_flushed(0_piece));
+		TEST_CHECK(!p->is_piece_flushed(1_piece));
+		TEST_CHECK(p->is_piece_flushed(2_piece));
+		TEST_CHECK(!p->is_piece_flushed(3_piece));
 	}
 
 	{
 		auto p = setup_picker("1111111", "       ", "4444444", "");
 		p->set_pad_bytes(2_piece, blocks_per_piece * default_block_size);
 		p->set_pad_bytes(1_piece, default_block_size);
-		TEST_CHECK(!p->have_piece(0_piece));
-		TEST_CHECK(!p->have_piece(1_piece));
-		TEST_CHECK(p->have_piece(2_piece));
-		TEST_CHECK(!p->have_piece(3_piece));
+		TEST_CHECK(!p->is_piece_flushed(0_piece));
+		TEST_CHECK(!p->is_piece_flushed(1_piece));
+		TEST_CHECK(p->is_piece_flushed(2_piece));
+		TEST_CHECK(!p->is_piece_flushed(3_piece));
 	}
 }
 
@@ -2431,7 +2432,7 @@ TORRENT_TEST(pad_blocks_some_wanted_odd_blocks)
 	auto p = std::make_shared<piece_picker>(
 		3 * piece_size, piece_size);
 
-	p->we_have(1_piece);
+	p->piece_flushed(1_piece);
 	p->set_piece_priority(1_piece, dont_download);
 	p->set_pad_bytes(2_piece, 1);
 	p->set_pad_bytes(1_piece, 2);
@@ -2484,7 +2485,7 @@ TORRENT_TEST(mark_as_pad_whole_piece_seeding)
 {
 	auto p = setup_picker("11", "  ", "44", "");
 	p->set_pad_bytes(0_piece, 0x4000 * 4);
-	TEST_CHECK(p->have_piece(0_piece));
+	TEST_CHECK(p->is_piece_flushed(0_piece));
 
 	TEST_CHECK(!p->is_seeding());
 
@@ -2772,8 +2773,8 @@ TORRENT_TEST(piece_extent_affinity_clear_done)
 
 	// now all 5 extents are in use, if we finish a whole extent, it should be
 	// removed from the list
-	p->we_have(0_piece);
-	p->we_have(1_piece);
+	p->piece_flushed(0_piece);
+	p->piece_flushed(1_piece);
 
 	// we need to invoke the piece picker once to detect and reap this full
 	// extent


### PR DESCRIPTION
rename 'have' -> 'flushed' and 'passed' -> 'have' to make it clearer that a piece that has passed the hash check, we 'have', and is available to be picked by peers.
This addresses an issue where we would wait for pieces to be written to disk before advertizing it to peers.