### PR TITLE
add python binding alert.timestamp()

### DIFF
--- a/bindings/python/libtorrent/__init__.pyi
+++ b/bindings/python/libtorrent/__init__.pyi
@@ -604,6 +604,11 @@ class alert(metaclass=_BoostBaseClass):
         tracker_notification: Literal[16]
         upload_notification: Literal[8388608]
 
+    def timestamp(self) -> datetime.datetime:
+        """
+        timestamp( (alert)arg1) -> datetime.datetime :
+        """
+
     def category(self) -> int:
         """
         category( (alert)arg1) -> object :

--- a/bindings/python/src/alert.cpp
+++ b/bindings/python/src/alert.cpp
@@ -309,6 +309,7 @@ void bind_alert()
 
 	{
 		scope alert_scope = class_<alert, noncopyable>("alert", no_init)
+								.def("timestamp", &alert::timestamp)
 								.def("message", &alert::message)
 								.def("what", &alert::what)
 								.def("category", &alert::category)

--- a/bindings/python/src/datetime.cpp
+++ b/bindings/python/src/datetime.cpp
@@ -65,13 +65,21 @@ struct time_point_to_python
 	static PyObject* convert(T const pt)
 	{
 		using std::chrono::duration_cast;
+		using std::chrono::microseconds;
+		using std::chrono::seconds;
 		using std::chrono::system_clock;
 		object result;
 		if (pt > T())
 		{
-			time_t const tm = system_clock::to_time_t(
-				system_clock::now() + duration_cast<system_clock::duration>(pt - now(::tag<T>()))
-			);
+			auto const system_tp =
+				(system_clock::now() + duration_cast<system_clock::duration>(pt - now(::tag<T>())));
+
+			// split into seconds and microseconds
+			auto const seconds_tp = std::chrono::time_point_cast<seconds>(system_tp);
+
+			time_t const tm = system_clock::to_time_t(seconds_tp);
+
+			auto const tm_usec = duration_cast<microseconds>(system_tp - seconds_tp).count();
 
 #ifdef TORRENT_WINDOWS
 			std::tm const* date = localtime(&tm);
@@ -80,16 +88,15 @@ struct time_point_to_python
 			std::tm const* date = localtime_r(&tm, &buf);
 #endif
 
-			result = datetime_datetime(
-				(int)1900 + date->tm_year
+			result = datetime_datetime((int)1900 + date->tm_year
 				// tm use 0-11 and we need 1-12
 				,
 				(int)date->tm_mon + 1,
 				(int)date->tm_mday,
 				date->tm_hour,
 				date->tm_min,
-				date->tm_sec
-			);
+				date->tm_sec,
+				(int)tm_usec);
 		}
 		else
 		{


### PR DESCRIPTION
useful to restore the exact time order of alerts
from multiple libtorrent instances running in parallel

### time precision

before f71405d7a0669eef90530ba292ebc8541e16d3bd
the time precision was limited to seconds
but for ordering alerts by time, we need higher precision
so now `alert.timestamp()` returns times with microsecond precision

todo? change more `convert` functions in
[libtorrent/bindings/python/src/datetime.cpp](https://github.com/arvidn/libtorrent/blob/RC_2_0/bindings/python/src/datetime.cpp)
to preserve microsecond precision

### cost

probably the binding for `alert.timestamp()`
has not-yet been added
because most users dont need it

which begs the question:
what is the cost of adding this binding?

as far as i can tell, the cost is near zero
because the conversion to python's `datetime.datetime`
happens only when `alert.timestamp` is actually called

### ordering

i have tried to preserve the order from
[libtorrent/include/libtorrent/alert.hpp](https://github.com/arvidn/libtorrent/blob/RC_2_0/include/libtorrent/alert.hpp)

```cc
	struct TORRENT_EXPORT alert
	{
		time_point timestamp() const;
		virtual int type() const noexcept = 0;
		virtual char const* what() const noexcept = 0;
		virtual std::string message() const = 0;
		virtual alert_category_t category() const noexcept = 0;
	};
```

### tests

i hope we can add this without tests...?

tested manually with

```py
def process_alerts(session, prefix, state):
    alerts = session.pop_alerts()
    for a in alerts:
        if isinstance(a, lt.peer_log_alert):
            print("a.timestamp()", a.timestamp().strftime(r"%FT%T.%f"))
```

example output

```
a.timestamp() 2026-05-13T22:01:28.760659
```

### disclosure

the changes were made with the help of AI (chatGPT)
but were optimized for a minimal diff

