### PR TITLE
optimizations to avoid unnecessary calls to piece_size_for_req()

### DIFF
--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -653,3 +653,4 @@ oversized
 cfg
 httpseeds
 GnuTLS
+size2

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -929,6 +929,10 @@ namespace libtorrent::aux {
 		// as v2-only and requests v2-sized blocks, so pad-file regions are never
 		// downloaded or written to disk. The flag is locked in at construct_storage()
 		// time so a later setting change cannot cause a storage/engine mismatch.
+		// Note: this is not a trivial accessor. For v2-only torrents it performs
+		// an O(log n) std::upper_bound over the file list (in piece_size2()) to
+		// resolve the file boundary that may shorten the piece. Cache the result
+		// when calling it repeatedly for the same piece in a hot path.
 		int piece_size_for_req(piece_index_t p) const
 		{
 			if (m_disable_v1_hashes)
@@ -937,6 +941,11 @@ namespace libtorrent::aux {
 		}
 
 		peer_request to_req(piece_block const& p) const;
+		// overload that takes a precomputed piece size to avoid recomputing
+		// piece_size_for_req() in hot paths. piece_size MUST equal
+		// piece_size_for_req(p.piece_index); this is checked by an assert in
+		// debug builds.
+		peer_request to_req(piece_block const& p, int piece_size) const;
 
 		void disconnect_all(error_code const& ec, operation_t op);
 		int disconnect_peers(int num, error_code const& ec);

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -513,6 +513,11 @@ TORRENT_VERSION_NAMESPACE_4
 		// the main piece size. For v1 and hybrid torrents, piece sizes must be
 		// full (except for the last piece) in order to correctly compute the
 		// piece hash.
+		// Note: this is not a trivial accessor. For v2-only torrents it calls
+		// file_storage::piece_size2(), which performs an O(log n) upper_bound
+		// over the file list to find the file boundary that may shorten the
+		// piece. Cache the result when calling it repeatedly for the same
+		// piece in a hot path.
 		int piece_size_for_req(piece_index_t index) const
 		{
 			return v1()

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1247,11 +1247,11 @@ namespace {
 		TORRENT_ASSERT(t->valid_metadata());
 		torrent_info const& ti = t->torrent_file();
 
-		return p.piece >= piece_index_t(0)
-			&& p.piece < ti.end_piece()
-			&& p.start >= 0
-			&& p.start < t->piece_size_for_req(p.piece)
-			&& t->to_req(piece_block(p.piece, p.start / t->block_size())) == p;
+		if (p.piece < piece_index_t(0) || p.piece >= ti.end_piece() || p.start < 0) return false;
+
+		int const piece_sz = t->piece_size_for_req(p.piece);
+		return p.start < piece_sz
+			&& t->to_req(piece_block(p.piece, p.start / t->block_size()), piece_sz) == p;
 	}
 
 	void peer_connection::attach_to_torrent(info_hash_t const& ih)
@@ -1575,12 +1575,11 @@ namespace {
 		if (is_disconnecting()) return;
 
 		int const block_size = t->block_size();
-		if (r.piece < piece_index_t{}
-			|| r.piece >= t->torrent_file().layout().end_piece()
-			|| r.start < 0
-			|| r.start >= t->piece_size_for_req(r.piece)
-			|| (r.start % block_size) != 0
-			|| r.length != std::min(t->piece_size_for_req(r.piece) - r.start, block_size))
+		bool const piece_in_range =
+			r.piece >= piece_index_t{} && r.piece < t->torrent_file().layout().end_piece();
+		int const piece_sz = piece_in_range ? t->piece_size_for_req(r.piece) : 0;
+		if (!piece_in_range || r.start < 0 || r.start >= piece_sz || (r.start % block_size) != 0
+			|| r.length != std::min(piece_sz - r.start, block_size))
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, peer_log_alert::reject, "invalid reject message (%d, %d, %d)"
@@ -4047,11 +4046,12 @@ namespace {
 				continue;
 			}
 
-			peer_request r = t->to_req(block.block);
+			int piece_sz = t->piece_size_for_req(block.block.piece_index);
+			peer_request r = t->to_req(block.block, piece_sz);
 			if (m_download_queue.empty())
 				m_counters.inc_stats_counter(counters::num_peers_down_requests);
 
-			TORRENT_ASSERT(validate_piece_request(t->to_req(block.block)));
+			TORRENT_ASSERT(validate_piece_request(r));
 			block.send_buffer_offset = aux::numeric_cast<std::uint32_t>(m_send_buffer.size());
 			m_download_queue.push_back(block);
 			m_outstanding_bytes += r.length;
@@ -4073,9 +4073,13 @@ namespace {
 					if (static_cast<int>(front.block.piece_index) * blocks_per_piece + front.block.block_index
 						!= static_cast<int>(block.block.piece_index) * blocks_per_piece + block.block.block_index + 1)
 						break;
+					// the merge loop can cross into a new piece when the previous
+					// piece had all blocks contiguous; refresh piece_sz then
+					bool const new_piece = front.block.piece_index != block.block.piece_index;
 					block = m_request_queue.front();
 					m_request_queue.erase(m_request_queue.begin());
-					TORRENT_ASSERT(validate_piece_request(t->to_req(block.block)));
+					if (new_piece) piece_sz = t->piece_size_for_req(block.block.piece_index);
+					TORRENT_ASSERT(validate_piece_request(t->to_req(block.block, piece_sz)));
 
 					if (m_download_queue.empty())
 						m_counters.inc_stats_counter(counters::num_peers_down_requests);
@@ -4085,9 +4089,7 @@ namespace {
 					if (m_queued_time_critical) --m_queued_time_critical;
 
 					int const block_offset = block.block.block_index * t->block_size();
-					int const bs =
-						std::min(t->piece_size_for_req(block.block.piece_index)
-							- block_offset, t->block_size());
+					int const bs = std::min(piece_sz - block_offset, t->block_size());
 					TORRENT_ASSERT(bs > 0);
 					TORRENT_ASSERT(bs <= t->block_size());
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1571,9 +1571,18 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 	peer_request torrent::to_req(piece_block const& p) const
 	{
+		return to_req(p, piece_size_for_req(p.piece_index));
+	}
+
+	// piece_size must be the value of piece_size_for_req(p.piece_index). This
+	// overload exists so callers in hot paths can cache piece_size_for_req()
+	// across multiple to_req() calls for the same piece, since
+	// piece_size_for_req() is O(log files) for v2-only torrents.
+	peer_request torrent::to_req(piece_block const& p, int const piece_size) const
+	{
+		TORRENT_ASSERT(piece_size == piece_size_for_req(p.piece_index));
 		int const block_offset = p.block_index * block_size();
-		int const piece_sz = piece_size_for_req(p.piece_index);
-		int const block = std::min(piece_sz - block_offset, block_size());
+		int const block = std::min(piece_size - block_offset, block_size());
 		TORRENT_ASSERT(block > 0);
 		TORRENT_ASSERT(block <= block_size());
 

--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -327,12 +327,13 @@ void web_peer_connection::write_request(peer_request const& r)
 
 	piece_index_t cur_piece = r.piece;
 	int cur_start = r.start;
+	int cur_piece_size = t->piece_size_for_req(cur_piece);
 
 	while (size > 0)
 	{
 		pr.piece = cur_piece;
 		pr.start = cur_start;
-		pr.length = std::min(std::min(block_size, size), t->piece_size_for_req(pr.piece) - pr.start);
+		pr.length = std::min(std::min(block_size, size), cur_piece_size - pr.start);
 		TORRENT_ASSERT(validate_piece_request(pr));
 		m_requests.push_back(pr);
 
@@ -369,10 +370,11 @@ void web_peer_connection::write_request(peer_request const& r)
 #endif
 		size -= pr.length;
 		cur_start += pr.length;
-		if (cur_start >= t->piece_size_for_req(cur_piece))
+		if (cur_start >= cur_piece_size)
 		{
 			cur_start = 0;
 			++cur_piece;
+			if (size > 0) cur_piece_size = t->piece_size_for_req(cur_piece);
 		}
 	}
 


### PR DESCRIPTION
as that's a log N search for v2 torrents