### PR TITLE
Add inbound and outbound tunnels length variance in i2p stream settings.

### DIFF
--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -107,6 +107,8 @@ struct i2p_session_options
 	int m_outbound_quantity = 3;
 	int m_inbound_length = 3;
 	int m_outbound_length = 3;
+	int m_inbound_length_variance = 0;
+	int m_outbound_length_variance = 0;
 };
 
 struct i2p_stream : proxy_base
@@ -446,9 +448,11 @@ private:
 		int size = std::snprintf(cmd, sizeof(cmd),
 			"SESSION CREATE STYLE=STREAM ID=%s "
 			"DESTINATION=TRANSIENT SIGNATURE_TYPE=7 i2cp.leaseSetEncType=4,0 "
-			"inbound.quantity=%d outbound.quantity=%d inbound.length=%d outbound.length=%d\n",
+			"inbound.quantity=%d outbound.quantity=%d inbound.length=%d outbound.length=%d "
+			"inbound.lengthVariance=%d outbound.lengthVariance=%d\n",
 			m_id, m_session_options.m_inbound_quantity, m_session_options.m_outbound_quantity,
-			m_session_options.m_inbound_length, m_session_options.m_outbound_length);
+			m_session_options.m_inbound_length, m_session_options.m_outbound_length,
+			m_session_options.m_inbound_length_variance, m_session_options.m_outbound_length_variance);
 		ADD_OUTSTANDING_ASYNC("i2p_stream::start_read_line");
 		async_write(m_sock, boost::asio::buffer(cmd, std::size_t(size)), wrap_allocator(
 			[this](error_code const& ec, std::size_t, Handler hn) {

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -2063,6 +2063,7 @@ namespace aux {
 			// Configures the SAM session
 			// quantity of I2P inbound and outbound tunnels [1..16].
 			// number of hops for I2P inbound and outbound tunnels [0..7]
+			// variance for I2P inbound and outbound tunnels [0..7]
 			// Changing these will not trigger a reconnect to the SAM bridge,
 			// they will take effect the next time the SAM connection is
 			// re-established (by restarting or changing i2p_hostname or
@@ -2071,6 +2072,8 @@ namespace aux {
 			i2p_outbound_quantity,
 			i2p_inbound_length,
 			i2p_outbound_length,
+			i2p_inbound_length_variance,
+			i2p_outbound_length_variance,
 
 			// ``announce_port`` is the port passed along as the ``port`` parameter
 			// to remote trackers such as HTTP or DHT. This setting does not affect

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2378,6 +2378,8 @@ namespace {
 			, m_settings.get_int(settings_pack::i2p_outbound_quantity)
 			, m_settings.get_int(settings_pack::i2p_inbound_length)
 			, m_settings.get_int(settings_pack::i2p_outbound_length)
+			, m_settings.get_int(settings_pack::i2p_inbound_length_variance)
+			, m_settings.get_int(settings_pack::i2p_outbound_length_variance)
 		};
 		m_i2p_conn.open(m_settings.get_str(settings_pack::i2p_hostname)
 			, m_settings.get_int(settings_pack::i2p_port)

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -402,6 +402,8 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(i2p_outbound_quantity, 3, nullptr),
 		SET(i2p_inbound_length, 3, nullptr),
 		SET(i2p_outbound_length, 3, nullptr),
+		SET(i2p_inbound_length_variance, 0, nullptr),
+		SET(i2p_outbound_length_variance, 0, nullptr),
 		SET(announce_port, 0, nullptr)
 	}});
 

--- a/test/test_settings_pack.cpp
+++ b/test/test_settings_pack.cpp
@@ -325,3 +325,25 @@ TORRENT_TEST(global_constructors)
 	TEST_CHECK(g_sett.get_int(lt::settings_pack::aio_threads) > 0);
 }
 #endif
+
+TORRENT_TEST(i2p_tunnel_variance_settings)
+{
+#if TORRENT_USE_I2P
+	lt::settings_pack pack;
+
+	// Default values should be 0
+	TEST_EQUAL(pack.get_int(lt::settings_pack::i2p_inbound_length_variance), 0);
+	TEST_EQUAL(pack.get_int(lt::settings_pack::i2p_outbound_length_variance), 0);
+
+	pack.set_int(lt::settings_pack::i2p_inbound_length_variance, 2);
+	pack.set_int(lt::settings_pack::i2p_outbound_length_variance, -3);
+	TEST_EQUAL(pack.get_int(lt::settings_pack::i2p_inbound_length_variance), 2);
+	TEST_EQUAL(pack.get_int(lt::settings_pack::i2p_outbound_length_variance), -3);
+
+	// After clearing, it should go back to defaults
+	pack.clear(lt::settings_pack::i2p_inbound_length_variance);
+	pack.clear(lt::settings_pack::i2p_outbound_length_variance);
+	TEST_EQUAL(pack.get_int(lt::settings_pack::i2p_inbound_length_variance), 0);
+	TEST_EQUAL(pack.get_int(lt::settings_pack::i2p_outbound_length_variance), 0);
+#endif
+}


### PR DESCRIPTION
As discussed here: https://github.com/arvidn/libtorrent/issues/7925 libtorrent is lacking the capibility of adding variance to I2P tunnels. Inbound and outbound tunnel length variance is natively handled by I2P https://geti2p.net/en/docs/protocol/i2cp (see inbound.lengthVariance and outbound.lengthVariance) but we need to set those values when creating the tunnel, otherwise they will default to 0.

To test this with a real I2P router, I made a sample program in C++ that uses my version of libtorrent and creates a I2P session setting the inbound and outbound tunnels variance.

![tunnel_configuration_test](https://github.com/user-attachments/assets/9baa0c06-15f0-4b52-bd8f-16178a54e430)
![sam_client_tunnel_config](https://github.com/user-attachments/assets/caaae17c-b83d-4d8b-85eb-14a3ef924dcf)

As you can see in the screenshots, the tunnel is configured with the variance I set using libtorrent and my sample program.

