### PR TITLE
clean ':' from filenames on macOS

### DIFF
--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -101,6 +101,9 @@ namespace libtorrent {
 		// style filesystems, which also further restricts valid characters
 		// https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/FileUtils.java;l=997?q=isValidFatFilenameChar
 		static const char invalid_chars[] = "\"*:<>?|";
+		// macOS does not permit use of a colon in a file or folder name
+#elif defined __APPLE__
+    static const char invalid_chars[] = ":";
 #else
 		static const char invalid_chars[] = "";
 #endif

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -103,7 +103,7 @@ namespace libtorrent {
 		static const char invalid_chars[] = "\"*:<>?|";
 		// macOS does not permit use of a colon in a file or folder name
 #elif defined __APPLE__
-    static const char invalid_chars[] = ":";
+		static const char invalid_chars[] = ":";
 #else
 		static const char invalid_chars[] = "";
 #endif

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -725,7 +725,7 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "dev:");
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "dev_");
 #else
 	TEST_EQUAL(path, "dev:");
@@ -734,7 +734,7 @@ TORRENT_TEST(sanitize_path)
 	path.clear();
 	sanitize_append_path_element(path, "c:");
 	sanitize_append_path_element(path, "b");
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "c_" SEPARATOR "b");
 #else
 	TEST_EQUAL(path, "c:" SEPARATOR "b");
@@ -744,7 +744,7 @@ TORRENT_TEST(sanitize_path)
 	sanitize_append_path_element(path, "c:");
 	sanitize_append_path_element(path, ".");
 	sanitize_append_path_element(path, "c");
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "c_" SEPARATOR "c");
 #else
 	TEST_EQUAL(path, "c:" SEPARATOR "c");

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -913,7 +913,7 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "dev:", true);
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "dev_");
 #else
 	TEST_EQUAL(path, "dev:");
@@ -922,7 +922,7 @@ TORRENT_TEST(sanitize_path_force)
 	path.clear();
 	sanitize_append_path_element(path, "c:", true);
 	sanitize_append_path_element(path, "b", true);
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "c_" SEPARATOR "b");
 #else
 	TEST_EQUAL(path, "c:" SEPARATOR "b");
@@ -932,7 +932,7 @@ TORRENT_TEST(sanitize_path_force)
 	sanitize_append_path_element(path, "c:", true);
 	sanitize_append_path_element(path, ".", true);
 	sanitize_append_path_element(path, "c", true);
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "c_" SEPARATOR "_" SEPARATOR "c");
 #else
 	TEST_EQUAL(path, "c:" SEPARATOR "_" SEPARATOR "c");
@@ -1082,7 +1082,7 @@ TORRENT_TEST(sanitize_path_colon)
 	using lt::aux::sanitize_append_path_element;
 	std::string path;
 	sanitize_append_path_element(path, "foo:bar");
-#ifdef TORRENT_WINDOWS
+#if defined TORRENT_WINDOWS || defined __APPLE__
 	TEST_EQUAL(path, "foo_bar");
 #else
 	TEST_EQUAL(path, "foo:bar");


### PR DESCRIPTION
libtorrent currently sanitizes ':' on Windows but not on macOS.
Since ':' is illegal on HFS+/APFS, this results in unusable filenames being passed to clients on macOS.
This patch adds ':' to invalid_chars for APPLE builds, consistent with Windows handling.