### PR TITLE
Fix UPnP content-type checks

### DIFF
--- a/include/libtorrent/upnp.hpp
+++ b/include/libtorrent/upnp.hpp
@@ -68,6 +68,8 @@ namespace aux {
 		std::array<char, 1500> buffer;
 		udp::endpoint remote;
 	};
+
+	TORRENT_EXTRA_EXPORT bool is_upnp_xml_content_type(string_view content_type);
 }
 
 namespace upnp_errors {

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -86,6 +86,15 @@ namespace upnp_errors
 
 static error_code ignore_error;
 
+bool aux::is_upnp_xml_content_type(string_view content_type)
+{
+	content_type = strip_string(split_string(content_type, ';').first);
+	return string_equal_no_case(content_type, "text/xml"_sv)
+		|| string_equal_no_case(content_type, "text/soap+xml"_sv)
+		|| string_equal_no_case(content_type, "application/xml"_sv)
+		|| string_equal_no_case(content_type, "application/soap+xml"_sv);
+}
+
 upnp::rootdevice::rootdevice() = default;
 
 #if TORRENT_USE_ASSERTS
@@ -1409,12 +1418,7 @@ void upnp::on_upnp_map_response(error_code const& e
 	}
 
 	std::string const& ct = p.header("content-type");
-	if (!ct.empty()
-		&& ct.find("text/xml") == std::string::npos
-		&& ct.find("text/soap+xml") == std::string::npos
-		&& ct.find("application/xml") == std::string::npos
-		&& ct.find("application/soap+xml") == std::string::npos
-		)
+	if (!ct.empty() && !aux::is_upnp_xml_content_type(ct))
 	{
 #ifndef TORRENT_DISABLE_LOGGING
 		log("error while adding port map: invalid content-type, \"%s\". "

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1410,10 +1410,10 @@ void upnp::on_upnp_map_response(error_code const& e
 
 	std::string const& ct = p.header("content-type");
 	if (!ct.empty()
-		&& ct.find_first_of("text/xml") == std::string::npos
-		&& ct.find_first_of("text/soap+xml") == std::string::npos
-		&& ct.find_first_of("application/xml") == std::string::npos
-		&& ct.find_first_of("application/soap+xml") == std::string::npos
+		&& ct.find("text/xml") == std::string::npos
+		&& ct.find("text/soap+xml") == std::string::npos
+		&& ct.find("application/xml") == std::string::npos
+		&& ct.find("application/soap+xml") == std::string::npos
 		)
 	{
 #ifndef TORRENT_DISABLE_LOGGING

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -340,7 +340,7 @@ TORRENT_TEST(upnp_wanipconnection)
 
 TORRENT_TEST(upnp_wanipconnection2)
 {
-	run_upnp_test(combine_path("..", "root3.xml").c_str(), "WANIPConnection_2", 2);
+	run_upnp_test(combine_path("..", "root3.xml").c_str(), "WANIPConnection", 2);
 }
 
 TORRENT_TEST(upnp_max_mappings)

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -363,3 +363,17 @@ TORRENT_TEST(upnp_max_mappings)
 		TEST_CHECK(mapping != port_mapping_t{-1});
 	}
 }
+
+TORRENT_TEST(upnp_content_type)
+{
+	TEST_CHECK(aux::is_upnp_xml_content_type("text/xml"));
+	TEST_CHECK(aux::is_upnp_xml_content_type("Text/XML"));
+	TEST_CHECK(aux::is_upnp_xml_content_type(" text/xml; charset=\"utf-8\""));
+	TEST_CHECK(aux::is_upnp_xml_content_type("application/soap+xml; charset=utf-8"));
+	TEST_CHECK(aux::is_upnp_xml_content_type("application/xml"));
+	TEST_CHECK(aux::is_upnp_xml_content_type("text/soap+xml"));
+
+	TEST_CHECK(!aux::is_upnp_xml_content_type("text/html;charset=utf-8"));
+	TEST_CHECK(!aux::is_upnp_xml_content_type("x-text/xml"));
+	TEST_CHECK(!aux::is_upnp_xml_content_type("application/json"));
+}

--- a/test/web_server.py
+++ b/test/web_server.py
@@ -34,6 +34,12 @@ class http_server_with_timeout(HTTPServer):
 
 class http_handler(BaseHTTPRequestHandler):
 
+    def normalize_request_path(self):
+        # if the request contains the hostname and port. strip it
+        if self.path.startswith('http://') or self.path.startswith('https://'):
+            self.path = self.path[8:]
+            self.path = self.path[self.path.find('/'):]
+
     def do_GET(self):
         try:
             self.inner_do_GET()
@@ -51,11 +57,7 @@ class http_handler(BaseHTTPRequestHandler):
         global chunked_encoding
         global keepalive
 
-        # if the request contains the hostname and port. strip it
-        if self.path.startswith('http://') or self.path.startswith('https://'):
-            self.path = self.path[8:]
-            self.path = self.path[self.path.find('/'):]
-
+        self.normalize_request_path()
         file_path = os.path.normpath(self.path)
         sys.stdout.flush()
 
@@ -206,6 +208,61 @@ class http_handler(BaseHTTPRequestHandler):
                     self.request.shutdown(socket.SHUT_RD)
                 except Exception:
                     pass
+
+        print("...DONE")
+        sys.stdout.flush()
+        self.wfile.flush()
+
+    def do_POST(self):
+        try:
+            self.inner_do_POST()
+        except Exception:
+            print('EXCEPTION')
+            traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
+
+    def inner_do_POST(self):
+        print('INCOMING-REQUEST [from: {}]: {}'.format(self.request.getsockname(), self.requestline))
+        print(self.headers)
+        sys.stdout.flush()
+
+        global keepalive
+
+        self.normalize_request_path()
+
+        content_length = self.headers.get('Content-Length')
+        if content_length is not None:
+            self.rfile.read(int(content_length))
+
+        if self.path not in ('/wipconn', '/WANIPConnection'):
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        filename = os.path.normpath(self.path[1:])
+        try:
+            f = open(filename, 'rb')
+            data = f.read()
+            f.close()
+
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/xml; charset="utf-8"')
+            self.send_header('Content-Length', "%d" % len(data))
+            if not keepalive:
+                self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(data)
+        except Exception as e:
+            print('FILE ERROR: ', filename, e)
+            traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            try:
+                self.end_headers()
+            except Exception:
+                pass
 
         print("...DONE")
         sys.stdout.flush()


### PR DESCRIPTION
This changes the UPnP response content-type checks to look for full media type substrings instead of any matching character.

The old find_first_of() calls could accept unrelated types like text/html because they only checked whether any character from text/xml was present. Using find() keeps the intended XML/SOAP allowlist behavior.
