### PR TITLE
V2 hash cursor

### DIFF
--- a/include/libtorrent/aux_/disk_cache.hpp
+++ b/include/libtorrent/aux_/disk_cache.hpp
@@ -256,38 +256,57 @@ struct disk_cache
 
 		auto& view = m_pieces.template get<0>();
 		auto i = view.find(loc);
-		if (i != view.end())
+		if (i == view.end())
 		{
-			if (i->hashing)
-			{
-				// TODO: it would probably be more efficient to wait here.
-				// #error we should hang the hash job onto the piece. If there is a
-				// job already, form a queue
-				l.unlock();
-				return f();
-			}
-			auto const& cbe = i->blocks[block_idx];
-			// There's nothing stopping the hash threads from hashing the blocks in
-			// parallel. This should not depend on the hasher_cursor. That's a v1
-			// concept
-			// TODO: v2 hashing should not depend on the hasher_cursor
-			if (i->hasher_cursor > block_idx)
-			{
-				TORRENT_ASSERT(i->block_hashes);
-				return i->block_hashes[block_idx];
-			}
-			if (cbe.buf().data())
-			{
-				hasher256 h;
-				h.update(cbe.buf());
-				return h.final();
-			}
+			l.unlock();
+			return f();
+		}
+		if (i->hashing)
+		{
+			// TODO: it would probably be more efficient to wait here.
+			// #error we should hang the hash job onto the piece. If there is a
+			// job already, form a queue
+			l.unlock();
+			return f();
+		}
+		auto const& cbe = i->blocks[block_idx];
+		// There's nothing stopping the hash threads from hashing the blocks in
+		// parallel. This should not depend on the hasher_cursor. That's a v1
+		// concept
+		TORRENT_ASSERT(i->block_hashes);
+		if (!i->block_hashes[block_idx].is_all_zeros())
+			return i->block_hashes[block_idx];
+		if (cbe.buf().data())
+		{
+			hasher256 h;
+			h.update(cbe.buf());
+			return h.final();
 		}
 		l.unlock();
 		return f();
 	}
 
