### PR TITLE
Python bindings: Revise supported python versions

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -16,10 +16,10 @@ cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR) # Configurable policies: <= C
 # Sets _ret to a list of python versions (major.minor) that use the same MSVC runtime as this build does
 # assumes MSVC was detected already
 # See https://en.wikipedia.org/wiki/Microsoft_Visual_C++#Internal_version_numbering
-# See https://devguide.python.org/#status-of-python-branches for supported python versions
+# See https://devguide.python.org/versions/#versions for supported python versions
 function(_get_compatible_python_versions _ret)
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20)
-		list(APPEND _tmp 3.6 3.7 3.8 3.9 3.10 3.11)
+		list(APPEND _tmp 3.9 3.10 3.11 3.12 3.13)
 	endif()
 	set(${_ret} ${_tmp} PARENT_SCOPE)
 endfunction()

--- a/bindings/python/src/module.cpp
+++ b/bindings/python/src/module.cpp
@@ -35,7 +35,6 @@ void bind_load_torrent();
 BOOST_PYTHON_MODULE(libtorrent)
 {
     Py_Initialize();
-    PyEval_InitThreads();
 
     bind_converters();
     bind_unicode_string_conversion();


### PR DESCRIPTION
* Drop support for Python <3.9 (EOL)
* Add Python 3.12 & 3.13 support
* Updated URL for "supported python versions"
* Remove PyEval_InitThreads() call for Python 3.7 and later as Python calls it automatically now.
This removes a deprecation warning when using Python 3.9.
https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads