### PR TITLE
GHA CI - Windows: Explicitly use `windows-latest`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
 
    simulations:
       name: Simulations
-      runs-on: windows-2019
+      runs-on: windows-latest
 
       steps:
       - name: checkout
@@ -122,7 +122,7 @@ jobs:
 
    build:
       name: Build
-      runs-on: windows-2019
+      runs-on: windows-latest
       continue-on-error: true
 
       strategy:


### PR DESCRIPTION
* [The Windows 2019 Actions runner image will begin deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30](https://github.com/actions/runner-images/issues/12045)