### PR TITLE
Fix wrong variable in CMake (RC_1_2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,7 +635,7 @@ if (APPLE)
 endif()
 
 # check if we need to link with libatomic (not needed on MSVC)
-if (NOT Windows)
+if (NOT MSVC)
 	# TODO: migrate to CheckSourceCompiles in CMake >= 3.19
 	include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
The `Windows` variable is not defined in CMake. The correct variable should be `MSVC`.
https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html#variables-that-describe-the-system

ps. This is the same as PR #7951 but backported to RC_1_2 branch.