### PR TITLE
add another phase to flushing blocks from the disk cache

### DIFF
--- a/.claude/rules/disk-cache.md
+++ b/.claude/rules/disk-cache.md
@@ -13,7 +13,10 @@ The disk cache (`src/disk_cache.cpp`, `include/libtorrent/aux_/disk_cache.hpp`) 
 
 - `disk_cache` — the cache itself; holds a `boost::multi_index_container` of `cached_piece_entry` objects, protected by a single `std::mutex`. The container has five indices: by `piece_location` (ordered), by `cheap_to_flush()` (ordered descending), by `need_force_flush()` (ordered descending), by `piece_location` (hashed, for fast lookup), and by `needs_hasher_kick()` (ordered descending).
 - `cached_piece_entry` — one entry per in-flight piece. Contains an array of `cached_block_entry` (one per block), an optional `piece_hasher` (`ph`, v1 only), an optional `block_hashes` array (`sha256_hash[]`, v2 only), and the cursors/flags described below.
-- `cached_block_entry` — holds either a pending `write_job` (the buffer is owned by the job) or a `buf_holder` (buffer kept alive after the write job has executed but before hashing is done). Once both flushed and hashed, the buffer is freed.
+- `cached_block_entry::write_state` — `std::variant` with three mutually exclusive states:
+  - `std::monostate` — no data present (the block has never been written, or its data has been fully released).
+  - `disk_job*` — a pending write job is queued. The buffer is owned by the job; `take_write_job()` consumes the job during flushing.
+  - `disk_buffer_ref` — the write has been flushed. The buffer may be non-null (`has_buf()`, "held alive" for future hashing) or null (already released). `is_flushed()` is true in either case and contributes to `flushed_cursor`.
 
 **Cursors:**
 
@@ -37,8 +40,19 @@ In both hashing and flushing cases, the lock is **released** for the duration of
 
 **Deferred clear:** If `try_clear_piece()` is called while `flushing_flag` or `hashing_flag` is set, the clear job is stored in `cached_piece_entry::clear_piece` and executed by the owning thread once it clears its flag.
 
-**Flush strategy (`flush_to_disk`):**
+**Held-alive buffers and the flush/hasher race:**
 
-1. Force-flush pass — flush pieces with `force_flush` set (piece fully downloaded and hashed); ordered by `need_force_flush()`.
-2. Cheap flush pass — flush blocks in the range `[flushed_cursor, hasher_cursor)` (already hashed, no future read-back needed); pieces ordered by `cheap_to_flush()` descending.
-3. Expensive flush pass — flush any dirty blocks even if they haven't been hashed yet, requiring a read-back later to complete the piece hash. Used only when the cache exceeds the high-water mark.
+When `flush_piece_impl` flushes a block, it checks `needed_by_hasher = (hashing_flag && block_index >= hasher_cursor)`. If a hasher is mid-snapshot (the `kick_hasher` window between snapshot and re-lock), the pointer to the buffer is in `blocks_storage[]` and must stay live. In that case the block transitions to `disk_buffer_ref{buf}` (non-null), and `m_blocks` is *not* decremented. Otherwise the buffer is freed immediately and `m_blocks` is decremented.
+
+`m_blocks` therefore counts both pending writes and held-alive buffers — both forms of memory pressure. `back_pressure` and `flush_request()` are driven off `m_blocks`.
+
+The held-alive buffer is reclaimed when `kick_hasher` next advances the cursor past it (its cleanup loop frees blocks in `[old_cursor, new_cursor)` via `take_buf`). However, if v1 SHA-1 is blocked by a missing earlier block, the cursor cannot advance and the buffer stays held until either the missing block arrives or the piece is cleared. The "drop held-alive" flush pass (below) handles the case where no further inserts will arrive — without it, back-pressure can pin the cache above the low watermark indefinitely (the back-pressure observer is only notified once `m_blocks` drops to the low watermark, so the producer that tripped back-pressure would never be woken up). Note that v2 hashes for held-alive blocks are typically already in `block_hashes[]` (computed by the kick that triggered the keep-alive), so freeing the buffer only loses the v1 read-back optimization, not v2 hash work.
+
+**Flush strategy (`flush_to_disk`), in order:**
+
+1. Force-flush pass (`view`) — flush pieces with `force_flush` set (piece fully downloaded and hashed); ordered by `need_force_flush()`.
+2. Cheap flush pass (`view2`) — flush blocks in the range `[flushed_cursor, hasher_cursor)` (already hashed, no future read-back needed); pieces ordered by `cheap_to_flush()` descending.
+3. Drop held-alive pass (`view3`) — for each piece without `flushing_flag` or `hashing_flag`, free all blocks where `has_buf()` (held-alive `disk_buffer_ref{buf}`). No I/O — the data is already on disk. Done before the expensive pass because it's free; only skipped if the target is already met. Loses the v1 read-back optimization for these blocks; a subsequent `async_hash` will read them from disk.
+4. Expensive flush pass (`view4`) — flush any dirty blocks even if they haven't been hashed yet, requiring a read-back later to complete the piece hash. Used only when the cache exceeds the high-water mark.
+
+Passes 2-4 run only when `optimistic=false`. The optimistic flush at the top of each disk thread's loop runs only pass 1.

