### PR TITLE
update default DSCP value and update docs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.0.12
 
+	* update default DSCP value and update docs
 	* fix python binding for set_notify_function()
 	* fix error handling in mmap disk I/O when hashing files
 	* improve copy_file_range() fallback

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -636,3 +636,4 @@ DAX
 WebDAV
 transmissionbt
 ouinet
+IANA's

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1318,11 +1318,14 @@ namespace aux {
 
 			// ``peer_dscp`` determines the DSCP field in the IP header of every
 			// packet sent to peers (including web seeds). ``0x0`` means no marking,
-			// ``0x04`` represents Lower Effort. For more details see `RFC 8622`_.
+			// ``0x01`` represents Lower Effort. For more details see `RFC 8622`_
+			// and IANA's `dscp registry`_.
 			//
 			// .. _`RFC 8622`: http://www.faqs.org/rfcs/rfc8622.html
+			// .. _`dscp registry`: https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
 			//
-			// ``peer_tos`` is the backwards compatible name for this setting.
+			// ``peer_tos`` is the old name for ``peer_dscp``, it's still
+			// available for backwards compatibility.
 			peer_dscp,
 
 			// hidden

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -285,7 +285,7 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(disk_io_read_mode, settings_pack::enable_os_cache, nullptr),
 		SET(outgoing_port, 0, nullptr),
 		SET(num_outgoing_ports, 0, nullptr),
-		SET(peer_dscp, 0x04, &session_impl::update_peer_dscp),
+		SET(peer_dscp, 0x01, &session_impl::update_peer_dscp),
 		SET(active_downloads, 3, &session_impl::trigger_auto_manage),
 		SET(active_seeds, 5, &session_impl::trigger_auto_manage),
 		SET(active_checking, 1, &session_impl::trigger_auto_manage),


### PR DESCRIPTION
according to https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
The "Low effort" DSCP is `1`. Referencing https://datatracker.ietf.org/doc/html/rfc8622#autoid-6