### PR TITLE
cirrus: Increment freebsd image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@
 # we only use it for its unique feature, FreeBSD images
 
 freebsd_instance:
-  image_family: freebsd-14-1
+  image_family: freebsd-14-2
 
 task:
   env:


### PR DESCRIPTION
* Bumped freebsd image to 14.2 (confirmed in different PR that it's actually available/working)