### PR TITLE
build against boost.json as header only. This makes it easier to chan…

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -1072,6 +1072,8 @@ lib torrent
 	<define>BOOST_NO_DEPRECATED
 	<link>shared:<define>BOOST_SYSTEM_SOURCE
 
+	<define>BOOST_JSON_HEADER_ONLY
+
 	# https://github.com/chriskohlhoff/asio/issues/290#issuecomment-377727614
 	<define>_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING
 


### PR DESCRIPTION
…ge standard library without causing ABI conflicts with binary packages