### PR TITLE
Don't leak file descriptors to child processes (RC_1_2)

### DIFF
--- a/include/libtorrent/aux_/dev_random.hpp
+++ b/include/libtorrent/aux_/dev_random.hpp
@@ -48,7 +48,11 @@ namespace libtorrent { namespace aux {
 		// https://www.mail-archive.com/cryptography@randombit.net/msg04763.html
 		// https://security.stackexchange.com/questions/3936/is-a-rand-from-dev-urandom-secure-for-a-login-key/3939#3939
 		dev_random()
+#ifdef O_CLOEXEC
+			: m_fd(::open("/dev/urandom", O_RDONLY | O_CLOEXEC))
+#else
 			: m_fd(::open("/dev/urandom", O_RDONLY))
+#endif
 		{
 			if (m_fd < 0)
 			{

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -634,6 +634,13 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		TORRENT_UNUSED(ios); // this may be unused depending on configuration
 		std::vector<ip_interface> ret;
 		ec.clear();
+
+#ifdef SOCK_CLOEXEC
+		int const flags = SOCK_CLOEXEC;
+#else
+		int const flags = 0;
+#endif
+
 #if defined TORRENT_BUILD_SIMULATOR
 
 		std::vector<address> ips = ios.get_ips();
@@ -652,7 +659,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 			ret.push_back(wan);
 		}
 #elif TORRENT_USE_NETLINK
-		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM, NETLINK_ROUTE);
+		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM | flags, NETLINK_ROUTE);
 		if (sock < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -707,7 +714,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 			return ret;
 		}
 #elif TORRENT_USE_IFADDRS
-		int const s = ::socket(AF_INET, SOCK_DGRAM, 0);
+		int const s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (s < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -731,7 +738,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		freeifaddrs(ifaddr);
 // MacOS X, BSD and solaris
 #elif TORRENT_USE_IFCONF
-		int const s = ::socket(AF_INET, SOCK_DGRAM, 0);
+		int const s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (s < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -927,7 +934,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		}
 #endif
 
-		SOCKET s = ::socket(AF_INET, SOCK_DGRAM, 0);
+		SOCKET s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (int(s) == SOCKET_ERROR)
 		{
 			ec = error_code(WSAGetLastError(), system_category());
@@ -1022,6 +1029,13 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		TORRENT_UNUSED(ios);
 		ec.clear();
 
+#ifdef SOCK_CLOEXEC
+		int const flags = SOCK_CLOEXEC;
+#else
+		int const flags = 0;
+#endif
+		TORRENT_UNUSED(flags);  // not used in every build config
+
 #ifdef TORRENT_BUILD_SIMULATOR
 
 		TORRENT_UNUSED(ec);
@@ -1070,7 +1084,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		m.m_rtm.rtm_seq = 0;
 		m.m_rtm.rtm_msglen = len;
 
-		int s = ::socket(PF_ROUTE, SOCK_RAW, AF_UNSPEC);
+		int s = ::socket(PF_ROUTE, SOCK_RAW | flags, AF_UNSPEC);
 		if (s == -1)
 		{
 			ec = error_code(errno, system_category());
@@ -1190,7 +1204,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 
 	char* end = buf.get() + needed;
 
-	int const s = ::socket(AF_INET, SOCK_DGRAM, 0);
+	int const s = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 	if (s < 0)
 	{
 		ec = error_code(errno, system_category());
@@ -1373,7 +1387,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		// Free memory
 		free(routes);
 #elif TORRENT_USE_NETLINK
-		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM, NETLINK_ROUTE);
+		int const sock = ::socket(PF_ROUTE, SOCK_DGRAM | flags, NETLINK_ROUTE);
 		if (sock < 0)
 		{
 			ec = error_code(errno, system_category());
@@ -1381,7 +1395,7 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 		}
 		socket_closer c1(sock);
 
-		int dgram_sock = ::socket(AF_INET, SOCK_DGRAM, 0);
+		int dgram_sock = ::socket(AF_INET, SOCK_DGRAM | flags, 0);
 		if (dgram_sock < 0)
 		{
 			ec = error_code(errno, system_category());

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -596,6 +596,9 @@ static_assert(!(open_mode::sparse & open_mode::attribute_mask), "internal flags 
 #endif
 
 		int open_mode = 0
+#ifdef O_CLOEXEC
+			| O_CLOEXEC
+#endif
 #ifdef O_NOATIME
 			| ((mode & open_mode::no_atime) ? O_NOATIME : 0)
 #endif

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -429,7 +429,12 @@ namespace {
 			ec.assign(errno, system_category());
 		copyfile_state_free(state);
 #else
-		int const infd = ::open(f1.c_str(), O_RDONLY);
+
+		int read_flags = O_RDONLY;
+#ifdef O_CLOEXEC
+		read_flags |= O_CLOEXEC;
+#endif
+		int const infd = ::open(f1.c_str(), read_flags);
 		if (infd < 0)
 		{
 			ec.assign(errno, system_category());
@@ -442,7 +447,12 @@ namespace {
 			| S_IRGRP | S_IWGRP
 			| S_IROTH | S_IWOTH;
 
-		int const outfd = ::open(f2.c_str(), O_WRONLY | O_CREAT, permissions);
+		int write_flags = O_WRONLY | O_CREAT;
+#ifdef O_CLOEXEC
+		write_flags |= O_CLOEXEC;
+#endif
+
+		int const outfd = ::open(f2.c_str(), write_flags, permissions);
 		if (outfd < 0)
 		{
 			close(infd);


### PR DESCRIPTION
Without `O_CLOEXEC` and `SOCK_CLOEXEC`, the file descriptors are available to the child process which would lead to leaking file descriptors and other unwanted behaviors.

This backporting #7937 to `RC_1_2` branch.