### PR TITLE
Prevent adding aborted torrent to lists in the session

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -8249,7 +8249,7 @@ namespace {
 		bool is_downloading = false;
 		bool is_seeding = false;
 
-		if (is_auto_managed() && !has_error())
+		if (is_auto_managed() && !has_error() && !m_abort)
 		{
 			if (m_state == torrent_status::checking_files)
 			{


### PR DESCRIPTION
Note: AI was used to assist in finding the root cause

I'm seeing a lot of crashes in `torrent::is_inactive`.

### Example stacktrace:

```
null pointer dereference: SIGSEGV  0x0000000000000001

#00 pc 0x599ee8 libclient.so (libtorrent::torrent::is_inactive() const [torrent.cpp:8862])

#01 pc 0x453e3c libclient.so (libtorrent::aux::session_impl::auto_manage_torrents(std::__ndk1::vector<libtorrent::torrent*, std::__ndk1::allocator<libtorrent::torrent*> >&, int&, int&, int&, int&, int) [session_impl.cpp:3946])

#02 pc 0x453e3c libclient.so (libtorrent::aux::session_impl::auto_manage_torrents(std::__ndk1::vector<libtorrent::torrent*, std::__ndk1::allocator<libtorrent::torrent*> >&, int&, int&, int&, int&, int) [session_impl.cpp:3946])

#03 pc 0x452628 libclient.so (libtorrent::aux::session_impl::recalculate_auto_managed_torrents() [session_impl.cpp:4060])

#04 pc 0x45c570 libclient.so (libtorrent::aux::session_impl::on_trigger_auto_manage() [session_impl.cpp:6569])

#05 pc 0x45ed24 libclient.so (void libtorrent::aux::session_impl::wrap<void (libtorrent::aux::session_impl::*)()>(void (libtorrent::aux::session_impl::*)()) [session_impl.cpp:582])

#06 pc 0x464ccc libclient.so (boost::asio::detail::executor_op<boost::asio::detail::binder0<libtorrent::aux::session_impl::trigger_auto_manage()::$_12>, std::__ndk1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) [session_impl.cpp:6555])

#07 pc 0x402a90 libclient.so (boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) [scheduler_operation.hpp:40])

#08 pc 0x4025fc libclient.so (boost::asio::detail::scheduler::run(boost::system::error_code&) [scheduler.ipp:210])

#09 pc 0x3fc968 libclient.so (boost::asio::io_context::run() [io_context.ipp:63])

#10 pc 0x42658c libclient.so (void* std::__ndk1::__thread_proxy<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct> >, libtorrent::session::start(libtorrent::flags::bitfield_flag<unsigned char, libtorrent::session_flags_tag, void>, libtorrent::v2::session_params&&, boost::asio::io_context*)::$_0> >(void*) [session.cpp:345])

```

The crash is a use-after-free caused by a race between remove_torrent and a subsequent `torrent_handle::async_call` operation (like `set_flags`, `resume`, or `auto_managed`) that re-adds the torrent to `m_torrent_lists` after `abort()` has unlinked it.

### Sequence

1. `remove_torrent` runs on the io_context: erases from `m_torrents`, calls `abort()` which unlinks from all lists, posts `trigger_auto_manage`
2. A previously-dispatched `torrent_handle::async_call` lambda runs (it holds a `shared_ptr` keeping the torrent alive)
3. The lambda calls an operation (e.g., `auto_managed(true)`, `resume()`, `set_flags()`) that doesn't check `m_abort`
4. This calls `update_state_list()` which re-adds the torrent to `torrent_downloading_auto_managed` (since the torrent is in `downloading_metadata` state (a magnet link)).
5. The lambda completes, its `shared_ptr` is dropped — the torrent is destroyed (no other references exist since it was erased from `m_torrents`)
6. `on_trigger_auto_manage` fires, snapshots the list containing the dangling pointer
7. `auto_manage_torrents` dereferences the dangling pointer → crash

### Reproducing the crash

Run this:
https://gist.github.com/Bhambya/d8cc842d768265776fb63c967c74c4f9

It does not crash after the fix in this PR.