--- a/src/disk_cache.cpp
+++ b/src/disk_cache.cpp
@@ -879,10 +879,53 @@ void disk_cache::flush_to_disk(
 			, blocks, clear_piece_fun);
 	}
 
-	// we may still need to flush blocks at this point, even though we
-	// would require read-back later to compute the piece hash
+	// before doing any more disk I/O, drop buffers that were kept alive
+	// for a hasher snapshot that has since released (the needed_by_hasher
+	// branch in flush_piece_impl). The data is already on disk, so freeing
+	// these buffers requires no I/O. Without this pass, when kick_hasher
+	// returns without advancing the cursor (e.g. v1 SHA-1 is blocked on a
+	// missing earlier block) the held-alive buffers stay in
+	// disk_buffer_ref{buf} state contributing to m_blocks. With nothing
+	// inserting more writes (back-pressure observers waiting for
+	// on_disk()) the cache can never drop below the low watermark and
+	// the back-pressure observer is never notified.
 	auto& view3 = m_pieces.template get<0>();
 	for (auto piece_iter = view3.begin(); piece_iter != view3.end();)
+	{
+		if (m_blocks - m_flushing_blocks <= target_blocks) return;
+
+		// skip pieces a hasher or another flush is currently using
+		if (piece_iter->flags
+			& (cached_piece_entry::flushing_flag | cached_piece_entry::hashing_flag))
+		{
+			++piece_iter;
+			continue;
+		}
+
+		TORRENT_ASSERT(m_allocator);
+		bulk_free_buffer to_free(*m_allocator);
+		int const hasher_cursor = piece_iter->hasher_cursor;
+		span<cached_block_entry> const blocks = piece_iter->get_blocks();
+		for (int i = 0; i < int(blocks.size()); ++i)
+		{
+			auto& blk = blocks[i];
+			if (!blk.has_buf()) continue;
+			to_free.add(blk.take_buf());
+			TORRENT_ASSERT(m_blocks > 0);
+			--m_blocks;
+			if (i >= hasher_cursor)
+			{
+				TORRENT_ASSERT(m_num_unhashed > 0);
+				--m_num_unhashed;
+			}
+		}
+		++piece_iter;
+	}
+
+	// we may still need to flush blocks at this point, even though we
+	// would require read-back later to compute the piece hash
+	auto& view4 = m_pieces.template get<0>();
+	for (auto piece_iter = view4.begin(); piece_iter != view4.end();)
 	{
 		// We avoid flushing if other threads have already initiated sufficient
 		// amount of flushing
@@ -905,8 +948,7 @@ void disk_cache::flush_to_disk(
 
 		span<cached_block_entry> const blocks = piece_iter->get_blocks();
 
-		piece_iter = flush_piece_impl(view3, piece_iter, f, l
-			, blocks, clear_piece_fun);
+		piece_iter = flush_piece_impl(view4, piece_iter, f, l, blocks, clear_piece_fun);
 	}
 }
 

--- a/test/test_slow_hash.cpp
+++ b/test/test_slow_hash.cpp
@@ -259,6 +259,68 @@ void test_hash_job_retry_when_piece_incomplete(test_mode_t const mode)
 	TEST_EQUAL(int(f.cache.size()), 0);
 }
 
