### PR TITLE
deprecate storing piece layers in `torrent_info`

### DIFF
--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -1081,7 +1081,9 @@ namespace libtorrent::aux {
 
 		std::shared_ptr<const torrent_info> get_torrent_file() const;
 
+#if TORRENT_ABI_VERSION < 4
 		std::shared_ptr<torrent_info> get_torrent_copy_with_hashes() const;
+#endif
 
 		std::vector<std::vector<sha256_hash>> get_piece_layers() const;
 
@@ -1674,10 +1676,12 @@ namespace libtorrent::aux {
 		// quarantine
 		bool m_pending_active_change:1;
 
+#if TORRENT_ABI_VERSION < 4
 		// this is set to true if all piece layers were successfully loaded and
 		// validated. Only for v2 torrents
 		// TODO: this member can probably be removed
 		bool m_v2_piece_layers_validated:1;
+#endif
 
 // ----
 

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -923,6 +923,13 @@ namespace aux {
 		// call save_resume_data() and write_torrent_file() the
 		// add_torrent_params object passed back in the alert.
 		//
+		// Note that a torrent added from a magnet link may not have the full
+		// merkle trees for all files, and hence not have the complete piece
+		// layers. In that state, you cannot create a .torrent file from the
+		// torrent_info returned. Once the torrent completes downloading all
+		// files, becoming a seed, you can make a .torrent file from it.
+		std::shared_ptr<const torrent_info> torrent_file() const;
+#if TORRENT_ABI_VERSION < 4
 		// torrent_file_with_hashes() returns a *copy* of the internal
 		// torrent_info and piece layer hashes (if it's a v2 torrent). The piece
 		// layers will only be included if they are available. If this torrent
@@ -933,15 +940,9 @@ namespace aux {
 		// The torrent_file_with_hashes() is here for backwards compatibility
 		// when constructing a create_torrent object from a torrent_info that's
 		// in a session. Prefer save_resume_data() + write_torrent_file().
-		//
-		// Note that a torrent added from a magnet link may not have the full
-		// merkle trees for all files, and hence not have the complete piece
-		// layers. In that state, you cannot create a .torrent file even from
-		// the torrent_info returned from torrent_file_with_hashes(). Once the
-		// torrent completes downloading all files, becoming a seed, you can
-		// make a .torrent file from it.
-		std::shared_ptr<const torrent_info> torrent_file() const;
+		TORRENT_DEPRECATED
 		std::shared_ptr<torrent_info> torrent_file_with_hashes() const;
+#endif
 
 		// returns the piece layers for all files in the torrent. If this is a
 		// v1 torrent (and doesn't have any piece layers) it returns an empty

--- a/simulation/test_transfer.cpp
+++ b/simulation/test_transfer.cpp
@@ -418,12 +418,12 @@ void run_torrent_test(std::shared_ptr<lt::torrent_info> ti)
 	sim::timer t(sim, lt::seconds(10), [&](boost::system::error_code const&)
 	{
 		auto h = ses[0]->get_torrents();
+#if TORRENT_ABI_VERSION < 4
 		auto ti = h[0].torrent_file_with_hashes();
 
 		if (ti->v2())
 			TEST_EQUAL(ti->v2_piece_hashes_verified(), true);
 
-#if TORRENT_ABI_VERSION < 4
 		auto downloaded = serialize(*ti);
 		auto added = serialize(*torrent);
 		TEST_CHECK(downloaded == added);

--- a/simulation/transfer_sim.hpp
+++ b/simulation/transfer_sim.hpp
@@ -206,6 +206,7 @@ void run_test(
 
 	sim::timer t(sim, timeout, [&](boost::system::error_code const&)
 	{
+#if TORRENT_ABI_VERSION < 4
 		auto h = ses[0]->get_torrents();
 		auto ti = h[0].torrent_file_with_hashes();
 
@@ -219,14 +220,13 @@ void run_test(
 			if (ti->v2())
 				TEST_EQUAL(ti->v2_piece_hashes_verified(), true);
 
-#if TORRENT_ABI_VERSION < 4
 			{
 				auto downloaded = serialize(*ti);
 				auto added = serialize(atp_copy);
 				TEST_CHECK(downloaded == added);
 			}
-#endif
 		}
+#endif
 
 		test(ses);
 

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -717,11 +717,13 @@ namespace libtorrent {
 			std::shared_ptr<const torrent_info>(), &aux::torrent::get_torrent_file);
 	}
 
+#if TORRENT_ABI_VERSION < 4
 	std::shared_ptr<torrent_info> torrent_handle::torrent_file_with_hashes() const
 	{
 		return sync_call_ret<std::shared_ptr<torrent_info>>(
 			std::shared_ptr<torrent_info>(), &aux::torrent::get_torrent_copy_with_hashes);
 	}
+#endif
 
 	std::vector<std::vector<sha256_hash>> torrent_handle::piece_layers() const
 	{

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1037,12 +1037,14 @@ namespace {
 
 	torrent_info::~torrent_info() = default;
 
+#if TORRENT_ABI_VERSION < 4
 	// internal
 	void torrent_info::set_piece_layers(aux::vector<aux::vector<char>, file_index_t> pl)
 	{
 		m_piece_layers = pl;
-		m_flags |= v2_has_piece_hashes;
+		m_flags |= deprecated_v2_has_piece_hashes;
 	}
+#endif
 
 	sha1_hash torrent_info::hash_for_piece(piece_index_t const index) const
 	{ return sha1_hash(hash_for_piece_ptr(index)); }
@@ -1418,6 +1420,7 @@ namespace {
 		return true;
 	}
 
+#if TORRENT_ABI_VERSION < 4
 	span<char const> torrent_info::piece_layer(file_index_t f) const
 	{
 		TORRENT_ASSERT_PRECOND(f >= file_index_t(0));
@@ -1438,10 +1441,9 @@ namespace {
 		m_piece_layers.clear();
 		m_piece_layers.shrink_to_fit();
 
-		m_flags &= ~v2_has_piece_hashes;
+		m_flags &= ~deprecated_v2_has_piece_hashes;
 	}
 
-#if TORRENT_ABI_VERSION < 4
 	void torrent_info::internal_set_creator(string_view const c)
 	{ m_created_by = std::string(c); }
 
@@ -1502,6 +1504,7 @@ namespace {
 			m_flags |= i2p;
 		}
 
+#if TORRENT_ABI_VERSION < 4
 		if (v2())
 		{
 			auto& trees = atp.merkle_trees;
@@ -1547,6 +1550,7 @@ namespace {
 			}
 			set_piece_layers(v2_hashes);
 		}
+#endif
 
 		for (auto const& url : atp.url_seeds)
 		{

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -218,9 +218,11 @@ void test_round_trip_torrent(std::string const& name)
 	TEST_CHECK(out_torrent.dict_find("info").data_section()
 		== in_torrent.dict_find("info").data_section());
 
+#if TORRENT_ABI_VERSION < 4
 	auto in_piece_layers = in_torrent.dict_find("piece layers").data_section();
 	auto out_piece_layers = out_torrent.dict_find("piece layers").data_section();
 	TEST_CHECK(out_piece_layers == in_piece_layers);
+#endif
 }
 
 }
@@ -638,11 +640,13 @@ TORRENT_TEST(piece_layer)
 	TEST_EQUAL(atp.merkle_trees[2_file].size(), 0);
 	TEST_EQUAL(atp.merkle_trees[3_file].size(), 0);
 
+#if TORRENT_ABI_VERSION < 4
 	auto info = std::make_shared<lt::torrent_info>(buffer, lt::from_span);
 	TEST_EQUAL(info->piece_layer(0_file).size(), lt::sha256_hash::size() * 2);
 	TEST_EQUAL(info->piece_layer(1_file).size(), lt::sha256_hash::size());
 	TEST_EQUAL(info->piece_layer(2_file).size(), lt::sha256_hash::size());
 	TEST_EQUAL(info->piece_layer(3_file).size(), 0);
+#endif
 }
 
 TORRENT_TEST(pieces_root_empty_file)

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -305,9 +305,11 @@ static test_torrent_t const test_torrents[] =
 			TEST_EQUAL(atp.merkle_trees.empty(), false);
 			TEST_EQUAL(atp.ti->num_files(), 5);
 			TEST_CHECK(atp.ti->v2());
+#if TORRENT_ABI_VERSION < 4
 			atp.ti->free_piece_layers();
 			TEST_CHECK(atp.ti->v2());
 			TEST_EQUAL(atp.ti->v2_piece_hashes_verified(), false);
+#endif
 		}
 	},
 	{ "v2_invalid_filename2.torrent", [](lt::add_torrent_params atp) {
@@ -1225,9 +1227,11 @@ TORRENT_TEST(parse_torrents)
 		TEST_CHECK(atp.ti->web_seeds().empty());
 #endif
 
+#if TORRENT_ABI_VERSION < 4
 		// piece layers are loaded into atp.merkle_trees and
 		// atp.merkle_trees_mask
 		TEST_CHECK(!atp.ti->v2_piece_hashes_verified());
+#endif
 
 		auto ti = atp.ti;
 		if (t.test) t.test(std::move(atp));


### PR DESCRIPTION
 in favor of `add_torrent_params`