### PR TITLE
add new setting disk_disable_copy_on_write

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.0.12
 
+	* add setting to set no-copy-on-write flag on new files
 	* add performance counters to file pool
 	* add high_priority flag to torrent_handle::force_reannounce()
 	* update default DSCP value and update docs

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -637,3 +637,5 @@ WebDAV
 transmissionbt
 ouinet
 IANA's
+NOCOW
+btrfs

--- a/include/libtorrent/aux_/open_mode.hpp
+++ b/include/libtorrent/aux_/open_mode.hpp
@@ -54,6 +54,9 @@ namespace aux {
 		constexpr open_mode_t executable = 7_bit;
 		constexpr open_mode_t allow_set_file_valid_data = 8_bit;
 		constexpr open_mode_t no_mmap = 9_bit;
+		// sets the FS_NOCOW_FL flag on the file, when creating it.
+		// This is currently linux specific, for btrfs filesystems
+		constexpr open_mode_t no_cow = 10_bit;
 	}
 } // aux
 

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -1026,6 +1026,11 @@ namespace aux {
 			// man-in-the-middle connections.
 			proxy_send_host_in_connect,
 
+			// When set, downloaded files will have the no-copy-on-write flag
+			// (``FS_NOCOW_FL``) set on Linux. This mitigates heavy
+			// fragmentation on filesystems like btrfs.
+			disk_disable_copy_on_write,
+
 			max_bool_setting_internal
 		};
 

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -981,6 +981,9 @@ error_code translate_error(std::error_code const& err, bool const write)
 		if (sett.get_bool(settings_pack::no_atime_storage))
 			mode |= aux::open_mode::no_atime;
 
+		if (sett.get_bool(settings_pack::disk_disable_copy_on_write))
+			mode |= aux::open_mode::no_cow;
+
 		if (files().file_size(file) / default_block_size
 			<= sett.get_int(settings_pack::mmap_file_size_cutoff))
 			mode |= aux::open_mode::no_mmap;

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -240,6 +240,7 @@ constexpr int DISK_WRITE_MODE = settings_pack::enable_os_cache;
 		SET(enable_set_file_valid_data, false, nullptr),
 		SET(socks5_udp_send_local_ep, false, nullptr),
 		SET(proxy_send_host_in_connect, false, nullptr),
+		SET(disk_disable_copy_on_write, true, nullptr),
 	}});
 
 	CONSTEXPR_SETTINGS


### PR DESCRIPTION
to set `FS_NOCOW_FL` on new files. This is enabled by default, Linux only and is expected to reduce fragmentation on btrfs filesystems.