### PR TITLE
disable python's and pytest's faulthandler

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,21 @@ envlist = py36,py37,py38,py39
 # windows. If we discover problems with this, consider restricting passenv with
 # platform-specific testenvs.
 passenv = *
+# PYTHONMALLOC=debug enables the debug allocator that aborts on bad allocs.
+# This used to be enabled via -X dev, but -X dev also installs Python's
+# faulthandler, which catches the original SIGSEGV from native code, prints
+# a Python traceback, and re-raises via raise() -- which mangles core dumps
+# (the crashing thread ends up at __pthread_kill instead of the real crash
+# site). For testing a native extension in CI we want raw cores, not Python
+# tracebacks, so we enable the debug allocator without -X dev.
+# PYTHONFAULTHANDLER and PYTHONDEVMODE are explicitly cleared because passenv=*
+# would otherwise let either one leak in from the parent environment and
+# re-enable faulthandler at interpreter startup, before pytest's
+# -p no:faulthandler has a chance to suppress it.
+setenv =
+    PYTHONMALLOC = debug
+    PYTHONFAULTHANDLER =
+    PYTHONDEVMODE =
 # tox's "real" support for installing bdists instead of sdists is to use pep517.
 # workaround from https://github.com/tox-dev/tox/issues/185
 changedir = bindings/python
@@ -20,9 +35,6 @@ deps =
 # Build the wheel to match our environment's python, and install it to the
 # environment.
 # Invocation notes:
-# - python -X dev: this enables a debug allocator which causes bad allocs to
-#   abort immediately, rather than corrupt memory. This has caught several bugs
-#   in the past
 # - We'd like to use python -W error::DeprecationWarning:tests.*, but this
 #   this example from the docs doesn't work, as the module regex is always
 #   escaped. We can't use a broader -W error::DeprecationWarning because
@@ -43,8 +55,8 @@ deps =
 #   in the python directory, only run mypy on the tests dir.
 
 commands =
-    {envpython} setup.py build_ext --b2-args "asserts=on invariant-checks=full" bdist_wheel
+    {envpython} setup.py build_ext --b2-args "asserts=on invariant-checks=full debug-symbols=on" bdist_wheel
     {envpython} -m pip install --upgrade --force-reinstall --ignore-installed --find-links=dist --no-index libtorrent
     {envpython} -m pip install -r test-requirements.txt
-    {envpython} -X dev -m pytest --log-level=DEBUG --log-cli-level=DEBUG
+    {envpython} -m pytest -p no:faulthandler --log-level=DEBUG --log-cli-level=DEBUG
     {envpython} -m mypy --config-file mypy-tox.ini tests


### PR DESCRIPTION
which obscures the true cause of segfaults