### PR TITLE
Handle short reads from part files

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -129,10 +129,17 @@ namespace aux {
 		OVERLAPPED ol{};
 		ol.Offset = offset & 0xffffffff;
 		ol.OffsetHigh = offset >> 32;
+		DWORD const bytes_to_read = DWORD(buf.size());
 		DWORD bytes_read = 0;
-		if (ReadFile(fd, buf.data(), DWORD(buf.size()), &bytes_read, &ol) == FALSE)
+		if (ReadFile(fd, buf.data(), bytes_to_read, &bytes_read, &ol) == FALSE)
 		{
 			ec = error_code(::GetLastError(), system_category());
+			return -1;
+		}
+
+		if (bytes_read != bytes_to_read)
+		{
+			ec.assign(errors::file_too_short, libtorrent_category());
 			return -1;
 		}
 
@@ -168,13 +175,13 @@ namespace aux {
 			auto const r = ::pread(handle, buf.data(), std::size_t(buf.size()), file_offset);
 			if (r == 0)
 			{
-				ec = boost::asio::error::eof;
-				return ret;
+				ec.assign(errors::file_too_short, libtorrent_category());
+				return -1;
 			}
 			if (r < 0)
 			{
 				ec = error_code(errno, system_category());
-				return ret;
+				return -1;
 			}
 			ret += r;
 			file_offset += r;

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -71,6 +71,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/storage_utils.hpp" // for iovec_t
 
+#include <boost/asio/error.hpp>
+
 #include <functional> // for std::function
 #include <cstdint>
 
@@ -79,6 +81,24 @@ namespace {
 	// round up to even kilobyte
 	int round_up(int n)
 	{ return (n + 1023) & ~0x3ff; }
+
+	void set_file_too_short(libtorrent::error_code& ec)
+	{
+		ec.assign(libtorrent::errors::file_too_short
+			, libtorrent::libtorrent_category());
+	}
+
+	int read_full(libtorrent::handle_type const fd
+		, libtorrent::span<char> const buf
+		, std::int64_t const offset, libtorrent::error_code& ec)
+	{
+		int const ret = int(libtorrent::aux::pread_all(fd, buf, offset, ec));
+		if (ret == int(buf.size())) return ret;
+
+		if (!ec || ec == boost::asio::error::eof)
+			set_file_too_short(ec);
+		return -1;
+	}
 }
 
 namespace libtorrent {
@@ -212,7 +232,7 @@ namespace libtorrent {
 		auto f = open_file(aux::open_mode::read_only | aux::open_mode::hidden, ec);
 		if (ec) return -1;
 
-		return int(aux::pread_all(f.fd(), buf, slot_offset(slot) + offset, ec));
+		return read_full(f.fd(), buf, slot_offset(slot) + offset, ec);
 	}
 
 	int part_file::hash(hasher& ph
@@ -258,7 +278,8 @@ namespace libtorrent {
 
 		std::vector<char> buffer(static_cast<std::size_t>(len));
 		std::int64_t const slot_offset = std::int64_t(m_header_size) + std::int64_t(static_cast<int>(slot)) * m_piece_size;
-		int const ret = int(aux::pread_all(f.fd(), buffer, slot_offset + offset, ec));
+		int const ret = read_full(f.fd(), buffer, slot_offset + offset, ec);
+		if (ret < 0) return -1;
 		ph.update(buffer);
 		return ret;
 	}
@@ -368,9 +389,8 @@ namespace libtorrent {
 				l.unlock();
 
 				span<char> v = {buf.get(), block_to_copy};
-				auto bytes_read = aux::pread_all(file.fd(), v, slot_offset(slot) + piece_offset, ec);
-				v = v.first(static_cast<std::ptrdiff_t>(bytes_read));
-				if (ec || v.empty()) return;
+				int const bytes_read = read_full(file.fd(), v, slot_offset(slot) + piece_offset, ec);
+				if (bytes_read < 0) return;
 
 				f(file_offset, {buf.get(), block_to_copy});
 

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -90,8 +90,8 @@ namespace {
 		, libtorrent::span<char> const buf
 		, std::int64_t const offset, libtorrent::error_code& ec)
 	{
-		int const ret = int(libtorrent::aux::pread_all(fd, buf, offset, ec));
-		if (ret == int(buf.size())) return ret;
+		int const ret = libtorrent::aux::pread_all(fd, buf, offset, ec);
+		if (ret >= 0 && ret == buf.size()) return ret;
 
 		if (ret >= 0)
 			set_file_too_short(ec);

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -71,8 +71,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/storage_utils.hpp" // for iovec_t
 
-#include <boost/asio/error.hpp>
-
 #include <functional> // for std::function
 #include <cstdint>
 
@@ -95,7 +93,7 @@ namespace {
 		int const ret = int(libtorrent::aux::pread_all(fd, buf, offset, ec));
 		if (ret == int(buf.size())) return ret;
 
-		if (!ec || ec == boost::asio::error::eof)
+		if (ret >= 0)
 			set_file_too_short(ec);
 		return -1;
 	}

--- a/src/part_file.cpp
+++ b/src/part_file.cpp
@@ -80,23 +80,6 @@ namespace {
 	int round_up(int n)
 	{ return (n + 1023) & ~0x3ff; }
 
-	void set_file_too_short(libtorrent::error_code& ec)
-	{
-		ec.assign(libtorrent::errors::file_too_short
-			, libtorrent::libtorrent_category());
-	}
-
-	int read_full(libtorrent::handle_type const fd
-		, libtorrent::span<char> const buf
-		, std::int64_t const offset, libtorrent::error_code& ec)
-	{
-		int const ret = libtorrent::aux::pread_all(fd, buf, offset, ec);
-		if (ret >= 0 && ret == buf.size()) return ret;
-
-		if (ret >= 0)
-			set_file_too_short(ec);
-		return -1;
-	}
 }
 
 namespace libtorrent {
@@ -230,7 +213,7 @@ namespace libtorrent {
 		auto f = open_file(aux::open_mode::read_only | aux::open_mode::hidden, ec);
 		if (ec) return -1;
 
-		return read_full(f.fd(), buf, slot_offset(slot) + offset, ec);
+		return aux::pread_all(f.fd(), buf, slot_offset(slot) + offset, ec);
 	}
 
 	int part_file::hash(hasher& ph
@@ -276,7 +259,7 @@ namespace libtorrent {
 
 		std::vector<char> buffer(static_cast<std::size_t>(len));
 		std::int64_t const slot_offset = std::int64_t(m_header_size) + std::int64_t(static_cast<int>(slot)) * m_piece_size;
-		int const ret = read_full(f.fd(), buffer, slot_offset + offset, ec);
+		int const ret = aux::pread_all(f.fd(), buffer, slot_offset + offset, ec);
 		if (ret < 0) return -1;
 		ph.update(buffer);
 		return ret;
@@ -387,7 +370,7 @@ namespace libtorrent {
 				l.unlock();
 
 				span<char> v = {buf.get(), block_to_copy};
-				int const bytes_read = read_full(file.fd(), v, slot_offset(slot) + piece_offset, ec);
+				int const bytes_read = aux::pread_all(file.fd(), v, slot_offset(slot) + piece_offset, ec);
 				if (bytes_read < 0) return;
 
 				f(file_offset, {buf.get(), block_to_copy});

--- a/src/posix_part_file.cpp
+++ b/src/posix_part_file.cpp
@@ -81,11 +81,6 @@ namespace {
 	int round_up(int n)
 	{ return (n + 1023) & ~0x3ff; }
 
-	void set_file_too_short(libtorrent::error_code& ec)
-	{
-		ec.assign(libtorrent::errors::file_too_short
-			, libtorrent::libtorrent_category());
-	}
 }
 
 namespace libtorrent {
@@ -292,7 +287,7 @@ namespace aux {
 		if (ret != buffer.size())
 		{
 			if (std::ferror(f.file())) ec.assign(errno, generic_category());
-			else set_file_too_short(ec);
+			else ec.assign(errors::file_too_short, libtorrent_category());
 			return -1;
 		}
 		ph.update(buffer);
@@ -413,7 +408,7 @@ namespace aux {
 				if (int(bytes_read) != block_to_copy)
 				{
 					if (std::ferror(file.file())) ec.assign(errno, generic_category());
-					else set_file_too_short(ec);
+					else ec.assign(errors::file_too_short, libtorrent_category());
 				}
 
 				if (ec) return;

--- a/src/posix_part_file.cpp
+++ b/src/posix_part_file.cpp
@@ -80,6 +80,12 @@ namespace {
 	// round up to even kilobyte
 	int round_up(int n)
 	{ return (n + 1023) & ~0x3ff; }
+
+	void set_file_too_short(libtorrent::error_code& ec)
+	{
+		ec.assign(libtorrent::errors::file_too_short
+			, libtorrent::libtorrent_category());
+	}
 }
 
 namespace libtorrent {
@@ -285,7 +291,8 @@ namespace aux {
 		auto const ret = std::fread(buffer.data(), 1, buffer.size(), f.file());
 		if (ret != buffer.size())
 		{
-			ec.assign(errno, generic_category());
+			if (std::ferror(f.file())) ec.assign(errno, generic_category());
+			else set_file_too_short(ec);
 			return -1;
 		}
 		ph.update(buffer);
@@ -404,7 +411,10 @@ namespace aux {
 				}
 				auto bytes_read = std::fread(buf.get(), 1, std::size_t(block_to_copy), file.file());
 				if (int(bytes_read) != block_to_copy)
-					ec.assign(errno, generic_category());
+				{
+					if (std::ferror(file.file())) ec.assign(errno, generic_category());
+					else set_file_too_short(ec);
+				}
 
 				if (ec) return;
 

--- a/test/test_part_file.cpp
+++ b/test/test_part_file.cpp
@@ -33,8 +33,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstring>
 #include <array>
-#include <fstream>
-#include <vector>
 
 #include "test.hpp"
 #include "test_utils.hpp"
@@ -42,6 +40,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/posix_part_file.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/file_storage.hpp"
+#include "libtorrent/truncate.hpp"
 
 using namespace lt;
 
@@ -54,16 +54,11 @@ int part_file_header_size(int const num_pieces)
 
 void truncate_part_file(std::string const& filename, std::int64_t const size)
 {
-	{
-		std::vector<char> buf(static_cast<std::size_t>(size));
-		std::ifstream in(filename.c_str(), std::ios_base::binary);
-		in.read(buf.data(), std::streamsize(buf.size()));
-		TEST_EQUAL(in.gcount(), std::streamsize(buf.size()));
-
-		std::ofstream out(filename.c_str()
-			, std::ios_base::binary | std::ios_base::trunc);
-		out.write(buf.data(), std::streamsize(buf.size()));
-	}
+	file_storage fs;
+	fs.add_file(libtorrent::filename(filename), size);
+	storage_error se;
+	truncate_files(fs, parent_path(filename), se);
+	TEST_CHECK(!se);
 
 	file_status st;
 	error_code ec;

--- a/test/test_part_file.cpp
+++ b/test/test_part_file.cpp
@@ -33,6 +33,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstring>
 #include <array>
+#include <fstream>
+#include <vector>
 
 #include "test.hpp"
 #include "test_utils.hpp"
@@ -53,8 +55,14 @@ int part_file_header_size(int const num_pieces)
 void truncate_part_file(std::string const& filename, std::int64_t const size)
 {
 	{
-		aux::file_handle f(filename, size
-			, aux::open_mode::write | aux::open_mode::truncate | aux::open_mode::sparse);
+		std::vector<char> buf(static_cast<std::size_t>(size));
+		std::ifstream in(filename.c_str(), std::ios_base::binary);
+		in.read(buf.data(), std::streamsize(buf.size()));
+		TEST_EQUAL(in.gcount(), std::streamsize(buf.size()));
+
+		std::ofstream out(filename.c_str()
+			, std::ios_base::binary | std::ios_base::trunc);
+		out.write(buf.data(), std::streamsize(buf.size()));
 	}
 
 	file_status st;

--- a/test/test_part_file.cpp
+++ b/test/test_part_file.cpp
@@ -52,8 +52,16 @@ int part_file_header_size(int const num_pieces)
 
 void truncate_part_file(std::string const& filename, std::int64_t const size)
 {
-	aux::file_handle f(filename, size
-		, aux::open_mode::write | aux::open_mode::truncate | aux::open_mode::sparse);
+	{
+		aux::file_handle f(filename, size
+			, aux::open_mode::write | aux::open_mode::truncate | aux::open_mode::sparse);
+	}
+
+	file_status st;
+	error_code ec;
+	stat_file(filename, &st, ec);
+	TEST_CHECK(!ec);
+	TEST_EQUAL(st.file_size, size);
 }
 
 template <typename PartFile>

--- a/test/test_part_file.cpp
+++ b/test/test_part_file.cpp
@@ -43,6 +43,73 @@ POSSIBILITY OF SUCH DAMAGE.
 
 using namespace lt;
 
+namespace {
+
+int part_file_header_size(int const num_pieces)
+{
+	return ((2 + num_pieces) * 4 + 1023) & ~0x3ff;
+}
+
+void truncate_part_file(std::string const& filename, std::int64_t const size)
+{
+	aux::file_handle f(filename, size
+		, aux::open_mode::write | aux::open_mode::truncate | aux::open_mode::sparse);
+}
+
+template <typename PartFile>
+void test_short_read(std::string const& test_dir)
+{
+	error_code ec;
+	std::string const cwd = complete(".");
+	std::string const path = combine_path(cwd, test_dir);
+	std::string const part_file_path = combine_path(path, "partfile.parts");
+	int const piece_size = 16 * 0x4000;
+	int const num_pieces = 100;
+
+	remove_all(path, ec);
+	if (ec == boost::system::errc::no_such_file_or_directory)
+		ec.clear();
+	TEST_CHECK(!ec);
+	create_directory(path, ec);
+	TEST_CHECK(!ec);
+
+	std::array<char, 1024> buf;
+	for (int i = 0; i < int(buf.size()); ++i)
+		buf[std::size_t(i)] = static_cast<char>(i);
+
+	PartFile pf(path, "partfile.parts", num_pieces, piece_size);
+	TEST_EQUAL(pf.write(buf, 10_piece, 0, ec), int(buf.size()));
+	TEST_CHECK(!ec);
+	pf.flush_metadata(ec);
+	TEST_CHECK(!ec);
+
+	truncate_part_file(part_file_path, part_file_header_size(num_pieces) + 512);
+
+	std::array<char, 1024> read_buf;
+	read_buf.fill(0);
+	TEST_EQUAL(pf.read(read_buf, 10_piece, 0, ec), -1);
+	TEST_EQUAL(ec, errors::file_too_short);
+
+	ec.clear();
+	hasher ph;
+	TEST_EQUAL(pf.hash(ph, int(buf.size()), 10_piece, 0, ec), -1);
+	TEST_EQUAL(ec, errors::file_too_short);
+
+	ec.clear();
+	bool exported = false;
+	pf.export_file([&exported](std::int64_t, span<char>)
+	{
+		exported = true;
+	}, 10 * piece_size, int(buf.size()), ec);
+	TEST_EQUAL(ec, errors::file_too_short);
+	TEST_CHECK(!exported);
+
+	remove_all(path, ec);
+	TEST_CHECK(!ec);
+}
+
+} // anonymous namespace
+
 TORRENT_TEST(part_file)
 {
 	error_code ec;
@@ -148,6 +215,11 @@ TORRENT_TEST(part_file)
 	}
 }
 
+TORRENT_TEST(part_file_short_read)
+{
+	test_short_read<part_file>("partfile_short_read_dir");
+}
+
 TORRENT_TEST(posix_part_file)
 {
 	error_code ec;
@@ -251,4 +323,9 @@ TORRENT_TEST(posix_part_file)
 		TEST_CHECK(!ec);
 		if (ec) std::printf("exists: %s\n", ec.message().c_str());
 	}
+}
+
+TORRENT_TEST(posix_part_file_short_read)
+{
+	test_short_read<aux::posix_part_file>("posix_partfile_short_read_dir");
 }


### PR DESCRIPTION
Part-file reads could return fewer bytes than requested and still be used by hash/export paths.

This treats short reads as `file_too_short` and adds tests for truncated part files.
