### PR TITLE
fix recent merge typo in torrent::force_tracker_request()

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3982,7 +3982,7 @@ namespace {
 		bool found_one = false;
 		if (tracker_idx == -1)
 		{
-			for (auto e : m_trackers)
+			for (auto& e : m_trackers)
 			{
 				// make sure we check for new endpoints from the listen sockets
 				refresh_endpoint_list(m_ses, is_ssl_torrent(), bool(m_complete_sent), e);


### PR DESCRIPTION
reported by https://github.com/arvidn/libtorrent/issues/8282