### PR TITLE
Fix resume file save trigger on PEX/LSD change

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -987,13 +987,13 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (mask & torrent_flags::disable_lsd)
 		{
 			bool const new_value = !bool(flags & torrent_flags::disable_lsd);
-			if (m_enable_dht != new_value) set_need_save_resume(torrent_handle::if_config_changed);
+			if (m_enable_lsd != new_value) set_need_save_resume(torrent_handle::if_config_changed);
 			m_enable_lsd = new_value;
 		}
 		if (mask & torrent_flags::disable_pex)
 		{
 			bool const new_value = !bool(flags & torrent_flags::disable_pex);
-			if (m_enable_dht != new_value) set_need_save_resume(torrent_handle::if_config_changed);
+			if (m_enable_pex != new_value) set_need_save_resume(torrent_handle::if_config_changed);
 			m_enable_pex = new_value;
 		}
 	}


### PR DESCRIPTION
When setting PEX or LSD enable flags, the resume file would only be saved (when using the only_if_modified flag) if the new PEX/LSD enable value was different from the value of the _DHT_ flag value (instead of the expected PEX/LSD flag).

This commit ensures that the resume file is saved when PEX/LSD flags change to a value different than their own current value.

Attached python scripts highlights the issue and can be used to check that the fix actually works: [test-pex-lsd-resume.py](https://github.com/user-attachments/files/27454000/test-pex-lsd-resume.py)
Run with a torrent file in argument: `./test-pex-lsd-resume.py <.torrent file>` 