### PR TITLE
pkg-config file generation: resolve CMAKE_INSTALL_PREFIX at install time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ libtool
 *.exp
 
 *.m4
-*.in
 *.pc
 *.libs
 *.deps

--- a/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
+++ b/cmake/Modules/GeneratePkgConfig/generate-pkg-config.cmake.in
@@ -57,4 +57,4 @@ set(_interface_compile_options "${_TARGET_INTERFACE_COMPILE_OPTIONS}")
 string(REPLACE ";" " " _interface_compile_options "${_interface_compile_options}")
 
 configure_file("@_pkg_config_file_template_filename@" "@_generate_target_dir@/@_package_name@.pc" @ONLY)
-file(INSTALL "@_generate_target_dir@/@_package_name@.pc" DESTINATION "@CMAKE_INSTALL_FULL_LIBDIR@/pkgconfig")
+file(INSTALL "@_generate_target_dir@/@_package_name@.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/@CMAKE_INSTALL_LIBDIR@/pkgconfig")


### PR DESCRIPTION
currently it's not straightforward to install into a destdir without providing the `CMAKE_INSTALL_PREFIX` definition at configure stage 

```
cmake -B builddir ...
cmake --build builddir ... 
cmake --install builddir --prefix=destdir
```
this currently tries to install pc file into `/usr/local/lib/pkgconfig` and neither works nor makes sense

this PR makes it work

i didn't try to understand the rationale behind this extra level of "in"direction for generating the pkg-file, so i might have missed the spot where to clean up the string replacement