### PR TITLE
docs: Use `ubuntu-slim` runner image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
 
    docs:
       name: Docs
-      runs-on: ubuntu-24.04
+      runs-on: ubuntu-slim
 
       steps:
       - name: checkout


### PR DESCRIPTION
* Use `ubuntu-slim` runner image for **docs** workflow

From https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners :
>This type of runner is optimized for automation tasks, issue operations and short-running jobs. They are not suitable for typical heavyweight CI/CD builds.

* https://github.com/actions/runner-images?tab=readme-ov-file#available-images
* https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md
* https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories