### PR TITLE
file_renamed_alert

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.0.12
 
+	* file_renamed_alert is always posted, regardless of alert mask
 	* add feature to request resume data synchronously
 	* don't leak file descriptors to child processes (O_CLOEXEC)
 	* optimize the utp resend

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5045,15 +5045,13 @@ namespace {
 
 		if (error)
 		{
-			if (alerts().should_post<file_rename_failed_alert>())
-				alerts().emplace_alert<file_rename_failed_alert>(get_handle()
-					, file_idx, error.ec);
+			alerts().emplace_alert<file_rename_failed_alert>(get_handle()
+				, file_idx, error.ec);
 		}
 		else
 		{
-			if (alerts().should_post<file_renamed_alert>())
-				alerts().emplace_alert<file_renamed_alert>(get_handle()
-					, filename, m_torrent_file->files().file_path(file_idx), file_idx);
+			alerts().emplace_alert<file_renamed_alert>(get_handle()
+				, filename, m_torrent_file->files().file_path(file_idx), file_idx);
 			m_torrent_file->rename_file(file_idx, filename);
 
 			set_need_save_resume(torrent_handle::if_state_changed);


### PR DESCRIPTION
Renaming a file is always caused by user action. Taking the mask into account is error prone.