### PR TITLE
Improve compatibility with C++23 (RC_1_2)

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -83,7 +83,7 @@ using lt::cache_status;
 using lt::total_seconds;
 using lt::torrent_flags_t;
 using lt::seconds;
-using lt::operator "" _sv;
+using lt::operator ""_sv;
 using lt::address_v4;
 using lt::address_v6;
 

--- a/include/libtorrent/flags.hpp
+++ b/include/libtorrent/flags.hpp
@@ -46,7 +46,7 @@ private:
 	int m_bit_idx;
 };
 
-constexpr bit_t operator "" _bit(unsigned long long int b) { return bit_t{static_cast<int>(b)}; }
+constexpr bit_t operator ""_bit(unsigned long long int b) { return bit_t{static_cast<int>(b)}; }
 
 namespace flags {
 

--- a/include/libtorrent/string_view.hpp
+++ b/include/libtorrent/string_view.hpp
@@ -98,7 +98,7 @@ namespace libtorrent {
 
 inline namespace literals {
 
-	constexpr string_view operator "" _sv(char const* str, std::size_t len)
+	constexpr string_view operator ""_sv(char const* str, std::size_t len)
 	{ return string_view(str, len); }
 }
 }

--- a/test/enum_if.cpp
+++ b/test/enum_if.cpp
@@ -40,7 +40,7 @@ using namespace lt;
 
 namespace {
 
-std::string operator "" _s(char const* str, size_t len) { return std::string(str, len); }
+std::string operator ""_s(char const* str, size_t len) { return std::string(str, len); }
 
 std::string print_flags(interface_flags const f)
 {

--- a/test/swarm_suite.hpp
+++ b/test/swarm_suite.hpp
@@ -37,7 +37,7 @@ using test_flags_t = libtorrent::flags::bitfield_flag<std::uint32_t, struct test
 
 namespace test_flags
 {
-	using libtorrent::operator "" _bit;
+	using libtorrent::operator ""_bit;
 	constexpr test_flags_t super_seeding = 1_bit;
 	constexpr test_flags_t strict_super_seeding = 2_bit;
 	constexpr test_flags_t seed_mode = 3_bit;

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -44,7 +44,7 @@ namespace libtorrent
 	EXPORT std::string test_listen_interface();
 }
 
-inline lt::download_priority_t operator "" _pri(unsigned long long const p)
+inline lt::download_priority_t operator ""_pri(unsigned long long const p)
 {
 	return lt::download_priority_t(static_cast<std::uint8_t>(p));
 }


### PR DESCRIPTION
This addresses the following warning when compiling with gcc c++23 mode:
warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]