### PR TITLE
deprecate `make_magnet_uri()` overloads

### DIFF
--- a/bindings/python/src/magnet_uri.cpp
+++ b/bindings/python/src/magnet_uri.cpp
@@ -91,8 +91,10 @@ namespace {
 		return p;
 	}
 
+#if TORRENT_ABI_VERSION < 4
 	std::string (*make_magnet_uri0)(torrent_handle const&) = make_magnet_uri;
 	std::string (*make_magnet_uri1)(torrent_info const&) = make_magnet_uri;
+#endif
 	std::string (*make_magnet_uri2)(add_torrent_params const&) = make_magnet_uri;
 }
 
@@ -101,8 +103,10 @@ void bind_magnet_uri()
 #if TORRENT_ABI_VERSION == 1
 	def("add_magnet_uri", &_add_magnet_uri);
 #endif
+#if TORRENT_ABI_VERSION < 4
 	def("make_magnet_uri", make_magnet_uri0);
 	def("make_magnet_uri", make_magnet_uri1);
+#endif
 	def("make_magnet_uri", make_magnet_uri2);
 	def("parse_magnet_uri", parse_magnet_uri_wrap);
 	def("parse_magnet_uri_dict", parse_magnet_uri_dict);

--- a/include/libtorrent/magnet_uri.hpp
+++ b/include/libtorrent/magnet_uri.hpp
@@ -43,14 +43,18 @@ namespace libtorrent {
 	// containing an add_torrent_params object. This can then be passed to
 	// make_magnet_uri().
 	//
+	// For more information about magnet links, see magnet-links_.
+	TORRENT_EXPORT std::string make_magnet_uri(add_torrent_params const& atp);
+
+#if TORRENT_ABI_VERSION < 4
 	// The overload that takes a torrent_handle will make blocking calls to
 	// query information about the torrent. If the torrent handle is invalid,
 	// an empty string is returned.
-	//
-	// For more information about magnet links, see magnet-links_.
-	TORRENT_EXPORT std::string make_magnet_uri(add_torrent_params const& atp);
-	TORRENT_EXPORT std::string make_magnet_uri(torrent_handle const& handle);
-	TORRENT_EXPORT std::string make_magnet_uri(torrent_info const& info);
+	TORRENT_DEPRECATED_EXPORT
+	std::string make_magnet_uri(torrent_handle const& handle);
+	TORRENT_DEPRECATED_EXPORT
+	std::string make_magnet_uri(torrent_info const& info);
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 #ifndef BOOST_NO_EXCEPTIONS

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -53,12 +53,14 @@ namespace aux {
 		, string_view element, bool force_element = false);
 	TORRENT_EXTRA_EXPORT bool verify_encoding(std::string& target);
 
+#if TORRENT_ABI_VERSION < 4
 	struct internal_drained_state
 	{
 		aux::vector<lt::announce_entry> urls;
 		std::vector<web_seed_entry> web_seeds;
 		std::vector<std::pair<std::string, int>> nodes;
 	};
+#endif
 }
 
 	// hidden
@@ -264,10 +266,10 @@ TORRENT_VERSION_NAMESPACE_4
 		std::vector<announce_entry> const& trackers() const { return m_urls; }
 		TORRENT_DEPRECATED
 		void clear_trackers();
-#endif
 
 		// internal
 		std::vector<announce_entry> const& internal_trackers() const { return m_urls; }
+#endif
 
 		// These two functions are related to `BEP 38`_ (mutable torrents). The
 		// vectors returned from these correspond to the "similar" and
@@ -319,13 +321,13 @@ TORRENT_VERSION_NAMESPACE_4
 		void add_http_seed(std::string const& url
 			, std::string const& extern_auth = std::string()
 			, web_seed_entry::headers_t const& extra_headers = web_seed_entry::headers_t());
-#endif
 
 		// internal
 		aux::internal_drained_state _internal_drain() {
 			return aux::internal_drained_state{std::move(m_urls), std::move(m_web_seeds), std::move(m_nodes)};
 		}
 		std::vector<web_seed_entry> const& internal_web_seeds() const { return m_web_seeds; }
+#endif
 
 		// ``total_size()`` returns the total number of bytes the torrent-file
 		// represents. Note that this is the number of pieces times the piece
@@ -694,9 +696,11 @@ TORRENT_VERSION_NAMESPACE_4
 		// instance
 		aux::copy_ptr<const file_storage> m_orig_files;
 
