### PR TITLE
Don't leak file descriptors to child processes

### DIFF
--- a/include/libtorrent/aux_/dev_random.hpp
+++ b/include/libtorrent/aux_/dev_random.hpp
@@ -49,7 +49,11 @@ namespace libtorrent { namespace aux {
 		// https://www.mail-archive.com/cryptography@randombit.net/msg04763.html
 		// https://security.stackexchange.com/questions/3936/is-a-rand-from-dev-urandom-secure-for-a-login-key/3939#3939
 		dev_random()
+#ifdef O_CLOEXEC
+			: m_fd(::open("/dev/urandom", O_RDONLY | O_CLOEXEC))
+#else
 			: m_fd(::open("/dev/urandom", O_RDONLY))
+#endif
 		{
 			if (m_fd < 0)
 			{

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -350,7 +350,11 @@ void copy_file(std::string const& inf, std::string const& newf, storage_error& s
 	native_path_string f1 = convert_to_native_path_string(inf);
 	native_path_string f2 = convert_to_native_path_string(newf);
 
-	aux::file_descriptor const infd = ::open(f1.c_str(), O_RDONLY);
+	int read_flags = O_RDONLY;
+#ifdef O_CLOEXEC
+	read_flags |= O_CLOEXEC;
+#endif
+	aux::file_descriptor const infd = ::open(f1.c_str(), read_flags);
 	if (infd.fd() < 0)
 	{
 		se.operation = operation_t::file_stat;
@@ -371,8 +375,11 @@ void copy_file(std::string const& inf, std::string const& newf, storage_error& s
 	// if the source file is not sparse we'll end up copying every byte anyway,
 	// there's no point in passing O_TRUNC. However, in order to preserve sparse
 	// regions, we *do* need to truncate the output file.
-	aux::file_descriptor const outfd = ::open(f2.c_str()
-		, input_is_sparse ? (O_RDWR | O_CREAT | O_TRUNC) : (O_RDWR | O_CREAT), in_stat.st_mode);
+	int write_flags = O_RDWR | O_CREAT | (input_is_sparse ? O_TRUNC : 0);
+#ifdef O_CLOEXEC
+	write_flags |= O_CLOEXEC;
+#endif
+	aux::file_descriptor const outfd = ::open(f2.c_str(), write_flags, in_stat.st_mode);
 	if (outfd.fd() < 0)
 	{
 		se.operation = operation_t::file_open;

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -630,6 +630,13 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		TORRENT_UNUSED(ios); // this may be unused depending on configuration
 		std::vector<ip_interface> ret;
 		ec.clear();
+
+#ifdef SOCK_CLOEXEC
+		int const flags = SOCK_CLOEXEC;
+#else
+		int const flags = 0;
+#endif
+
 #if defined TORRENT_BUILD_SIMULATOR
 
 		std::vector<address> ips = ios.get_ips();
@@ -648,7 +655,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 			ret.push_back(wan);
 		}
 #elif TORRENT_USE_NETLINK
-		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM, NETLINK_ROUTE);
+		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM | flags, NETLINK_ROUTE);
 		if (sock < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -703,7 +710,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 			return ret;
 		}
 #elif TORRENT_USE_IFADDRS
-		int const s = ::socket(AF_INET, SOCK_DGRAM, 0);
+		int const s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (s < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -727,7 +734,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		freeifaddrs(ifaddr);
 // MacOS X, BSD, solaris and Haiku
 #elif TORRENT_USE_IFCONF
-		int const s = ::socket(AF_INET, SOCK_DGRAM, 0);
+		int const s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (s < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -921,7 +928,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		}
 #endif
 
-		SOCKET s = ::socket(AF_INET, SOCK_DGRAM, 0);
+		SOCKET s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (int(s) == SOCKET_ERROR)
 		{
 			ec = error_code(WSAGetLastError(), system_category());
@@ -1015,6 +1022,13 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		TORRENT_UNUSED(ios);
 		ec.clear();
 
+#ifdef SOCK_CLOEXEC
+		int const flags = SOCK_CLOEXEC;
+#else
+		int const flags = 0;
+#endif
+		TORRENT_UNUSED(flags);  // not used in every build config
+
 #ifdef TORRENT_BUILD_SIMULATOR
 
 		TORRENT_UNUSED(ec);
@@ -1063,7 +1077,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		m.m_rtm.rtm_seq = 0;
 		m.m_rtm.rtm_msglen = len;
 
-		int s = ::socket(PF_ROUTE, SOCK_RAW, AF_UNSPEC);
+		int s = ::socket(PF_ROUTE, SOCK_RAW | flags, AF_UNSPEC);
 		if (s == -1)
 		{
 			ec = error_code(errno, system_category());
@@ -1183,7 +1197,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 
 	char* end = buf.get() + needed;
 
-	int const s = ::socket(AF_INET, SOCK_DGRAM, 0);
+	int const s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 	if (s < 0)
 	{
 		ec = error_code(errno, system_category());
@@ -1366,7 +1380,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		// Free memory
 		free(routes);
 #elif TORRENT_USE_NETLINK
-		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM, NETLINK_ROUTE);
+		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM | flags, NETLINK_ROUTE);
 		if (sock < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -1374,7 +1388,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		}
 		socket_closer c1(sock);
 
-		int dgram_sock = ::socket(AF_INET, SOCK_DGRAM, 0);
+		int dgram_sock = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (dgram_sock < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -1404,7 +1418,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 
 		for (int fam = 0; fam < 2; ++fam)
 		{
-			int const s = ::socket(fam == 0 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
+			int const s = ::socket(fam == 0 ? AF_INET : AF_INET6, SOCK_DGRAM | flags, 0);
 			if (s < 0)
 			{
 				ec = error_code(errno, system_category());

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -383,8 +383,10 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 
 	int file_flags(open_mode_t const mode)
 	{
-		return ((mode & open_mode::write)
-			? O_RDWR | O_CREAT : O_RDONLY)
+		return ((mode & open_mode::write) ? O_RDWR | O_CREAT : O_RDONLY)
+#ifdef O_CLOEXEC
+			| O_CLOEXEC
+#endif
 #ifdef O_NOATIME
 			| ((mode & open_mode::no_atime) ? O_NOATIME : 0)
 #endif

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -195,6 +195,9 @@ file_mapping::file_mapping(file_handle file, open_mode_t const mode, std::int64_
 		// ignore errors here, since this is best-effort
 			| MADV_DONTDUMP
 #endif
+#ifdef MADV_DONTFORK
+			| MADV_DONTFORK
+#endif
 #ifdef MADV_NOCORE
 		// This is the BSD counterpart to exclude a range from core dumps
 			| MADV_NOCORE

--- a/src/truncate.cpp
+++ b/src/truncate.cpp
@@ -128,7 +128,12 @@ void truncate_files(file_storage const& fs, std::string const& save_path, storag
 		if (fs.pad_file_at(i)) continue;
 		auto const fn = fs.file_path(i, save_path);
 		native_path_string const file_path = convert_to_native_path_string(fn);
-		int const fd = ::open(file_path.c_str(), O_RDWR);
+
+		int flags = O_RDWR;
+#ifdef O_CLOEXEC
+		flags |= O_CLOEXEC;
+#endif
+		int const fd = ::open(file_path.c_str(), flags);
 
 		if (fd < 0)
 		{


### PR DESCRIPTION
Without `O_CLOEXEC`, `SOCK_CLOEXEC` and `MADV_DONTFORK`, the file descriptors are available to the child process which would lead to leaking file descriptors and other unwanted behaviors.