### PR TITLE
Suppress msvc C5054 warning

### DIFF
--- a/include/libtorrent/performance_counters.hpp
+++ b/include/libtorrent/performance_counters.hpp
@@ -460,7 +460,7 @@ namespace libtorrent {
 			num_queued_tracker_announces,
 
 			num_counters,
-			num_gauges_counters = num_counters - num_stats_counters
+			num_gauges_counters = num_counters - static_cast<int>(num_stats_counters)
 		};
 #ifdef ATOMIC_LLONG_LOCK_FREE
 #define TORRENT_COUNTER_NOEXCEPT noexcept


### PR DESCRIPTION
The warning is emitted when compiling in C++20 mode.
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5054?view=msvc-170

Fixes #7881.

ps. This needs to be ported to `RC_1_2` and `master` too.