+#if TORRENT_ABI_VERSION < 4
 		// the URLs to the trackers
 		aux::vector<announce_entry> m_urls;
 		std::vector<web_seed_entry> m_web_seeds;
+#endif
 		// dht nodes to add to the routing table/bootstrap from
 		std::vector<std::pair<std::string, int>> m_nodes;
 

--- a/simulation/test_metadata_extension.cpp
+++ b/simulation/test_metadata_extension.cpp
@@ -93,11 +93,11 @@ void run_metadata_test(int flags)
 		, [&ti](lt::add_torrent_params& params) {
 			// we want to add the torrent via magnet link
 			error_code ec;
+			add_torrent_params const p = parse_magnet_uri(
+				lt::make_magnet_uri(params), ec);
+			TEST_CHECK(!ec);
 			ti = params.ti;
 			params.ti.reset();
-			add_torrent_params const p = parse_magnet_uri(
-				lt::make_magnet_uri(*ti), ec);
-			TEST_CHECK(!ec);
 			params.name = p.name;
 			params.trackers = p.trackers;
 			params.tracker_tiers = p.tracker_tiers;

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -22,6 +22,7 @@ see LICENSE file.
 
 namespace libtorrent {
 
+#if TORRENT_ABI_VERSION < 4
 	std::string make_magnet_uri(torrent_handle const& handle)
 	{
 		if (!handle.is_valid()) return "";
@@ -76,6 +77,7 @@ namespace libtorrent {
 
 		return make_magnet_uri(atp);
 	}
+#endif
 
 	std::string make_magnet_uri(add_torrent_params const& atp)
 	{

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -269,14 +269,16 @@ bool is_downloading_state(int const st)
 
 		// --- WEB SEEDS ---
 
+		std::vector<web_seed_t> ws;
+#if TORRENT_ABI_VERSION < 4
 		// if override web seed flag is set, don't load any web seeds from the
 		// torrent file.
-		std::vector<web_seed_t> ws;
 		if (!(p.flags & torrent_flags::deprecated_override_web_seeds))
 		{
 			for (auto const& e : m_torrent_file->internal_web_seeds())
 				ws.emplace_back(e);
 		}
+#endif
 
 		// add web seeds from add_torrent_params
 		bool const multi_file = m_torrent_file->is_valid()
@@ -300,11 +302,13 @@ bool is_downloading_state(int const st)
 
 		// --- TRACKERS ---
 
+#if TORRENT_ABI_VERSION < 4
 		// if override trackers flag is set, don't load trackers from torrent file
 		if (!(p.flags & torrent_flags::deprecated_override_trackers))
 		{
 			m_trackers.replace(m_torrent_file->internal_trackers());
 		}
+#endif
 
 		int tier = 0;
 		auto tier_iter = p.tracker_tiers.begin();

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1518,7 +1518,6 @@ namespace {
 		m_comment = atp.comment;
 		m_created_by = atp.created_by;
 		m_creation_date = atp.creation_date;
-#endif
 		int tier = 0;
 		for (std::size_t i = 0; i < atp.trackers.size(); ++i)
 		{
@@ -1528,6 +1527,7 @@ namespace {
 			ent.tier = std::uint8_t(tier);
 			m_urls.push_back(std::move(ent));
 		}
+#endif
 
 		if (atp.flags & torrent_flags::i2p_torrent)
 		{
@@ -1582,16 +1582,14 @@ namespace {
 		}
 #endif
 
+#if TORRENT_ABI_VERSION < 4
 		for (auto const& url : atp.url_seeds)
 		{
 			web_seed_entry ent(url);
-#if TORRENT_ABI_VERSION < 4
 			ent.type = web_seed_entry::url_seed;
-#endif
 			m_web_seeds.push_back(std::move(ent));
 		}
 
-#if TORRENT_ABI_VERSION < 4
 		for (auto const& url : atp.http_seeds)
 		{
 			web_seed_entry ent(url);

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -403,8 +403,10 @@ TORRENT_TEST(make_magnet_uri)
 
 	TEST_EQUAL(al.size(), atp.trackers.size());
 
+#if TORRENT_ABI_VERSION < 4
 	std::string magnet = make_magnet_uri(*atp.ti);
 	std::printf("%s len: %d\n", magnet.c_str(), int(magnet.size()));
+#endif
 }
 
 TORRENT_TEST(make_magnet_uri2)


### PR DESCRIPTION
that take `torrent_handle` and `torrent_info`, in favor of `add_torrent_params`. Also deprecate web seeds being stored in `torrent_info`.