### PR TITLE
Fix wrong variable in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,7 +657,7 @@ if (APPLE)
 endif()
 
 # check if we need to link with libatomic (not needed on MSVC)
-if (NOT Windows)
+if (NOT MSVC)
 	# TODO: migrate to CheckSourceCompiles in CMake >= 3.19
 	include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
The `Windows` variable is not defined in CMake. The correct variable should be `MSVC`.
https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html#variables-that-describe-the-system