### PR TITLE
Improve compatibility with C++23

### DIFF
--- a/include/libtorrent/string_view.hpp
+++ b/include/libtorrent/string_view.hpp
@@ -98,7 +98,7 @@ namespace libtorrent {
 
 inline namespace literals {
 
-	constexpr string_view operator "" _sv(char const* str, std::size_t len)
+	constexpr string_view operator ""_sv(char const* str, std::size_t len)
 	{ return string_view(str, len); }
 }
 }

--- a/tools/disk_io_stress_test.cpp
+++ b/tools/disk_io_stress_test.cpp
@@ -51,7 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 using disk_test_mode_t = lt::flags::bitfield_flag<std::uint8_t, struct disk_test_mode_tag>;
 
 using lt::operator""_bit;
-using lt::operator "" _sv;
+using lt::operator ""_sv;
 
 namespace test_mode {
 constexpr disk_test_mode_t sparse = 0_bit;


### PR DESCRIPTION
This addresses the following warning when compiling with gcc c++23 mode:
warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]