### PR TITLE
move the code loading torrents

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -205,7 +205,7 @@ jobs:
 
    test:
       name: Tests
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       continue-on-error: true
 
       strategy:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -242,22 +242,22 @@ jobs:
         run: |
           sudo apt install libgnutls28-dev
 
-      - name: install clang-12
+      - name: install clang-16
         continue-on-error: true
         run: |
-          sudo apt install clang-12
+          sudo apt install clang-16
 
-      - name: install GCC-12
+      - name: install GCC-14
         continue-on-error: true
         run: |
-          sudo apt install gcc-12
+          sudo apt install gcc-14
 
       - name: install boost
         run: |
           sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
           pip install websockets
-          echo "using gcc : 12 : g++-12 ;" >>~/user-config.jam
-          echo "using clang : 12 : clang++-12 ;" >>~/user-config.jam
+          echo "using gcc : 14 : g++-14 ;" >>~/user-config.jam
+          echo "using clang : 16 : clang++-16 ;" >>~/user-config.jam
 
       - name: build and run tests
         run: |

--- a/Jamfile
+++ b/Jamfile
@@ -319,8 +319,11 @@ rule warnings ( properties * )
 		result += <cflags>-Wextra ;
 		result += <cflags>-Wpedantic ;
 		result += <cflags>-Wvla ;
-		result += <cflags>-Wno-format-zero-length ;
-		result += <cxxflags>-Wno-noexcept-type ;
+		result += <cflags>-Wno-error=format-zero-length ;
+		result += <cxxflags>-Wno-error=noexcept-type ;
+		# these warnings seem to have a lot of false positives
+		result += <cxxflags>-Wno-error=stringop-overflow ;
+		result += <cxxflags>-Wno-error=array-bounds ;
 	}
 
 	if <toolset>msvc in $(properties)

--- a/include/libtorrent/load_torrent.hpp
+++ b/include/libtorrent/load_torrent.hpp
@@ -40,7 +40,11 @@ namespace libtorrent {
 		bdecode_node const& torrent_file, load_torrent_limits const& cfg);
 	TORRENT_EXPORT add_torrent_params load_torrent_parsed(
 		bdecode_node const& torrent_file);
+}
 
+namespace libtorrent::aux {
+	void parse_torrent_file(bdecode_node const& torrent_file
+		, error_code& ec, load_torrent_limits const& cfg, add_torrent_params& out);
 }
 
 #endif

--- a/src/load_torrent.cpp
+++ b/src/load_torrent.cpp
@@ -15,88 +15,13 @@ see LICENSE file.
 #include "libtorrent/aux_/throw.hpp"
 #include "libtorrent/aux_/file_pointer.hpp"
 #include "libtorrent/aux_/path.hpp"
