### PR TITLE
authenticate webtorrent tracker certificates by default

### DIFF
--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -652,3 +652,4 @@ ofstream
 oversized
 cfg
 httpseeds
+GnuTLS

--- a/include/libtorrent/aux_/websocket_tracker_connection.hpp
+++ b/include/libtorrent/aux_/websocket_tracker_connection.hpp
@@ -82,7 +82,7 @@ private:
 	void fail(operation_t op, error_code const& ec);
 
 	io_context& m_io_context;
-	ssl::context m_ssl_context;
+	ssl::context* m_ssl_context;
 	std::shared_ptr<aux::websocket_stream> m_websocket;
 	boost::beast::flat_buffer m_read_buffer;
 	std::string m_write_data;

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -957,11 +957,12 @@ namespace aux {
 			// small piece sizes
 			piece_extent_affinity,
 
-			// when set to true, the certificate of HTTPS trackers and HTTPS web
-			// seeds will be validated against the system's certificate store
-			// (as defined by OpenSSL). If the system does not have a
-			// certificate store, this option may have to be disabled in order
-			// to get trackers and web seeds to work).
+			// when set to true, the certificate of HTTPS trackers, HTTPS web
+			// seeds and WebTorrent (wss://) trackers will be validated
+			// against the system's certificate store (as defined by
+			// OpenSSL/GnuTLS). If the system does not have a certificate
+			// store, this option may have to be disabled in order to get
+			// trackers and web seeds to work).
 			validate_https_trackers,
 
 			// when enabled, tracker and web seed requests are subject to

--- a/src/websocket_stream.cpp
+++ b/src/websocket_stream.cpp
@@ -200,6 +200,17 @@ void websocket_stream::do_ssl_handshake()
 		return;
 	}
 
+	// match the certificate's subject against the hostname we connected to.
+	// this only takes effect when verify_peer is set on the SSL context;
+	// when the user has disabled validation this callback is not invoked.
+	ssl_stream.set_verify_callback(ssl::host_name_verification(m_hostname), ec);
+	if (ec)
+	{
+		if (auto handler = std::exchange(m_connect_handler, nullptr))
+			post(m_io_service, std::bind(std::move(handler), ec));
+		return;
+	}
+
 	ADD_OUTSTANDING_ASYNC("websocket_stream::on_ssl_handshake");
 	ssl_stream.async_handshake(ssl::stream_base::client
 			, std::bind(&websocket_stream::on_ssl_handshake, shared_from_this(), _1));

--- a/src/websocket_tracker_connection.cpp
+++ b/src/websocket_tracker_connection.cpp
@@ -61,13 +61,15 @@ std::string utf8_latin1(json::string const& sv)
 
 }
 
-websocket_tracker_connection::websocket_tracker_connection(io_context& ios
-		, tracker_manager& man
-		, tracker_request const& req
-		, std::weak_ptr<request_callback> cb)
+websocket_tracker_connection::websocket_tracker_connection(
+	io_context& ios,
+	tracker_manager& man,
+	tracker_request const& req,
+	std::weak_ptr<request_callback> cb
+)
 	: tracker_connection(man, req, ios, cb)
-	  , m_io_context(ios)
-	  , m_ssl_context(ssl::context::tlsv12_client)
+	, m_io_context(ios)
+	, m_ssl_context(req.ssl_ctx)
 {
 	queue_request(req, std::move(cb));
 }
@@ -78,7 +80,8 @@ void websocket_tracker_connection::start()
 
 	auto const& settings = m_man.settings();
 	auto const& req = tracker_req();
-	m_websocket = std::make_shared<aux::websocket_stream>(m_io_context, m_man.host_resolver(), &m_ssl_context);
+	m_websocket =
+		std::make_shared<aux::websocket_stream>(m_io_context, m_man.host_resolver(), m_ssl_context);
 
 	// in anonymous mode we omit the user agent to mitigate fingerprinting of
 	// the client. Private torrents is an exception because some private


### PR DESCRIPTION
Controlled by the same setting to validate regular tracker certificates