### PR TITLE
`generate_torrent()`

### DIFF
--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -34,6 +34,7 @@ see LICENSE file.
 #include "libtorrent/aux_/merkle.hpp"
 #include "libtorrent/disk_interface.hpp" // for default_block_size
 #include "libtorrent/aux_/ip_helpers.hpp"
+#include "libtorrent/load_torrent.hpp"
 
 #include "test.hpp"
 #include "test_utils.hpp"
@@ -56,7 +57,7 @@ using namespace lt;
 #define SEPARATOR "/"
 #endif
 
-std::shared_ptr<torrent_info> generate_torrent(bool const with_files, bool const with_hashes)
+lt::add_torrent_params generate_torrent(bool const with_files, bool const with_hashes)
 {
 	if (with_files)
 	{
@@ -106,7 +107,7 @@ std::shared_ptr<torrent_info> generate_torrent(bool const with_files, bool const
 	}
 
 	std::vector<char> const buf = bencode(t.generate());
-	return std::make_shared<torrent_info>(buf, from_span);
+	return load_torrent_buffer(buf);
 }
 
 namespace {

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -21,8 +21,9 @@ see LICENSE file.
 #include "libtorrent/units.hpp"
 #include "libtorrent/create_torrent.hpp"
 #include "libtorrent/fwd.hpp"
+#include "libtorrent/add_torrent_params.hpp"
 
-EXPORT std::shared_ptr<lt::torrent_info> generate_torrent(bool with_files = false, bool with_hashes = false);
+EXPORT lt::add_torrent_params generate_torrent(bool with_files = false, bool with_hashes = false);
 
 EXPORT int load_file(std::string const& filename, std::vector<char>& v
 	, lt::error_code& ec, int limit = 8000000);

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -136,7 +136,7 @@ TORRENT_TEST(read_resume_missing_file_format)
 }
 
 namespace {
-std::shared_ptr<torrent_info> generate_torrent()
+add_torrent_params generate_torrent()
 {
 	std::vector<lt::create_file_entry> fs;
 	fs.emplace_back("test_resume/tmp1", 128 * 1024 * 8);
@@ -156,39 +156,39 @@ std::shared_ptr<torrent_info> generate_torrent()
 		t.set_hash(i, ph);
 	}
 
-	return load_torrent_buffer(bencode(t.generate())).ti;
+	return load_torrent_buffer(bencode(t.generate()));
 }
 } // anonymous namespace
 
 TORRENT_TEST(read_resume_torrent)
 {
-	std::shared_ptr<torrent_info> ti = generate_torrent();
+	add_torrent_params p = generate_torrent();
 
 	entry rd;
 	rd["file-format"] = "libtorrent resume file";
 	rd["file-version"] = 1;
-	rd["info-hash"] = ti->info_hashes().v1.to_string();
-	rd["info"] = bdecode(ti->info_section());
+	rd["info-hash"] = p.ti->info_hashes().v1.to_string();
+	rd["info"] = bdecode(p.ti->info_section());
 
 	// the info-hash field does not match the torrent in the "info" field, so it
 	// will be ignored
 	add_torrent_params atp = read_resume_data(bencode(rd));
 	TEST_CHECK(atp.ti);
 
-	TEST_EQUAL(atp.ti->info_hashes(), ti->info_hashes());
-	TEST_EQUAL(atp.ti->name(), ti->name());
+	TEST_EQUAL(atp.ti->info_hashes(), p.ti->info_hashes());
+	TEST_EQUAL(atp.ti->name(), p.ti->name());
 }
 
 TORRENT_TEST(mismatching_v1_hash)
 {
-	std::shared_ptr<torrent_info> ti = generate_torrent();
+	add_torrent_params p = generate_torrent();
 
 	entry rd;
 	rd["file-format"] = "libtorrent resume file";
 	rd["file-version"] = 1;
 	rd["info-hash"] = "abababababababababab";
-	rd["info-hash2"] = ti->info_hashes().v2;
-	rd["info"] = bdecode(ti->info_section());
+	rd["info-hash2"] = p.ti->info_hashes().v2;
+	rd["info"] = bdecode(p.ti->info_section());
 
 	std::vector<char> resume_data;
 	bencode(std::back_inserter(resume_data), rd);
@@ -202,14 +202,14 @@ TORRENT_TEST(mismatching_v1_hash)
 
 TORRENT_TEST(mismatching_v2_hash)
 {
-	std::shared_ptr<torrent_info> ti = generate_torrent();
+	add_torrent_params p = generate_torrent();
 
 	entry rd;
 	rd["file-format"] = "libtorrent resume file";
 	rd["file-version"] = 1;
-	rd["info-hash"] = ti->info_hashes().v1;
+	rd["info-hash"] = p.ti->info_hashes().v1;
 	rd["info-hash2"] = "abababababababababababababababab";
-	rd["info"] = bdecode(ti->info_section());
+	rd["info"] = bdecode(p.ti->info_section());
 
 	std::vector<char> resume_data;
 	bencode(std::back_inserter(resume_data), rd);

--- a/test/test_time_critical.cpp
+++ b/test/test_time_critical.cpp
@@ -21,13 +21,11 @@ TORRENT_TEST(time_crititcal)
 
 TORRENT_TEST(time_crititcal_zero_prio)
 {
-	auto ti = generate_torrent();
+	lt::add_torrent_params atp = generate_torrent();
 
 	lt::session ses(settings());
 
-	lt::add_torrent_params atp;
-	atp.ti = ti;
-	atp.piece_priorities.resize(std::size_t(ti->num_pieces()), lt::dont_download);
+	atp.piece_priorities.resize(std::size_t(atp.ti->num_pieces()), lt::dont_download);
 	atp.save_path = ".";
 	auto h = ses.add_torrent(atp);
 

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -831,8 +831,7 @@ TORRENT_TEST(redundant_add_piece)
 TORRENT_TEST(test_in_session)
 {
 	lt::session ses(settings());
-	add_torrent_params p;
-	p.ti = generate_torrent();
+	add_torrent_params p = generate_torrent();
 	p.save_path = ".";
 	torrent_handle h = ses.add_torrent(std::move(p));
 	TEST_CHECK(h.in_session());


### PR DESCRIPTION
transition test function `generate_torrent()` to return an `add_torrent_params` object, to include all the fields that are no longer part of `torrent_info`.