+#include "libtorrent/aux_/escape_string.hpp" // maybe_url_encode
+#include "libtorrent/magnet_uri.hpp"
+#include "libtorrent/aux_/string_util.hpp" // for is_i2p_url, ltrim, ensure_trailing_slash
 
 namespace libtorrent {
 
 namespace {
-	void update_atp(std::shared_ptr<torrent_info> ti, add_torrent_params& atp)
-	{
-		// This is a temporary measure until all non info-dict content is parsed
-		// here, rather than the torrent_info constructor
-		auto drained_state = ti->_internal_drain();
-		for (auto const& ae : drained_state.urls)
-		{
-			atp.trackers.push_back(std::move(ae.url));
-			atp.tracker_tiers.push_back(ae.tier);
-		}
-
-		if (ti->is_i2p())
-			atp.flags |= torrent_flags::i2p_torrent;
-
-		for (auto const& ws : drained_state.web_seeds)
-		{
-#if TORRENT_ABI_VERSION < 4
-			if (ws.type == web_seed_entry::url_seed)
-#endif
-				atp.url_seeds.push_back(std::move(ws.url));
-#if TORRENT_ABI_VERSION < 4
-			else if (ws.type == web_seed_entry::http_seed)
-				atp.http_seeds.push_back(std::move(ws.url));
-#endif
-		}
-
-		atp.dht_nodes = std::move(drained_state.nodes);
-
-		if (ti->v2_piece_hashes_verified())
-		{
-			int const blocks_per_piece = ti->files().blocks_per_piece();
-			std::vector<sha256_hash> scratch;
-			sha256_hash const pad = merkle_pad(blocks_per_piece, 1);
-			file_storage const& fs = ti->files();
-			atp.merkle_trees.resize(fs.num_files());
-			atp.merkle_tree_mask.resize(fs.num_files());
-			for (auto const f : fs.file_range())
-			{
-				if (fs.pad_file_at(f)) continue;
-				if (fs.file_size(f) <= fs.piece_length()) continue;
-				auto const bytes = ti->piece_layer(f);
-				auto& layer = atp.merkle_trees[f];
-				layer.reserve(std::size_t(bytes.size() / sha256_hash::size()));
-				for (int i = 0; i < bytes.size(); i += int(sha256_hash::size()))
-					layer.emplace_back(bytes.data() + i);
-
-				int const full_size = merkle_num_nodes(
-					merkle_num_leafs(fs.file_num_blocks(f)));
-				int const num_pieces = fs.file_num_pieces(f);
-				int const piece_layer_size = merkle_num_leafs(num_pieces);
-
-				if (!layer.empty())
-				{
-					sha256_hash const computed_root = merkle_root_scratch(layer
-						, piece_layer_size
-						, pad
-						, scratch);
-					if (computed_root != fs.root(f))
-						aux::throw_ex<system_error>(errors::torrent_invalid_piece_layer);
-				}
-
-				auto& mask = atp.merkle_tree_mask[f];
-				mask.resize(full_size, false);
-				for (int i = merkle_first_leaf(piece_layer_size)
-					, end = i + num_pieces; i < end; ++i)
-				{
-					mask.set_bit(i);
-				}
-			}
-			ti->free_piece_layers();
-		}
-
-		atp.comment = ti->comment();
-		atp.created_by = ti->creator();
-		atp.creation_date = ti->creation_date();
-		atp.info_hashes = ti->info_hashes();
-		atp.ti = std::move(ti);
-	}
 
 	void load_file(std::string const& filename, std::vector<char>& v
 		, error_code& ec, int const max_buffer_size)
@@ -147,6 +72,258 @@ namespace {
 			ec.assign(errno, generic_category());
 		}
 	}
+
+	void parse_piece_layers(bdecode_node const& e, file_storage const& fs, error_code& ec, add_torrent_params& out)
+	{
+		std::map<sha256_hash, string_view> piece_layers;
+
+		if (e.type() != bdecode_node::dict_t)
+		{
+			ec = errors::torrent_missing_piece_layer;
+			return;
+		}
+
+		std::map<sha256_hash, file_index_t> all_file_roots;
+		for (file_index_t i : fs.file_range())
+		{
+			if (fs.file_size(i) <= fs.piece_length())
+				continue;
+			all_file_roots.insert(std::make_pair(fs.root(i), i));
+		}
+
+		out.merkle_trees.resize(fs.num_files());
+		out.merkle_tree_mask.resize(fs.num_files());
+		out.verified_leaf_hashes.resize(fs.num_files());
+
+		for (int i = 0; i < e.dict_size(); ++i)
+		{
+			auto const f = e.dict_at(i);
+			if (f.first.size() != static_cast<std::size_t>(sha256_hash::size())
+				|| f.second.type() != bdecode_node::string_t
+				|| f.second.string_length() % sha256_hash::size() != 0)
+			{
+				ec = errors::torrent_invalid_piece_layer;
+				return;
+			}
+
+			sha256_hash const root(f.first);
+			auto file_index = all_file_roots.find(root);
+			if (file_index == all_file_roots.end())
+			{
+				// This piece layer doesn't refer to any file in this torrent
+				ec = errors::torrent_invalid_piece_layer;
+				return;
+			}
+
+			file_index_t const file = file_index->second;
+			string_view const piece_layer = f.second.string_value();
+			int const num_pieces = fs.file_num_pieces(file);
+			if (ptrdiff_t(piece_layer.size()) != num_pieces * sha256_hash::size())
+			{
+				ec = errors::torrent_invalid_piece_layer;
+				return;
+			}
+
+			aux::merkle_tree tree(fs.file_num_blocks(file), fs.blocks_per_piece(), fs.root_ptr(file));
+			if (!tree.load_piece_layer(piece_layer))
+			{
+				ec = errors::torrent_invalid_piece_layer;
+				return;
+			}
+
+			auto [sparse_tree, mask] = tree.build_sparse_vector();
+			out.merkle_trees[file] = std::move(sparse_tree);
+			out.merkle_tree_mask[file] = std::move(mask);
+			out.verified_leaf_hashes[file] = tree.verified_leafs();
+
+			// make sure we don't have duplicate piece layers
+			all_file_roots.erase(file_index);
+		}
+	}
+}
+
+namespace aux
+{
+	void parse_torrent_file(bdecode_node const& torrent_file
+		, error_code& ec, load_torrent_limits const& cfg, add_torrent_params& out)
+	{
+		if (torrent_file.type() != bdecode_node::dict_t)
+		{
+			ec = errors::torrent_is_no_dict;
+			return;
+		}
+
+		bdecode_node const info = torrent_file.dict_find_dict("info");
+		if (!info)
+		{
+			bdecode_node const uri = torrent_file.dict_find_string("magnet-uri");
+			if (uri)
+			{
+				parse_magnet_uri(uri.string_value(), out, ec);
+				return;
+			}
+
+			ec = errors::torrent_missing_info;
+			return;
+		}
+
+		auto ti = std::make_shared<torrent_info>(info, ec, cfg, from_info_section);
+		if (ec) return;
+
+		if (ti->v2())
+		{
+			// allow torrent files without piece layers, just like we allow magnet
+			// links. However, if there are piece layers, make sure they're
+			// valid
+			bdecode_node const& e = torrent_file.dict_find_dict("piece layers");
+			if (e)
+			{
+				parse_piece_layers(e, ti->orig_files(), ec, out);
+				if (ec) return;
+			}
+		}
+
+#ifndef TORRENT_DISABLE_MUTABLE_TORRENTS
+		bdecode_node const similar = torrent_file.dict_find_list("similar");
+		if (similar)
+		{
+			std::vector<sha1_hash> similar_torrents;
+			for (int i = 0; i < similar.list_size(); ++i)
+			{
+				if (similar.list_at(i).type() != bdecode_node::string_t)
+					continue;
+
+				if (similar.list_at(i).string_length() != 20)
+					continue;
+
+				similar_torrents.emplace_back(
+					similar.list_at(i).string_ptr());
+			}
+			ti->internal_set_similar(std::move(similar_torrents));
+		}
+
+		bdecode_node const collections = torrent_file.dict_find_list("collections");
+		if (collections)
+		{
+			std::vector<std::string> owned_collections;
+			for (int i = 0; i < collections.list_size(); ++i)
+			{
+				bdecode_node const str = collections.list_at(i);
+
+				if (str.type() != bdecode_node::string_t) continue;
+
+				owned_collections.emplace_back(str.string_ptr()
+					, aux::numeric_cast<std::size_t>(str.string_length()));
+			}
+			ti->internal_set_collections(owned_collections);
+		}
+#endif // TORRENT_DISABLE_MUTABLE_TORRENTS
+
+		// extract the url of the tracker
+		bdecode_node const announce_node = torrent_file.dict_find_list("announce-list");
+		if (announce_node)
+		{
+			out.trackers.reserve(std::size_t(announce_node.list_size()));
+			out.tracker_tiers.reserve(std::size_t(announce_node.list_size()));
+
+			for (int j = 0, end(announce_node.list_size()); j < end; ++j)
+			{
+				bdecode_node const tier = announce_node.list_at(j);
+				if (tier.type() != bdecode_node::list_t) continue;
+				for (int k = 0, end2(tier.list_size()); k < end2; ++k)
+				{
+					string_view const url = tier.list_string_value_at(k);
+					if (url.empty()) continue;
+#if TORRENT_USE_I2P
+					if (aux::is_i2p_url(url)) out.flags |= torrent_flags::i2p_torrent;
+#endif
+					std::string u(url);
+					aux::ltrim(u);
+					out.trackers.push_back(std::move(u));
+					out.tracker_tiers.push_back(j);
+				}
+			}
+		}
+
+		if (out.trackers.empty())
+		{
+			string_view const url = torrent_file.dict_find_string_value("announce");
+#if TORRENT_USE_I2P
+			if (aux::is_i2p_url(url)) out.flags |= torrent_flags::i2p_torrent;
+#endif
+			if (!url.empty())
+			{
+				std::string u(url);
+				aux::ltrim(u);
+				out.trackers.push_back(std::move(u));
+				out.tracker_tiers.push_back(0);
+			}
+		}
+
+		bdecode_node const nodes = torrent_file.dict_find_list("nodes");
+		if (nodes)
+		{
+			for (int i = 0, end(nodes.list_size()); i < end; ++i)
+			{
+				bdecode_node const n = nodes.list_at(i);
+				if (n.type() != bdecode_node::list_t
+					|| n.list_size() < 2
+					|| n.list_at(0).type() != bdecode_node::string_t
+					|| n.list_at(1).type() != bdecode_node::int_t)
+					continue;
+				out.dht_nodes.emplace_back(
+					n.list_at(0).string_value()
+					, int(n.list_at(1).int_value()));
+			}
+		}
+
+		// extract creation date
+		std::int64_t const cd = torrent_file.dict_find_int_value("creation date", -1);
+		if (cd >= 0)
+		{
+			out.creation_date = std::time_t(cd);
+		}
+
+		// if there are any url-seeds, extract them
+		bdecode_node const url_seeds = torrent_file.dict_find("url-list");
+		if (url_seeds && url_seeds.type() == bdecode_node::string_t
+			&& url_seeds.string_length() > 0)
+		{
+			std::string url = maybe_url_encode(url_seeds.string_value());
+			if (ti->num_files() > 1)
+				aux::ensure_trailing_slash(url);
+			out.url_seeds.push_back(std::move(url));
+		}
+		else if (url_seeds && url_seeds.type() == bdecode_node::list_t)
+		{
+			// only add a URL once
+			std::set<string_view> unique;
+			for (int i = 0, end(url_seeds.list_size()); i < end; ++i)
+			{
+				string_view const url = url_seeds.list_string_value_at(i, ""_sv);
+				if (url.empty()) continue;
+				if (!unique.insert(url).second) continue;
+				std::string new_url = maybe_url_encode(url);
+				if (ti->num_files() > 1)
+					aux::ensure_trailing_slash(new_url);
+				out.url_seeds.push_back(new_url);
+			}
+		}
+
+		out.comment = torrent_file.dict_find_string_value("comment.utf-8");
+		if (out.comment.empty()) out.comment = torrent_file.dict_find_string_value("comment");
+		aux::verify_encoding(out.comment);
+
+		out.created_by = torrent_file.dict_find_string_value("created by.utf-8");
+		if (out.created_by.empty()) out.created_by = torrent_file.dict_find_string_value("created by");
+		aux::verify_encoding(out.created_by);
+
+		out.info_hashes = ti->info_hashes();
+
+		ti->internal_set_creation_date(out.creation_date);
+
+		out.ti = std::move(ti);
+	}
 }
 
 	add_torrent_params load_torrent_file(std::string const& filename)
