### PR TITLE
make message output for torrent_alert more concise

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.1.0 not released
 
+	* deprecate torrent_alert::torrent_name()
 	* requires OpenSSL minimum version 1.1.0 with SNI support
 	* try harder to bind TCP and UDP sockets to the same port
 	* made disk_interface's status_t type a flags type

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -409,7 +409,9 @@ void bind_alert()
     class_<torrent_alert, bases<alert>, noncopyable>(
         "torrent_alert", no_init)
         .add_property("handle", make_getter(&torrent_alert::handle, by_value()))
+#if TORRENT_ABI_VERSION < 4
         .add_property("torrent_name", &torrent_alert::torrent_name)
+#endif
         ;
 
     class_<tracker_alert, bases<torrent_alert>, noncopyable>(

--- a/docs/upgrade_to_1.2.rst
+++ b/docs/upgrade_to_1.2.rst
@@ -156,6 +156,14 @@ libtorrent session plugins no longer have all callbacks called unconditionally.
 The plugin has to register which callbacks it's interested in receiving by returning a bitmask from ``feature_flags_t implemented_features()``.
 The return value is documented in the plugin class.
 
+torrent_alert deprecation
+=========================
+
+torrent_alert::torrent_name() was deprecated. When ABI version < 4 (controlled
+by the ``deprecated-functions`` feature in the Jamfile), the ABI of
+torrent_alert is changed. The name of the torrent is no longer allocated and
+copied into every alert deriving from torrent_alert.
+
 RSS functions removed
 =====================
 

--- a/include/libtorrent/alert_types.hpp
+++ b/include/libtorrent/alert_types.hpp
@@ -103,7 +103,7 @@ namespace libtorrent {
 		int last_active;
 	};
 
-TORRENT_VERSION_NAMESPACE_3
+TORRENT_VERSION_NAMESPACE_4
 
 	// This is a base class for alerts that are associated with a
 	// specific torrent. It contains a handle to the torrent.
@@ -127,12 +127,16 @@ TORRENT_VERSION_NAMESPACE_3
 		// alert is associated with.
 		torrent_handle handle;
 
-		char const* torrent_name() const;
+#if TORRENT_ABI_VERSION < 4
+		TORRENT_DEPRECATED char const* torrent_name() const;
+#endif
 
 	protected:
 		std::reference_wrapper<aux::stack_allocator const> m_alloc;
 	private:
+#if TORRENT_ABI_VERSION < 4
 		aux::allocation_slot m_name_idx;
+#endif
 #if TORRENT_ABI_VERSION == 1
 	public:
 		TORRENT_DEPRECATED std::string name;
@@ -2952,7 +2956,7 @@ TORRENT_VERSION_NAMESPACE_3
 		operation_t op;
 	};
 
-TORRENT_VERSION_NAMESPACE_3_END
+TORRENT_VERSION_NAMESPACE_4_END
 
 	// this alert may be posted when the initial checking of resume data and files
 	// on disk (just existence, not piece hashes) completes. If a file belonging

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -26,7 +26,7 @@ struct alert;
 
 // include/libtorrent/alert_types.hpp
 struct dht_routing_bucket;
-TORRENT_VERSION_NAMESPACE_3
+TORRENT_VERSION_NAMESPACE_4
 struct torrent_alert;
 struct peer_alert;
 struct tracker_alert;
@@ -119,7 +119,7 @@ struct block_uploaded_alert;
 struct alerts_dropped_alert;
 struct socks5_alert;
 struct file_prio_alert;
-TORRENT_VERSION_NAMESPACE_3_END
+TORRENT_VERSION_NAMESPACE_4_END
 struct oversized_file_alert;
 struct torrent_conflict_alert;
 struct peer_info_alert;
@@ -276,12 +276,12 @@ struct web_seed_entry;
 #if TORRENT_ABI_VERSION <= 2
 
 // include/libtorrent/alert_types.hpp
-TORRENT_VERSION_NAMESPACE_3
+TORRENT_VERSION_NAMESPACE_4
 struct torrent_added_alert;
 struct stats_alert;
 struct anonymous_mode_alert;
 struct mmap_cache_alert;
-TORRENT_VERSION_NAMESPACE_3_END
+TORRENT_VERSION_NAMESPACE_4_END
 
 // include/libtorrent/file_storage.hpp
 struct file_entry;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -58,6 +58,7 @@ namespace libtorrent {
 		: handle(h)
 		, m_alloc(alloc)
 	{
+#if TORRENT_ABI_VERSION < 4
 		auto t = h.native_handle();
 		if (t)
 		{
@@ -78,16 +79,19 @@ namespace libtorrent {
 		{
 			m_name_idx = alloc.copy_string("");
 		}
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 		name = m_alloc.get().ptr(m_name_idx);
 #endif
 	}
 
+#if TORRENT_ABI_VERSION < 4
 	char const* torrent_alert::torrent_name() const
 	{
 		return m_alloc.get().ptr(m_name_idx);
 	}
+#endif
 
 	std::string torrent_alert::message() const
 	{

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -39,6 +39,10 @@ see LICENSE file.
 #include "libtorrent/peer_info.hpp"
 #include "libtorrent/aux_/ip_helpers.hpp" // for is_v4
 
+#ifndef TORRENT_DISABLE_ALERT_MSG
+#include "libtorrent/info_hash.hpp"
+#endif
+
 #if TORRENT_ABI_VERSION == 1
 #include "libtorrent/write_resume_data.hpp"
 #endif
@@ -90,8 +94,12 @@ namespace libtorrent {
 #ifdef TORRENT_DISABLE_ALERT_MSG
 		return {};
 #else
-		if (!handle.is_valid()) return " - ";
-		return torrent_name();
+		info_hash_t const ih = handle.info_hashes();
+		if (ih.has_v2())
+			return aux::to_hex(span<char const>(ih.v2).first(3));
+		if (ih.has_v1())
+			return aux::to_hex(span<char const>(ih.v1).first(3));
+		return "------";
 #endif
 	}
 


### PR DESCRIPTION
and deprecate `torrent_alert::torrent_name()` to avoid copying the name of the torrent for every torrent alert.