### PR TITLE
cirrus: Bump freebsd image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@
 # we only use it for its unique feature, FreeBSD images
 
 freebsd_instance:
-  image_family: freebsd-14-0
+  image_family: freebsd-14-1
 
 task:
   env:


### PR DESCRIPTION
* Bump freebsd image to 14-1 (https://cirrus-ci.org/guide/FreeBSD/#list-of-available-image-families)