### PR TITLE
deprecated remap_files()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.1.0 not released
 
+	* deprecated remap_files(), and prevent it from breaking v2 torrents
 	* fix peer_info holding an i2p destination
 	* implement i2p_pex, peer exchange support for i2p torrents
 	* deprecate torrent_alert::torrent_name()

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -465,7 +465,9 @@ void bind_torrent_info()
         .def("ssl_cert", &torrent_info::ssl_cert)
         .def("num_files", &torrent_info::num_files)
         .def("rename_file", rename_file0)
-        .def("remap_files", &torrent_info::remap_files)
+#if TORRENT_ABI_VERSION < 4
+        .def("remap_files", depr(&torrent_info::remap_files))
+#endif
         .def("files", &torrent_info::files, return_internal_reference<>())
         .def("orig_files", &torrent_info::orig_files, return_internal_reference<>())
 #if TORRENT_ABI_VERSION == 1

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -216,10 +216,6 @@ TORRENT_VERSION_NAMESPACE_4
 		// filename is reflected by the ``file_storage`` returned by ``files()``
 		// but not by the one returned by ``orig_files()``.
 		//
-		// If you want to rename the base name of the torrent (for a multi file
-		// torrent), you can copy the ``file_storage`` (see files() and
-		// orig_files() ), change the name, and then use `remap_files()`_.
-		//
 		// The ``new_filename`` can both be a relative path, in which case the
 		// file name is relative to the ``save_path`` of the torrent. If the
 		// ``new_filename`` is an absolute path (i.e. ``is_complete(new_filename)
@@ -228,6 +224,7 @@ TORRENT_VERSION_NAMESPACE_4
 		// invoked.
 		void rename_file(file_index_t index, std::string const& new_filename);
 
+#if TORRENT_ABI_VERSION < 4
 		// .. warning::
 		// 	Using `remap_files()` is discouraged as it's incompatible with v2
 		// 	torrents. This is because the piece boundaries and piece hashes in
@@ -242,9 +239,9 @@ TORRENT_VERSION_NAMESPACE_4
 		//
 		// The new specified ``file_storage`` must have the exact same size as
 		// the current one.
+		TORRENT_DEPRECATED
 		void remap_files(file_storage const& f);
 
-#if TORRENT_ABI_VERSION < 4
 		// ``add_tracker()`` adds a tracker to the announce-list. The ``tier``
 		// determines the order in which the trackers are to be tried.
 		// The ``trackers()`` function will return a sorted vector of

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -878,6 +878,7 @@ namespace {
 		return true;
 	}
 
+#if TORRENT_ABI_VERSION < 4
 	void torrent_info::remap_files(file_storage const& f)
 	{
 		INVARIANT_CHECK;
@@ -885,14 +886,22 @@ namespace {
 		TORRENT_ASSERT(is_loaded());
 		// the new specified file storage must have the exact
 		// same size as the current file storage
-		TORRENT_ASSERT(m_files.total_size() == f.total_size());
+		TORRENT_ASSERT_PRECOND(m_files.total_size() == f.total_size());
+
+		// v2 torrents cannot be remapped. The file sizes are tied to the merkle
+		// trees.
+		TORRENT_ASSERT_PRECOND(!m_files.v2());
+		TORRENT_ASSERT_PRECOND(!f.v2());
 
 		if (m_files.total_size() != f.total_size()) return;
+		if (m_files.v2() || f.v2()) return;
+
 		copy_on_write();
 		m_files = f;
 		m_files.set_num_pieces(m_orig_files->num_pieces());
 		m_files.set_piece_length(m_orig_files->piece_length());
 	}
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 #ifndef BOOST_NO_EXCEPTIONS

--- a/test/test_remap_files.cpp
+++ b/test/test_remap_files.cpp
@@ -50,7 +50,10 @@ void test_remap_files(storage_mode_t storage_mode = storage_mode_sparse)
 	// the file priorities don't break things
 	int const piece_size = 0x8000;
 	auto orig_files = make_files({{0x8000 * 2, false}, {0x8000, false}});
-	add_torrent_params params = make_torrent(std::move(orig_files), piece_size);
+
+	// v2 torrents and hybrid torrents cannot have their files remapped, that's
+	// why this has to be v1 only
+	add_torrent_params params = make_torrent(std::move(orig_files), piece_size, lt::create_torrent::v1_only);
 
 	static std::array<const int, 2> const remap_file_sizes
 		{{0x8000, 0x8000 * 2}};


### PR DESCRIPTION
And make it to not work for v2 (or hybrid) torrents, since they don't support it.