### PR TITLE
add high_priority flag to tracker announcements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.0.12
 
+	* add high_priority flag to torrent_handle::force_reannounce()
 	* update default DSCP value and update docs
 	* fix python binding for set_notify_function()
 	* fix error handling in mmap disk I/O when hashing files

--- a/bindings/python/src/torrent_handle.cpp
+++ b/bindings/python/src/torrent_handle.cpp
@@ -596,6 +596,7 @@ void bind_torrent_handle()
         ;
 
     s.attr("ignore_min_interval") = torrent_handle::ignore_min_interval;
+    s.attr("high_priority") = torrent_handle::high_priority;
     s.attr("overwrite_existing") = torrent_handle::overwrite_existing;
     s.attr("piece_granularity") = torrent_handle::piece_granularity;
     s.attr("graceful_pause") = torrent_handle::graceful_pause;

--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -828,7 +828,7 @@ namespace libtorrent {
 		// forcefully sets next_announce to the current time
 		void force_tracker_request(time_point, int tracker_idx, reannounce_flags_t flags);
 		void scrape_tracker(int idx, bool user_triggered);
-		void announce_with_tracker(event_t = event_t::none);
+		void announce_with_tracker(event_t = event_t::none, bool high_priority = false);
 
 #ifndef TORRENT_DISABLE_DHT
 		void dht_announce();

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1166,6 +1166,11 @@ namespace aux {
 		// and the tracker is announced immediately.
 		static constexpr reannounce_flags_t ignore_min_interval = 0_bit;
 
+		// by default, force-reannounce will queue the announce normally.
+		// If this flag is set, the announce will be put at the front of the
+		// tracker queue for immediate processing.
+		static constexpr reannounce_flags_t high_priority = 1_bit;
+
 		// ``force_reannounce()`` will force this torrent to do another tracker
 		// request, to receive new peers. The ``seconds`` argument specifies how
 		// many seconds from now to issue the tracker announces.
@@ -1179,7 +1184,7 @@ namespace aux {
 		// If set to -1 (which is the default), all trackers are re-announce.
 		//
 		// The ``flags`` argument can be used to affect the re-announce. See
-		// ignore_min_interval.
+		// ignore_min_interval and high_priority.
 		//
 		// ``force_dht_announce`` will announce the torrent to the DHT
 		// immediately.

--- a/include/libtorrent/tracker_manager.hpp
+++ b/include/libtorrent/tracker_manager.hpp
@@ -108,6 +108,11 @@ enum class event_t : std::uint8_t
 		// see parse_tracker_response()
 		static constexpr tracker_request_flags_t i2p = 1_bit;
 
+		// If set, this announce should be prioritized in the tracker queue.
+		// This does not bypass concurrency caps; it only moves the request to
+		// the front of the pending queue if we are at capacity.
+		static constexpr tracker_request_flags_t high_priority = 2_bit;
+
 		std::string url;
 		std::string trackerid;
 #if TORRENT_ABI_VERSION == 1

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -81,6 +81,7 @@ namespace libtorrent {
 	constexpr pause_flags_t torrent_handle::clear_disk_cache;
 	constexpr deadline_flags_t torrent_handle::alert_when_available;
 	constexpr reannounce_flags_t torrent_handle::ignore_min_interval;
+	constexpr reannounce_flags_t torrent_handle::high_priority;
 	constexpr file_progress_flags_t torrent_handle::piece_granularity;
 
 	constexpr status_flags_t torrent_handle::query_distributed_copies;


### PR DESCRIPTION
to put them at the front of the queue. This can be done manually in force_reannounce() or will happen automatically as part of connection-boost.

This is based on https://github.com/arvidn/libtorrent/pull/8026