### PR TITLE
fix race in session_handle::wait_for_alert()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.1.0 not released
 
+	* fix race in wait_for_alert(), and update its return value
 	* optimize torrent_handle::torrent_file()
 	* add option to not validate v1 hashes for hybrid torrents
 	* add post_file_status() to query them asynchronously

--- a/bindings/python/libtorrent/__init__.pyi
+++ b/bindings/python/libtorrent/__init__.pyi
@@ -3405,9 +3405,9 @@ class session(metaclass=_BoostBaseClass):
         upload_rate_limit( (session)arg1) -> int :
         """
 
-    def wait_for_alert(self, _ms: int) -> alert | None:
+    def wait_for_alert(self, _ms: int) -> bool:
         """
-        wait_for_alert( (session)arg1, (int)arg2) -> alert :
+        wait_for_alert( (session)arg1, (int)arg2) -> bool :
         """
 
     def web_seed_proxy(self) -> proxy_type_t.proxy_settings:

--- a/bindings/python/src/session.cpp
+++ b/bindings/python/src/session.cpp
@@ -548,14 +548,14 @@ namespace {
 		}
 	}
 
-	alert const* wait_for_alert(lt::session& s, int ms)
+	bool wait_for_alert(lt::session& s, int ms)
 	{
-		alert const* a;
-		{
-			allow_threading_guard guard;
-			a = s.wait_for_alert(milliseconds(ms));
-		}
-		return a;
+		allow_threading_guard guard;
+#if TORRENT_ABI_VERSION < 4
+		return s.wait_for_alert(milliseconds(ms)) != nullptr;
+#else
+		return s.wait_for_alert(milliseconds(ms));
+#endif
 	}
 
 	list get_torrents(lt::session& s)
@@ -1294,7 +1294,7 @@ void bind_session()
 				.def("load_state", &load_state, (arg("entry"), arg("flags") = 0xffffffff))
 				.def("save_state", &save_state, (arg("entry"), arg("flags") = 0xffffffff))
 				.def("pop_alerts", &pop_alerts)
-				.def("wait_for_alert", &wait_for_alert, return_internal_reference<>())
+				.def("wait_for_alert", &wait_for_alert)
 				.def("set_alert_notify", &set_alert_notify)
 				.def("set_alert_fd", &set_alert_fd)
 				.def("add_extension", &add_extension)

--- a/bindings/python/tests/session_test.py
+++ b/bindings/python/tests/session_test.py
@@ -1007,13 +1007,12 @@ class AlertHandlingTest(unittest.TestCase):
         self.session = lt.session(settings)
 
     def test_wait_and_pop(self) -> None:
-        # wait_for_alert() shouldn't return anything with no pending alerts
-        self.assertIsNone(self.session.wait_for_alert(0))
+        # wait_for_alert() should report no pending alerts
+        self.assertFalse(self.session.wait_for_alert(0))
 
         # Force an alert to fire
         self.session.post_torrent_updates()
-        alert = self.session.wait_for_alert(10000)
-        self.assertIsInstance(alert, lt.state_update_alert)
+        self.assertTrue(self.session.wait_for_alert(10000))
         alerts = self.session.pop_alerts()
         self.assertEqual(len(alerts), 1)
         self.assertIsInstance(alerts[0], lt.state_update_alert)
@@ -1113,24 +1112,27 @@ class PostAlertsTest(unittest.TestCase):
         settings["alert_mask"] = 0
         self.session = lt.session(settings)
 
+    def _assert_pending_alert(self, alert_type: type) -> None:
+        self.assertTrue(self.session.wait_for_alert(10000))
+        alerts = self.session.pop_alerts()
+        self.assertTrue(any(isinstance(a, alert_type) for a in alerts))
+
     def test_post_torrent_updates(self) -> None:
         # no args
         self.session.post_torrent_updates()
-        self.assertIsInstance(self.session.wait_for_alert(10000), lt.state_update_alert)
+        self._assert_pending_alert(lt.state_update_alert)
 
-        self.session.pop_alerts()
         # positional args
         self.session.post_torrent_updates(0)
-        self.assertIsInstance(self.session.wait_for_alert(10000), lt.state_update_alert)
+        self._assert_pending_alert(lt.state_update_alert)
 
-        self.session.pop_alerts()
         # kwargs
         self.session.post_torrent_updates(flags=0)
-        self.assertIsInstance(self.session.wait_for_alert(10000), lt.state_update_alert)
+        self._assert_pending_alert(lt.state_update_alert)
 
     def test_post_dht_stats(self) -> None:
         self.session.post_dht_stats()
-        self.assertIsInstance(self.session.wait_for_alert(10000), lt.dht_stats_alert)
+        self._assert_pending_alert(lt.dht_stats_alert)
 
 
 class AddTorrentTest(unittest.TestCase):

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -2403,8 +2403,7 @@ done:
 
 	while (num_outstanding_resume_data > 0)
 	{
-		alert const* a = ses.wait_for_alert(seconds(10));
-		if (a == nullptr) continue;
+		if (!ses.wait_for_alert(seconds(10))) continue;
 		pop_alerts(client_state, ses);
 	}
 

--- a/examples/upnp_test.cpp
+++ b/examples/upnp_test.cpp
@@ -47,8 +47,7 @@ int main(int argc, char*[])
 
 	for (;;)
 	{
-		alert const* a = s.wait_for_alert(seconds(5));
-		if (a == nullptr)
+		if (!s.wait_for_alert(seconds(5)))
 		{
 			p.set_bool(settings_pack::enable_upnp, false);
 			p.set_bool(settings_pack::enable_natpmp, false);
@@ -68,8 +67,7 @@ int main(int argc, char*[])
 
 	for (;;)
 	{
-		alert const* a = s.wait_for_alert(seconds(5));
-		if (a == nullptr) break;
+		if (!s.wait_for_alert(seconds(5))) break;
 		std::vector<alert*> alerts;
 		s.pop_alerts(&alerts);
 		for (std::vector<alert*>::iterator i = alerts.begin()

--- a/include/libtorrent/aux_/alert_manager.hpp
+++ b/include/libtorrent/aux_/alert_manager.hpp
@@ -83,7 +83,7 @@ namespace aux {
 			return bool(m_alert_mask.load(std::memory_order_relaxed) & T::static_category);
 		}
 
-		alert* wait_for_alert(time_duration max_wait);
+		bool wait_for_alert(time_duration max_wait);
 
 		void set_alert_mask(alert_category_t const m) noexcept
 		{

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -610,7 +610,22 @@ namespace aux {
 			std::vector<torrent_handle> get_torrents() const;
 
 			void pop_alerts(std::vector<alert*>* alerts);
-			alert* wait_for_alert(time_duration max_wait);
+			bool wait_for_alert(time_duration max_wait);
+
+#if TORRENT_ABI_VERSION < 4
+			// a placeholder alert returned by the legacy session_handle::wait_for_alert
+			// signature when an alert is pending. The pointer to the head of the
+			// alert queue can't be returned because the queue may grow and reallocate
+			// concurrently, invalidating the pointer.
+			struct legacy_dummy_alert : alert
+			{
+				int type() const noexcept override { return -1; }
+				char const* what() const noexcept override { return "dummy"; }
+				std::string message() const override { return {}; }
+				alert_category_t category() const noexcept override { return {}; }
+			};
+			legacy_dummy_alert m_legacy_dummy_alert;
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 			TORRENT_DEPRECATED void pop_alerts();

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -950,18 +950,20 @@ namespace aux { struct torrent; }
 		// between the popping threads.
 		//
 		// ``wait_for_alert`` will block the current thread for ``max_wait`` time
-		// duration, or until another alert is posted. If an alert is available
-		// at the time of the call, it returns immediately. The returned alert
-		// pointer is the head of the alert queue. ``wait_for_alert`` does not
-		// pop alerts from the queue, it merely peeks at it. The returned alert
-		// will stay valid until ``pop_alerts`` is called twice. The first time
-		// will pop it and the second will free it.
+		// duration, or until another alert is posted. If an alert is already
+		// available at the time of the call, it returns immediately. It returns
+		// ``true`` if an alert is pending (i.e. a subsequent ``pop_alerts``
+		// call would return at least one alert), and ``false`` if the timeout
+		// expired with no alert available.
 		//
-		// If there is no alert in the queue and no alert arrives within the
-		// specified timeout, ``wait_for_alert`` returns nullptr.
+		// In ``TORRENT_ABI_VERSION < 4`` the return type is ``alert*`` for
+		// backwards compatibility; the returned pointer is non-null when an
+		// alert is pending and null on timeout, but it does not point at any
+		// real alert (it is a placeholder) and must not be dereferenced. Use
+		// ``pop_alerts`` to retrieve the actual alerts.
 		//
 		// In the python binding, ``wait_for_alert`` takes the number of
-		// milliseconds to wait as an integer.
+		// milliseconds to wait as an integer and returns a ``bool``.
 		//
 		// The alert queue in the session will not grow indefinitely. Make sure
 		// to pop periodically to not miss notifications. To control the max
@@ -1001,7 +1003,11 @@ namespace aux { struct torrent; }
 		// ``alert::type()`` but can also be queries from a concrete type via
 		// ``T::alert_type``, as a static constant.
 		void pop_alerts(std::vector<alert*>* alerts);
+#if TORRENT_ABI_VERSION < 4
 		alert* wait_for_alert(time_duration max_wait);
+#else
+		bool wait_for_alert(time_duration max_wait);
+#endif
 		void set_alert_notify(std::function<void()> const& fun);
 
 #if TORRENT_ABI_VERSION == 1

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -817,10 +817,8 @@ namespace aux {
 		//
 		//	while (outstanding_resume_data > 0)
 		//	{
-		//		alert const* a = ses.wait_for_alert(seconds(30));
-		//
 		//		// if we don't get an alert within 30 seconds, abort
-		//		if (a == nullptr) break;
+		//		if (!ses.wait_for_alert(seconds(30))) break;
 		//
 		//		std::vector<alert*> alerts;
 		//		ses.pop_alerts(&alerts);

--- a/src/alert_manager.cpp
+++ b/src/alert_manager.cpp
@@ -28,19 +28,15 @@ namespace libtorrent::aux {
 
 	alert_manager::~alert_manager() = default;
 
-	alert* alert_manager::wait_for_alert(time_duration max_wait)
+	bool alert_manager::wait_for_alert(time_duration max_wait)
 	{
 		std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
-		if (!m_alerts[m_generation & 1].empty())
-			return m_alerts[m_generation & 1].front();
+		if (!m_alerts[m_generation & 1].empty()) return true;
 
 		// this call can be interrupted prematurely by other signals
 		m_condition.wait_for(lock, max_wait);
-		if (!m_alerts[m_generation & 1].empty())
-			return m_alerts[m_generation & 1].front();
-
-		return nullptr;
+		return !m_alerts[m_generation & 1].empty();
 	}
 
 	void alert_manager::maybe_notify(alert* a)

--- a/src/session_handle.cpp
+++ b/src/session_handle.cpp
@@ -1153,12 +1153,21 @@ namespace {
 		s->pop_alerts(alerts);
 	}
 
+#if TORRENT_ABI_VERSION < 4
 	alert* session_handle::wait_for_alert(time_duration max_wait)
+	{
+		std::shared_ptr<session_impl> s = m_impl.lock();
+		if (!s) aux::throw_ex<system_error>(errors::invalid_session_handle);
+		return s->wait_for_alert(max_wait) ? &s->m_legacy_dummy_alert : nullptr;
+	}
+#else
+	bool session_handle::wait_for_alert(time_duration max_wait)
 	{
 		std::shared_ptr<session_impl> s = m_impl.lock();
 		if (!s) aux::throw_ex<system_error>(errors::invalid_session_handle);
 		return s->wait_for_alert(max_wait);
 	}
+#endif
 
 	void session_handle::set_alert_notify(std::function<void()> const& fun)
 	{

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -6971,7 +6971,7 @@ retry:
 
 #endif
 
-	alert* session_impl::wait_for_alert(time_duration max_wait)
+	bool session_impl::wait_for_alert(time_duration max_wait)
 	{
 		return m_alerts.wait_for_alert(max_wait);
 	}

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -429,15 +429,14 @@ bool print_alerts(lt::session& ses, char const* name
 void wait_for_listen(lt::session& ses, char const* name)
 {
 	bool listen_done = false;
-	alert const* a = nullptr;
 	do
 	{
 		listen_done = print_alerts(ses, name, true, true, [](lt::alert const* al)
 			{ return alert_cast<listen_failed_alert>(al) || alert_cast<listen_succeeded_alert>(al); }
 			, false);
 		if (listen_done) break;
-		a = ses.wait_for_alert(milliseconds(500));
-	} while (a);
+	}
+	while (ses.wait_for_alert(milliseconds(500)));
 	// we din't receive a listen alert!
 	TEST_CHECK(listen_done);
 }
@@ -446,7 +445,6 @@ void wait_for_downloading(lt::session& ses, char const* name)
 {
 	time_point start = clock_type::now();
 	bool downloading_done = false;
-	alert const* a = nullptr;
 	do
 	{
 		downloading_done = print_alerts(ses, name, true, true
@@ -457,8 +455,8 @@ void wait_for_downloading(lt::session& ses, char const* name)
 			}, false);
 		if (downloading_done) break;
 		if (clock_type::now() - start > seconds(30)) break;
-		a = ses.wait_for_alert(seconds(5));
-	} while (a);
+	}
+	while (ses.wait_for_alert(seconds(5)));
 	if (!downloading_done)
 	{
 		std::printf("%s: did not receive a state_changed_alert indicating "
@@ -471,7 +469,6 @@ void wait_for_seeding(lt::session& ses, char const* name)
 {
 	time_point start = clock_type::now();
 	bool seeding = false;
-	alert const* a = nullptr;
 	do
 	{
 		seeding = print_alerts(ses, name, true, true
@@ -482,8 +479,8 @@ void wait_for_seeding(lt::session& ses, char const* name)
 			}, false);
 		if (seeding) break;
 		if (clock_type::now() - start > seconds(30)) break;
-		a = ses.wait_for_alert(seconds(5));
-	} while (a);
+	}
+	while (ses.wait_for_alert(seconds(5)));
 	if (!seeding)
 	{
 		std::printf("%s: did not receive a state_changed_alert indicating "

--- a/test/swarm_suite.cpp
+++ b/test/swarm_suite.cpp
@@ -177,8 +177,7 @@ void test_swarm(test_flags_t const flags)
 	// this should time out (ret == 0) and it should take
 	// about 2 seconds
 	time_point start = clock_type::now();
-	alert const* ret;
-	while ((ret = ses1.wait_for_alert(seconds(2))))
+	while (ses1.wait_for_alert(seconds(2)))
 	{
 		std::printf("wait returned: %d ms\n"
 			, int(total_milliseconds(clock_type::now() - start)));

--- a/test/test_alert_types.cpp
+++ b/test/test_alert_types.cpp
@@ -191,7 +191,11 @@ TORRENT_TEST(dht_get_peers_reply_alert)
 
 	mgr.emplace_alert<dht_get_peers_reply_alert>(ih, v);
 
-	auto const* a = alert_cast<dht_get_peers_reply_alert>(mgr.wait_for_alert(seconds(0)));
+	TEST_CHECK(mgr.wait_for_alert(seconds(0)));
+	std::vector<alert*> alerts;
+	mgr.get_all(alerts);
+	TEST_EQUAL(alerts.size(), 1);
+	auto const* a = alert_cast<dht_get_peers_reply_alert>(alerts.front());
 	TEST_CHECK(a != nullptr);
 
 	TEST_EQUAL(a->info_hash, ih);
@@ -229,7 +233,11 @@ TORRENT_TEST(dht_live_nodes_alert)
 
 	mgr.emplace_alert<dht_live_nodes_alert>(ih, v);
 
-	auto const* a = alert_cast<dht_live_nodes_alert>(mgr.wait_for_alert(seconds(0)));
+	TEST_CHECK(mgr.wait_for_alert(seconds(0)));
+	std::vector<alert*> alerts;
+	mgr.get_all(alerts);
+	TEST_EQUAL(alerts.size(), 1);
+	auto const* a = alert_cast<dht_live_nodes_alert>(alerts.front());
 	TEST_CHECK(a != nullptr);
 
 	TEST_EQUAL(a->node_id, ih);
@@ -303,7 +311,11 @@ TORRENT_TEST(dht_sample_infohashes_alert)
 
 	mgr.emplace_alert<dht_sample_infohashes_alert>(node_id, endpoint, interval, num, v, nv);
 
-	auto const* a = alert_cast<dht_sample_infohashes_alert>(mgr.wait_for_alert(seconds(0)));
+	TEST_CHECK(mgr.wait_for_alert(seconds(0)));
+	std::vector<alert*> alerts;
+	mgr.get_all(alerts);
+	TEST_EQUAL(alerts.size(), 1);
+	auto const* a = alert_cast<dht_sample_infohashes_alert>(alerts.front());
 	TEST_CHECK(a != nullptr);
 
 	TEST_EQUAL(a->node_id, node_id);

--- a/test/test_direct_dht.cpp
+++ b/test/test_direct_dht.cpp
@@ -50,11 +50,11 @@ dht_direct_response_alert* get_direct_response(lt::session& ses)
 {
 	for (;;)
 	{
-		alert* a = ses.wait_for_alert(seconds(30));
 		// it shouldn't take more than 30 seconds to get a response
 		// so fail the test and bail out if we don't get an alert in that time
-		TEST_CHECK(a);
-		if (!a) return nullptr;
+		bool const got = ses.wait_for_alert(seconds(30));
+		TEST_CHECK(got);
+		if (!got) return nullptr;
 		std::vector<alert*> alerts;
 		ses.pop_alerts(&alerts);
 		for (std::vector<alert*>::iterator i = alerts.begin(); i != alerts.end(); ++i)

--- a/test/test_remap_files.cpp
+++ b/test/test_remap_files.cpp
@@ -110,8 +110,7 @@ void test_remap_files(storage_mode_t storage_mode = storage_mode_sparse)
 
 	while (!all_of(pieces) || !all_of(passed) || !all_of(files))
 	{
-		alert* a = ses.wait_for_alert(lt::seconds(5));
-		if (a == nullptr) break;
+		if (!ses.wait_for_alert(lt::seconds(5))) break;
 
 		std::vector<alert*> alerts;
 		ses.pop_alerts(&alerts);


### PR DESCRIPTION
The alert pointer it returned could become invalid immediately, not safe to dereference. Update its signature.

The underlying issue is that alert pointers are not stable until you call `pop_alerts()`, at which point the buffers are swapped. The batch of alerts returned are stable, whereas the next batch that's still being built are not. Pushing a new alert may reallocate the queue, and move all the alert objects. So, if another alert is pushed immediately after `wait_for_alert()` returns, the returned pointer may already be dangling.

The solution is to alter this call to instead just return a `bool`, indicating whether there's a pending alert or not.