@@ -176,13 +353,11 @@ namespace {
 
 	add_torrent_params load_torrent_parsed(bdecode_node const& torrent_file, load_torrent_limits const& cfg)
 	{
-		auto ti = std::make_shared<torrent_info>(info_hash_t{});
-		// TODO: move load_torrent_file logic into here
 		error_code ec;
-		ti->parse_torrent_file(torrent_file, ec, cfg);
-		if (ec) aux::throw_ex<system_error>(ec);
 		add_torrent_params ret;
-		update_atp(std::move(ti), ret);
+		aux::parse_torrent_file(torrent_file, ec, cfg, ret);
+		if (ec) aux::throw_ex<system_error>(ec);
+		//update_atp(std::move(ti), ret);
 		return ret;
 	}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3877,6 +3877,8 @@ namespace {
 		{
 			debug_log("*** found no tracker endpoints to announce");
 		}
+#else
+		TORRENT_UNUSED(found_one);
 #endif
 		update_tracker_timer(aux::time_now32());
 	}

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -33,6 +33,8 @@ see LICENSE file.
 #include "libtorrent/disk_interface.hpp" // for default_block_size
 #include "libtorrent/span.hpp"
 
+#include "libtorrent/load_torrent.hpp" // for parse_torrent_file()
+
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/crc.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
@@ -51,6 +53,7 @@ see LICENSE file.
 namespace libtorrent {
 
 	TORRENT_EXPORT from_span_t from_span;
+	TORRENT_EXPORT from_info_section_t from_info_section;
 
 	namespace {
 
@@ -354,7 +357,11 @@ namespace {
 		, std::ptrdiff_t const info_offset, char const* info_buffer
 		, error_code& ec)
 	{
-		if (dict.type() != bdecode_node::dict_t) return false;
+		if (dict.type() != bdecode_node::dict_t)
+		{
+			ec = errors::torrent_file_parse_failed;
+			return false;
+		}
 
 		file_flags_t file_flags = get_file_attributes(dict);
 
@@ -1021,6 +1028,13 @@ namespace {
 		: m_info_hash(info_hash)
 	{}
 
+	torrent_info::torrent_info(bdecode_node const& info_section, error_code& ec
+		, load_torrent_limits const& cfg, from_info_section_t)
+	{
+		if (!parse_info_section(info_section, ec, cfg.max_pieces)) return;
+		if (!resolve_duplicate_filenames(cfg.max_duplicate_filenames, ec)) return;
+	}
+
 	torrent_info::~torrent_info() = default;
 
 	// internal
@@ -1404,79 +1418,6 @@ namespace {
 		return true;
 	}
 
-	bool torrent_info::parse_piece_layers(bdecode_node const& e, error_code& ec)
-	{
-		std::map<sha256_hash, string_view> piece_layers;
-
-		if (e.type() != bdecode_node::dict_t)
-		{
-			ec = errors::torrent_missing_piece_layer;
-			return false;
-		}
-
-		std::set<sha256_hash> all_file_roots;
-		auto const& fs = orig_files();
-		for (file_index_t i : fs.file_range())
-		{
-			if (fs.file_size(i) <= fs.piece_length())
-				continue;
-			all_file_roots.insert(fs.root(i));
-		}
-
-		for (int i = 0; i < e.dict_size(); ++i)
-		{
-			auto const f = e.dict_at(i);
-			if (f.first.size() != static_cast<std::size_t>(sha256_hash::size())
-				|| f.second.type() != bdecode_node::string_t
-				|| f.second.string_length() % sha256_hash::size() != 0)
-			{
-				ec = errors::torrent_invalid_piece_layer;
-				return false;
-			}
-
-			sha256_hash const root(f.first);
-			if (all_file_roots.find(root) == all_file_roots.end())
-			{
-				// This piece layer doesn't refer to any file in this torrent
-				ec = errors::torrent_invalid_piece_layer;
-				return false;
-			}
-
-			piece_layers.emplace(sha256_hash(f.first), f.second.string_value());
-		}
-
-		m_piece_layers.resize(fs.num_files());
-
-		for (file_index_t i : fs.file_range())
-		{
-			if (fs.file_size(i) <= fs.piece_length())
-				continue;
-
-			auto const piece_layer = piece_layers.find(fs.root(i));
-			if (piece_layer == piece_layers.end()) continue;
-
-			int const num_pieces = fs.file_num_pieces(i);
-
-			if (ptrdiff_t(piece_layer->second.size()) != num_pieces * sha256_hash::size())
-			{
-				ec = errors::torrent_invalid_piece_layer;
-				return false;
-			}
-
-			auto const hashes = piece_layer->second;
-			if ((hashes.size() % sha256_hash::size()) != 0)
-			{
-				ec = errors::torrent_invalid_piece_layer;
-				return false;
-			}
-
-			m_piece_layers[i].assign(hashes.begin(), hashes.end());
-		}
-
-		m_flags |= v2_has_piece_hashes;
-		return true;
-	}
-
 	span<char const> torrent_info::piece_layer(file_index_t f) const
 	{
 		TORRENT_ASSERT_PRECOND(f >= file_index_t(0));
@@ -1504,12 +1445,12 @@ namespace {
 	void torrent_info::internal_set_creator(string_view const c)
 	{ m_created_by = std::string(c); }
 
-	void torrent_info::internal_set_creation_date(std::time_t const t)
-	{ m_creation_date = t; }
-
 	void torrent_info::internal_set_comment(string_view const s)
 	{ m_comment = std::string(s); }
 #endif
+
+	void torrent_info::internal_set_creation_date(std::time_t const t)
+	{ m_creation_date = t; }
 
 	bdecode_node torrent_info::info(char const* key) const
 	{
@@ -1526,188 +1467,110 @@ namespace {
 	bool torrent_info::parse_torrent_file(bdecode_node const& torrent_file
 		, error_code& ec, load_torrent_limits const& cfg)
 	{
-		if (torrent_file.type() != bdecode_node::dict_t)
+		add_torrent_params atp;
+		aux::parse_torrent_file(torrent_file, ec, cfg, atp);
+		if (ec) return false;
+
+		if (atp.ti)
 		{
-			ec = errors::torrent_is_no_dict;
-			return false;
+			*this = std::move(*atp.ti);
+		}
+		else
+		{
+			// this is a magnet-link "torrent" file
+			m_info_hash = atp.info_hashes;
+			return true;
 		}
 
-		bdecode_node const info = torrent_file.dict_find_dict("info");
-		if (!info)
+		m_comment = atp.comment;
+		m_created_by = atp.created_by;
+		m_creation_date = atp.creation_date;
+		int tier = 0;
+		for (std::size_t i = 0; i < atp.trackers.size(); ++i)
 		{
-			bdecode_node const uri = torrent_file.dict_find_string("magnet-uri");
-			if (uri)
-			{
-				auto const p = parse_magnet_uri(uri.string_value(), ec);
-				if (ec) return false;
-
-				m_info_hash = p.info_hashes;
-				m_urls.reserve(m_urls.size() + p.trackers.size());
-				for (auto const& url : p.trackers)
-					m_urls.emplace_back(url);
-
-				return true;
-			}
-
-			ec = errors::torrent_missing_info;
-			return false;
+			if (atp.tracker_tiers.size() < i) tier = atp.tracker_tiers[i];
+			announce_entry ent;
+			ent.url = atp.trackers[i];
+			ent.tier = std::uint8_t(tier);
+			m_urls.push_back(std::move(ent));
 		}
 
-		if (!parse_info_section(info, ec, cfg.max_pieces)) return false;
-		if (!resolve_duplicate_filenames(cfg.max_duplicate_filenames, ec)) return false;
-
-		if (m_info_hash.has_v2())
+		if (atp.flags & torrent_flags::i2p_torrent)
 		{
-			// allow torrent files without piece layers, just like we allow magnet
-			// links. However, if there are piece layers, make sure they're
-			// valid
-			bdecode_node const& e = torrent_file.dict_find_dict("piece layers");
-			if (e && !parse_piece_layers(e, ec))
-			{
-				TORRENT_ASSERT(ec);
-				// mark the torrent as invalid
-				m_files.set_piece_length(0);
-				return false;
-			}
+			m_flags |= i2p;
 		}
 
-#ifndef TORRENT_DISABLE_MUTABLE_TORRENTS
-		bdecode_node const similar = torrent_file.dict_find_list("similar");
-		if (similar)
+		if (v2())
 		{
-			for (int i = 0; i < similar.list_size(); ++i)
+			auto& trees = atp.merkle_trees;
+			auto& mask = atp.merkle_tree_mask;
+			auto& verified = atp.verified_leaf_hashes;
+
+			aux::vector<aux::vector<char>, file_index_t> v2_hashes;
+
+			auto const& fs = orig_files();
+			bitfield const empty_verified;
+			for (file_index_t i : fs.file_range())
 			{
-				if (similar.list_at(i).type() != bdecode_node::string_t)
-					continue;
-
-				if (similar.list_at(i).string_length() != 20)
-					continue;
-
-				m_owned_similar_torrents.emplace_back(
-					similar.list_at(i).string_ptr());
-			}
-		}
-
-		bdecode_node const collections = torrent_file.dict_find_list("collections");
-		if (collections)
-		{
-			for (int i = 0; i < collections.list_size(); ++i)
-			{
-				bdecode_node const str = collections.list_at(i);
-
-				if (str.type() != bdecode_node::string_t) continue;
-
-				m_owned_collections.emplace_back(str.string_ptr()
-					, aux::numeric_cast<std::size_t>(str.string_length()));
-			}
-		}
-#endif // TORRENT_DISABLE_MUTABLE_TORRENTS
-
-		// extract the url of the tracker
-		bdecode_node const announce_node = torrent_file.dict_find_list("announce-list");
-		if (announce_node)
-		{
-			m_urls.reserve(announce_node.list_size());
-			for (int j = 0, end(announce_node.list_size()); j < end; ++j)
-			{
-				bdecode_node const tier = announce_node.list_at(j);
-				if (tier.type() != bdecode_node::list_t) continue;
-				for (int k = 0, end2(tier.list_size()); k < end2; ++k)
+				if (fs.pad_file_at(i) || fs.file_size(i) <= fs.piece_length())
 				{
-					announce_entry e(tier.list_string_value_at(k));
-					aux::ltrim(e.url);
-					if (e.url.empty()) continue;
-					e.tier = std::uint8_t(j);
-					e.fail_limit = 0;
-					e.source = announce_entry::source_torrent;
-#if TORRENT_USE_I2P
-					if (aux::is_i2p_url(e.url)) m_flags |= i2p;
-#endif
-					m_urls.push_back(e);
-				}
-			}
-
-			if (!m_urls.empty())
-			{
-				// shuffle each tier
-				aux::random_shuffle(m_urls);
-				std::stable_sort(m_urls.begin(), m_urls.end()
-					, [](announce_entry const& lhs, announce_entry const& rhs)
-					{ return lhs.tier < rhs.tier; });
-			}
-		}
-
-		if (m_urls.empty())
-		{
-			announce_entry e(torrent_file.dict_find_string_value("announce"));
-			e.fail_limit = 0;
-			e.source = announce_entry::source_torrent;
-			aux::ltrim(e.url);
-#if TORRENT_USE_I2P
-			if (aux::is_i2p_url(e.url)) m_flags |= i2p;
-#endif
-			if (!e.url.empty()) m_urls.push_back(e);
-		}
-
-		bdecode_node const nodes = torrent_file.dict_find_list("nodes");
-		if (nodes)
-		{
-			for (int i = 0, end(nodes.list_size()); i < end; ++i)
-			{
-				bdecode_node const n = nodes.list_at(i);
-				if (n.type() != bdecode_node::list_t
-					|| n.list_size() < 2
-					|| n.list_at(0).type() != bdecode_node::string_t
-					|| n.list_at(1).type() != bdecode_node::int_t)
+					v2_hashes.emplace_back();
 					continue;
-				m_nodes.emplace_back(
-					n.list_at(0).string_value()
-					, int(n.list_at(1).int_value()));
+				}
+
+				if (i >= atp.merkle_trees.end_index()) break;
+				bitfield const& verified_bitmask = (i >= verified.end_index()) ? empty_verified : verified[i];
+
+				aux::merkle_tree tree(fs.file_num_blocks(i), fs.blocks_per_piece(), fs.root_ptr(i));
+				if (i < mask.end_index() && !mask[i].empty())
+				{
+					tree.load_sparse_tree(trees[i], mask[i], verified_bitmask);
+				}
+				else
+				{
+					tree.load_tree(trees[i], verified_bitmask);
+				}
+
+				auto const& layer = tree.get_piece_layer();
+				std::vector<char> out_layer;
+				out_layer.reserve(layer.size() * sha256_hash::size());
+				for (auto const& h : layer)
+				{
+					// we're missing a piece layer. We can't return a valid
+					// torrent
+					if (h.is_all_zeros()) break;
+					out_layer.insert(out_layer.end(), h.data(), h.data() + sha256_hash::size());
+				}
+				v2_hashes.emplace_back(std::move(out_layer));
 			}
+			set_piece_layers(v2_hashes);
 		}
 
-		// extract creation date
-		std::int64_t const cd = torrent_file.dict_find_int_value("creation date", -1);
-		if (cd >= 0)
+		for (auto const& url : atp.url_seeds)
 		{
-			m_creation_date = std::time_t(cd);
-		}
-
-		// if there are any url-seeds, extract them
-		bdecode_node const url_seeds = torrent_file.dict_find("url-list");
-		if (url_seeds && url_seeds.type() == bdecode_node::string_t
-			&& url_seeds.string_length() > 0)
-		{
-			web_seed_entry ent(maybe_url_encode(url_seeds.string_value()));
-			if ((m_flags & multifile) && num_files() > 1)
-				aux::ensure_trailing_slash(ent.url);
+			web_seed_entry ent(url);
+#if TORRENT_ABI_VERSION < 4
+			ent.type = web_seed_entry::url_seed;
+#endif
 			m_web_seeds.push_back(std::move(ent));
 		}
-		else if (url_seeds && url_seeds.type() == bdecode_node::list_t)
+
+#if TORRENT_ABI_VERSION < 4
+		for (auto const& url : atp.http_seeds)
 		{
-			// only add a URL once
-			std::set<std::string> unique;
-			for (int i = 0, end(url_seeds.list_size()); i < end; ++i)
-			{
-				bdecode_node const url = url_seeds.list_at(i);
-				if (url.type() != bdecode_node::string_t) continue;
-				if (url.string_length() == 0) continue;
-				web_seed_entry ent(maybe_url_encode(url.string_value()));
-				if ((m_flags & multifile) && num_files() > 1)
-					aux::ensure_trailing_slash(ent.url);
-				if (!unique.insert(ent.url).second) continue;
-				m_web_seeds.push_back(std::move(ent));
-			}
+			web_seed_entry ent(url);
+			ent.type = web_seed_entry::http_seed;
+			m_web_seeds.push_back(std::move(ent));
+		}
+#endif
+
+		for (auto const& n : atp.dht_nodes)
+		{
+			m_nodes.emplace_back(n);
 		}
 
-		m_comment = torrent_file.dict_find_string_value("comment.utf-8");
-		if (m_comment.empty()) m_comment = torrent_file.dict_find_string_value("comment");
-		aux::verify_encoding(m_comment);
-
-		m_created_by = torrent_file.dict_find_string_value("created by.utf-8");
-		if (m_created_by.empty()) m_created_by = torrent_file.dict_find_string_value("created by");
-		aux::verify_encoding(m_created_by);
-
+		// TODO: collections
+		// TODO: similar
 		return true;
 	}
 

--- a/test/test_alloca.cpp
+++ b/test/test_alloca.cpp
@@ -61,7 +61,7 @@ TORRENT_TEST(alloca_empty)
 {
 	{
 		destructed = 0;
-		TORRENT_ALLOCA(vec, B, 0);
+		TORRENT_ALLOCA(vec, B, destructed);
 	}
 	TEST_EQUAL(destructed, 0);
 }

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -2332,7 +2332,7 @@ TORRENT_TEST(immutable_put)
 				TEST_ERROR(t.error_string);
 				continue;
 			}
-			char tok[11];
+			char tok[50];
 			std::snprintf(tok, sizeof(tok), "%02d", idx);
 
 			msg_args args;
@@ -2363,7 +2363,7 @@ TORRENT_TEST(immutable_put)
 				TEST_EQUAL(put_immutable_item_keys[2].string_value(), "put");
 				span<const char> const v = put_immutable_item_keys[6].data_section();
 				TEST_EQUAL(v, span<char const>(flat_data));
-				char tok[11];
+				char tok[50];
 				std::snprintf(tok, sizeof(tok), "%02d", idx);
 				TEST_EQUAL(put_immutable_item_keys[5].string_value(), tok);
 				if (put_immutable_item_keys[0].string_value() != "q"
@@ -2437,7 +2437,7 @@ TORRENT_TEST(mutable_put)
 				TEST_ERROR(t.error_string);
 				continue;
 			}
-			char tok[11];
+			char tok[50];
 			std::snprintf(tok, sizeof(tok), "%02d", idx);
 
 			msg_args args;
@@ -2473,7 +2473,7 @@ TORRENT_TEST(mutable_put)
 					, std::string(sig.bytes.data(), signature::len));
 				span<const char> const v = put_mutable_item_keys[10].data_section();
 				TEST_CHECK(v == itemv);
-				char tok[11];
+				char tok[50];
 				std::snprintf(tok, sizeof(tok), "%02d", idx);
 				TEST_EQUAL(put_mutable_item_keys[9].string_value(), tok);
 				if (put_mutable_item_keys[0].string_value() != "q"

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -118,7 +118,7 @@ static test_torrent_t const test_torrents[] =
 			// make sure we trimmed the url
 			TEST_CHECK(atp.trackers.size() > 0);
 			if (atp.trackers.size() > 0)
-				TEST_CHECK(atp.trackers[0] == "udp://test.com/announce");
+				TEST_EQUAL(atp.trackers[0], "udp://test.com/announce");
 		}
 	},
 	{ "duplicate_files.torrent", [](lt::add_torrent_params atp) {


### PR DESCRIPTION
from the torrent_info constructor into load_torrent.

This is a step towards making `torrent_info` only hold the immutable info-section of the torrent, and make `add_torrent_params` hold the rest.