### PR TITLE
clear_piece

### DIFF
--- a/.claude/rules/disk-cache.md
+++ b/.claude/rules/disk-cache.md
@@ -38,7 +38,7 @@ Flags are stored in `cached_piece_flags flags` (a `bitfield_flag<uint8_t>` bitfi
 
 In both hashing and flushing cases, the lock is **released** for the duration of the actual I/O (hashing or `pwrite()`), then re-acquired to update cursors/flags and potentially free buffers.
 
-**Deferred clear:** If `try_clear_piece()` is called while `flushing_flag` or `hashing_flag` is set, the clear job is stored in `cached_piece_entry::clear_piece` and executed by the owning thread once it clears its flag.
+**Deferred clear (`clearing_flag`):** `clear_piece` is *not* a storage fence. `try_clear_piece()` clears the piece's block state in place (aborting its pending write jobs) if the piece is idle. If `flushing_flag` or `hashing_flag` is set, it cannot reset the block state safely, so it stores the clear job in `disk_cache::m_pending_clears` (a map keyed by piece — kept out of `cached_piece_entry` since pending clears are rare), sets `clearing_flag`, and returns deferred. The deferred clear is run by whichever thread releases the *last* of `flushing_flag`/`hashing_flag` — `flush_piece_impl()`, `kick_hasher()`, and `hash_piece()` all call `run_deferred_clear_impl()`, which runs `clear_piece_impl()` and routes the aborted writes + clear job through `clear_piece_fun` only once neither flag remains set. While `clearing_flag` is set, `kick_pending_hashers()` will not start a new hash on the piece, so a pending clear can never race a freshly started hasher. The BitTorrent engine locks the piece in the picker (`lock_piece`/`write_failed`) before requesting the clear and only restores it in the completion handler, so no new writes arrive while a clear is pending.
 
 **Held-alive buffers and the flush/hasher race:**
 

--- a/include/libtorrent/aux_/disk_cache.hpp
+++ b/include/libtorrent/aux_/disk_cache.hpp
@@ -166,10 +166,6 @@ struct cached_piece_entry
 	// the last block, we should post this
 	disk_job* hash_job = nullptr;
 
-	// if the piece has been requested to be cleared, but it was locked
-	// (flushing) at the time. We hang this job here to complete it once the
-	// thread currently flushing is done with it
-	disk_job* clear_piece = nullptr;
 	// the exact v2 size of this piece (respecting file boundaries).
 	// Used for bytes_left computation in kick_hasher's v2 path.
 	int piece_size2;
@@ -239,6 +235,15 @@ struct cached_piece_entry
 	// thread holds hashing_flag. When kick_hasher() later clears
 	// hashing_flag it will see this flag and free+erase the piece itself.
 	static constexpr cached_piece_flags pending_free_flag = 8_bit;
+
+	// set by try_clear_piece() when a clear was requested while the piece was
+	// being flushed or hashed by another thread. The clear_piece job is stored
+	// in disk_cache::m_pending_clears (keyed by piece) -- not in every entry,
+	// since pending clears are rare -- and the deferred clear is run by whichever
+	// of flush_piece_impl()/kick_hasher()/hash_piece() releases the last of
+	// flushing_flag and hashing_flag. While set, kick_pending_hashers() will not
+	// start a new hash on the piece, so it cannot race with the pending clear.
+	static constexpr cached_piece_flags clearing_flag = 9_bit;
 
 	// flags are protected by the main disk cache mutex and may only be
 	// accessed while holding it
@@ -389,7 +394,10 @@ struct TORRENT_EXTRA_EXPORT disk_cache
 	// already been flushed to disk are freed. If all blocks are flushed, the
 	// piece entry is removed from the cache entirely.
 	template <typename Fun>
-	hash_piece_result hash_piece(piece_location const loc, disk_job* j, Fun f)
+	hash_piece_result hash_piece(piece_location const loc,
+		disk_job* j,
+		Fun f,
+		std::function<void(jobqueue_t, disk_job*)> const& clear_piece_fun)
 	{
 		std::unique_lock<std::mutex> l(m_mutex);
 
@@ -443,6 +451,16 @@ struct TORRENT_EXTRA_EXPORT disk_cache
 			});
 			TORRENT_ASSERT(m_num_unhashed >= num_unhashed);
 			m_num_unhashed -= num_unhashed;
