### PR TITLE
GHA CI: Replace `third party` action with `node24 compatible` variant

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
            python-version: "3.x"
-      - uses: pre-commit/action@v3.0.1
+      - uses: j178/prek-action@v2
 
    build:
       name: build


### PR DESCRIPTION
* [pre-commit/action](https://github.com/pre-commit/action) -> [j178/prek-action](https://github.com/j178/prek-action)

Closes #8317.