-	// returns false if the piece is not in the cache
+	// Looks up the piece in the cache and calls f() to complete its hash computation.
+	// Returns false if the piece is not in the cache; the caller must then read all
+	// blocks from disk itself.
+	//
+	// When the piece is found, hash_piece() takes a snapshot of the cache state under
+	// the mutex, sets hashing=true (which pins all buffers at index >= hasher_cursor
+	// so flush_piece_impl cannot free them), then releases the lock and calls:
+	//
+	//   f(ph, hasher_cursor, blocks, v2_hashes)
+	//
+	//   ph: SHA1 piece hasher already fed blocks [0, hasher_cursor).
+	//   hasher_cursor: index of the first block not yet incorporated in ph.
+	//     f() must continue feeding blocks from this index onward.
+	//   blocks: per-block buffer pointers. A null entry means the block is not
+	//     in the cache and must be read from disk.
+	//   v2_hashes: per-block SHA256 hash snapshots. all-zeros means not-yet-computed.
+	//     a non-zero entry is a pre-computed hash that f() may use directly without re-hashing.
+	//
+	// After f() returns hasher_cursor is advanced and buffers that have
+	// already been flushed to disk are freed. If all blocks are flushed, the
+	// piece entry is removed from the cache entirely.
 	template <typename Fun>
 	bool hash_piece(piece_location const loc, Fun f)
 	{

--- a/src/disk_cache.cpp
+++ b/src/disk_cache.cpp
@@ -245,7 +245,8 @@ insert_result_flags disk_cache::insert(piece_location const loc
 	if (m_back_pressure.has_back_pressure(m_blocks, std::move(o)))
 		ret |= exceeded_limit;
 
-	if (i->hasher_cursor == block_idx)
+	if (i->hasher_cursor == block_idx
+		|| (i->v2_hashes && !i->piece_hash_returned))
 		ret |= need_hasher_kick;
 
 	return ret;
@@ -287,6 +288,7 @@ disk_cache::hash_result disk_cache::try_hash_piece(piece_location const loc, pre
 			e.piece_hash_returned = true;
 
 			auto& job = std::get<aux::job::hash>(hash_job->action);
+			TORRENT_ASSERT(bool(e.ph) == e.v1_hashes);
 			job.piece_hash = e.ph ? e.ph->final_hash() : sha1_hash{};
 			if (!job.block_hashes.empty())
 			{
@@ -342,18 +344,19 @@ void disk_cache::kick_hasher(piece_location const& loc, jobqueue_t& completed_jo
 		return;
 	}
 
-	TORRENT_ALLOCA(blocks_storage, span<char const>, piece_iter->blocks_in_piece);
 	std::uint16_t cursor = piece_iter->hasher_cursor;
+	TORRENT_ALLOCA(blocks_storage, span<char const>, piece_iter->blocks_in_piece - int(cursor));
 keep_going:
-	std::uint16_t block_idx = 0;
+	// Snapshot all block buffer pointers from cursor onwards while holding the
+	// mutex. New blocks may be added asynchronously after we release the lock,
+	// so we must not read their buf() pointers then.
+	int const n = piece_iter->blocks_in_piece - int(cursor);
+	for (int i = 0; i < n; ++i)
+		blocks_storage[i] = piece_iter->blocks[int(cursor) + i].buf();
+	// end = first gap in the contiguous run, needed for flushed_cursor trimming
 	std::uint16_t end = cursor;
-	while (end < piece_iter->blocks_in_piece && piece_iter->blocks[end].buf().data())
-	{
-		blocks_storage[block_idx] = piece_iter->blocks[end].buf();
-		++block_idx;
+	while (end < piece_iter->blocks_in_piece && blocks_storage[end - cursor].data())
 		++end;
-	}
-	auto const blocks = blocks_storage.first(block_idx);
 
 	TORRENT_ASSERT(piece_iter->hashing == false);
 	view.modify(piece_iter, [](cached_piece_entry& e) { e.hashing = true; });
@@ -366,29 +369,42 @@ keep_going:
 		, cursor, end
 		, need_v1, need_v2
 		, piece_iter->ph.get());
+
 	l.unlock();
 
-	int bytes_left = piece_iter->piece_size2 - (cursor * default_block_size);
 	int count_hashed = 0;
-	for (auto& buf: blocks)
+	std::uint16_t const cursor_start = cursor;
+	int bytes_left = piece_iter->piece_size2 - int(cursor_start) * default_block_size;
+	bool contiguous = true;
+	for (int i = 0; i < n; ++i, bytes_left -= default_block_size)
 	{
-		if (need_v1)
+		span<char const> const buf = blocks_storage[i];
+		if (buf.data() == nullptr)
 		{
-			TORRENT_ASSERT(piece_iter->ph);
-			auto& ctx = const_cast<aux::piece_hasher&>(*piece_iter->ph);
-			ctx.update(buf);
+			contiguous = false;
+			if (!need_v2) break;
+			continue;
 		}
 
-		if (need_v2 && bytes_left > 0)
+		if (contiguous)
+		{
+			if (need_v1)
+			{
+				TORRENT_ASSERT(piece_iter->ph);
+				auto& ctx = const_cast<aux::piece_hasher&>(*piece_iter->ph);
+				ctx.update(buf);
+			}
+			++cursor;
+			++count_hashed;
+		}
+
+		if (need_v2)
 		{
 			TORRENT_ASSERT(piece_iter->block_hashes);
-			int const this_block_size = std::min(bytes_left, default_block_size);
-			piece_iter->block_hashes[cursor] = hasher256(buf.first(this_block_size)).final();
-			bytes_left -= default_block_size;
+			int const blk_idx = int(cursor_start) + i;
+			if (bytes_left > 0 && piece_iter->block_hashes[blk_idx].is_all_zeros())
+				piece_iter->block_hashes[blk_idx] = hasher256(buf.first(std::min(bytes_left, default_block_size))).final();
 		}
-
-		++cursor;
-		++count_hashed;
 	}
 
 	l.lock();
@@ -446,11 +462,12 @@ keep_going:
 		e.piece_hash_returned = true;
 		// we've hashed all blocks, and there's a hash job associated with
 		// this piece, post it.
+		TORRENT_ASSERT(bool(e.ph) == e.v1_hashes);
 		piece_hash = e.ph ? e.ph->final_hash() : sha1_hash{};
 	});
 
 	auto& job = std::get<job::hash>(j->action);
-	job.piece_hash = piece_hash;
+	if (need_v1) job.piece_hash = piece_hash;
 	if (!job.block_hashes.empty())
 	{
 		TORRENT_ASSERT(need_v2);
@@ -918,6 +935,8 @@ void disk_cache::clear_piece_impl(cached_piece_entry& cpe, jobqueue_t& aborted)
 	cpe.piece_hash_returned = false;
 	cpe.hasher_cursor = 0;
 	cpe.flushed_cursor = 0;
+	if (cpe.block_hashes)
+		std::fill_n(cpe.block_hashes.get(), cpe.blocks_in_piece, sha256_hash{});
 	TORRENT_ASSERT(cpe.num_jobs >= jobs);
 	cpe.num_jobs -= jobs;
 	if (cpe.ph) *cpe.ph = piece_hasher{};

--- a/src/pread_disk_io.cpp
+++ b/src/pread_disk_io.cpp
@@ -880,8 +880,6 @@ void pread_disk_io::async_clear_piece(storage_index_t const storage
 
 status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 {
-	// we're not using a cache. This is the simple path
-	// just read straight from the file
 	bool const v1 = bool(j->flags & disk_interface::v1_hash);
 	bool const v2 = !a.block_hashes.empty();
 
@@ -896,22 +894,36 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 
 	int const blocks_to_read = std::max(blocks_in_piece, blocks_in_piece2);
 
-	// this creates a function object, ready to be passed to
-	// m_cache.hash_piece()
+	// Callable matching the hash_piece() protocol (see disk_cache.hpp).
+	// Completes piece hash computation using the cache snapshot passed by hash_piece(),
+	// reading any missing blocks from disk.
+	// * Copies all non-zero v2_hashes entries into a.block_hashes (capturing both
+	//   in-order hashes and any out-of-order hashes computed by kick_hasher's second
+	//   pass).
+	// * Iterates blocks [hasher_cursor, blocks_to_read): for each block, either reads
+	//   it from disk (buf == nullptr) or hashes it from the in-memory buffer. Skips
+	//   the SHA256 work for any block whose v2 hash is already pre-computed (v2_done).
+	// * Finalises the SHA1 hash into a.piece_hash.
+	//
+	// Also invoked directly as a fallback (all-null blocks, hasher_cursor=0) when the
+	// piece is not in the cache at all, in which case every block is read from disk.
 	auto hash_partial_piece = [&] (lt::aux::piece_hasher* ph
 		, int const hasher_cursor
 		, span<char const*> const blocks
 		, span<sha256_hash> const v2_hashes)
 	{
+		// ph: SHA1 hasher already fed blocks [0, hasher_cursor)
+		// hasher_cursor: first block index that still needs processing for SHA1.
+		// blocks: per-block buffer pointers from the cache snapshot.
+		// v2_hashes: SHA256 block hashes from the cache snapshot.
 		time_point const start_time = clock_type::now();
 
-		if (v2 && hasher_cursor > 0)
+		// copy all pre-computed v2 hashes, including out-of-order ones
+		if (v2)
 		{
-			for (int i = 0; i < hasher_cursor; ++i)
-			{
-				TORRENT_ASSERT(!v2_hashes[i].is_all_zeros());
-				a.block_hashes[i] = v2_hashes[i];
-			}
+			for (int i = 0; i < blocks_in_piece2; ++i)
+				if (!v2_hashes[i].is_all_zeros())
+					a.block_hashes[i] = v2_hashes[i];
 		}
 
 		int offset = hasher_cursor * default_block_size;
@@ -919,9 +931,10 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 		for (int i = hasher_cursor; i < blocks_to_read; ++i)
 		{
 			bool const v2_block = i < blocks_in_piece2;
+			bool const v2_done = v2_block && !v2_hashes[i].is_all_zeros();
 
 			std::ptrdiff_t const len = v1 ? std::min(default_block_size, piece_size - offset) : 0;
-			std::ptrdiff_t const len2 = v2_block ? std::min(default_block_size, piece_size2 - offset) : 0;
+			std::ptrdiff_t const len2 = (v2_block && !v2_done) ? std::min(default_block_size, piece_size2 - offset) : 0;
 
 			hasher256 ph2;
 			char const* buf = blocks[i];
@@ -940,14 +953,15 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 
 					j->storage->hash(m_settings, ph->ctx(), len, a.piece
 						, offset, file_mode, flags, j->error);
+					++blocks_read_from_disk;
 				}
-				if (v2_block)
+				if (v2_block && !v2_done)
 				{
 					j->storage->hash2(m_settings, ph2, len2, a.piece, offset
 						, file_mode, j->flags, j->error);
+					++blocks_read_from_disk;
 				}
 				if (j->error) break;
-				++blocks_read_from_disk;
 			}
 			else
 			{
@@ -956,12 +970,12 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 					TORRENT_ASSERT(ph);
 					ph->update({ buf, len });
 				}
-				if (v2_block)
+				if (v2_block && !v2_done)
 					ph2.update({buf, len2});
 			}
 			offset += default_block_size;
 
-			if (v2_block)
+			if (v2_block && !v2_done)
 				a.block_hashes[i] = ph2.final();
 		}
 


### PR DESCRIPTION
hash v2 blocks out-of-order, in the disk cache. Since v2 torrents use a merkle tree, we don't need the hash cursor