+
+			// If a clear_piece was deferred on this piece while we were hashing,
+			// run it now (unless a flush thread still holds flushing_flag, which
+			// will run it instead). clear_piece_impl() resets all block state and
+			// aborts pending writes, so it supersedes the flushed-buffer cleanup
+			// and the erase below. Without this, a clear deferred behind the
+			// async_hash path would be lost (and the piece possibly erased,
+			// dropping the clear_piece job).
+			if (run_deferred_clear_impl(loc, clear_piece_fun)) return;
+
 			{
 				TORRENT_ASSERT(m_allocator);
 				bulk_free_buffer to_free(*m_allocator);
@@ -540,7 +558,12 @@ struct TORRENT_EXTRA_EXPORT disk_cache
 	// thread should be woken to flush those pieces to disk.
 	// Jobs hung on a piece that stops hashing early are extracted and placed in
 	// retry_jobs so the caller can re-submit them.
-	bool kick_pending_hashers(jobqueue_t& completed_jobs, jobqueue_t& retry_jobs);
+	// If a clear_piece was deferred on a piece while it was being hashed,
+	// clear_piece_fun is invoked with the aborted write jobs and the clear_piece
+	// job once hashing completes (see clearing_flag).
+	bool kick_pending_hashers(jobqueue_t& completed_jobs,
+		jobqueue_t& retry_jobs,
+		std::function<void(jobqueue_t, disk_job*)> clear_piece_fun);
 
 	// this should be called by a disk thread
 	// the callback should return the number of blocks it successfully flushed
@@ -568,19 +591,32 @@ struct TORRENT_EXTRA_EXPORT disk_cache
 #endif
 
 private:
-
 	// this should be called from a hasher thread, with m_mutex held.
 	// hashing_flag must already be set on the piece by the caller.
 	// Returns true if force_flush_flag was set on the piece.
 	// Jobs hung on a piece that stops hashing early are placed in retry_jobs.
-	bool kick_hasher(piece_container::nth_index<4>::type::iterator piece_iter
-		, std::unique_lock<std::mutex>& l, jobqueue_t& completed_jobs
-		, jobqueue_t& retry_jobs);
+	// If a clear was deferred on this piece (clearing_flag), it is run once
+	// hashing_flag is cleared and clear_piece_fun is invoked with the aborted
+	// write jobs and the clear_piece job.
+	bool kick_hasher(piece_container::nth_index<4>::type::iterator piece_iter,
+		std::unique_lock<std::mutex>& l,
+		jobqueue_t& completed_jobs,
+		jobqueue_t& retry_jobs,
+		std::function<void(jobqueue_t, disk_job*)> const& clear_piece_fun);
 
 	void free_piece(cached_piece_entry const& cpe);
 
 	// this requires the mutex to be locked
 	void clear_piece_impl(cached_piece_entry& cpe, jobqueue_t& aborted);
+
+	// Requires the mutex to be locked. If a clear_piece was deferred on loc
+	// (clearing_flag set, see try_clear_piece) and no thread still holds
+	// flushing_flag/hashing_flag, run clear_piece_impl, route the aborted write
+	// jobs and the clear_piece job through clear_piece_fun, and return true.
+	// Called from every site that releases the last flushing_flag/hashing_flag
+	// (flush_piece_impl, kick_hasher, hash_piece).
+	bool run_deferred_clear_impl(
+		piece_location loc, std::function<void(jobqueue_t, disk_job*)> const& clear_piece_fun);
 
 	template <typename Iter, typename View>
 	Iter flush_piece_impl(View& view,
@@ -593,6 +629,12 @@ private:
 	mutable std::mutex m_mutex;
 	std::condition_variable m_flushing_cv;
 	piece_container m_pieces;
+
+	// clear_piece jobs deferred because the piece was being flushed or hashed
+	// when the clear was requested (see clearing_flag). Stored here rather than
+	// in every cached_piece_entry because pending clears are rare. An entry
+	// exists iff the corresponding piece has clearing_flag set.
+	std::unordered_map<piece_location, disk_job*, boost::hash<piece_location>> m_pending_clears;
 
 	// allocator used for all disk buffers in this cache. Set lazily on the
 	// first insert() call. All blocks share the same allocator.

--- a/src/disk_cache.cpp
+++ b/src/disk_cache.cpp
@@ -203,26 +203,22 @@ bool disk_cache::try_clear_piece(piece_location const loc, disk_job* j, jobqueue
 	auto& view = m_pieces.template get<0>();
 	auto i = view.find(loc);
 	if (i == view.end()) return true;
-	if (i->flags & cached_piece_entry::flushing_flag)
+
+	// If another thread is currently flushing this piece to disk or hashing
+	// it, we cannot reset the block state yet. Hang the clear_piece job on the
+	// piece and set clearing_flag. Whichever thread releases the last of
+	// flushing_flag / hashing_flag will run clear_piece_impl and post j (see
+	// flush_piece_impl() and kick_hasher()). clearing_flag also stops
+	// kick_pending_hashers() from starting a fresh hash on the piece, so a
+	// pending clear can never race a newly-started hasher.
+	if (i->flags & (cached_piece_entry::flushing_flag | cached_piece_entry::hashing_flag))
 	{
-		// postpone the clearing until we're done flushing
-		view.modify(i, [&](cached_piece_entry& e) { e.clear_piece = j; });
+		view.modify(i, [](cached_piece_entry& e) { e.flags |= cached_piece_entry::clearing_flag; });
+		m_pending_clears[loc] = j;
 		return false;
 	}
 
-	// we clear a piece after it fails the hash check. It doesn't make sense
-	// to be hashing still
-	TORRENT_ASSERT(!(i->flags & cached_piece_entry::hashing_flag));
-	if (i->flags & cached_piece_entry::hashing_flag)
-	{
-		// postpone the clearing until we're done hashing
-		view.modify(i, [&](cached_piece_entry& e) { e.clear_piece = j; });
-		return false;
-	}
-
-	view.modify(i, [&](cached_piece_entry& e) {
-		clear_piece_impl(e, aborted);
-	});
+	view.modify(i, [&](cached_piece_entry& e) { clear_piece_impl(e, aborted); });
 	return true;
 }
 
@@ -382,9 +378,11 @@ disk_cache::hash_result disk_cache::try_hash_piece(piece_location const loc, dis
 // NOTE: if pending_free_flag is set, this function will erase the piece from
 // the cache before returning, invalidating piece_iter. Callers must not
 // dereference it after this call returns.
-bool disk_cache::kick_hasher(piece_container::nth_index<4>::type::iterator piece_iter
-	, std::unique_lock<std::mutex>& l, jobqueue_t& completed_jobs
-	, jobqueue_t& retry_jobs)
+bool disk_cache::kick_hasher(piece_container::nth_index<4>::type::iterator piece_iter,
+	std::unique_lock<std::mutex>& l,
+	jobqueue_t& completed_jobs,
+	jobqueue_t& retry_jobs,
+	std::function<void(jobqueue_t, disk_job*)> const& clear_piece_fun)
 {
 	INVARIANT_CHECK;
 	TORRENT_ASSERT(l.owns_lock());
@@ -510,6 +508,8 @@ keep_going:
 		});
 		if (rj) retry_jobs.push_back(rj);
 
+		run_deferred_clear_impl(piece_iter->piece, clear_piece_fun);
+
 		if (piece_iter->flags & cached_piece_entry::pending_free_flag)
 		{
 			free_piece(*piece_iter);
@@ -529,6 +529,8 @@ keep_going:
 			e.flags &= ~cached_piece_entry::hashing_flag;
 			e.flags |= cached_piece_entry::force_flush_flag;
 		});
+
+		run_deferred_clear_impl(piece_iter->piece, clear_piece_fun);
 
 		if (piece_iter->flags & cached_piece_entry::pending_free_flag)
 		{
@@ -576,6 +578,8 @@ keep_going:
 		, static_cast<int>(piece_iter->piece.piece));
 	completed_jobs.push_back(j);
 
+	run_deferred_clear_impl(piece_iter->piece, clear_piece_fun);
+
 	if (piece_iter->flags & cached_piece_entry::pending_free_flag)
 	{
 		free_piece(*piece_iter);
@@ -588,7 +592,9 @@ keep_going:
 
 // returns true if any piece finished hashing, and is ready to be flushed to
 // disk. Any such piece will also have had the force_flush_flag set.
-bool disk_cache::kick_pending_hashers(jobqueue_t& completed_jobs, jobqueue_t& retry_jobs)
+bool disk_cache::kick_pending_hashers(jobqueue_t& completed_jobs,
+	jobqueue_t& retry_jobs,
+	std::function<void(jobqueue_t, disk_job*)> clear_piece_fun)
 {
 	bool needs_flush = false;
 	std::unique_lock<std::mutex> l(m_mutex);
@@ -600,8 +606,12 @@ bool disk_cache::kick_pending_hashers(jobqueue_t& completed_jobs, jobqueue_t& re
 			break;
 
 		// Skip pieces already being hashed or fully hashed; just clear the flag.
+		// Also skip pieces with a pending clear: starting a hash on them would
+		// race the deferred clear_piece (which would then have to wait for this
+		// hash to finish anyway). The clear runs without us hashing.
 		if ((it->flags & cached_piece_entry::hashing_flag)
-			|| (it->flags & cached_piece_entry::piece_hash_returned_flag))
+			|| (it->flags & cached_piece_entry::piece_hash_returned_flag)
+			|| (it->flags & cached_piece_entry::clearing_flag))
 		{
 			view.modify(it, [](cached_piece_entry& e)
 				{ e.flags &= ~cached_piece_entry::needs_hasher_kick_flag; });
@@ -615,7 +625,7 @@ bool disk_cache::kick_pending_hashers(jobqueue_t& completed_jobs, jobqueue_t& re
 				| cached_piece_entry::hashing_flag;
 		});
 
-		needs_flush |= kick_hasher(it, l, completed_jobs, retry_jobs);
+		needs_flush |= kick_hasher(it, l, completed_jobs, retry_jobs, clear_piece_fun);
 	}
 	return needs_flush;
 }
@@ -747,22 +757,22 @@ Iter disk_cache::flush_piece_impl(View& view,
 	DLOG("flush_piece_impl: piece: %d flushed_cursor: %d force_flush: %d\n"
 		, static_cast<int>(piece_iter->piece.piece), piece_iter->flushed_cursor, bool(piece_iter->flags & cached_piece_entry::force_flush_flag));
 	TORRENT_ASSERT(count <= blocks.size());
-	if (piece_iter->clear_piece)
-	{
-		jobqueue_t aborted;
-		disk_job* clear_piece = nullptr;
-		view.modify(piece_iter, [&](cached_piece_entry& e) {
-			clear_piece_impl(e, aborted);
-			clear_piece = std::exchange(e.clear_piece, nullptr);
-		});
-		clear_piece_fun(std::move(aborted), clear_piece);
-	}
+	// If a clear_piece was deferred on this piece, run it now that this flush is
+	// done (flushing_flag was cleared above). If a hasher thread still holds
+	// hashing_flag, run_deferred_clear_impl leaves it for kick_hasher()/
+	// hash_piece() to run when hashing finishes.
+	run_deferred_clear_impl(piece_iter->piece, clear_piece_fun);
 
 	return next_iter;
 }
 
 void disk_cache::free_piece(cached_piece_entry const& cpe)
 {
+	// normally a deferred clear is run (and its map entry removed) before the
+	// piece is freed; this drops any entry left over from a teardown race,
+	// mirroring how the old per-entry clear_piece pointer vanished with the
+	// entry. Cheap: m_pending_clears is empty unless a clear is in flight.
+	if (!m_pending_clears.empty()) m_pending_clears.erase(cpe.piece);
 #if TORRENT_USE_ASSERTS
 	if (cpe.flags & cached_piece_entry::piece_hash_returned_flag)
 	{
@@ -842,8 +852,7 @@ void disk_cache::flush_to_disk(std::function<int(bitfield&, span<disk_job* const
 		}
 		span<cached_block_entry> blocks = piece_iter->get_blocks();
 
-		auto const next_iter = flush_piece_impl(view, piece_iter, f, l
-			, blocks, clear_piece_fun);
+		auto const next_iter = flush_piece_impl(view, piece_iter, f, l, blocks, clear_piece_fun);
 
 		if (piece_iter->flushed_cursor == piece_iter->blocks_in_piece()
 			&& bool(piece_iter->flags & cached_piece_entry::piece_hash_returned_flag)
@@ -887,8 +896,7 @@ void disk_cache::flush_to_disk(std::function<int(bitfield&, span<disk_job* const
 			piece_iter->flushed_cursor
 			, num_eligible_blocks);
 
-		piece_iter = flush_piece_impl(view2, piece_iter, f, l
-			, blocks, clear_piece_fun);
+		piece_iter = flush_piece_impl(view2, piece_iter, f, l, blocks, clear_piece_fun);
 	}
 
 	// before doing any more disk I/O, drop buffers that were kept alive
@@ -1068,6 +1076,7 @@ void disk_cache::check_invariant() const
 	int flushed_blocks = 0;
 	int flushing_blocks = 0;
 	int unhashed_blocks = 0;
+	int clearing_pieces = 0;
 
 	auto& view = m_pieces.template get<2>();
 	for (auto const& piece_entry : view)
@@ -1087,6 +1096,14 @@ void disk_cache::check_invariant() const
 		// It must never outlive the hashing window.
 		if (piece_entry.flags & cached_piece_entry::pending_free_flag)
 			TORRENT_ASSERT(piece_entry.flags & cached_piece_entry::hashing_flag);
+
+		// clearing_flag and m_pending_clears must agree: a piece carries the
+		// flag iff its deferred clear_piece job is stored in the map.
+		if (piece_entry.flags & cached_piece_entry::clearing_flag)
+		{
+			TORRENT_ASSERT(m_pending_clears.find(piece_entry.piece) != m_pending_clears.end());
+			++clearing_pieces;
+		}
 
 		int idx = 0;
 		for (auto& be : blocks)
@@ -1133,8 +1150,41 @@ void disk_cache::check_invariant() const
 	TORRENT_ASSERT(dirty_blocks + flushed_blocks == m_blocks);
 	TORRENT_ASSERT(flushing_blocks >= m_flushing_blocks);
 	TORRENT_ASSERT(unhashed_blocks == m_num_unhashed);
+	// every map entry corresponds to a piece carrying clearing_flag
+	TORRENT_ASSERT(std::size_t(clearing_pieces) == m_pending_clears.size());
 }
 #endif
+
+// this requires the mutex to be locked
+bool disk_cache::run_deferred_clear_impl(
+	piece_location const loc, std::function<void(jobqueue_t, disk_job*)> const& clear_piece_fun)
+{
+	auto& view = m_pieces.template get<0>();
+	auto i = view.find(loc);
+	if (i == view.end()) return false;
+	if (!(i->flags & cached_piece_entry::clearing_flag)) return false;
+	// another thread is still flushing or hashing this piece; whichever
+	// releases the last of those flags will run the clear.
+	if (i->flags & (cached_piece_entry::flushing_flag | cached_piece_entry::hashing_flag))
+		return false;
+
+	// clearing_flag is set, so the deferred clear job must be in the map.
+	auto const mit = m_pending_clears.find(loc);
+	TORRENT_ASSERT(mit != m_pending_clears.end());
+	disk_job* const clear_job = mit->second;
+
+	jobqueue_t aborted;
+	view.modify(i, [&](cached_piece_entry& e) {
+		clear_piece_impl(e, aborted);
+		e.flags &= ~cached_piece_entry::clearing_flag;
+	});
+	// erase the map entry only after the modify: clear_piece_impl runs an
+	// invariant check that requires clearing_flag and the map to agree, so the
+	// entry must stay until clearing_flag is cleared above.
+	m_pending_clears.erase(loc);
+	clear_piece_fun(std::move(aborted), clear_job);
+	return true;
+}
 
 // this requires the mutex to be locked
 void disk_cache::clear_piece_impl(cached_piece_entry& cpe, jobqueue_t& aborted)

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -3477,14 +3477,16 @@ get_out:
 		TORRENT_ASSERT(&info >= &m_block_info[0]);
 		TORRENT_ASSERT(&info < &m_block_info[0] + m_block_info.size());
 		TORRENT_ASSERT(info.piece_index == block.piece_index);
+
+		// reaching this with the block in any other state means a disk-job
+		// completion got out-of-order with a picker state transition (a
+		// programmer error). In release builds, bail out instead of
+		// double-accounting i->writing.
 		TORRENT_ASSERT(info.state == block_info::state_writing);
 		TORRENT_ASSERT(info.num_peers == 0);
-
 		TORRENT_ASSERT(i->writing > 0);
-		TORRENT_ASSERT(info.state == block_info::state_writing);
-
-		if (info.state == block_info::state_finished) return;
-		if (info.state == block_info::state_writing) --i->writing;
+		if (info.state != block_info::state_writing) return;
+		--i->writing;
 
 		info.peer = nullptr;
 		info.state = block_info::state_none;

--- a/src/pread_disk_io.cpp
+++ b/src/pread_disk_io.cpp
@@ -632,9 +632,10 @@ bool pread_disk_io::async_write(storage_index_t const storage, peer_request cons
 		std::uint16_t(r.length)
 	);
 
-	DLOG("async_write: piece: %d offset: %d flags: %x\n"
-		, int(r.piece), int(r.start)
-		, static_cast<std::uint8_t>(flags));
+	DLOG("async_write: piece: %d offset: %d flags: %x\n",
+		int(r.piece),
+		int(r.start),
+		static_cast<std::uint8_t>(flags));
 	bool const force_flush = bool(flags & flush_piece);
 	file_storage const& fs = j->storage->files();
 	// in order to compute v1 hashes, we need the full piece, including pad
@@ -642,18 +643,15 @@ bool pread_disk_io::async_write(storage_index_t const storage, peer_request cons
 	int const piece_size = j->storage->v1() ? fs.piece_size(r.piece) : fs.piece_size2(r.piece);
 	TORRENT_ASSERT(r.length == std::min(piece_size - r.start, default_block_size));
 	aux::disk_cache::piece_entry_params const piece_params{
-		fs.piece_size2(r.piece)
-		, piece_size
-		, j->storage->v1()
-		, j->storage->v2()
-	};
-	auto const result = m_cache.insert(
-		{j->storage->storage_index(), r.piece}
-		, r.start / default_block_size
-		, force_flush, std::move(o), j, piece_params);
+		fs.piece_size2(r.piece), piece_size, j->storage->v1(), j->storage->v2()};
+	auto const result = m_cache.insert({j->storage->storage_index(), r.piece},
+		r.start / default_block_size,
+		force_flush,
+		std::move(o),
+		j,
+		piece_params);
 
-	if (result & aux::disk_cache::need_hasher_kick)
-		m_hash_threads.interrupt();
+	if (result & aux::disk_cache::need_hasher_kick) m_hash_threads.interrupt();
 
 	std::unique_lock<std::mutex> l(m_job_mutex);
 	if (!m_flush_target)
@@ -881,8 +879,8 @@ void pread_disk_io::async_clear_piece(storage_index_t const storage
 	// clear piece must wait for all write jobs issued to the piece finish
 	// before it completes.
 	jobqueue_t aborted_jobs;
-	bool const immediate_completion = m_cache.try_clear_piece(
-		{j->storage->storage_index(), index}, j, aborted_jobs);
+	bool const immediate_completion =
+		m_cache.try_clear_piece({j->storage->storage_index(), index}, j, aborted_jobs);
 
 	m_completed_jobs.abort_jobs(m_ios, std::move(aborted_jobs));
 	if (immediate_completion)
@@ -1016,8 +1014,12 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 		}
 	};
 
-	auto const hpr = m_cache.hash_piece({ j->storage->storage_index(), a.piece}
-		, j, hash_partial_piece);
+	auto const hpr = m_cache.hash_piece({j->storage->storage_index(), a.piece},
+		j,
+		hash_partial_piece,
+		[&](jobqueue_t aborted, aux::disk_job* clear) {
+			clear_piece_jobs(std::move(aborted), static_cast<aux::pread_disk_job*>(clear));
+		});
 
 	if (hpr == aux::disk_cache::hash_piece_result::deferred)
 		return disk_status::job_deferred;
@@ -1528,7 +1530,13 @@ void pread_disk_io::thread_fun(aux::disk_io_thread_pool& pool
 			l.unlock();
 			jobqueue_t completed;
 			jobqueue_t retry;
-			bool const needs_flush = m_cache.kick_pending_hashers(completed, retry);
+			// if a clear_piece was deferred on a piece while it was being hashed,
+			// kick_pending_hashers runs it once hashing finishes and routes the
+			// aborted write jobs + clear_piece job through clear_piece_jobs.
+			bool const needs_flush = m_cache.kick_pending_hashers(
+				completed, retry, [&](jobqueue_t aborted, aux::disk_job* clear) {
+					clear_piece_jobs(std::move(aborted), static_cast<aux::pread_disk_job*>(clear));
+				});
 			add_completed_jobs(std::move(completed));
 
 			l.lock();

--- a/test/disk_cache_test_utils.hpp
+++ b/test/disk_cache_test_utils.hpp
@@ -171,7 +171,7 @@ struct cache_fixture
 	void kick_hashers()
 	{
 		lt::jobqueue_t completed, retry;
-		cache.kick_pending_hashers(completed, retry);
+		cache.kick_pending_hashers(completed, retry, [](lt::jobqueue_t, lt::aux::disk_job*) {});
 	}
 
 	// Simulate flush_storage(): marks every block with a write_job as flushed.

--- a/test/test_disk_cache.cpp
+++ b/test/test_disk_cache.cpp
@@ -191,7 +191,7 @@ void test_disk_bottleneck(test_mode_t const mode)
 	TEST_EQUAL(int(f.cache.size()), 2);
 
 	jobqueue_t completed, retry;
-	TEST_CHECK(f.cache.kick_pending_hashers(completed, retry));
+	TEST_CHECK(f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {}));
 	TEST_CHECK(completed.empty());
 
 	std::vector<sha256_hash> block_hashes(mode & test_mode::v2 ? 2 : 0);
@@ -250,7 +250,7 @@ void test_multi_piece(test_mode_t const mode)
 	TEST_EQUAL(int(f.cache.size()), 3);
 
 	jobqueue_t completed, retry;
-	f.cache.kick_pending_hashers(completed, retry);
+	f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {});
 
 	for (auto p : {0_piece, 1_piece, 2_piece})
 	{
@@ -323,7 +323,7 @@ TORRENT_TEST(v2_hash2_from_cache)
 
 	// Let the hasher compute SHA256 for block 0.
 	jobqueue_t completed, retry;
-	f.cache.kick_pending_hashers(completed, retry);
+	f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {});
 
 	bool fallback_called = false;
 	sha256_hash h = f.cache.hash2(f.loc(0_piece), 0, [&]() -> sha256_hash {
@@ -376,7 +376,7 @@ TORRENT_TEST(hash_failure_clear)
 	f.insert(0_piece, 1);
 
 	jobqueue_t completed, retry;
-	f.cache.kick_pending_hashers(completed, retry);
+	f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {});
 
 	auto hash_job = std::make_unique<pread_disk_job>();
 	hash_job->action = job::hash{{}, 0_piece, span<sha256_hash>{}, sha1_hash{}};
@@ -401,7 +401,7 @@ TORRENT_TEST(clear_piece_partially_flushed)
 	f.insert(0_piece, 0);
 	{
 		jobqueue_t completed, retry;
-		f.cache.kick_pending_hashers(completed, retry);
+		f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {});
 	}
 
 	// Flush block 0 (cheap: already hashed).
@@ -686,7 +686,7 @@ void test_piece_size2_smaller_than_piece_size(test_mode_t const mode)
 	}
 
 	jobqueue_t completed, retry;
-	f.cache.kick_pending_hashers(completed, retry);
+	f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {});
 
 	int const v2_blocks = (piece_size2 + default_block_size - 1) / default_block_size;
 	std::vector<sha256_hash> block_hashes(need_v2 ? v2_blocks : 0);

