### PR TITLE
Fix bandwidth channel iteration

### DIFF
--- a/src/bandwidth_queue_entry.cpp
+++ b/src/bandwidth_queue_entry.cpp
@@ -59,7 +59,7 @@ namespace aux {
 		--ttl;
 		if (quota == 0) return quota;
 
-		for (int j = 0; j < 5 && channel[j]; ++j)
+		for (int j = 0; j < max_bandwidth_channels && channel[j]; ++j)
 		{
 			if (channel[j]->throttle() == 0) continue;
 			if (channel[j]->tmp == 0) continue;
@@ -67,7 +67,7 @@ namespace aux {
 				* priority / channel[j]->tmp), quota);
 		}
 		assigned += quota;
-		for (int j = 0; j < 5 && channel[j]; ++j)
+		for (int j = 0; j < max_bandwidth_channels && channel[j]; ++j)
 			channel[j]->use_quota(quota);
 		TORRENT_ASSERT(assigned <= request_size);
 		return quota;


### PR DESCRIPTION
Use the existing max_bandwidth_channels limit when walking bandwidth request channels.

This avoids stopping after the first 5 slots when the request can hold up to 10.
