### PR TITLE
Fix arguments of dispatched functions cannot be actually moved

### DIFF
--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -8,6 +8,7 @@ Copyright (c) 2017, Falcosc
 Copyright (c) 2018, Steven Siloti
 Copyright (c) 2019, Andrei Kurushin
 Copyright (c) 2019, ghbplayer
+Copyright (c) 2025, Vladimir Golovnev (glassez)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -122,12 +123,12 @@ namespace libtorrent {
 		std::shared_ptr<torrent> t = m_torrent.lock();
 		if (!t) aux::throw_ex<system_error>(errors::invalid_torrent_handle);
 		auto& ses = static_cast<session_impl&>(t->session());
-		dispatch(ses.get_context(), [=,&ses] ()
+		dispatch(ses.get_context(), std::bind([t, f, &ses](auto&&... args) mutable
 		{
 #ifndef BOOST_NO_EXCEPTIONS
 			try {
 #endif
-				(t.get()->*f)(std::move(a)...);
+				(t.get()->*f)(std::forward<Args>(args)...);
 #ifndef BOOST_NO_EXCEPTIONS
 			} catch (system_error const& e) {
 				ses.alerts().emplace_alert<torrent_error_alert>(torrent_handle(t)
@@ -140,7 +141,7 @@ namespace libtorrent {
 					, error_code(), "unknown error");
 			}
 #endif
-		} );
+		}, std::forward<Args>(a)...));
 	}
 
 	template<typename Fun, typename... Args>
@@ -154,12 +155,12 @@ namespace libtorrent {
 		bool done = false;
 
 		std::exception_ptr ex;
-		dispatch(ses.get_context(), [=,&done,&ses,&ex] ()
+		dispatch(ses.get_context(), std::bind([t, f, &done, &ses, &ex](auto&&... args) mutable
 		{
 #ifndef BOOST_NO_EXCEPTIONS
 			try {
 #endif
-				(t.get()->*f)(std::move(a)...);
+				(t.get()->*f)(std::forward<Args>(args)...);
 #ifndef BOOST_NO_EXCEPTIONS
 			} catch (...) {
 				ex = std::current_exception();
@@ -168,7 +169,7 @@ namespace libtorrent {
 			std::unique_lock<std::mutex> l(ses.mut);
 			done = true;
 			ses.cond.notify_all();
-		} );
+		}, std::forward<Args>(a)...));
 
 		aux::torrent_wait(done, ses);
 		if (ex) std::rethrow_exception(ex);
@@ -190,12 +191,12 @@ namespace libtorrent {
 		bool done = false;
 
 		std::exception_ptr ex;
-		dispatch(ses.get_context(), [=,&r,&done,&ses,&ex] ()
+		dispatch(ses.get_context(), std::bind([t, f, &r, &done, &ses, &ex](auto&&... args) mutable
 		{
 #ifndef BOOST_NO_EXCEPTIONS
 			try {
 #endif
-				r = (t.get()->*f)(std::move(a)...);
+				r = (t.get()->*f)(std::forward<Args>(args)...);
 #ifndef BOOST_NO_EXCEPTIONS
 			} catch (...) {
 				ex = std::current_exception();
@@ -204,7 +205,7 @@ namespace libtorrent {
 			std::unique_lock<std::mutex> l(ses.mut);
 			done = true;
 			ses.cond.notify_all();
-		} );
+		}, std::forward<Args>(a)...));
 
 		aux::torrent_wait(done, ses);
 
@@ -511,8 +512,8 @@ namespace libtorrent {
 
 	void torrent_handle::piece_availability(std::vector<int>& avail) const
 	{
-		auto availr = std::ref(static_cast<aux::vector<int, piece_index_t>&>(avail));
-		sync_call(&torrent::piece_availability, availr);
+		auto& arg = static_cast<aux::vector<int, piece_index_t>&>(avail);
+		sync_call(&torrent::piece_availability, std::ref(arg));
 	}
 
 	void torrent_handle::piece_priority(piece_index_t index, download_priority_t priority) const
@@ -641,7 +642,8 @@ namespace libtorrent {
 #if !TORRENT_NO_FPU
 	void torrent_handle::file_progress(std::vector<float>& progress) const
 	{
-		sync_call(&torrent::file_progress_float, std::ref(static_cast<aux::vector<float, file_index_t>&>(progress)));
+		auto& arg = static_cast<aux::vector<float, file_index_t>&>(progress);
+		sync_call(&torrent::file_progress_float, std::ref(arg));
 	}
 #endif
 
@@ -796,8 +798,7 @@ namespace libtorrent {
 	entry torrent_handle::write_resume_data() const
 	{
 		add_torrent_params params;
-		auto retr = std::ref(params);
-		sync_call(&torrent::write_resume_data, resume_data_flags_t{}, retr);
+		sync_call(&torrent::write_resume_data, resume_data_flags_t{}, std::ref(params));
 		return libtorrent::write_resume_data(params);
 	}
 

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -4,7 +4,7 @@ Copyright (c) 2005, 2007-2010, 2012-2022, Arvid Norberg
 Copyright (c) 2016, 2018, Alden Torres
 Copyright (c) 2016, Andrei Kurushin
 Copyright (c) 2016-2018, Steven Siloti
-Copyright (c) 2016, Vladimir Golovnev
+Copyright (c) 2016, 2025, Vladimir Golovnev (glassez)
 Copyright (c) 2018, d-komarov
 All rights reserved.
 
@@ -928,11 +928,12 @@ void test_fastresume(bool const test_deprecated)
 		p.storage_mode = storage_mode_sparse;
 		error_code ignore;
 		torrent_handle h = ses.add_torrent(std::move(p), ignore);
-		TEST_CHECK(exists(combine_path(p.save_path, "temporary")));
-		if (!exists(combine_path(p.save_path, "temporary")))
+
+		torrent_status s = h.status();
+		TEST_CHECK(exists(combine_path(s.save_path, "temporary")));
+		if (!exists(combine_path(s.save_path, "temporary")))
 			return;
 
-		torrent_status s;
 		for (int i = 0; i < 50; ++i)
 		{
 			print_alerts(ses, "ses");


### PR DESCRIPTION
It seems that move-only arguments were never used, so the problem went unnoticed. I discovered it when I was experimenting with `boost::promise`.