### PR TITLE
Disable DTLS 1.0, TLS 1.0 and TLS 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,7 +746,8 @@ if(NOT gnutls)
 				OPENSSL_NO_SSL2
 				OPENSSL_NO_SSL3
 				OPENSSL_NO_TLS1
-				OPENSSL_NO_TLS1_1)
+				OPENSSL_NO_TLS1_1
+				OPENSSL_NO_DTLS1)
 	endif()
 endif()
 

--- a/Jamfile
+++ b/Jamfile
@@ -654,7 +654,8 @@ feature.compose <crypto>openssl
 	<define>OPENSSL_NO_SSL2
 	<define>OPENSSL_NO_SSL3
 	<define>OPENSSL_NO_TLS1
-	<define>OPENSSL_NO_TLS1_1 ;
+	<define>OPENSSL_NO_TLS1_1
+	<define>OPENSSL_NO_DTLS1 ;
 feature.compose <crypto>openssl-shared
 	: <define>TORRENT_USE_LIBCRYPTO
 	<define>TORRENT_USE_OPENSSL
@@ -662,7 +663,8 @@ feature.compose <crypto>openssl-shared
 	<define>OPENSSL_NO_SSL2
 	<define>OPENSSL_NO_SSL3
 	<define>OPENSSL_NO_TLS1
-	<define>OPENSSL_NO_TLS1_1 ;
+	<define>OPENSSL_NO_TLS1_1
+	<define>OPENSSL_NO_DTLS1 ;
 feature.compose <crypto>wolfssl
 	: <define>TORRENT_USE_WOLFSSL
 	<define>TORRENT_USE_LIBCRYPTO


### PR DESCRIPTION
* [RFC 8996 - Deprecating TLS 1.0 and TLS 1.1](https://www.ietf.org/rfc/rfc8996.html)
* DTLS 1.0/TLS 1.0/TLS 1.1 were formally **deprecated** by the [Internet Engineering Task Force (IETF)](https://www.packetmania.net/en/2022/11/10/Stop-TLS1-0-TLS1-1/) in March 2021.