### PR TITLE
Fix quoted I2P SAM values

### DIFF
--- a/include/libtorrent/i2p_stream.hpp
+++ b/include/libtorrent/i2p_stream.hpp
@@ -314,8 +314,6 @@ private:
 			if (!remaining.empty() && remaining[0] == '"')
 			{
 				std::tie(value, remaining) = split_string(remaining.substr(1), '"');
-				if (value.empty()) { handle_error(invalid_response, h); return; }
-				value.remove_suffix(1);
 			}
 			else
 			{


### PR DESCRIPTION
This fixes quoted SAM response value parsing.

split_string(..., '"') already returns the value without the closing quote, so remove_suffix() dropped a valid character. The parser also now accepts quoted empty values, which SAM 3.2 allows implementations to send.

Checked locally with quoted, unquoted, and quoted-empty response values, plus the i2p_stream.cpp CMake compile and pre-commit hooks for the touched file.