+// Exercises phase 3 of flush_to_disk - the "drop held-alive" pass.
+//
+// After a block is written to disk we usually keep its buffer in the cache so
+// the piece hash can be computed in-memory rather than read back from disk.
+// kick_hasher naturally releases these buffers as it hashes past them, but if
+// the hasher cursor can't advance (e.g. v1 SHA-1 is blocked on a missing
+// earlier block), they sit pinned in the cache. Phase 3 evicts them anyway
+// when the cache is full and we need the room - sacrificing the read-back
+// optimization is cheaper than letting back-pressure stall the producer.
+//
+// Setup: a 3-block piece with blocks 0 and 2 inserted (block 1 missing).
+// The hasher thread runs kick_pending_hashers; under slow-hash it spends
+// ~1.6s in each hash update, holding hashing_flag with hasher_cursor=0.
+// During that window the main thread calls flush_to_disk(target=0): phase 4
+// flushes blocks 0 and 2 via flush_piece_impl, and because hashing_flag is
+// set and both block indices are >= hasher_cursor, both transition to the
+// held-alive state (disk_buffer_ref{buf}) - m_blocks does NOT drop.
+// When kick_hasher finishes, cursor=1 (block 0 hashed contiguously, block 1
+// missing stops it). Its cleanup pass over [0, 1) reclaims block 0. Block 2
+// (index 2 >= cursor=1) is left held-alive.
+// A subsequent flush_to_disk's phase 3 must free block 2's buffer with no
+// disk I/O - the data has already been written.
+void test_drop_held_alive_buffers(test_mode_t const mode)
+{
+	cache_fixture f(3, mode);
+	f.insert(0_piece, 0);
+	f.insert(0_piece, 2);
+	TEST_EQUAL(int(f.cache.size()), 2);
+	TEST_EQUAL(f.alloc.live, 2);
+
+	jobqueue_t completed, retry;
+
+	std::thread hasher_thread([&]() { f.cache.kick_pending_hashers(completed, retry); });
+	// Wait until kick_hasher has released the mutex inside its slow hash
+	// update. The 50ms is comfortably inside the ~1.6s slow-hash window.
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Flush while hashing_flag is set on the piece and hasher_cursor=0.
+	// In phase 4 of flush_to_disk, flush_piece_impl flushes blocks 0 and 2;
+	// the needed_by_hasher branch puts both into the held-alive state.
+	TEST_EQUAL(f.flush(), 2);
+
+	hasher_thread.join();
+
+	// kick_hasher hashed block 0 contiguously (cursor advanced to 1), then
+	// hit the gap at block 1 and stopped. Its cleanup pass over [0, 1)
+	// released block 0's held-alive buffer. Block 2 remains held-alive at
+	// index 2 >= cursor=1 - exactly the state phase 3 is meant to clean up.
+	TEST_EQUAL(int(f.cache.size()), 1);
+	TEST_EQUAL(f.alloc.live, 1);
+
+	// Phase 3 of flush_to_disk reclaims block 2's held-alive buffer.
+	// No write_jobs remain, so the flush callback returns 0.
+	TEST_EQUAL(f.flush(), 0);
+	TEST_EQUAL(int(f.cache.size()), 0);
+	TEST_EQUAL(f.alloc.live, 0);
+
+	jobqueue_t aborted;
+	TEST_CHECK(f.cache.try_clear_piece(f.loc(0_piece), nullptr, aborted));
+	TEST_CHECK(aborted.empty());
+}
+
 // Regression test for the pending_free_flag mechanism.
 //
 // flush_storage() is called to tear down a storage while a hasher thread
@@ -333,5 +395,12 @@ TORRENT_TEST(flush_storage_during_hashing_v2)
 	{ test_flush_storage_during_hashing(test_mode::v2); }
 TORRENT_TEST(flush_storage_during_hashing_hybrid)
 	{ test_flush_storage_during_hashing(test_mode::v1 | test_mode::v2); }
+
+	TORRENT_TEST(drop_held_alive_v1) { test_drop_held_alive_buffers(test_mode::v1); }
+	TORRENT_TEST(drop_held_alive_v2) { test_drop_held_alive_buffers(test_mode::v2); }
+	TORRENT_TEST(drop_held_alive_hybrid)
+	{
+		test_drop_held_alive_buffers(test_mode::v1 | test_mode::v2);
+	}
 
 #endif // TORRENT_SIMULATE_SLOW_HASH


### PR DESCRIPTION
to evict buffers that have been written to disk but not hashed yet. This is the penultimate resort, in cacse we fill up the buffer. However, we need to free buffers in order to keep the flow going once we hit the high watermark