### PR TITLE
Adds support for v2 infohash to `load_torrent`.

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -714,6 +714,7 @@ namespace aux {
 			void abort_stage2() noexcept;
 
 			torrent_handle find_torrent_handle(sha1_hash const& info_hash);
+			torrent_handle find_torrent_handle_v2(sha256_hash const& info_hash);
 
 			void announce_lsd(sha1_hash const& ih, int port) override;
 

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -254,6 +254,7 @@ namespace libtorrent {
 		// ``get_torrents()`` returns a vector of torrent_handles to all the
 		// torrents currently in the session.
 		torrent_handle find_torrent(sha1_hash const& info_hash) const;
+		torrent_handle find_torrent(sha256_hash const& info_hash) const;
 		std::vector<torrent_handle> get_torrents() const;
 
 		// You add torrents through the add_torrent() function where you give an

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -266,6 +266,12 @@ namespace libtorrent {
 		return sync_call_ret<torrent_handle>(&session_impl::find_torrent_handle, info_hash);
 	}
 
+	torrent_handle session_handle::find_torrent(sha256_hash const& info_hash) const
+	{
+		return sync_call_ret<torrent_handle>(&session_impl::find_torrent_handle_v2, info_hash);
+	}
+
+
 	std::vector<torrent_handle> session_handle::get_torrents() const
 	{
 		return sync_call_ret<std::vector<torrent_handle>>(&session_impl::get_torrents);

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -4879,6 +4879,12 @@ namespace {
 		return torrent_handle(find_torrent(info_hash_t(info_hash)));
 	}
 
+	torrent_handle session_impl::find_torrent_handle_v2(sha256_hash const& info_hash)
+	{
+		return torrent_handle(find_torrent(info_hash_t(info_hash)));
+	}
+
+
 	void session_impl::async_add_torrent(add_torrent_params* params)
 	{
 		std::unique_ptr<add_torrent_params> holder(params);


### PR DESCRIPTION
Tried to keep it backwards compatible, so not the prettiest. Compiler couldn't deduce the overload between handle->impl, hence the new `find_torrent_handle_v2` method to be explicit.

Fixes #7914.