### PR TITLE
Fix backslash handling in filenames on non-Windows systems

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -586,9 +586,9 @@ namespace {
 	{
 		if (f.empty()) return f;
 
-#ifdef TORRENT_WINDOWS
+		#ifdef TORRENT_WINDOWS
 		if (f == "\\\\") return "";
-#endif
+		#endif
 		if (f == "/") return "";
 
 		int len = int(f.size());
@@ -597,8 +597,11 @@ namespace {
 		while (len > 0)
 		{
 			--len;
-			if (f[std::size_t(len)] == '/' || f[std::size_t(len)] == '\\')
-				break;
+			#ifdef TORRENT_WINDOWS
+			if (f[std::size_t(len)] == '/' || f[std::size_t(len)] == '\\') break;
+			#else
+			if (f[std::size_t(len)] == '/') break;  
+			#endif		
 		}
 
 		if (f[std::size_t(len)] == '/' || f[std::size_t(len)] == '\\') ++len;


### PR DESCRIPTION
### Fix handling of backslash ('\\') in filenames on non-Windows systems

**Description:**

This PR addresses an issue where backslashes ('\\') in filenames are incorrectly treated as path separators on non-Windows platforms, leading to unintended directory creation and empty folders. This manifests downstream in applications like qBittorrent, as reported in issues such as qbittorrent/qBittorrent#17049 and qbittorrent/qBittorrent#17752.

#### Background
- On POSIX systems (Linux, macOS, etc.), '\\' is a valid filename character (not reserved like '/' or null '\\0'). Tools like `touch` and file managers (e.g., Nemo) allow it, though it's discouraged due to potential parsing issues in scripts.
- On Windows, both '/' and '\\' are path separators and reserved in filenames, so handling remains unchanged.
- The bug occurs because `parent_path()` in `path.cpp` checks for both '/' and '\\' as separators universally, causing misinterpretation. For example:
  - Renaming "Big Buck Bunny/poster.jpg" to "Big Buck Bunny/p\oster.jpg" in Linux incorrectly creates an empty dir "Big Buck Bunny/p\" instead of treating "p\oster.jpg" as a single file.

Debug example (from mmap_storage.cpp during rename):
```
Libtorrent mmap_storage::rename_file: new_path = /path/to/Big Buck Bunny/p\oster.jpg
Libtorrent mmap_storage::rename_file: new_dir = /path/to/Big Buck Bunny/p\  # Incorrect; creates empty "p\" dir
```

We can see this happening here below:

<img width="640" height="578" alt="qBittorrent_behaviour_scaled" src="https://github.com/user-attachments/assets/f81de9e3-f45c-4dc2-bcbd-f64db730f8f3" />





#### Changes
- In `path.cpp::parent_path()`, limit the separator check to '/' on non-Windows systems. Windows retains checks for both '/' and '\\'. 
- No functional change for Windows; invalid chars like '\\' can be blocked downstream (e.g., see qbittorrent/qBittorrent#23060 for related qBittorrent PR).
- Tested on Linux; resolves the empty folder creation issue while preserving valid '\\' usage in filenames.

Diff excerpt:
```cpp
while (len > 0) {
    --len;
#ifdef TORRENT_WINDOWS
    if (f[std::size_t(len)] == '/' || f[std::size_t(len)] == '\\') break;
#else
    if (f[std::size_t(len)] == '/') break;  // Only check '/' on POSIX
#endif
}
```

This aligns libtorrent with other BitTorrent clients (commonly bundled with  in Linux distros) that handle '\\' in renames without issues.

#### Build and Test Notes
- Built and tested on a POSIX system (Linux Mint 22.1 as the reference environment).
- Used Boost 1.88.0 and libtorrent 2.0.11 (development branch based on RC_2_0).
- Built with CMake 4.1.0 and Qt 6.9.1 (for downstream qBittorrent 5.2.x integration testing).
- Debug output (e.g., from mmap_storage.cpp) generated during manual testing on Linux.
- Tested the behaviour of other torrent clients on Linux and confirmed they are able to rename files to include "\\" without generating additional folders.  
- Confirmed the renaming issue (empty folder creation) applies to both folders and files, with these changes resolving it effectively across both.