### PR TITLE
cibuildwheel: update workflow

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -6,7 +6,7 @@ name: cibuildwheel
 # sample.
 
 # The full list of cibuildwheel's build targets can be found here:
-# https://github.com/pypa/cibuildwheel/blob/v2.21.3/cibuildwheel/resources/build-platforms.toml
+# https://github.com/pypa/cibuildwheel/blob/v2.22.0/cibuildwheel/resources/build-platforms.toml
 
 # Notes on build targets we (don't) support:
 # - pypy: libtorrent doesn't build with pypy as of writing
@@ -45,31 +45,65 @@ jobs:
       MATRIX_PULL_REQUEST: |
         {
           "include": [
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp39-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp39-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp39-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp39-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
-            {"os": "macos-12", "CIBW_BUILD": "cp39-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "12"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp39-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp39-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp39-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp39-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
             {"os": "macos-13", "CIBW_BUILD": "cp39-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
             {"os": "macos-14", "CIBW_BUILD": "cp39-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
             {"os": "macos-15", "CIBW_BUILD": "cp39-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
-            {"os": "windows-latest", "CIBW_BUILD": "cp39-win32", "CIBW_ARCHS_WINDOWS": "x86"},
-            {"os": "windows-latest", "CIBW_BUILD": "cp39-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"}
+            {"os": "windows-2022", "CIBW_BUILD": "cp39-win32", "CIBW_ARCHS_WINDOWS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp39-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"}
           ]
         }
       MATRIX_WORKFLOW_DISPATCH: |
         {
           "include": [
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp*-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp*-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp*-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
-            {"os": "ubuntu-latest", "CIBW_BUILD": "cp*-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
-            {"os": "macos-12", "CIBW_BUILD": "cp*-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "12"},
-            {"os": "macos-13", "CIBW_BUILD": "cp*-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
-            {"os": "macos-14", "CIBW_BUILD": "cp*-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
-            {"os": "macos-15", "CIBW_BUILD": "cp*-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
-            {"os": "windows-latest", "CIBW_BUILD": "cp*-win32", "CIBW_ARCHS_WINDOWS": "x86"},
-            {"os": "windows-latest", "CIBW_BUILD": "cp*-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"}
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp39-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp310-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp311-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp312-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp313-manylinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp39-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp310-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp311-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp312-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp313-manylinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp39-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp310-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp311-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp312-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04", "CIBW_BUILD": "cp313-musllinux_x86_64", "CIBW_ARCHS_LINUX": "x86_64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp39-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp310-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp311-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp312-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "ubuntu-24.04-arm", "CIBW_BUILD": "cp313-musllinux_aarch64", "CIBW_ARCHS_LINUX": "aarch64"},
+            {"os": "macos-13", "CIBW_BUILD": "cp39-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
+            {"os": "macos-13", "CIBW_BUILD": "cp310-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
+            {"os": "macos-13", "CIBW_BUILD": "cp311-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
+            {"os": "macos-13", "CIBW_BUILD": "cp312-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
+            {"os": "macos-13", "CIBW_BUILD": "cp313-macosx_x86_64", "CIBW_ARCHS_MACOS": "x86_64", "MACOSX_DEPLOYMENT_TARGET": "13"},
+            {"os": "macos-14", "CIBW_BUILD": "cp39-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
+            {"os": "macos-14", "CIBW_BUILD": "cp310-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
+            {"os": "macos-14", "CIBW_BUILD": "cp311-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
+            {"os": "macos-14", "CIBW_BUILD": "cp312-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
+            {"os": "macos-14", "CIBW_BUILD": "cp313-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "14"},
+            {"os": "macos-15", "CIBW_BUILD": "cp39-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
+            {"os": "macos-15", "CIBW_BUILD": "cp310-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
+            {"os": "macos-15", "CIBW_BUILD": "cp311-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
+            {"os": "macos-15", "CIBW_BUILD": "cp312-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
+            {"os": "macos-15", "CIBW_BUILD": "cp313-macosx_arm64", "CIBW_ARCHS_MACOS": "arm64", "MACOSX_DEPLOYMENT_TARGET": "15"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp39-win32", "CIBW_ARCHS_WINDOWS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp310-win32", "CIBW_ARCHS_WINDOWS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp311-win32", "CIBW_ARCHS_WINDOWS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp312-win32", "CIBW_ARCHS_WINDOWS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp313-win32", "CIBW_ARCHS_WINDOWS": "x86"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp39-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp310-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp311-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp312-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"},
+            {"os": "windows-2022", "CIBW_BUILD": "cp313-win_amd64", "CIBW_ARCHS_WINDOWS": "AMD64"}
           ]
         }
 
@@ -126,7 +160,7 @@ jobs:
         vcpkg install openssl:x86-windows
         New-Item -Path "C:\Program Files\OpenSSL" -ItemType SymbolicLink -Value "C:\vcpkg\packages\openssl_x86-windows\"
 
-    - uses: pypa/cibuildwheel@v2.21.3
+    - uses: pypa/cibuildwheel@v2.22.0
       if: steps.cache-wheel.outputs.cache-hit != 'true'
 
     - uses: actions/upload-artifact@v4

--- a/tools/cibuildwheel/setup_boost.sh
+++ b/tools/cibuildwheel/setup_boost.sh
@@ -14,7 +14,7 @@ TEMP_ARCHIVE="$(mktemp)"
 
 mkdir -p "$BOOST_ROOT"
 
-curl -L -o "$TEMP_ARCHIVE" "https://boostorg.jfrog.io/artifactory/main/release/${VERSION}/source/boost_${VUNDER}.tar.gz"
+curl -L -o "$TEMP_ARCHIVE" "https://archives.boost.io/release/${VERSION}/source/boost_${VUNDER}.tar.gz"
 
 tar -z -x -C "$BOOST_ROOT" -f "$TEMP_ARCHIVE" --strip-components 1
 rm "$TEMP_ARCHIVE"


### PR DESCRIPTION
* Bumped cibuildwheel action
* Removed macos-12 runner (deprecated)
* Updated Boost Download URL
* Used more appropriate OS Runners for required jobs (architecure specific)
* Explicitly declare each cibuildwheel identifier