### PR TITLE
Bump CodeQL actions to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install --yes libboost-all-dev libssl-dev ninja-build
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -49,6 +49,6 @@ jobs:
           cmake --build .
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
CodeQL Action `v3` will be deprecated in December 2026.
Please update all occurrences of the CodeQL Action in your workflow files to `v4`.
For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/