### PR TITLE
deprecate keeping DHT nodes in `torrent_info`

### DIFF
--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -40,6 +40,7 @@ namespace
 #if TORRENT_ABI_VERSION < 4
     std::vector<announce_entry>::const_iterator begin_trackers(torrent_info& i)
     {
+        python_deprecated("trackers() is deprecated");
         return i.trackers().begin();
     }
 
@@ -47,15 +48,16 @@ namespace
     {
         return i.trackers().end();
     }
-#endif
 
     void add_node(torrent_info& ti, char const* hostname, int port)
     {
+        python_deprecated("add_node() is deprecated");
         ti.add_node(std::make_pair(hostname, port));
     }
 
     list nodes(torrent_info const& ti)
     {
+        python_deprecated("nodes() is deprecated");
         list result;
 
         for (auto const& i : ti.nodes())
@@ -64,9 +66,9 @@ namespace
         return result;
     }
 
-#if TORRENT_ABI_VERSION < 4
     list get_web_seeds(torrent_info const& ti)
     {
+        python_deprecated("web_seeds() is deprecated");
         std::vector<web_seed_entry> const& ws = ti.web_seeds();
         list ret;
         for (std::vector<web_seed_entry>::const_iterator i = ws.begin()
@@ -83,6 +85,7 @@ namespace
 
     void set_web_seeds(torrent_info& ti, list ws)
     {
+        python_deprecated("set_web_seeds is deprecated");
         std::vector<web_seed_entry> web_seeds;
         int const len = static_cast<int>(boost::python::len(ws));
         for (int i = 0; i < len; i++)
@@ -99,6 +102,7 @@ namespace
 #if TORRENT_ABI_VERSION <= 2
     list get_merkle_tree(torrent_info const& ti)
     {
+        python_deprecated("get_merkle_tree is deprecated");
         std::vector<sha1_hash> const& mt = ti.merkle_tree();
         list ret;
         for (std::vector<sha1_hash>::const_iterator i = mt.begin()
@@ -111,6 +115,7 @@ namespace
 
     void set_merkle_tree(torrent_info& ti, list hashes)
     {
+        python_deprecated("set_merkle_tree is deprecated");
         std::vector<sha1_hash> h;
         for (int i = 0, e = int(len(hashes)); i < e; ++i)
             h.push_back(sha1_hash(bytes(extract<bytes>(hashes[i])).arr.data()));
@@ -476,10 +481,9 @@ void bind_torrent_info()
 #if TORRENT_ABI_VERSION < 4
         .def("trackers", range(begin_trackers, end_trackers))
         .def("creation_date", &torrent_info::creation_date)
-#endif
-
         .def("add_node", &add_node)
         .def("nodes", &nodes)
+#endif
 #if TORRENT_ABI_VERSION <= 2
         .def("metadata", depr(&metadata))
         .def("metadata_size", depr(&torrent_info::metadata_size))

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -557,17 +557,19 @@ TORRENT_VERSION_NAMESPACE_4
 		TORRENT_DEPRECATED
 		const std::string& comment() const
 		{ return m_comment; }
-#endif
 
 		// If this torrent contains any DHT nodes, they are put in this vector in
 		// their original form (host name and port number).
+		TORRENT_DEPRECATED
 		std::vector<std::pair<std::string, int>> const& nodes() const
 		{ return m_nodes; }
 
 		// This is used when creating torrent. Use this to add a known DHT node.
 		// It may be used, by the client, to bootstrap into the DHT network.
+		TORRENT_DEPRECATED
 		void add_node(std::pair<std::string, int> const& node)
 		{ m_nodes.push_back(node); }
+#endif
 
 		// populates the torrent_info by providing just the info-dict buffer.
 		// This is used when loading a torrent from a magnet link for instance,
@@ -700,9 +702,9 @@ TORRENT_VERSION_NAMESPACE_4
 		// the URLs to the trackers
 		aux::vector<announce_entry> m_urls;
 		std::vector<web_seed_entry> m_web_seeds;
-#endif
 		// dht nodes to add to the routing table/bootstrap from
 		std::vector<std::pair<std::string, int>> m_nodes;
+#endif
 
 		// the info-hashes (20 bytes each) in the "similar" key. These are offsets
 		// into the info dict buffer.

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -732,9 +732,11 @@ TORRENT_VERSION_NAMESPACE_4
 		aux::vector<sha1_hash> m_merkle_tree;
 #endif
 
+#if TORRENT_ABI_VERSION < 4
 		// v2 merkle tree for each file
 		// the actual hash buffers are always divisible by 32 (sha256_hash::size())
 		aux::vector<aux::vector<char>, file_index_t> m_piece_layers;
+#endif
 
 		// this is a copy of the info section from the torrent.
 		// it use maintained in this flat format in order to

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5033,11 +5033,13 @@ retry:
 		for (auto const& n : params.dht_nodes)
 			add_dht_node_name(n);
 
+#if TORRENT_ABI_VERSION < 4
 		if (params.ti)
 		{
 			for (auto const& n : params.ti->nodes())
 				add_dht_node_name(n);
 		}
+#endif
 #endif
 
 		INVARIANT_CHECK;

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1580,9 +1580,7 @@ namespace {
 			}
 			set_piece_layers(v2_hashes);
 		}
-#endif
 
-#if TORRENT_ABI_VERSION < 4
 		for (auto const& url : atp.url_seeds)
 		{
 			web_seed_entry ent(url);
@@ -1596,12 +1594,12 @@ namespace {
 			ent.type = web_seed_entry::http_seed;
 			m_web_seeds.push_back(std::move(ent));
 		}
-#endif
 
 		for (auto const& n : atp.dht_nodes)
 		{
 			m_nodes.emplace_back(n);
 		}
+#endif
 
 		// TODO: collections
 		// TODO: similar


### PR DESCRIPTION
in favor of `add_torrent_params`