### PR TITLE
fix issue in filtered piece accounting in the piece_picker

### DIFF
--- a/include/libtorrent/aux_/piece_picker.hpp
+++ b/include/libtorrent/aux_/piece_picker.hpp
@@ -383,7 +383,7 @@ namespace libtorrent::aux {
 		{
 			int peer_count;
 			int priority;
-			bool have;
+			bool flushed;
 			bool downloading;
 		};
 
@@ -667,10 +667,14 @@ namespace libtorrent::aux {
 			std::set<const aux::torrent_peer*> have_peers;
 #endif
 
-			// index is set to this to indicate that we have the
-			// piece. There is no entry for the piece in the
-			// buckets if this is the case.
-			static inline constexpr prio_index_t we_have_index{-1};
+			// index is set to this to indicate that this piece has been
+			// flushed (i.e. the picker has finalized accounting for it
+			// and removed it from the priority buckets). The flushed flag
+			// is the strict notion of "had": piece_picker::have_piece()
+			// is the loose notion (passed_hash_check OR flushed). Most
+			// internal code wants the strict notion (e.g. cursor advance
+			// is driven by piece_flushed()).
+			static inline constexpr prio_index_t flushed_index{-1};
 
 			// the priority value that means the piece is filtered
 			static constexpr std::uint32_t filter_priority = 0;
@@ -678,9 +682,9 @@ namespace libtorrent::aux {
 			// the max number the peer count can hold
 			static constexpr std::uint32_t max_peer_count = 0xffff;
 
-			bool have() const { return index == we_have_index; }
-			void set_have() { index = we_have_index; TORRENT_ASSERT(have()); }
-			void set_not_have() { index = prio_index_t(0); TORRENT_ASSERT(!have()); }
+			bool flushed() const { return index == flushed_index; }
+			void set_flushed() { index = flushed_index; TORRENT_ASSERT(flushed()); }
+			void set_not_flushed() { index = prio_index_t(0); TORRENT_ASSERT(!flushed()); }
 			bool downloading() const { return state() != piece_open; }
 
 			bool filtered() const { return piece_priority == filter_priority; }
@@ -710,7 +714,7 @@ namespace libtorrent::aux {
 				// filtered pieces (prio = 0), pieces we have or pieces with
 				// availability = 0 should not be present in the piece list
 				// returning -1 indicates that they shouldn't.
-				if (filtered() || have() || peer_count + picker->m_seeds == 0
+				if (filtered() || flushed() || peer_count + picker->m_seeds == 0
 					|| state() == piece_full
 					|| state() == piece_finished)
 					return -1;
@@ -797,8 +801,8 @@ namespace libtorrent::aux {
 
 		// this maps indices to number of peers that has this piece and
 		// index into the m_piece_info vectors.
-		// piece_pos::we_have_index means that we have the piece, so it
-		// doesn't exist in the piece_info buckets
+		// piece_pos::flushed_index means the picker has finalized the
+		// piece, so it doesn't exist in the piece_info buckets
 		// pieces with the filtered flag set doesn't have entries in
 		// the m_piece_info buckets either
 		// TODO: should this be allocated lazily?
@@ -881,12 +885,23 @@ namespace libtorrent::aux {
 		int m_num_have_filtered = 0;
 
 		// we have all pieces in the range [start_range, m_cursor)
-		// m_cursor is the first piece we don't have
+		// m_cursor is the first piece we don't have.
+		//
+		// "have" here is the strict notion: piece_pos::flushed(). The
+		// cursor is only advanced past a piece by piece_flushed() (and
+		// the cursor walks in set_piece_priority() when filtering, since
+		// filtered pieces are also out of the picker's working set). A
+		// piece that has only passed_hash_check but is not yet flushed
+		// will not move the cursor; the cursor lags until piece_flushed()
+		// runs (typically from mark_as_finished() once the last block
+		// completes). This avoids needing to walk the cursor backwards
+		// if write_failed() later clears passed_hash_check.
 		piece_index_t m_cursor{0};
 
 		// we have all pieces in the range [m_reverse_cursor, end_range)
 		// m_reverse_cursor is the first piece where we also have
-		// all the subsequent pieces
+		// all the subsequent pieces.
+		// Same strict-flushed semantics as m_cursor above.
 		piece_index_t m_reverse_cursor{0};
 
 		// the number of pieces we have (i.e. passed hash check).

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -172,11 +172,11 @@ namespace libtorrent::aux {
 		}
 
 		for (auto i = m_piece_map.begin() + static_cast<int>(m_cursor)
-			, end(m_piece_map.end()); i != end && (i->have() || i->filtered());
+			, end(m_piece_map.end()); i != end && (i->flushed() || i->filtered());
 			++i, ++m_cursor);
 
 		for (auto i = m_piece_map.rend() - static_cast<int>(m_reverse_cursor);
-			m_reverse_cursor > piece_index_t(0) && (i->have() || i->filtered());
+			m_reverse_cursor > piece_index_t(0) && (i->flushed() || i->filtered());
 			++i, --m_reverse_cursor);
 
 		m_blocks_in_last_piece = aux::numeric_cast<std::uint16_t>(blocks_in_last_piece);
@@ -203,7 +203,7 @@ namespace libtorrent::aux {
 		st.index = index;
 		st.writing = 0;
 		st.requested = 0;
-		if (m_piece_map[index].have())
+		if (m_piece_map[index].flushed())
 		{
 			st.finished = std::uint16_t(blocks_in_piece(index));
 			return;
@@ -217,7 +217,7 @@ namespace libtorrent::aux {
 		piece_stats_t ret = {
 			int(pp.peer_count + m_seeds),
 			pp.priority(this),
-			pp.have(),
+			pp.flushed(),
 			pp.downloading()
 		};
 		return ret;
@@ -365,11 +365,11 @@ namespace libtorrent::aux {
 		m_cursor = first_piece;
 		m_reverse_cursor = next(last_piece);
 		for (auto i = m_piece_map.begin() + static_cast<int>(m_cursor)
-			, end(m_piece_map.end()); i != end && (i->have() || i->filtered());
+			, end(m_piece_map.end()); i != end && (i->flushed() || i->filtered());
 			++i, ++m_cursor);
 
 		for (auto i = m_piece_map.rend() - static_cast<int>(m_reverse_cursor);
-			m_reverse_cursor > piece_index_t(0) && (i->have() || i->filtered());
+			m_reverse_cursor > piece_index_t(0) && (i->flushed() || i->filtered());
 			++i, --m_reverse_cursor);
     }
 
@@ -420,7 +420,7 @@ namespace libtorrent::aux {
 		for (piece_block const& pb : picked)
 		{
 			TORRENT_ASSERT(bits[pb.piece_index]);
-			TORRENT_ASSERT(!m_piece_map[pb.piece_index].have());
+			TORRENT_ASSERT(!m_piece_map[pb.piece_index].flushed());
 			TORRENT_ASSERT(!m_piece_map[pb.piece_index].filtered());
 		}
 	}
@@ -584,8 +584,8 @@ namespace libtorrent::aux {
 			{
 				if (m_cursor < m_reverse_cursor)
 				{
-					TORRENT_ASSERT(!m_piece_map[m_cursor].have() && !m_piece_map[m_cursor].filtered());
-					TORRENT_ASSERT(!m_piece_map[prev(m_reverse_cursor)].have() &&
+					TORRENT_ASSERT(!m_piece_map[m_cursor].flushed() && !m_piece_map[m_cursor].filtered());
+					TORRENT_ASSERT(!m_piece_map[prev(m_reverse_cursor)].flushed() &&
 						!m_piece_map[prev(m_reverse_cursor)].filtered());
 				}
 			}
@@ -623,7 +623,7 @@ namespace libtorrent::aux {
 						num_filtered_pad_bytes += pad_bytes;
 					}
 				}
-				else if (p.have())
+				else if (p.flushed())
 				{
 					++num_have_filtered;
 					num_have_filtered_pad_bytes += pad_bytes;
@@ -638,7 +638,7 @@ namespace libtorrent::aux {
 #ifdef TORRENT_DEBUG_REFCOUNTS
 			TORRENT_ASSERT(int(p.have_peers.size()) == p.peer_count + m_seeds);
 #endif
-			if (p.have())
+			if (p.flushed())
 			{
 				++num_have;
 				num_have_pad_bytes += pad_bytes;
@@ -764,7 +764,7 @@ namespace libtorrent::aux {
 		{
 			int peer_count = int(i->peer_count);
 			// take ourself into account
-			if (i->have()) ++peer_count;
+			if (i->flushed()) ++peer_count;
 			if (min_availability > peer_count)
 			{
 				min_availability = peer_count;
@@ -811,7 +811,7 @@ namespace libtorrent::aux {
 		TORRENT_ASSERT(!m_dirty);
 		piece_pos const& p = m_piece_map[index];
 		TORRENT_ASSERT(!p.filtered());
-		TORRENT_ASSERT(!p.have());
+		TORRENT_ASSERT(!p.flushed());
 
 		int priority = p.priority(this);
 		TORRENT_ASSERT(priority >= 0);
@@ -937,7 +937,7 @@ namespace libtorrent::aux {
 		piece_index_t const index = m_pieces[elem_index];
 		// update the piece_map
 		piece_pos& p = m_piece_map[index];
-		TORRENT_ASSERT(p.index == elem_index || p.have());
+		TORRENT_ASSERT(p.index == elem_index || p.flushed());
 
 		int const new_priority = p.priority(this);
 
@@ -1621,7 +1621,7 @@ namespace libtorrent::aux {
 			<< index << ")" << std::endl;
 #endif
 
-		bool have_piece = p.have();
+		bool have_piece = p.flushed();
 		if (!have_piece)
 		{
 			// even though we don't have the piece, it
@@ -1647,7 +1647,7 @@ namespace libtorrent::aux {
 			}
 		}
 
-		p.set_not_have();
+		p.set_not_flushed();
 
 		if (m_dirty) return;
 		if (p.priority(this) >= 0) add(index);
@@ -1669,7 +1669,7 @@ namespace libtorrent::aux {
 		int const priority = p.priority(this);
 		TORRENT_ASSERT(priority < int(m_priority_boundaries.size()) || m_dirty);
 
-		if (p.have()) return;
+		if (p.flushed()) return;
 
 		auto const state = p.download_queue();
 		bool passed_hash_check = false;
@@ -1693,7 +1693,7 @@ namespace libtorrent::aux {
 			account_have(index);
 		}
 
-		p.set_have();
+		p.set_flushed();
 		if (m_cursor == prev(m_reverse_cursor)
 			&& m_cursor == index)
 		{
@@ -1705,18 +1705,18 @@ namespace libtorrent::aux {
 		{
 			++m_cursor;
 			for (auto i = m_piece_map.begin() + static_cast<int>(m_cursor)
-				, end(m_piece_map.end()); i != end && (i->have() || i->filtered());
+				, end(m_piece_map.end()); i != end && (i->flushed() || i->filtered());
 				++i, ++m_cursor);
 		}
 		else if (prev(m_reverse_cursor) == index)
 		{
 			--m_reverse_cursor;
-			TORRENT_ASSERT(m_piece_map[m_reverse_cursor].have()
+			TORRENT_ASSERT(m_piece_map[m_reverse_cursor].flushed()
 				|| m_piece_map[m_reverse_cursor].filtered());
 			for (auto i = m_piece_map.begin() + static_cast<int>(m_reverse_cursor) - 1;
-				m_reverse_cursor > piece_index_t(0) && (i->have() || i->filtered());
+				m_reverse_cursor > piece_index_t(0) && (i->flushed() || i->filtered());
 				--i, --m_reverse_cursor);
-			TORRENT_ASSERT(m_piece_map[m_reverse_cursor].have()
+			TORRENT_ASSERT(m_piece_map[m_reverse_cursor].flushed()
 				|| m_piece_map[m_reverse_cursor].filtered());
 		}
 		TORRENT_ASSERT(m_reverse_cursor > m_cursor
@@ -1752,7 +1752,7 @@ namespace libtorrent::aux {
 		for (auto& queue : m_downloads) queue.clear();
 		for (auto& p : m_piece_map)
 		{
-			p.set_have();
+			p.set_flushed();
 			p.state(piece_pos::piece_open);
 		}
 	}
@@ -1779,12 +1779,21 @@ namespace libtorrent::aux {
 		int const prev_priority = p.priority(this);
 		TORRENT_ASSERT(m_dirty || prev_priority < int(m_priority_boundaries.size()));
 
+		// a downloading piece that has passed its hash check counts as
+		// "had" for the filtered/have-filtered accounting (see how the
+		// invariant in check_invariant() classifies it). This matters when
+		// the hasher completes ahead of the last write completion, leaving
+		// the piece in m_downloads with passed_hash_check set but p.flushed()
+		// still false. Use have_piece() so the counter we increment here
+		// matches what the invariant computes.
+		bool const had = have_piece(index);
+
 		bool ret = false;
 		if (new_piece_priority == dont_download
 			&& p.piece_priority != piece_pos::filter_priority)
 		{
 			// the piece just got filtered
-			if (p.have())
+			if (had)
 			{
 				m_have_filtered_pad_bytes += pad_bytes_in_piece(index);
 				++m_num_have_filtered;
@@ -1793,8 +1802,14 @@ namespace libtorrent::aux {
 			{
 				m_filtered_pad_bytes += pad_bytes_in_piece(index);
 				++m_num_filtered;
+			}
 
-				// update m_cursor
+			// the cursor is only advanced past a piece by piece_flushed(),
+			// so it may still point at this piece in the transient
+			// passed_hash_check state. Update it whenever p.flushed() is
+			// false.
+			if (!p.flushed())
+			{
 				if (m_cursor == prev(m_reverse_cursor) && m_cursor == index)
 				{
 					m_cursor = m_piece_map.end_index();
@@ -1804,7 +1819,7 @@ namespace libtorrent::aux {
 				{
 					++m_cursor;
 					while (m_cursor < m_piece_map.end_index()
-						&& (m_piece_map[m_cursor].have()
+						&& (m_piece_map[m_cursor].flushed()
 						|| m_piece_map[m_cursor].filtered()))
 						++m_cursor;
 				}
@@ -1812,7 +1827,7 @@ namespace libtorrent::aux {
 				{
 					--m_reverse_cursor;
 					while (m_reverse_cursor > piece_index_t(0)
-						&& (m_piece_map[prev(m_reverse_cursor)].have()
+						&& (m_piece_map[prev(m_reverse_cursor)].flushed()
 						|| m_piece_map[prev(m_reverse_cursor)].filtered()))
 						--m_reverse_cursor;
 				}
@@ -1823,7 +1838,7 @@ namespace libtorrent::aux {
 			&& p.piece_priority == piece_pos::filter_priority)
 		{
 			// the piece just got unfiltered
-			if (p.have())
+			if (had)
 			{
 				TORRENT_ASSERT(m_have_filtered_pad_bytes >= pad_bytes_in_piece(index));
 				m_have_filtered_pad_bytes -= pad_bytes_in_piece(index);
@@ -1836,6 +1851,10 @@ namespace libtorrent::aux {
 				m_filtered_pad_bytes -= pad_bytes_in_piece(index);
 				TORRENT_ASSERT(m_num_filtered > 0);
 				--m_num_filtered;
+			}
+
+			if (!p.flushed())
+			{
 				// update cursors
 				if (m_reverse_cursor == m_cursor)
 				{
@@ -2185,7 +2204,7 @@ namespace {
 						bool have_all = true;
 						for (piece_index_t const p : extent_for(e))
 						{
-							if (!m_piece_map[p].have()) have_all = false;
+							if (!m_piece_map[p].flushed()) have_all = false;
 							if (!is_piece_free(p, pieces)) continue;
 							if ((options & sequential) && p >= m_cursor && p < m_reverse_cursor) continue;
 
@@ -2357,7 +2376,7 @@ get_out:
 			// if we already have the piece, obviously we should not have
 			// since this is a partial piece in the piece_downloading state, we
 			// should not already have it
-			TORRENT_ASSERT(!m_piece_map[dp.index].have());
+			TORRENT_ASSERT(!m_piece_map[dp.index].flushed());
 
 			// if it was filtered, it would be in the prio_zero queue
 			TORRENT_ASSERT(!m_piece_map[dp.index].filtered());
@@ -2499,7 +2518,7 @@ get_out:
 		TORRENT_ASSERT(index >= piece_index_t(0));
 
 		piece_pos const& p = m_piece_map[index];
-		return p.have();
+		return p.flushed();
 	}
 
 	int piece_picker::blocks_in_piece(piece_index_t const index) const
@@ -2516,7 +2535,7 @@ get_out:
 		, typed_bitfield<piece_index_t> const& bitmask) const
 	{
 		return bitmask[piece]
-			&& !m_piece_map[piece].have()
+			&& !m_piece_map[piece].flushed()
 			&& !m_piece_map[piece].filtered();
 	}
 
@@ -2524,7 +2543,7 @@ get_out:
 		, typed_bitfield<piece_index_t> const& bitmask) const
 	{
 		return bitmask[piece]
-			&& !m_piece_map[piece].have()
+			&& !m_piece_map[piece].flushed()
 			// TODO: when expanding pieces for cache stripe reasons,
 			// the !downloading condition doesn't make much sense
 			&& !m_piece_map[piece].downloading()
@@ -2820,7 +2839,7 @@ get_out:
 	bool piece_picker::is_piece_finished(piece_index_t const index) const
 	{
 		piece_pos const& p = m_piece_map[index];
-		if (p.index == piece_pos::we_have_index) return true;
+		if (p.index == piece_pos::flushed_index) return true;
 
 		auto const state = p.download_queue();
 		if (state == piece_pos::piece_open)
@@ -2861,13 +2880,14 @@ get_out:
 		return i->hashing > 0;
 	}
 
+	// returns true if the piece has passed the hash check
 	bool piece_picker::have_piece(piece_index_t const index) const
 	{
 		TORRENT_ASSERT(index < m_piece_map.end_index());
 		TORRENT_ASSERT(index >= piece_index_t(0));
 
 		piece_pos const& p = m_piece_map[index];
-		if (p.have()) return true;
+		if (p.flushed()) return true;
 
 		auto const state = p.download_queue();
 		if (state == piece_pos::piece_open)
@@ -3015,7 +3035,7 @@ get_out:
 		TORRENT_ASSERT(block.piece_index < m_piece_map.end_index());
 
 		piece_pos const& p = m_piece_map[block.piece_index];
-		if (p.index == piece_pos::we_have_index) return true;
+		if (p.index == piece_pos::flushed_index) return true;
 		auto const state = p.download_queue();
 		if (state == piece_pos::piece_open) return false;
 		auto const i = find_dl_piece(state, block.piece_index);
@@ -3034,7 +3054,7 @@ get_out:
 		TORRENT_ASSERT(block.piece_index < m_piece_map.end_index());
 
 		piece_pos const& p = m_piece_map[block.piece_index];
-		if (p.index == piece_pos::we_have_index) return true;
+		if (p.index == piece_pos::flushed_index) return true;
 		auto const state = p.download_queue();
 		if (state == piece_pos::piece_open) return false;
 		auto const i = find_dl_piece(state, block.piece_index);
@@ -3082,7 +3102,7 @@ get_out:
 		{
 			if (piece == p) continue;
 
-			if (!m_piece_map[piece].have()) have_all = false;
+			if (!m_piece_map[piece].flushed()) have_all = false;
 
 			// if at least one piece in this extent has a different priority than
 			// the one we just started downloading, don't create an affinity for
@@ -3121,7 +3141,7 @@ get_out:
 		TORRENT_ASSERT(block.piece_index != piece_block::invalid.piece_index);
 		TORRENT_ASSERT(block.piece_index < m_piece_map.end_index());
 		TORRENT_ASSERT(block.block_index < blocks_in_piece(block.piece_index));
-		TORRENT_ASSERT(!m_piece_map[block.piece_index].have());
+		TORRENT_ASSERT(!m_piece_map[block.piece_index].flushed());
 
 		piece_pos& p = m_piece_map[block.piece_index];
 		if (p.download_queue() == piece_pos::piece_open)
@@ -3667,7 +3687,16 @@ get_out:
 		m_pads_in_piece[piece] = bytes;
 
 		piece_pos& p = m_piece_map[piece];
-		if (p.have())
+		// the "had" notion used for the pad-byte and filtered counters is
+		// have_piece() (i.e. p.flushed() OR a downloading piece that has passed
+		// the hash check). check_invariant() classifies pieces this way, and
+		// account_have()/account_lost()/set_piece_priority() update the
+		// counters using this same notion, so set_pad_bytes() must agree.
+		// In practice this is called during torrent initialisation, before
+		// any piece can be in the transient passed-hash-check state, but we
+		// keep the test consistent here so the convention is uniform.
+		bool const had = have_piece(piece);
+		if (had)
 		{
 			m_have_pad_bytes += bytes;
 			if (p.filtered())
@@ -3882,7 +3911,7 @@ get_out:
 	{
 		++m_num_have;
 		piece_pos& p = m_piece_map[index];
-		TORRENT_ASSERT(!p.have());
+		TORRENT_ASSERT(!p.flushed());
 		int const pad_bytes = pad_bytes_in_piece(index);
 		if (p.filtered())
 		{

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10782,13 +10782,13 @@ namespace {
 		{
 			piece_picker::piece_stats_t ps = m_picker->piece_stats(i);
 			if (ps.peer_count == 0) continue;
-			if (ps.priority == 0 && (ps.have || ps.downloading))
+			if (ps.priority == 0 && (ps.flushed || ps.downloading))
 			{
 				m_picker->set_piece_priority(i, default_priority);
 				continue;
 			}
 			// don't count pieces we already have or are trying to download
-			if (ps.priority > 0 || ps.have) continue;
+			if (ps.priority > 0 || ps.flushed) continue;
 			if (ps.peer_count > rarest_rarity) continue;
 			if (ps.peer_count == rarest_rarity)
 			{

--- a/test/test_piece_picker.cpp
+++ b/test/test_piece_picker.cpp
@@ -1791,12 +1791,12 @@ TORRENT_TEST(piece_stats)
 
 	piece_picker::piece_stats_t stat = p->piece_stats(0_piece);
 	TEST_EQUAL(stat.peer_count, 3);
-	TEST_EQUAL(stat.have, 1);
+	TEST_EQUAL(stat.flushed, 1);
 	TEST_EQUAL(stat.downloading, 0);
 
 	stat = p->piece_stats(1_piece);
 	TEST_EQUAL(stat.peer_count, 4);
-	TEST_EQUAL(stat.have, 0);
+	TEST_EQUAL(stat.flushed, 0);
 	TEST_EQUAL(stat.downloading, 1);
 }
 
@@ -1831,6 +1831,133 @@ TORRENT_TEST(piece_passed)
 	p->mark_as_finished({2_piece, 2}, &tmp1);
 	p->mark_as_finished({2_piece, 3}, &tmp1);
 	TEST_EQUAL(p->is_piece_flushed(2_piece), true);
+}
+
+// The picker may be notified of piece_passed() while some blocks are still in
+// state_writing, leaving the piece in a transient state: passed_hash_check is
+// set, the piece is in m_downloads, but p.flushed() is still false.
+// set_piece_priority() must account for this case so that filtering or
+// un-filtering such a piece keeps m_num_filtered / m_num_have_filtered
+// consistent with what check_invariant() computes by walking m_piece_map.
+TORRENT_TEST(set_piece_priority_passed_hash_check)
+{
+	// piece 1 has blocks 0,1,2 finished but block 3 still pending
+	auto p = setup_picker("1111111", "       ", "", "0700000");
+
+	TEST_EQUAL(p->have_piece(1_piece), false);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
+	TEST_EQUAL(p->num_have(), 0);
+	TEST_EQUAL(p->want().num_pieces, 7);
+	TEST_EQUAL(p->have_want().num_pieces, 0);
+
+	// hash check arrives ahead of the last write completion
+	p->piece_passed(1_piece);
+
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 7);
+	TEST_EQUAL(p->have_want().num_pieces, 1);
+
+	// filter the piece while it is in the transient state. without the fix,
+	// this would drive m_num_filtered out of sync with the invariant scan
+	// (which classifies the piece as filtered + had).
+	p->set_piece_priority(1_piece, dont_download);
+
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 6);
+	TEST_EQUAL(p->have_want().num_pieces, 0);
+
+	// the late mark_as_finished must drive piece_flushed() since
+	// passed_hash_check is set, and counters must stay consistent.
+	p->mark_as_finished({1_piece, 3}, &tmp1);
+
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), true);
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 6);
+	TEST_EQUAL(p->have_want().num_pieces, 0);
+
+	// un-filtering the (now actually had) piece should give us a wanted+had
+	// piece back.
+	p->set_piece_priority(1_piece, top_priority);
+
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 7);
+	TEST_EQUAL(p->have_want().num_pieces, 1);
+}
+
+// same as above but un-filters before the final block completes, exercising
+// the symmetric path in set_piece_priority().
+TORRENT_TEST(set_piece_priority_passed_hash_check_unfilter)
+{
+	auto p = setup_picker("1111111", "       ", "", "0700000");
+
+	p->piece_passed(1_piece);
+	p->set_piece_priority(1_piece, dont_download);
+
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 6);
+	TEST_EQUAL(p->have_want().num_pieces, 0);
+
+	// un-filter while the piece is still in transient state. the counter
+	// decrement must come out of m_num_have_filtered (not m_num_filtered)
+	// to match the increment from the filter call above.
+	p->set_piece_priority(1_piece, top_priority);
+
+	TEST_EQUAL(p->have_piece(1_piece), true);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), false);
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 7);
+	TEST_EQUAL(p->have_want().num_pieces, 1);
+
+	// finally complete the last write; piece_flushed() runs on the back
+	// of mark_as_finished because passed_hash_check is set.
+	p->mark_as_finished({1_piece, 3}, &tmp1);
+	TEST_EQUAL(p->is_piece_flushed(1_piece), true);
+	TEST_EQUAL(p->num_have(), 1);
+	TEST_EQUAL(p->want().num_pieces, 7);
+	TEST_EQUAL(p->have_want().num_pieces, 1);
+}
+
+// covers the case where the piece hash comes first, then the flushed blocks
+TORRENT_TEST(set_piece_priority_passed_hash_check_bulk_filter)
+{
+	auto p = setup_picker("1111111", "       ", "", "7777777");
+
+	// hash result for every piece arrives before the last block of each
+	// piece has been flushed.
+	for (auto i = 0_piece; i < piece_index_t(7); ++i)
+		p->piece_passed(i);
+
+	TEST_EQUAL(p->num_have(), 7);
+	TEST_EQUAL(p->want().num_pieces, 7);
+	TEST_EQUAL(p->have_want().num_pieces, 7);
+
+	// bulk filter (matches torrent_handle::prioritize_pieces(all
+	// dont_download))
+	for (auto i = 0_piece; i < piece_index_t(7); ++i)
+		p->set_piece_priority(i, dont_download);
+
+	TEST_EQUAL(p->num_have(), 7);
+	TEST_EQUAL(p->want().num_pieces, 0);
+	TEST_EQUAL(p->have_want().num_pieces, 0);
+
+	// finishing the last block of each piece must transition each one
+	// through piece_flushed without disturbing the invariants.
+	for (auto i = 0_piece; i < piece_index_t(7); ++i)
+	{
+		p->mark_as_finished({i, 3}, &tmp1);
+		TEST_EQUAL(p->is_piece_flushed(i), true);
+	}
+
+	TEST_EQUAL(p->num_have(), 7);
+	TEST_EQUAL(p->want().num_pieces, 0);
+	TEST_EQUAL(p->have_want().num_pieces, 0);
 }
 
 TORRENT_TEST(piece_passed_causing_we_have)


### PR DESCRIPTION
related to pieces whose hash is correct, but not yet flushed to disk. Rename some parts of piece_picker to make the distinction between passed-hash-check and flushed-to-disk clearer