### PR TITLE
Return partial byte count from pwrite_all on error

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -199,7 +199,7 @@ namespace aux {
 			if (r < 0)
 			{
 				ec = error_code(errno, system_category());
-				return -1;
+				return ret;
 			}
 			ret += r;
 			file_offset += r;


### PR DESCRIPTION
pwrite_all already tracks how many bytes were written before an error, but returned -1 when the final write failed.

This returns the partial count instead, matching pread_all behavior.
