### PR TITLE
transition more tests to use `add_torrent_params`

### DIFF
--- a/simulation/create_torrent.cpp
+++ b/simulation/create_torrent.cpp
@@ -29,7 +29,6 @@ lt::add_torrent_params create_torrent(int const idx, bool const seed
 {
 	// TODO: if we want non-seeding torrents, that could be a bit cheaper to
 	// create
-	lt::add_torrent_params params;
 	int swarm_id = unit_test::test_counter();
 	char name[200];
 	std::snprintf(name, sizeof(name), "temp-%02d", swarm_id);
@@ -39,7 +38,7 @@ lt::add_torrent_params create_torrent(int const idx, bool const seed
 	if (ec) std::printf("failed to create directory: \"%s\": %s\n"
 		, path.c_str(), ec.message().c_str());
 	std::ofstream file(lt::combine_path(path, name).c_str());
-	params.ti = ::create_torrent(&file, name, 0x4000, num_pieces + idx, false, flags);
+	lt::add_torrent_params params = ::create_torrent(&file, name, 0x4000, num_pieces + idx, false, flags);
 	file.close();
 
 	// by setting the save path to a dummy path, it won't be seeding

--- a/simulation/disk_io.cpp
+++ b/simulation/disk_io.cpp
@@ -17,6 +17,7 @@ see LICENSE file.
 #include "libtorrent/disk_observer.hpp"
 #include "libtorrent/aux_/apply_pad_files.hpp"
 #include "libtorrent/aux_/random.hpp"
+#include "libtorrent/load_torrent.hpp"
 
 #include <utility> // for exchange()
 
@@ -230,7 +231,7 @@ int pads_in_req(std::unordered_map<lt::piece_index_t, int> const& pb
 	return std::max(0, std::min(req_end - pad_start, r.length));
 }
 
-std::shared_ptr<lt::torrent_info> create_test_torrent(int const piece_size
+lt::add_torrent_params create_test_torrent(int const piece_size
 	, int const num_pieces, lt::create_flags_t const flags, int const num_files)
 {
 	std::vector<lt::create_file_entry> ifs;
@@ -308,16 +309,14 @@ std::shared_ptr<lt::torrent_info> create_test_torrent(int const piece_size
 	}
 
 	std::vector<char> const tmp = bencode(t.generate());
-	lt::error_code ec;
-	return std::make_shared<lt::torrent_info>(tmp, ec, lt::from_span);
+	return lt::load_torrent_buffer(tmp);
 }
 
 lt::add_torrent_params create_test_torrent(
 	int const num_pieces, lt::create_flags_t const flags, int const blocks_per_piece
 	, int const num_files)
 {
-	lt::add_torrent_params params;
-	params.ti = ::create_test_torrent(lt::default_block_size * blocks_per_piece, num_pieces, flags, num_files);
+	lt::add_torrent_params params = ::create_test_torrent(lt::default_block_size * blocks_per_piece, num_pieces, flags, num_files);
 	// this is unused by the test disk I/O
 	params.save_path = ".";
 	return params;

--- a/simulation/disk_io.hpp
+++ b/simulation/disk_io.hpp
@@ -27,7 +27,7 @@ lt::sha1_hash generate_hash2(lt::piece_index_t p, lt::file_storage const& fs
 	, lt::span<lt::sha256_hash> const hashes);
 lt::sha256_hash generate_block_hash(lt::piece_index_t p, int offset);
 void generate_block(char* b, lt::peer_request r, int pad_bytes, int piece_size);
-std::shared_ptr<lt::torrent_info> create_test_torrent(int piece_size
+lt::add_torrent_params create_test_torrent(int piece_size
 	, int num_pieces, lt::create_flags_t flags, int num_files = 1);
 lt::add_torrent_params create_test_torrent(
 	int num_pieces, lt::create_flags_t flags, int blocks_per_piece, int num_files = 1);

--- a/simulation/setup_swarm.cpp
+++ b/simulation/setup_swarm.cpp
@@ -201,7 +201,7 @@ void setup_swarm(int num_nodes
 	int const swarm_id = unit_test::test_counter();
 	std::string path = save_path(swarm_id, 0);
 
-	std::shared_ptr<lt::torrent_info> ti;
+	lt::add_torrent_params atp;
 
 	if (type & swarm_test::real_disk)
 	{
@@ -209,11 +209,11 @@ void setup_swarm(int num_nodes
 		if (ec) std::printf("failed to create directory: \"%s\": %s\n"
 			, path.c_str(), ec.message().c_str());
 		std::ofstream file(lt::combine_path(path, "temporary").c_str());
-		ti = ::create_torrent(&file, "temporary", 0x4000, (type & swarm_test::large_torrent) ? 50 : 9, false);
+		atp = ::create_torrent(&file, "temporary", 0x4000, (type & swarm_test::large_torrent) ? 50 : 9, false);
 	}
 	else
 	{
-		ti = ::create_test_torrent(0x4000, (type & swarm_test::large_torrent) ? 50 : 9, {});
+		atp = ::create_test_torrent(0x4000, (type & swarm_test::large_torrent) ? 50 : 9, {});
 	}
 
 	if (bool(type & swarm_test::download) && bool(type & swarm_test::upload))
@@ -294,8 +294,11 @@ void setup_swarm(int num_nodes
 		{
 			p.save_path = ".";
 		}
+		p.ti = atp.ti;
+		p.merkle_trees = atp.merkle_trees;
+		p.merkle_tree_mask = atp.merkle_tree_mask;
+		p.verified_leaf_hashes = atp.verified_leaf_hashes;
 
-		p.ti = ti;
 		if (i == 0) add_torrent(p);
 		ses->async_add_torrent(p);
 

--- a/simulation/test_swarm.cpp
+++ b/simulation/test_swarm.cpp
@@ -870,7 +870,7 @@ TORRENT_TEST(pex)
 	if (ec) std::printf("failed to create directory: \"%s\": %s\n"
 		, path.c_str(), ec.message().c_str());
 	std::ofstream file(lt::combine_path(path, "temporary").c_str());
-	auto ti = ::create_torrent(&file, "temporary", 0x4000, 50, false);
+	lt::add_torrent_params p = ::create_torrent(&file, "temporary", 0x4000, 50, false);
 	file.close();
 
 	int const num_nodes = 3;
@@ -896,7 +896,6 @@ TORRENT_TEST(pex)
 			std::make_shared<lt::session>(pack, *io_service.back());
 		nodes.push_back(ses);
 
-		lt::add_torrent_params p;
 		p.flags &= ~lt::torrent_flags::paused;
 		p.flags &= ~lt::torrent_flags::auto_managed;
 
@@ -905,7 +904,6 @@ TORRENT_TEST(pex)
 		// It's important that node 1 and 2 want to stay connected, otherwise
 		// node 1 won't be able to gossip about 2 to 0.
 		p.save_path = save_path(swarm_id, i > 1 ? 0 : 1);
-		p.ti = ti;
 		ses->async_add_torrent(p);
 
 		ses->set_alert_notify([&, i]() {

--- a/simulation/test_v2.cpp
+++ b/simulation/test_v2.cpp
@@ -106,6 +106,7 @@ lt::info_hash_t setup_conflict(lt::session& seed, lt::session& downloader)
 	// add v1-only magnet link
 	atp.ti.reset();
 	atp.info_hashes.v1 = ih.v1;
+	atp.info_hashes.v2.clear();
 	downloader.async_add_torrent(atp);
 
 	// add v2-only magnet link

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -521,22 +521,25 @@ bool is_downloading_state(int const st)
 		m_was_started = true;
 #endif
 
+		update_want_tick();
+
 		// Some of these calls may log to the torrent debug log, which requires a
 		// call to get_handle(), which requires the torrent object to be fully
 		// constructed, as it relies on get_shared_from_this()
 		if (m_add_torrent_params)
 		{
+			add_torrent_params const& p = *m_add_torrent_params;
+
 #if TORRENT_ABI_VERSION == 1
-			if (m_add_torrent_params->internal_resume_data_error
+			if (p.internal_resume_data_error
 				&& m_ses.alerts().should_post<fastresume_rejected_alert>())
 			{
 				m_ses.alerts().emplace_alert<fastresume_rejected_alert>(get_handle()
-					, m_add_torrent_params->internal_resume_data_error, ""
+					, p.internal_resume_data_error, ""
 					, operation_t::unknown);
 			}
 #endif
 
-			add_torrent_params const& p = *m_add_torrent_params;
 
 			set_max_uploads(p.max_uploads, false);
 			set_max_connections(p.max_connections, false);
@@ -610,7 +613,6 @@ bool is_downloading_state(int const st)
 
 		update_want_peers();
 		update_want_scrape();
-		update_want_tick();
 		update_state_list();
 
 		if (m_torrent_file->is_valid())

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -71,7 +71,7 @@ EXPORT lt::file_storage make_file_storage(lt::span<const int> file_sizes
 EXPORT std::shared_ptr<lt::torrent_info> make_torrent(std::vector<lt::create_file_entry> files, int piece_size, lt::create_flags_t flags = {});
 EXPORT std::vector<lt::create_file_entry> create_random_files(std::string const& path, lt::span<const int> file_sizes);
 
-EXPORT std::shared_ptr<lt::torrent_info> create_torrent(std::ostream* file = nullptr
+EXPORT lt::add_torrent_params create_torrent(std::ostream* file = nullptr
 	, char const* name = "temporary", int piece_size = 16 * 1024, int num_pieces = 13
 	, bool add_tracker = true, lt::create_flags_t flags = {}, std::string ssl_certificate = "");
 
@@ -81,9 +81,8 @@ EXPORT std::tuple<lt::torrent_handle
 setup_transfer(lt::session* ses1, lt::session* ses2
 	, lt::session* ses3, bool clear_files, bool use_metadata_transfer = true
 	, bool connect = true, std::string suffix = "", int piece_size = 16 * 1024
-	, std::shared_ptr<lt::torrent_info>* torrent = nullptr
+	, lt::add_torrent_params const* atp = nullptr
 	, bool super_seeding = false
-	, lt::add_torrent_params const* p = nullptr
 	, bool stop_lsd = true, bool use_ssl_ports = false
 	, std::shared_ptr<lt::torrent_info>* torrent2 = nullptr
 	, lt::create_flags_t flags = {});

--- a/test/swarm_suite.cpp
+++ b/test/swarm_suite.cpp
@@ -100,7 +100,7 @@ void test_swarm(test_flags_t const flags)
 	// test v1 metadata using piece sizes smaller than 16kB
 	int const piece_size = (flags & test_flags::v1_meta) ? 8 * 1024 : 16 * 1024;
 	auto const [tor1, tor2, tor3] = setup_transfer(&ses1, &ses2, &ses3, true
-		, false, true, "_swarm", piece_size, nullptr, bool(flags & test_flags::super_seeding), &p
+		, false, true, "_swarm", piece_size, &p, bool(flags & test_flags::super_seeding)
 		, true, false, nullptr
 		, (flags & test_flags::v1_meta) ? create_torrent::v1_only
 		: (flags & test_flags::v2_meta) ? create_torrent::v2_only

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -433,10 +433,10 @@ TORRENT_TEST(make_magnet_uri2)
 
 TORRENT_TEST(make_magnet_uri_v2)
 {
-	auto ti = ::create_torrent(nullptr, "temporary", 16 * 1024, 13
+	auto atp = ::create_torrent(nullptr, "temporary", 16 * 1024, 13
 		, true, lt::create_torrent::v2_only);
 
-	std::string magnet = make_magnet_uri(*ti);
+	std::string magnet = make_magnet_uri(atp);
 	std::printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
 	TEST_CHECK(magnet.find("xt=urn:btmh:1220") != std::string::npos);
 	TEST_CHECK(magnet.find("xt=urn:btih:") == std::string::npos);
@@ -444,9 +444,9 @@ TORRENT_TEST(make_magnet_uri_v2)
 
 TORRENT_TEST(make_magnet_uri_hybrid)
 {
-	auto ti = ::create_torrent(nullptr, "temporary", 16 * 1024, 13);
+	auto atp = ::create_torrent(nullptr, "temporary", 16 * 1024, 13);
 
-	std::string magnet = make_magnet_uri(*ti);
+	std::string magnet = make_magnet_uri(atp);
 	std::printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
 	TEST_CHECK(magnet.find("xt=urn:btih:") != std::string::npos);
 	TEST_CHECK(magnet.find("xt=urn:btmh:1220") != std::string::npos);
@@ -454,9 +454,9 @@ TORRENT_TEST(make_magnet_uri_hybrid)
 
 TORRENT_TEST(make_magnet_uri_v1)
 {
-	auto ti = ::create_torrent(nullptr, "temporary", 16 * 1024, 13, true, lt::create_torrent::v1_only);
+	auto atp = ::create_torrent(nullptr, "temporary", 16 * 1024, 13, true, lt::create_torrent::v1_only);
 
-	std::string magnet = make_magnet_uri(*ti);
+	std::string magnet = make_magnet_uri(atp);
 	std::printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
 	TEST_CHECK(magnet.find("xt=urn:btih:") != std::string::npos);
 	TEST_CHECK(magnet.find("xt=urn:btmh:1220") == std::string::npos);
@@ -676,15 +676,13 @@ TORRENT_TEST(hybrid_info_hashes)
 
 TORRENT_TEST(torrent_info_hash)
 {
-	auto ti = ::create_torrent(nullptr, "temporary", 16 * 1024, 13
+	auto atp = ::create_torrent(nullptr, "temporary", 16 * 1024, 13
 		, true);
 
-	add_torrent_params atp;
-	atp.ti = ti;
-
 	TEST_EQUAL(make_magnet_uri(atp), std::string{}
-		+ "magnet:?xt=urn:btih:" + aux::to_hex(ti->info_hashes().v1)
-		+ "&xt=urn:btmh:1220" + aux::to_hex(ti->info_hashes().v2));
+		+ "magnet:?xt=urn:btih:" + aux::to_hex(atp.ti->info_hashes().v1)
+		+ "&xt=urn:btmh:1220" + aux::to_hex(atp.ti->info_hashes().v2)
+		+ "&tr=http%3a&tr=foo%3a%2f%2fnon%2fexistent-name.com%2fannounce");
 }
 
 #if TORRENT_ABI_VERSION < 3

--- a/test/test_privacy.cpp
+++ b/test/test_privacy.cpp
@@ -105,10 +105,9 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, flags_t flags)
 	remove_all("tmp1_privacy", ec);
 	create_directory("tmp1_privacy", ec);
 	std::ofstream file(combine_path("tmp1_privacy", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params addp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params addp;
 	char http_tracker_url[200];
 	std::snprintf(http_tracker_url, sizeof(http_tracker_url)
 		, "http://127.0.0.1:%d/announce", http_port);
@@ -130,7 +129,6 @@ session_proxy test_proxy(settings_pack::proxy_type_t proxy_type, flags_t flags)
 	// seeding it, announcing to trackers and connecting to peers
 	addp.flags |= torrent_flags::seed_mode;
 
-	addp.ti = t;
 	addp.save_path = "tmp1_privacy";
 	addp.dht_nodes.push_back(std::pair<std::string, int>("127.0.0.1", dht_port));
 	torrent_handle h = s->add_torrent(addp);

--- a/test/test_recheck.cpp
+++ b/test/test_recheck.cpp
@@ -69,14 +69,12 @@ TORRENT_TEST(recheck)
 	create_directory("tmp1_recheck", ec);
 	if (ec) std::printf("create_directory: %s\n", ec.message().c_str());
 	std::ofstream file("tmp1_recheck/temporary");
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 4 * 1024 * 1024
+	add_torrent_params param = ::create_torrent(&file, "temporary", 4 * 1024 * 1024
 		, 7, false);
 	file.close();
 
-	add_torrent_params param;
 	param.flags &= ~torrent_flags::paused;
 	param.flags &= ~torrent_flags::auto_managed;
-	param.ti = t;
 	param.save_path = "tmp1_recheck";
 	param.flags |= torrent_flags::seed_mode;
 	torrent_handle tor1 = ses1.add_torrent(param, ec);

--- a/test/test_remove_torrent.cpp
+++ b/test/test_remove_torrent.cpp
@@ -63,7 +63,7 @@ void test_remove_torrent(remove_flags_t const remove_options
 	remove_all("tmp2_remove", ec);
 	create_directory("tmp1_remove", ec);
 	std::ofstream file("tmp1_remove/temporary");
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary"
+	add_torrent_params atp = ::create_torrent(&file, "temporary"
 		, 8 * 1024, num_pieces, false, create_torrent::v1_only);
 	file.close();
 
@@ -72,7 +72,7 @@ void test_remove_torrent(remove_flags_t const remove_options
 
 	// test using piece sizes smaller than 16kB
 	std::tie(tor1, tor2, ignore) = setup_transfer(&ses1, &ses2, nullptr
-		, true, false, true, "_remove", 8 * 1024, &t, false, nullptr, true, false, nullptr
+		, true, false, true, "_remove", 8 * 1024, &atp, false, true, false, nullptr
 		, create_torrent::v1_only);
 
 	if (test == partial_download)
@@ -84,8 +84,8 @@ void test_remove_torrent(remove_flags_t const remove_options
 	}
 	else if (test == mid_download)
 	{
-		tor1.set_upload_limit(static_cast<int>(t->total_size()));
-		tor2.set_download_limit(static_cast<int>(t->total_size()));
+		tor1.set_upload_limit(static_cast<int>(atp.ti->total_size()));
+		tor2.set_download_limit(static_cast<int>(atp.ti->total_size()));
 	}
 
 	torrent_status st1;

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -252,9 +252,8 @@ TORRENT_TEST(paused_session)
 	lt::session s(settings());
 	s.pause();
 
-	lt::add_torrent_params ps;
 	std::ofstream file("temporary");
-	ps.ti = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	lt::add_torrent_params ps = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	ps.flags = lt::torrent_flags::paused;
 	ps.save_path = ".";
 

--- a/test/test_ssl.cpp
+++ b/test/test_ssl.cpp
@@ -170,11 +170,10 @@ void test_ssl(int const test_idx, bool const use_utp)
 
 	create_directory("tmp1_ssl", ec);
 	std::ofstream file("tmp1_ssl/temporary");
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary"
+	add_torrent_params addp = ::create_torrent(&file, "temporary"
 		, 16 * 1024, 13, false, {}, combine_path("..", combine_path("ssl", "root_ca_cert.pem")));
 	file.close();
 
-	add_torrent_params addp;
 	addp.save_path = "tmp1_ssl";
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
@@ -184,7 +183,7 @@ void test_ssl(int const test_idx, bool const use_utp)
 	peer_errors = 0;
 
 	std::tie(tor1, tor2, ignore) = setup_transfer(&ses1, &ses2, nullptr
-		, true, false, false, "_ssl", 16 * 1024, &t, false, &addp, true);
+		, true, false, false, "_ssl", 16 * 1024, &addp, false, true);
 
 	if (test.seed_has_cert)
 	{
@@ -553,17 +552,15 @@ void test_malicious_peer()
 	// create torrent
 	create_directory("tmp3_ssl", ec);
 	std::ofstream file("tmp3_ssl/temporary");
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary"
+	add_torrent_params addp = ::create_torrent(&file, "temporary"
 		, 16 * 1024, 13, false, {}, combine_path("..", combine_path("ssl", "root_ca_cert.pem")));
 	file.close();
 
-	TEST_CHECK(!t->ssl_cert().empty());
+	TEST_CHECK(!addp.ti->ssl_cert().empty());
 
-	add_torrent_params addp;
 	addp.save_path = "tmp3_ssl";
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
-	addp.ti = t;
 
 	torrent_handle tor1 = ses1.add_torrent(addp, ec);
 
@@ -583,7 +580,7 @@ void test_malicious_peer()
 
 	for (int i = 0; i < num_attacks; ++i)
 	{
-		bool const success = try_connect(ses1, port, t, attacks[i].flags);
+		bool const success = try_connect(ses1, port, addp.ti, attacks[i].flags);
 		TEST_EQUAL(success, attacks[i].expect);
 	}
 }

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -874,7 +874,7 @@ void test_fastresume(bool const test_deprecated)
 	if (ec) std::cout << "create_directory '" << combine_path(test_path, "tmp1")
 		<< "': " << ec.message() << std::endl;
 	ofstream file(combine_path(test_path, "tmp1/temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file);
+	add_torrent_params atp = ::create_torrent(&file);
 	file.close();
 	TEST_CHECK(exists(complete("tmp1/temporary")));
 	if (!exists(complete("tmp1/temporary")))
@@ -885,8 +885,7 @@ void test_fastresume(bool const test_deprecated)
 		settings_pack pack = settings();
 		lt::session ses(pack);
 
-		add_torrent_params p;
-		p.ti = std::make_shared<torrent_info>(std::cref(*t));
+		add_torrent_params p = atp;
 		p.save_path = combine_path(test_path, "tmp1");
 		p.storage_mode = storage_mode_sparse;
 		error_code ignore;
@@ -951,7 +950,7 @@ void test_fastresume(bool const test_deprecated)
 
 		p.flags &= ~torrent_flags::paused;
 		p.flags &= ~torrent_flags::auto_managed;
-		p.ti = std::make_shared<torrent_info>(std::cref(*t));
+		p.ti = atp.ti;
 		p.save_path = combine_path(test_path, "tmp1");
 		p.storage_mode = storage_mode_sparse;
 		torrent_handle h = ses.add_torrent(std::move(p), ec);
@@ -1073,7 +1072,7 @@ void test_rename_file_fastresume(bool test_deprecated)
 	create_directory(combine_path(test_path, "tmp2"), ec);
 	if (ec) std::cout << "create_directory: " << ec.message() << std::endl;
 	ofstream file(combine_path(test_path, "tmp2/temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file);
+	add_torrent_params atp = ::create_torrent(&file);
 	file.close();
 	TEST_CHECK(exists(combine_path(test_path, "tmp2/temporary")));
 
@@ -1083,7 +1082,7 @@ void test_rename_file_fastresume(bool test_deprecated)
 		lt::session ses(pack);
 
 		add_torrent_params p;
-		p.ti = std::make_shared<torrent_info>(std::cref(*t));
+		p.ti = atp.ti;
 		p.save_path = combine_path(test_path, "tmp2");
 		p.storage_mode = storage_mode_sparse;
 		torrent_handle h = ses.add_torrent(std::move(p), ec);
@@ -1134,7 +1133,7 @@ void test_rename_file_fastresume(bool test_deprecated)
 		{
 			p = read_resume_data(resume_data);
 		}
-		p.ti = std::make_shared<torrent_info>(std::cref(*t));
+		p.ti = atp.ti;
 		p.save_path = combine_path(test_path, "tmp2");
 		p.storage_mode = storage_mode_sparse;
 		torrent_handle h = ses.add_torrent(std::move(p), ec);

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -342,10 +342,9 @@ void test_udp_tracker(std::string const& iface, address tracker, tcp::endpoint c
 	remove_all("tmp1_tracker", ec);
 	create_directory("tmp1_tracker", ec);
 	ofstream file(combine_path("tmp1_tracker", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params addp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params addp;
 	char tracker_url[200];
 	std::snprintf(tracker_url, sizeof(tracker_url), "udp://%s:%d/announce", iface.c_str(), udp_port);
 	addp.trackers.push_back(tracker_url);
@@ -353,7 +352,6 @@ void test_udp_tracker(std::string const& iface, address tracker, tcp::endpoint c
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
 	addp.flags |= torrent_flags::seed_mode;
-	addp.ti = t;
 	addp.save_path = "tmp1_tracker";
 	torrent_handle h = s->add_torrent(addp);
 
@@ -440,10 +438,9 @@ TORRENT_TEST(http_peers)
 	remove_all("tmp2_tracker", ec);
 	create_directory("tmp2_tracker", ec);
 	ofstream file(combine_path("tmp2_tracker", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params addp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params addp;
 	char tracker_url[200];
 	std::snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
 		, http_port);
@@ -452,7 +449,6 @@ TORRENT_TEST(http_peers)
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
 	addp.flags |= torrent_flags::seed_mode;
-	addp.ti = t;
 	addp.save_path = "tmp2_tracker";
 	torrent_handle h = s->add_torrent(addp);
 
@@ -513,10 +509,9 @@ TORRENT_TEST(current_tracker)
 	remove_all("tmp3_tracker", ec);
 	create_directory("tmp3_tracker", ec);
 	ofstream file(combine_path("tmp3_tracker", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params addp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params addp;
 	char tracker_url[200];
 	std::snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
 		, http_port);
@@ -525,7 +520,6 @@ TORRENT_TEST(current_tracker)
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
 	addp.flags |= torrent_flags::seed_mode;
-	addp.ti = t;
 	addp.save_path = "tmp3_tracker";
 	torrent_handle h = s->add_torrent(addp);
 
@@ -705,10 +699,9 @@ TORRENT_TEST(websocket_tracker)
 	remove_all("tmp4_tracker", ec);
 	create_directory("tmp4_tracker", ec);
 	std::ofstream file(combine_path("tmp4_tracker", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params addp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params addp;
 	char tracker_url[200];
 	std::snprintf(tracker_url, sizeof(tracker_url), "ws://127.0.0.1:%d/announce"
 		, http_port);
@@ -717,7 +710,6 @@ TORRENT_TEST(websocket_tracker)
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
 	addp.flags |= torrent_flags::seed_mode;
-	addp.ti = t;
 	addp.save_path = "tmp4_tracker";
 	torrent_handle h = s->add_torrent(addp);
 
@@ -766,10 +758,9 @@ void test_proxy(bool proxy_trackers)
 	remove_all("tmp2_tracker", ec);
 	create_directory("tmp2_tracker", ec);
 	ofstream file(combine_path("tmp2_tracker", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params addp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params addp;
 	char tracker_url[200];
 	// and this should not be announced to (since the one before it succeeded)
 	std::snprintf(tracker_url, sizeof(tracker_url), "http://127.0.0.1:%d/announce"
@@ -779,7 +770,6 @@ void test_proxy(bool proxy_trackers)
 	addp.flags &= ~torrent_flags::paused;
 	addp.flags &= ~torrent_flags::auto_managed;
 	addp.flags |= torrent_flags::seed_mode;
-	addp.ti = t;
 	addp.save_path = "tmp2_tracker";
 	torrent_handle h = s->add_torrent(addp);
 
@@ -867,14 +857,12 @@ void test_stop_tracker_timeout(int const timeout)
 	remove_all("tmp4_tracker", ec);
 	create_directory("tmp4_tracker", ec);
 	ofstream file(combine_path("tmp4_tracker", "temporary").c_str());
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
+	add_torrent_params tp = ::create_torrent(&file, "temporary", 16 * 1024, 13, false);
 	file.close();
 
-	add_torrent_params tp;
 	tp.flags &= ~torrent_flags::paused;
 	tp.flags &= ~torrent_flags::auto_managed;
 	tp.flags |= torrent_flags::seed_mode;
-	tp.ti = t;
 	tp.save_path = "tmp4_tracker";
 	torrent_handle h = s.add_torrent(tp);
 

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -182,12 +182,11 @@ void test_transfer(int const proxy_type, settings_pack const& sett
 
 	create_directory("tmp1_transfer", ec);
 	std::ofstream file("tmp1_transfer/temporary");
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", piece_size, 13, false);
+	add_torrent_params atp = ::create_torrent(&file, "temporary", piece_size, 13, false);
 	file.close();
 
 	TEST_CHECK(exists(combine_path("tmp1_transfer", "temporary")));
 
-	add_torrent_params atp;
 	atp.storage_mode = storage_mode;
 	atp.flags &= ~torrent_flags::paused;
 	atp.flags &= ~torrent_flags::auto_managed;
@@ -200,7 +199,7 @@ void test_transfer(int const proxy_type, settings_pack const& sett
 
 	// test using piece sizes smaller than 16kB
 	std::tie(tor1, tor2, ignore) = setup_transfer(&ses1, &ses2, nullptr
-		, true, false, true, "_transfer", 1024 * 1024, &t, false, &atp);
+		, true, false, true, "_transfer", 1024 * 1024, &atp, false);
 
 	int num_pieces = tor2.torrent_file()->num_pieces();
 	std::vector<int> priorities(std::size_t(num_pieces), 1);
@@ -208,7 +207,7 @@ void test_transfer(int const proxy_type, settings_pack const& sett
 	if (flags & piece_deadline)
 	{
 		int deadline = 1;
-		for (auto const p : t->piece_range())
+		for (auto const p : atp.ti->piece_range())
 		{
 			++deadline;
 			tor2.set_piece_deadline(p, deadline, lt::torrent_handle::alert_when_available);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -14,6 +14,8 @@ see LICENSE file.
 #include "libtorrent/create_torrent.hpp"
 #include "libtorrent/aux_/merkle.hpp"
 #include "libtorrent/aux_/random.hpp"
+#include "libtorrent/write_resume_data.hpp" // for write_torrent_file_buf()
+#include "libtorrent/add_torrent_params.hpp"
 
 #ifdef _WIN32
 #include <io.h>
@@ -114,6 +116,12 @@ std::vector<char> serialize(lt::torrent_info const& ti)
 	entry e = ct.generate();
 	std::vector<char> const out_buffer = bencode(e);
 	return out_buffer;
+}
+
+std::vector<char> serialize(lt::add_torrent_params atp)
+{
+	atp.creation_date = 0;
+	return write_torrent_file_buf(atp, {});
 }
 #endif
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -41,6 +41,7 @@ constexpr inline lt::piece_index_t operator "" _piece(unsigned long long const p
 
 #if TORRENT_ABI_VERSION < 4
 EXPORT std::vector<char> serialize(lt::torrent_info const& ti);
+EXPORT std::vector<char> serialize(lt::add_torrent_params atp);
 #endif
 
 EXPORT lt::aux::vector<lt::sha256_hash> build_tree(int const size);

--- a/test/test_utp.cpp
+++ b/test/test_utp.cpp
@@ -80,18 +80,17 @@ void test_transfer()
 			, ec.value(), ec.message().c_str());
 	}
 	std::ofstream file("tmp1_utp/temporary");
-	std::shared_ptr<torrent_info> t = ::create_torrent(&file, "temporary", 128 * 1024, 6, false);
+	add_torrent_params atp = ::create_torrent(&file, "temporary", 128 * 1024, 6, false);
 	file.close();
 
 	// for performance testing
-	add_torrent_params atp;
 	atp.flags &= ~torrent_flags::paused;
 	atp.flags &= ~torrent_flags::auto_managed;
 //	atp.storage = &disabled_storage_constructor;
 
 	// test using piece sizes smaller than 16kB
 	std::tie(tor1, tor2, std::ignore) = setup_transfer(&ses1, &ses2, nullptr
-		, true, false, true, "_utp", 0, &t, false, &atp);
+		, true, false, true, "_utp", 0, &atp, false);
 
 	const int timeout = 16;
 


### PR DESCRIPTION
and `load_torrent_buffer()` instead of the deprecated use of torrent_info.