### PR TITLE
Add support for overriding the NAT-PMP gateway with a nat_pmp_gateway config option

### DIFF
--- a/include/libtorrent/natpmp.hpp
+++ b/include/libtorrent/natpmp.hpp
@@ -91,7 +91,7 @@ struct TORRENT_EXTRA_EXPORT natpmp final
 {
 	natpmp(io_context& ios, aux::portmap_callback& cb, aux::listen_socket_handle ls);
 
-	void start(ip_interface const& ip);
+	void start(ip_interface const& ip, boost::optional<address> const& gateway);
 
 	// maps the ports, if a port is set to 0
 	// it will not be mapped

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -391,6 +391,11 @@ namespace aux {
 			// ``router.bt.ouinet.work:6881``,
 			dht_bootstrap_nodes,
 
+			// Overrides the NAT-PMP service gateway. When set, libtorrent won't try
+			// to resolve the default gateway and instead will send the requests to
+			// the address specified.
+			nat_pmp_gateway,
+
 			max_string_setting_internal
 		};
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5676,7 +5676,11 @@ namespace {
 			ip.netmask = s->netmask;
 			std::strncpy(ip.name, s->device.c_str(), sizeof(ip.name) - 1);
 			ip.name[sizeof(ip.name) - 1] = '\0';
-			s->natpmp_mapper->start(ip);
+
+			error_code ignored;
+			std::string gateway = m_settings.get_str(settings_pack::nat_pmp_gateway);
+			boost::optional<address> gateway_addr = make_address(gateway, ignored);
+			s->natpmp_mapper->start(ip, gateway == "" ? boost::none : gateway_addr);
 		}
 	}
 

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -149,7 +149,8 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(proxy_password, "", &session_impl::update_proxy),
 		SET(i2p_hostname, "", &session_impl::update_i2p_bridge),
 		SET(peer_fingerprint, "-LT20B0-", nullptr),
-		SET(dht_bootstrap_nodes, "dht.libtorrent.org:25401", &session_impl::update_dht_bootstrap_nodes)
+		SET(dht_bootstrap_nodes, "dht.libtorrent.org:25401", &session_impl::update_dht_bootstrap_nodes),
+		SET(nat_pmp_gateway, "", &session_impl::update_upnp)
 	}});
 
 	CONSTEXPR_SETTINGS


### PR DESCRIPTION
As discussed in #7681, this pull request updates farcaller's changes to the latest commit on RC_2_0.

**This hasn't been thoroughly been tested yet.** This seems to fix users behind ProtonVPN not being able to seed due to the default gateway not being set. However, it's difficult to tell because I fail to find a good torrent to test (I used the Arch Linux image). I sometimes get speeds in the kilobytes instead of plain nothing, which is better than nothing but still not ideal.