### PR TITLE
Update cibuildwheel workflow

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -6,7 +6,7 @@ name: cibuildwheel
 # sample.
 
 # The full list of cibuildwheel's build targets can be found here:
-# https://github.com/pypa/cibuildwheel/blob/v2.22.0/cibuildwheel/resources/build-platforms.toml
+# https://github.com/pypa/cibuildwheel/blob/v2.23.4/cibuildwheel/resources/build-platforms.toml
 
 # Notes on build targets we (don't) support:
 # - pypy: libtorrent doesn't build with pypy as of writing
@@ -133,19 +133,19 @@ jobs:
       CIBW_TEST_SKIP: "*-win32"
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 1
         filter: tree:0
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache-wheel
       with:
         path: wheelhouse
         key: wheel-${{ matrix.os }}-${{ matrix.CIBW_BUILD }}
 
-    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-qemu-action@v4
       if: steps.cache-wheel.outputs.cache-hit != 'true' && runner.os == 'Linux'
 
     - name: Install OpenSSL (windows)
@@ -159,10 +159,10 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo apt-get install libssl-dev
 
-    - uses: pypa/cibuildwheel@v2.22.0
+    - uses: pypa/cibuildwheel@v2.23.4
       if: ${{ steps.cache-wheel.outputs.cache-hit != 'true' || github.event_name == 'pull_request' }}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-${{ matrix.os }}-${{ matrix.CIBW_BUILD }}
@@ -173,12 +173,12 @@ jobs:
     if: needs.build_wheels.result == 'success'
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: wheels-ubuntu-24.04-cp39-manylinux_x86_64
         path: wheelhouse
         merge-multiple: true
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.9'
     - name: test wheel type issues
@@ -193,7 +193,7 @@ jobs:
     if: needs.build_wheels.result == 'success' && github.event.inputs.publish == 'PUBLISH'
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: wheels-*
         path: wheelhouse
@@ -211,7 +211,7 @@ jobs:
     if: needs.build_wheels.result == 'success' && github.event.inputs.publish_test == 'PUBLISH_TEST'
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: wheels-*
         path: wheelhouse


### PR DESCRIPTION
* Bumped `actions/download-artifact` -> `v8`
* Bumped `actions/upload-artifact` -> `v7`
* Bumped `actions/checkout` -> `v6`
* Bumped `actions/cache` -> `v5`
* Bumped `pypa/cibuildwheel` -> `v2.23.4`
* Bumped `actions/setup-python` -> `v6`
* Bumped `docker/setup-qemu-action` -> `v4` 