### PR TITLE
RC_2_1 - GHA CI: Bump numerous action revs (node24 compliance)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,7 +80,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
            submodules: recursive
 

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-24.04, macos-latest, windows-2022 ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -236,7 +236,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: wheels-*
         path: wheelhouse

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -39,7 +39,7 @@ jobs:
 
       steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
            submodules: false
            fetch-depth: 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -333,7 +333,7 @@ jobs:
       - name: build tarball
         run: AAFIGURE=~/.local/bin/aafigure RST2HTML=rst2html make dist
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: tarball-${{ matrix.os }}
           path: libtorrent-rasterbar-*.tar.gz

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,7 +48,7 @@ jobs:
     #  - setup-python sets up PATH so 'python' and 'python3' point to the
     #    requested version on mac and linux, but on windows it only sets up
     #    'python'.
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v6
       with:
          python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Addresses most of the Annotation/warnings:
`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected`