### PR TITLE
deprecate creator, comment and creation-date

### DIFF
--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -432,8 +432,10 @@ void bind_torrent_info()
 #endif
 
         .def("name", &torrent_info::name, copy)
+#if TORRENT_ABI_VERSION < 4
         .def("comment", &torrent_info::comment, copy)
         .def("creator", &torrent_info::creator, copy)
+#endif
         .def("total_size", &torrent_info::total_size)
         .def("size_on_disk", &torrent_info::size_on_disk)
         .def("piece_length", &torrent_info::piece_length)
@@ -467,9 +469,8 @@ void bind_torrent_info()
 #endif
 #if TORRENT_ABI_VERSION < 4
         .def("trackers", range(begin_trackers, end_trackers))
-#endif
-
         .def("creation_date", &torrent_info::creation_date)
+#endif
 
         .def("add_node", &add_node)
         .def("nodes", &nodes)

--- a/docs/upgrade_to_1.2.rst
+++ b/docs/upgrade_to_1.2.rst
@@ -156,6 +156,28 @@ libtorrent session plugins no longer have all callbacks called unconditionally.
 The plugin has to register which callbacks it's interested in receiving by returning a bitmask from ``feature_flags_t implemented_features()``.
 The return value is documented in the plugin class.
 
+torrent_info deprecation
+========================
+
+torrent_info has been made to only hold the immutable part of a torrent file, i.e.
+what's in the info-section. This is the content that determines the info-hash, and
+therefore the uniqueness of the torrent.
+
+Properties that don't belong in the info-dictionary have been deprecated from
+torrent_info, they are now placed in add_torrent_params instead. This includes properties like:
+
+* trackers
+* DHT nodes
+* comment
+* creation date
+* created by
+* piece layers (for v2 torrents)
+* collections and similar torrent lists (except for the ones that live in the
+  info dict)
+
+It also means constructing a torrent_info object from a whole torrent file is
+deprecated. Use load_torrent_*() instead.
+
 torrent_alert deprecation
 =========================
 

--- a/examples/dump_torrent.cpp
+++ b/examples/dump_torrent.cpp
@@ -133,8 +133,8 @@ int main(int argc, char const* argv[]) try
 		, atp.ti->num_pieces()
 		, atp.ti->piece_length()
 		, ih.str().c_str()
-		, atp.ti->comment().c_str()
-		, atp.ti->creator().c_str()
+		, atp.comment.c_str()
+		, atp.created_by.c_str()
 		, make_magnet_uri(atp).c_str()
 		, atp.name.c_str()
 		, atp.ti->num_files());

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -521,23 +521,28 @@ TORRENT_VERSION_NAMESPACE_3
 		// name contains UTF-8 encoded string.
 		const std::string& name() const { return m_files.name(); }
 
+#if TORRENT_ABI_VERSION < 4
 		// ``creation_date()`` returns the creation date of the torrent as time_t
 		// (`posix time`_). If there's no time stamp in the torrent file, 0 is
 		// returned.
 		// .. _`posix time`: http://www.opengroup.org/onlinepubs/009695399/functions/time.html
+		TORRENT_DEPRECATED
 		std::time_t creation_date() const
 		{ return m_creation_date; }
 
 		// ``creator()`` returns the creator string in the torrent. If there is
 		// no creator string it will return an empty string.
+		TORRENT_DEPRECATED
 		const std::string& creator() const
 		{ return m_created_by; }
 
 		// ``comment()`` returns the comment associated with the torrent. If
 		// there's no comment, it will return an empty string.
 		// comment contains UTF-8 encoded string.
+		TORRENT_DEPRECATED
 		const std::string& comment() const
 		{ return m_comment; }
+#endif
 
 		// If this torrent contains any DHT nodes, they are put in this vector in
 		// their original form (host name and port number).
@@ -608,8 +613,8 @@ TORRENT_VERSION_NAMESPACE_3
 		// internal
 		void internal_set_creator(string_view);
 		void internal_set_comment(string_view);
-#endif
 		void internal_set_creation_date(std::time_t);
+#endif
 
 		// internal
 		void internal_set_collections(std::vector<std::string> c)
@@ -713,6 +718,7 @@ TORRENT_VERSION_NAMESPACE_3
 		// make it available through the metadata extension
 		boost::shared_array<char const> m_info_section;
 
+#if TORRENT_ABI_VERSION < 4
 		// if a comment is found in the torrent file
 		// this will be set to that comment
 		std::string m_comment;
