### PR TITLE
cache stack_allocator's allocation of torrent name

### DIFF
--- a/include/libtorrent/aux_/alert_manager.hpp
+++ b/include/libtorrent/aux_/alert_manager.hpp
@@ -73,7 +73,7 @@ namespace aux {
 		{
 			std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
-			heterogeneous_queue<alert>& queue = m_alerts[m_generation];
+			heterogeneous_queue<alert>& queue = m_alerts[m_generation & 1];
 
 			// don't add more than this number of alerts, unless it's a
 			// high priority alert, in which case we try harder to deliver it
@@ -86,7 +86,7 @@ namespace aux {
 			}
 
 			T& alert = queue.emplace_back<T>(
-				m_allocations[m_generation], std::forward<Args>(args)...);
+				m_allocations[m_generation & 1], std::forward<Args>(args)...);
 
 			maybe_notify(&alert);
 		}
@@ -157,12 +157,12 @@ namespace aux {
 		// the alert_manager is allowed to use right now. This is swapped when
 		// the client calls get_all(), at which point all of the alert objects
 		// passed to the client will be owned by libtorrent again, and reset.
-		int m_generation = 0;
+		std::uint32_t m_generation = 0;
 
 		// this is where all alerts are queued up. There are two heterogeneous
 		// queues to double buffer the thread access. The std::mutex in the alert
-		// manager gives exclusive access to m_alerts[m_generation] and
-		// m_allocations[m_generation] whereas the other copy is exclusively
+		// manager gives exclusive access to m_alerts[m_generation & 1] and
+		// m_allocations[m_generation & 1] whereas the other copy is exclusively
 		// used by the client thread.
 		aux::array<heterogeneous_queue<alert>, 2> m_alerts;
 

--- a/include/libtorrent/stack_allocator.hpp
+++ b/include/libtorrent/stack_allocator.hpp
@@ -84,11 +84,34 @@ namespace aux {
 		char* ptr(allocation_slot idx);
 		char const* ptr(allocation_slot idx) const;
 		void swap(stack_allocator& rhs);
-		void reset();
+		void reset(std::uint32_t generation);
+		std::uint32_t gen() const { return m_generation; }
 
 	private:
 
 		std::vector<char> m_storage;
+		std::uint32_t m_generation = 0;
+	};
+
+	struct cached_slot
+	{
+		template <typename F>
+		allocation_slot copy_string(stack_allocator& a, F fun)
+		{
+			if (m_generation != a.gen() || !m_idx.is_valid())
+			{
+				m_idx = a.copy_string(fun());
+				m_generation = a.gen();
+			}
+			return m_idx;
+		}
+
+		void clear() { m_idx = aux::allocation_slot(); }
+
+	private:
+
+		allocation_slot m_idx;
+		std::uint32_t m_generation = 0;
 	};
 
 }

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -533,6 +533,7 @@ namespace libtorrent {
 		void maybe_connect_web_seeds();
 
 		std::string name() const;
+		aux::allocation_slot name_idx(aux::stack_allocator& a);
 
 		stat statistics() const { return m_stat; }
 		boost::optional<std::int64_t> bytes_left() const;
@@ -1413,6 +1414,7 @@ namespace libtorrent {
 #endif
 
 		std::string m_save_path;
+		aux::cached_slot m_name_idx;
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 		// this is a list of all pieces that we have announced
@@ -1471,7 +1473,7 @@ namespace libtorrent {
 		// in this swarm
 		std::time_t m_swarm_last_seen_complete = 0;
 
-		// keep a copy if the info-hash here, so it can be accessed from multiple
+		// keep a copy of the info-hash here, so it can be accessed from multiple
 		// threads, and be cheap to access from the client
 		info_hash_t m_info_hash;
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -112,24 +112,7 @@ namespace libtorrent {
 	{
 		std::shared_ptr<torrent> t = h.native_handle();
 		if (t)
-		{
-			std::string name_str = t->name();
-			if (!name_str.empty())
-			{
-				m_name_idx = alloc.copy_string(name_str);
-			}
-			else
-			{
-				if (t->info_hash().has_v2())
-					m_name_idx = alloc.copy_string(aux::to_hex(t->info_hash().v2));
-				else
-					m_name_idx = alloc.copy_string(aux::to_hex(t->info_hash().v1));
-			}
-		}
-		else
-		{
-			m_name_idx = alloc.copy_string("");
-		}
+			m_name_idx = t->name_idx(alloc);
 
 #if TORRENT_ABI_VERSION == 1
 		name = m_alloc.get().ptr(m_name_idx);
@@ -2733,7 +2716,7 @@ namespace {
 		, error_code e, string_view error_str)
 		: error(e)
 		, m_alloc(alloc)
-		, m_msg_idx(alloc.copy_buffer(error_str))
+		, m_msg_idx(alloc.copy_string(error_str))
 	{}
 
 	std::string session_error_alert::message() const

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -56,20 +56,20 @@ namespace aux {
 	{
 		std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
-		if (!m_alerts[m_generation].empty())
-			return m_alerts[m_generation].front();
+		if (!m_alerts[m_generation & 1].empty())
+			return m_alerts[m_generation & 1].front();
 
 		// this call can be interrupted prematurely by other signals
 		m_condition.wait_for(lock, max_wait);
-		if (!m_alerts[m_generation].empty())
-			return m_alerts[m_generation].front();
+		if (!m_alerts[m_generation & 1].empty())
+			return m_alerts[m_generation & 1].front();
 
 		return nullptr;
 	}
 
 	void alert_manager::maybe_notify(alert* a)
 	{
-		if (m_alerts[m_generation].size() == 1)
+		if (m_alerts[m_generation & 1].size() == 1)
 		{
 			// we just posted to an empty queue. If anyone is waiting for
 			// alerts, we need to notify them. Also (potentially) call the
@@ -94,7 +94,7 @@ namespace aux {
 	{
 		std::unique_lock<std::recursive_mutex> lock(m_mutex);
 		m_notify = fun;
-		if (!m_alerts[m_generation].empty())
+		if (!m_alerts[m_generation & 1].empty())
 		{
 			if (m_notify) m_notify();
 		}
@@ -111,7 +111,7 @@ namespace aux {
 	{
 		std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
-		if (m_alerts[m_generation].empty())
+		if (m_alerts[m_generation & 1].empty())
 		{
 			alerts.clear();
 			return;
@@ -122,19 +122,19 @@ namespace aux {
 			m_dropped.reset();
 		}
 
-		m_alerts[m_generation].get_pointers(alerts);
+		m_alerts[m_generation & 1].get_pointers(alerts);
 
 		// swap buffers
-		m_generation = (m_generation + 1) & 1;
+		m_generation += 1;
 		// clear the one we will start writing to now
-		m_alerts[m_generation].clear();
-		m_allocations[m_generation].reset();
+		m_alerts[m_generation & 1].clear();
+		m_allocations[m_generation & 1].reset(m_generation);
 	}
 
 	bool alert_manager::pending() const
 	{
 		std::lock_guard<std::recursive_mutex> lock(m_mutex);
-		return !m_alerts[m_generation].empty();
+		return !m_alerts[m_generation & 1].empty();
 	}
 
 	int alert_manager::set_alert_queue_size_limit(int queue_size_limit_)

--- a/src/stack_allocator.cpp
+++ b/src/stack_allocator.cpp
@@ -145,11 +145,13 @@ namespace aux {
 	void stack_allocator::swap(stack_allocator& rhs)
 	{
 		m_storage.swap(rhs.m_storage);
+		std::swap(m_generation, rhs.m_generation);
 	}
 
-	void stack_allocator::reset()
+	void stack_allocator::reset(std::uint32_t const generation)
 	{
 		m_storage.clear();
+		m_generation = generation;
 	}
 }
 }

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1484,6 +1484,18 @@ bool is_downloading_state(int const st)
 		return "";
 	}
 
+	aux::allocation_slot torrent::name_idx(aux::stack_allocator& a)
+	{
+		return m_name_idx.copy_string(a, [this]() -> std::string {
+			if (valid_metadata()) return m_torrent_file->name();
+			if (m_name) return *m_name;
+			if (m_info_hash.has_v2())
+				return aux::to_hex(m_info_hash.v2);
+			else
+				return aux::to_hex(m_info_hash.v1);
+		});
+	}
+
 #ifndef TORRENT_DISABLE_EXTENSIONS
 
 	void torrent::add_extension(std::shared_ptr<torrent_plugin> ext)
@@ -7811,6 +7823,7 @@ namespace {
 		if (failed) return true;
 		if (m_abort) return true;
 
+		m_name_idx.clear();
 		m_torrent_file = info;
 		m_info_hash = m_torrent_file->info_hashes();
 


### PR DESCRIPTION
(used in all tracker alerts) to optimize memory footprint. This is to mitigate https://github.com/arvidn/libtorrent/issues/7835