--- a/test/test_slow_hash.cpp
+++ b/test/test_slow_hash.cpp
@@ -189,9 +189,8 @@ void test_hash_job_dispatched_by_hasher(test_mode_t const mode)
 	// With slow hashing each block takes ~1.6 s. Run the hasher in a thread
 	// and call try_hash_piece after a short sleep, reliably catching the
 	// window where hashing_flag is set.
-	std::thread t([&]() {
-		f.cache.kick_pending_hashers(completed, retry);
-	});
+	std::thread t(
+		[&]() { f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {}); });
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	auto const result = f.cache.try_hash_piece(f.loc(0_piece), hash_job.get());
@@ -233,9 +232,8 @@ void test_hash_job_retry_when_piece_incomplete(test_mode_t const mode)
 
 	// Slow hashing gives us a wide window. Run the hasher in a thread, park
 	// the hash job while hashing_flag is set, then let the hasher finish.
-	std::thread t([&]() {
-		f.cache.kick_pending_hashers(completed, retry);
-	});
+	std::thread t(
+		[&]() { f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {}); });
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	// hashing_flag is set; block 1 is absent so the hasher will stall at
@@ -291,7 +289,8 @@ void test_drop_held_alive_buffers(test_mode_t const mode)
 
 	jobqueue_t completed, retry;
 