@@ -721,14 +727,15 @@ TORRENT_VERSION_NAMESPACE_3
 		// to create the torrent file
 		std::string m_created_by;
 
-		// the info section parsed. points into m_info_section
-		// parsed lazily
-		mutable bdecode_node m_info_dict;
-
 		// if a creation date is found in the torrent file
 		// this will be set to that, otherwise it'll be
 		// 1970, Jan 1
 		std::time_t m_creation_date = 0;
+#endif
+
+		// the info section parsed. points into m_info_section
+		// parsed lazily
+		mutable bdecode_node m_info_dict;
 
 		// the hash(es) that identify this torrent
 		info_hash_t m_info_hash;

--- a/src/load_torrent.cpp
+++ b/src/load_torrent.cpp
@@ -320,7 +320,9 @@ namespace aux
 
 		out.info_hashes = ti->info_hashes();
 
+#if TORRENT_ABI_VERSION < 4
 		ti->internal_set_creation_date(out.creation_date);
+#endif
 
 		out.ti = std::move(ti);
 	}

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1447,10 +1447,10 @@ namespace {
 
 	void torrent_info::internal_set_comment(string_view const s)
 	{ m_comment = std::string(s); }
-#endif
 
 	void torrent_info::internal_set_creation_date(std::time_t const t)
 	{ m_creation_date = t; }
+#endif
 
 	bdecode_node torrent_info::info(char const* key) const
 	{
@@ -1482,9 +1482,11 @@ namespace {
 			return true;
 		}
 
+#if TORRENT_ABI_VERSION < 4
 		m_comment = atp.comment;
 		m_created_by = atp.created_by;
 		m_creation_date = atp.creation_date;
+#endif
 		int tier = 0;
 		for (std::size_t i = 0; i < atp.trackers.size(); ++i)
 		{

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -310,7 +310,10 @@ TORRENT_TEST(test_non_metadata)
 
 	TEST_EQUAL(p.comment, "test comment");
 	TEST_EQUAL(p.created_by, "libtorrent test");
-	auto const creation_date = ti->creation_date();
+	auto const creation_date = p.creation_date;
+#if TORRENT_ABI_VERSION < 4
+	TEST_EQUAL(ti->creation_date(), creation_date);
+#endif
 
 	h.save_resume_data(torrent_handle::save_info_dict);
 	alert const* a = wait_for_alert(ses, save_resume_data_alert::alert_type);
@@ -327,6 +330,9 @@ TORRENT_TEST(test_non_metadata)
 		TEST_EQUAL(atp.comment, "test comment");
 		TEST_EQUAL(atp.created_by, "libtorrent test");
 		TEST_EQUAL(atp.creation_date, creation_date);
+#if TORRENT_ABI_VERSION < 4
+		TEST_EQUAL(atp.ti->creation_date(), creation_date);
+#endif
 
 		std::vector<char> resume_data = write_resume_data_buf(atp);
 		p = read_resume_data(resume_data);
@@ -343,7 +349,9 @@ TORRENT_TEST(test_non_metadata)
 	TEST_EQUAL(h.trackers().at(0).url, "http://torrent_file_tracker2.com/announce");
 	TEST_CHECK(h.url_seeds() == std::set<std::string>{"http://torrent.com/"});
 	auto t = h.status().torrent_file.lock();
-	TEST_EQUAL(ti->creation_date(), creation_date);
+#if TORRENT_ABI_VERSION < 4
+	TEST_EQUAL(t->creation_date(), creation_date);
+#endif
 }
 
 TORRENT_TEST(test_remove_trackers)

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -135,11 +135,17 @@ static test_torrent_t const test_torrents[] =
 		}
 	},
 	{ "creation_date.torrent", [](lt::add_torrent_params atp) {
+#if TORRENT_ABI_VERSION < 4
 			TEST_EQUAL(atp.ti->creation_date(), 1234567);
+#endif
+			TEST_EQUAL(atp.creation_date, 1234567);
 		}
 	},
 	{ "no_creation_date.torrent", [](lt::add_torrent_params atp) {
+#if TORRENT_ABI_VERSION < 4
 			TEST_CHECK(!atp.ti->creation_date());
+#endif
+			TEST_CHECK(!atp.creation_date);
 		}
 	},
 	{ "url_seed.torrent", [](lt::add_torrent_params atp) {


### PR DESCRIPTION
in torrent_info (in favor of add_torrent_params)