### PR TITLE
add surpport for custom tracker proxy

### DIFF
--- a/include/libtorrent/aux_/proxy_settings.hpp
+++ b/include/libtorrent/aux_/proxy_settings.hpp
@@ -63,6 +63,15 @@ namespace aux {
 
 		// if true, tracker connections are subject to the proxy settings
 		bool proxy_tracker_connections = true;
+
+		//defaults to false, it means that all tracker connections are subject if proxy_tracker_connections is true;
+		// if true, only in proxy_tracker_list connections are subject to the proxy settings
+		bool proxy_tracker_list_enable = false;
+
+		//if proxy_tracker_connections is true, and proxy_tracker_list_enable is true;
+		//then the proxy_tracker_list will be used, only in proxy_tracker_list ,the tracker connection are proxied
+		std::vector<std::string> proxy_tracker_list;
+
 	};
 
 }}

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -340,6 +340,9 @@ namespace aux {
 			proxy_username,
 			proxy_password,
 
+			//custom some tracker subject to proxy, not all tracker use proxy setting.
+			proxy_tracker_list, 
+
 			// sets the i2p_ SAM bridge to connect to. set the port with the
 			// ``i2p_port`` setting. Unless this is set, i2p torrents are not
 			// supported. This setting is separate from the other proxy settings
@@ -878,6 +881,9 @@ namespace aux {
 			// if true, tracker connections are made over the configured proxy, if
 			// any.
 			proxy_tracker_connections,
+
+			//if ture, the tracker only in proxy_tracker_list are subject to proxy,
+			proxy_tracker_list_enable, 
 
 			// Starts and stops the internal IP table route changes notifier.
 			//

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -237,6 +237,16 @@ namespace libtorrent::aux {
 		// are that we're shutting down, and this should be a best-effort
 		// attempt. It's not worth stalling shutdown.
 		aux::proxy_settings ps(settings);
+		bool bProxy = ps.proxy_tracker_connections;
+		if (bProxy && ps.proxy_tracker_list_enable) {
+			//use tracker list to judge
+			for (std::string host : ps.proxy_tracker_list) {
+				if (url.find(host) != std::string::npos) {
+					bProxy = true;
+					break;
+				}
+			}
+		}
 		m_tracker_connection->get(url, seconds(timeout)
 			, ps.proxy_tracker_connections ? &ps : nullptr
 			, 5, user_agent, bi

--- a/src/proxy_settings.cpp
+++ b/src/proxy_settings.cpp
@@ -11,6 +11,9 @@ see LICENSE file.
 #include "libtorrent/settings_pack.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
 
+#include <boost/algorithm/string.hpp> 
+#include <boost/algorithm/string/trim.hpp>
+
 namespace libtorrent { namespace aux {
 
 namespace {
@@ -28,6 +31,21 @@ void init(proxy_settings& p, Settings const& sett)
 		settings_pack::proxy_peer_connections);
 	p.proxy_tracker_connections = sett.get_bool(
 		settings_pack::proxy_tracker_connections);
+	p.proxy_tracker_list_enable = sett.get_bool(
+		settings_pack::proxy_tracker_list_enable);
+
+	std::string source = sett.get_str(settings_pack::proxy_tracker_list);
+	if (source.length()>0) {
+		std::vector<std::string> trackers;
+     	boost::split(trackers, source, boost::is_any_of(";, "));
+		//tracker trim
+		for(std::string tracker : trackers) {
+			boost::trim(tracker);
+			if (tracker.length()>0) {
+				p.proxy_tracker_list.push_back(tracker);
+			}
+		}
+	}
 }
 
 }

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -197,6 +197,7 @@ namespace {
 		SET(proxy_peer_connections, true, nullptr),
 		SET(auto_sequential, true, &session_impl::update_auto_sequential),
 		SET(proxy_tracker_connections, true, nullptr),
+		SET(proxy_tracker_list_enable, false, nullptr),
 		SET(enable_ip_notifier, true, &session_impl::update_ip_notifier),
 		SET(dht_prefer_verified_node_ids, true, nullptr),
 		SET(dht_restrict_routing_ips, true, nullptr),


### PR DESCRIPTION
i have lots of pt website,because of isp,some tracker only could connect successful by using proxy server.
befor, i use two qbittorrent client for my pt. one use proxy, one connect without proxy.
so i want to need custom proxy rule.
if the libtorrent  surpport, i  would only use one qbittorrent.
