### PR TITLE
cibuildwheel: Migrate away from deprecated input

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -203,4 +203,4 @@ jobs:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         packages-dir: wheelhouse
         skip-existing: true
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Takes care of "Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead."