### PR TITLE
Utp resend optimization

### DIFF
--- a/include/libtorrent/aux_/utp_stream.hpp
+++ b/include/libtorrent/aux_/utp_stream.hpp
@@ -754,6 +754,10 @@ private:
 	packet_ptr acquire_packet(int const allocate);
 	void release_packet(packet_ptr p);
 
+	// insert the given packet at `m_seq_nr` in `m_outbuf`
+	// and release any packet that was there already
+	void insert_packet(packet_ptr p);
+
 	void set_state(state_t s);
 	state_t state() const { return static_cast<state_t>(m_state); }
 
@@ -1055,6 +1059,9 @@ private:
 	// packet for this connection with a correct ack_nr, confirming that the
 	// other end is not spoofing its source IP
 	bool m_confirmed:1;
+
+	// packets that need to be resent. Points to packets in m_outbuf
+	std::vector<packet*> m_needs_resend;
 };
 
 }

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -220,7 +220,11 @@ void utp_socket_impl::insert_packet(packet_ptr p)
 	{
 //		TORRENT_ASSERT(reinterpret_cast<utp_header*>(old->buf)->seq_nr == m_seq_nr);
 		if (old->need_resend)
-			m_needs_resend.erase(std::find(m_needs_resend.begin(), m_needs_resend.end(), &*old));
+		{
+			auto entry = std::find(m_needs_resend.begin(), m_needs_resend.end(), &*old);
+			// old should always exist in m_needs_resend, but we check just in case
+			if (entry != m_needs_resend.end()) m_needs_resend.erase(entry);
+		}
 		else m_bytes_in_flight -= old->size - old->header_size;
 		release_packet(std::move(old));
 	}
@@ -2187,7 +2191,10 @@ std::uint32_t utp_socket_impl::ack_packet(packet_ptr p, time_point const receive
 //	TORRENT_ASSERT(reinterpret_cast<utp_header*>(p->buf)->seq_nr == seq_nr);
 
 	if (p->need_resend)
-		m_needs_resend.erase(std::find(m_needs_resend.begin(), m_needs_resend.end(), p.get()));
+	{
+		auto entry = std::find(m_needs_resend.begin(), m_needs_resend.end(), p.get());
+		if (entry != m_needs_resend.end()) m_needs_resend.erase(entry);
+	}
 	else
 	{
 		TORRENT_ASSERT(m_bytes_in_flight >= p->size - p->header_size);

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1488,8 +1488,10 @@ bool utp_socket_impl::send_pkt(int const flags)
 	bool const force_flush_nagle = m_out_eof && m_write_buffer_size;
 
 	// first see if we need to resend any packets
-	for (packet *p: m_needs_resend)
+
+	while (!m_needs_resend.empty())
 	{
+		packet *p = m_needs_resend[0];
 		if (!resend_packet(p))
 		{
 			// we couldn't resend the packet. It probably doesn't

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -2062,7 +2062,7 @@ bool utp_socket_impl::resend_packet(packet* p, bool fast_resend)
 		if (p->need_resend)
 		{
 			p->need_resend = false;
-			auto entry = std::find(m_needs_resend.begin(), m_needs_resend.end(), p.get());
+			auto entry = std::find(m_needs_resend.begin(), m_needs_resend.end(), p);
 			if (entry != m_needs_resend.end()) m_needs_resend.erase(entry);
 		}
 
@@ -3482,7 +3482,7 @@ void utp_socket_impl::tick(time_point const now)
 			if (!p) continue;
 			if (p->need_resend) continue;
 			p->need_resend = true;
-			if (i != m_acked_seq_nr && i != m_seq_nr) m_needs_resend.push_back(p.get());
+			if (i != m_acked_seq_nr && i != m_seq_nr) m_needs_resend.push_back(p);
 			TORRENT_ASSERT(m_bytes_in_flight >= p->size - p->header_size);
 			m_bytes_in_flight -= p->size - p->header_size;
 			UTP_LOGV("%8p: Packet %d lost (timeout).\n", static_cast<void*>(this), i);

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -1491,7 +1491,7 @@ bool utp_socket_impl::send_pkt(int const flags)
 
 	while (!m_needs_resend.empty())
 	{
-		packet *p = m_needs_resend[0];
+		packet *p = m_needs_resend.front();
 		if (!resend_packet(p))
 		{
 			// we couldn't resend the packet. It probably doesn't

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -218,7 +218,7 @@ void utp_socket_impl::insert_packet(packet_ptr p)
 	packet_ptr old = m_outbuf.insert(m_seq_nr, std::move(p));
 	if (old)
 	{
-//		TORRENT_ASSERT(reinterpret_cast<utp_header*>(old->buf)->seq_nr == m_seq_nr);
+		TORRENT_ASSERT(reinterpret_cast<utp_header*>(old->buf)->seq_nr == m_seq_nr);
 		if (old->need_resend)
 		{
 			auto entry = std::find(m_needs_resend.begin(), m_needs_resend.end(), &*old);
@@ -2190,7 +2190,7 @@ std::uint32_t utp_socket_impl::ack_packet(packet_ptr p, time_point const receive
 
 	// verify that the packet we're removing was in fact sent
 	// with the sequence number we expect
-//	TORRENT_ASSERT(reinterpret_cast<utp_header*>(p->buf)->seq_nr == seq_nr);
+	TORRENT_ASSERT(reinterpret_cast<utp_header*>(p->buf)->seq_nr == seq_nr);
 
 	if (p->need_resend)
 	{

--- a/src/utp_stream.cpp
+++ b/src/utp_stream.cpp
@@ -2005,7 +2005,7 @@ bool utp_socket_impl::resend_packet(packet* p, bool fast_resend)
 #if TORRENT_USE_ASSERTS
 	if (fast_resend) ++p->num_fast_resend;
 #endif
-	bool need_resend = p->need_resend;
+	bool const need_resend = p->need_resend;
 	p->need_resend = false;
 	auto* h = reinterpret_cast<utp_header*>(p->buf);
 	// update packet header


### PR DESCRIPTION
There has been a TODO message in `utp_socket_impl::send_pkt` for over 10 years now saying that the current implementation isn't very efficient, and it isn't.

This PR adds a new `std::vector` `m_needs_resend` for each utp connection to track the packets that need to be resent. I've kept the behaviour the same as the previous implementation - the packets at `m_acked_seq_nr` (last acked packet) and `m_seq_nr` (FIN packet) will never be added to `m_needs_resend`.