### PR TITLE
RC_1_2 - README: Remove LGTM badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,17 +7,11 @@ libtorrent
 .. image:: https://ci.appveyor.com/api/projects/status/w7teauvub5813mew/branch/master?svg=true
     :target: https://ci.appveyor.com/project/arvidn/libtorrent/branch/master
 
-.. image:: https://img.shields.io/lgtm/alerts/g/arvidn/libtorrent.svg?logo=lgtm&logoWidth=18
-	:target: https://lgtm.com/projects/g/arvidn/libtorrent/alerts/
-
 .. image:: https://oss-fuzz-build-logs.storage.googleapis.com/badges/libtorrent.svg
     :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&q=proj%3Alibtorrent&can=1
 
 .. image:: https://codecov.io/github/arvidn/libtorrent/coverage.svg?branch=master
     :target: https://codecov.io/github/arvidn/libtorrent?branch=master&view=all#sort=missing&dir=desc
-
-.. image:: https://img.shields.io/lgtm/grade/cpp/g/arvidn/libtorrent.svg?logo=lgtm&logoWidth=18
-	:target: https://lgtm.com/projects/g/arvidn/libtorrent/context:cpp
 
 .. image:: https://sonarcloud.io/api/project_badges/measure?project=libtorrent&metric=alert_status
 	:target: https://sonarcloud.io/dashboard?id=libtorrent


### PR DESCRIPTION
LGTM was sunset in December 2022 https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

@arvidn I didn't seem to be able to find any associated config file?!