### PR TITLE
allow bypassing announce queue

### DIFF
--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -225,7 +225,8 @@ namespace aux {
 		virtual session_settings const& settings() const = 0;
 
 		virtual void queue_tracker_request(tracker_request req
-			, std::weak_ptr<request_callback> c) = 0;
+			, std::weak_ptr<request_callback> c
+			, bool priority = false) = 0;
 
 		// peer-classes
 		virtual void set_peer_classes(peer_class_set* s, address const& a, socket_type_t st) = 0;

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -828,7 +828,7 @@ namespace libtorrent {
 		// forcefully sets next_announce to the current time
 		void force_tracker_request(time_point, int tracker_idx, reannounce_flags_t flags);
 		void scrape_tracker(int idx, bool user_triggered);
-		void announce_with_tracker(event_t = event_t::none);
+		void announce_with_tracker(event_t = event_t::none, bool priority = false);
 
 #ifndef TORRENT_DISABLE_DHT
 		void dht_announce();

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1165,6 +1165,11 @@ namespace aux {
 		// published by the tracker. If this flag is set, it will be ignored
 		// and the tracker is announced immediately.
 		static constexpr reannounce_flags_t ignore_min_interval = 0_bit;
+		
+		// by default, force-reannounce will queue the announce normally.
+		// If this flag is set, the announce will be put at the front of the
+		// tracker queue for immediate processing.
+		static constexpr reannounce_flags_t priority_queue = 1_bit;
 
 		// ``force_reannounce()`` will force this torrent to do another tracker
 		// request, to receive new peers. The ``seconds`` argument specifies how
@@ -1179,7 +1184,7 @@ namespace aux {
 		// If set to -1 (which is the default), all trackers are re-announce.
 		//
 		// The ``flags`` argument can be used to affect the re-announce. See
-		// ignore_min_interval.
+		// ignore_min_interval and priority_queue.
 		//
 		// ``force_dht_announce`` will announce the torrent to the DHT
 		// immediately.

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -348,7 +348,8 @@ enum class event_t : std::uint8_t
 			, tracker_request&& r
 			, aux::session_settings const& sett
 			, std::weak_ptr<request_callback> c
-				= std::weak_ptr<request_callback>());
+				= std::weak_ptr<request_callback>()
+			, bool priority = false);
 		void queue_request(
 			io_context& ios
 			, tracker_request const& r

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1284,7 +1284,8 @@ namespace {
 }
 
 	void session_impl::queue_tracker_request(tracker_request req
-		, std::weak_ptr<request_callback> c)
+		, std::weak_ptr<request_callback> c
+		, bool priority)
 	{
 		req.listen_port = 0;
 #if TORRENT_USE_I2P
@@ -1319,7 +1320,7 @@ namespace {
 			TORRENT_ASSERT(req.kind == tracker_request::i2p);
 			req.listen_port = 1;
 		}
-		m_tracker_manager.queue_request(get_context(), std::move(req), m_settings, c);
+		m_tracker_manager.queue_request(get_context(), std::move(req), m_settings, c, priority);
 	}
 
 	void session_impl::set_peer_class(peer_class_t const cid, peer_class_info const& pci)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2976,7 +2976,7 @@ namespace {
 		};
 	}
 
-	void torrent::announce_with_tracker(event_t e)
+	void torrent::announce_with_tracker(event_t e, bool priority)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(e == event_t::stopped || state() != torrent_status::checking_files);
@@ -3283,12 +3283,12 @@ namespace {
 					if (m_abort && m_ses.should_log())
 					{
 						auto tl = std::make_shared<aux::tracker_logger>(m_ses);
-						m_ses.queue_tracker_request(req, tl);
+						m_ses.queue_tracker_request(req, tl, priority);
 					}
 					else
 #endif
 					{
-						m_ses.queue_tracker_request(req, shared_from_this());
+						m_ses.queue_tracker_request(req, shared_from_this(), priority);
 					}
 
 					a.updating = true;
@@ -3842,7 +3842,15 @@ namespace {
 			debug_log("*** found no tracker endpoints to announce");
 		}
 #endif
-		update_tracker_timer(aux::time_now32());
+		
+		if (flags & torrent_handle::priority_queue)
+		{
+			announce_with_tracker(event_t::none, true);
+		}
+		else
+		{
+			update_tracker_timer(aux::time_now32());
+		}
 	}
 
 #if TORRENT_ABI_VERSION == 1


### PR DESCRIPTION
When adding a torrent to a client with a lot of torrents, its announce (as far as I understand) is pushed to the end of a queue that could take a while to be processed.

As a workaround if I need to leech immediately, I'd just restart my client and the newer torrents would be added at the top of the queue, but it's rather inelegant. 

I'd like a flag for force re-announce to bypass that queue for the torrent to start faster. This PR compiles, but I'm not familiar with the codebase whatsoever so this might not be the appropriate approach. For instance, I'm not sure about how this may or may not be related to https://www.libtorrent.org/reference-Torrent_Handle.html#queue_position_top()

This is more of a feature request than a PR