-	std::thread hasher_thread([&]() { f.cache.kick_pending_hashers(completed, retry); });
+	std::thread hasher_thread(
+		[&]() { f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {}); });
 	// Wait until kick_hasher has released the mutex inside its slow hash
 	// update. The 50ms is comfortably inside the ~1.6s slow-hash window.
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -340,9 +339,8 @@ void test_flush_storage_during_hashing(test_mode_t const mode)
 
 	// With slow hashing each block takes ~1.6 s. Run the hasher in a
 	// background thread so flush_storage() races with it.
-	std::thread hasher_thread([&]() {
-		f.cache.kick_pending_hashers(completed, retry);
-	});
+	std::thread hasher_thread(
+		[&]() { f.cache.kick_pending_hashers(completed, retry, [](jobqueue_t, disk_job*) {}); });
 
 	// Give the hasher time to set hashing_flag and release the mutex.
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -362,6 +360,65 @@ void test_flush_storage_during_hashing(test_mode_t const mode)
 	TEST_EQUAL(f.alloc.live, 0);
 }
 
+// Regression test for the clearing_flag mechanism.
+//
+// A clear_piece is requested (try_clear_piece) while a hasher thread holds
+// hashing_flag (mutex released mid-hash). The clear must be deferred -- the
+// clear_piece job is hung on the piece and clearing_flag is set -- and then
+// run by kick_hasher() once hashing completes, routing the aborted write jobs
+// and the clear_piece job through clear_piece_fun. Without the interlock the
+// clear would either race the hasher (tripping clear_piece_impl's
+// !hashing_flag assert) or be lost entirely (the old code asserted hashing was
+// not in progress).
+void test_clear_piece_during_hashing(test_mode_t const mode)
+{
+	// 2-block piece so the hasher spends real time hashing.
+	cache_fixture f(2, mode);
+	f.insert(0_piece, 0);
+	f.insert(0_piece, 1);
+
+	jobqueue_t completed, retry;
+
+	// Recorded by clear_piece_fun when the deferred clear runs (hasher thread).
+	// Read on the main thread only after join(), so no synchronization needed.
+	int clear_calls = 0;
+	int aborted_count = 0;
+	lt::aux::disk_job* routed_clear = nullptr;
+
+	// A clear_piece job to hang on the piece. The cache only stores and returns
+	// the pointer; it never inspects the action.
+	auto clear_job = std::make_unique<pread_disk_job>();
+
+	std::thread hasher_thread([&]() {
+		f.cache.kick_pending_hashers(completed, retry, [&](jobqueue_t aborted, disk_job* clear) {
+			++clear_calls;
+			aborted_count = int(aborted.size());
+			routed_clear = clear;
+		});
+	});
+
+	// Give the hasher time to set hashing_flag and release the mutex.
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Request the clear while hashing_flag is set: try_clear_piece must defer
+	// (return false) and abort nothing yet.
+	jobqueue_t aborted_now;
+	bool const immediate = f.cache.try_clear_piece(f.loc(0_piece), clear_job.get(), aborted_now);
+	TEST_CHECK(!immediate);
+	TEST_CHECK(aborted_now.empty());
+
+	hasher_thread.join();
+
+	// kick_hasher() finished hashing, saw clearing_flag, ran the deferred clear
+	// and routed the aborted write jobs + the clear_piece job exactly once.
+	TEST_EQUAL(clear_calls, 1);
+	TEST_CHECK(routed_clear == clear_job.get());
+	TEST_EQUAL(aborted_count, 2); // both blocks' write jobs were aborted
+	// the piece's blocks are gone from the cache's accounting; the two block
+	// buffers are now owned by the aborted write jobs (freed when the caller
+	// completes them, as clear_piece_jobs() does in production).
+	TEST_EQUAL(int(f.cache.size()), 0);
+}
 }
 
 TORRENT_TEST(test_pread_hash_job_retry)
@@ -395,6 +452,13 @@ TORRENT_TEST(flush_storage_during_hashing_v2)
 	{ test_flush_storage_during_hashing(test_mode::v2); }
 TORRENT_TEST(flush_storage_during_hashing_hybrid)
 	{ test_flush_storage_during_hashing(test_mode::v1 | test_mode::v2); }
+
+	TORRENT_TEST(clear_piece_during_hashing_v1) { test_clear_piece_during_hashing(test_mode::v1); }
+	TORRENT_TEST(clear_piece_during_hashing_v2) { test_clear_piece_during_hashing(test_mode::v2); }
+	TORRENT_TEST(clear_piece_during_hashing_hybrid)
+	{
+		test_clear_piece_during_hashing(test_mode::v1 | test_mode::v2);
+	}
 
 	TORRENT_TEST(drop_held_alive_v1) { test_drop_held_alive_buffers(test_mode::v1); }
 	TORRENT_TEST(drop_held_alive_v2) { test_drop_held_alive_buffers(test_mode::v2); }


### PR DESCRIPTION
`async_clear_piece()` is currently not a proper fence job, and may not correctly synchronize with outstanding write and hash jobs.

this PR is work-in-progress