### PR TITLE
Add BEP 39 update-url and originator support

### DIFF
--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -281,6 +281,14 @@ namespace libtorrent {
 		// This is optional.
 		void set_creator(char const* str);
 
+		// Sets the update feed URL for the torrent. The string ``str`` should be utf-8 encoded.
+		// This corresponds to the BEP 39 ``update-url`` key inside the info dict.
+		void set_update_url(char const* str);
+
+		// Sets the originator certificate for the torrent. This corresponds to the
+		// BEP 39 ``originator`` key inside the info dict.
+		void set_originator(char const* str);
+
 		// sets the "creation time" field. Defaults to the system clock at the
 		// time of construction of the create_torrent object. The timestamp is
 		// specified in seconds, posix time. If the creation date is set to 0,
@@ -455,6 +463,12 @@ namespace libtorrent {
 		// if a comment is found in the torrent file
 		// this will be set to that comment
 		std::string m_comment;
+
+		// The BEP 39 update URL.
+		std::string m_update_url;
+
+		// The BEP 39 originator certificate.
+		std::string m_originator;
 
 		// an optional string naming the software used
 		// to create the torrent file

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -578,6 +578,17 @@ TORRENT_VERSION_NAMESPACE_3
 		const std::string& comment() const
 		{ return m_comment; }
 
+		// ``update_url()`` returns the feed URL for this torrent, per BEP 39.
+		// If there is no update feed, it returns an empty string.
+		const std::string& update_url() const
+		{ return m_update_url; }
+
+		// ``originator()`` returns the originator certificate for signed
+		// update feeds, per BEP 39. If there is no originator, it returns an
+		// empty string.
+		const std::string& originator() const
+		{ return m_originator; }
+
 		// If this torrent contains any DHT nodes, they are put in this vector in
 		// their original form (host name and port number).
 		std::vector<std::pair<std::string, int>> const& nodes() const
@@ -649,6 +660,8 @@ TORRENT_VERSION_NAMESPACE_3
 		void internal_set_creator(string_view);
 		void internal_set_creation_date(std::time_t);
 		void internal_set_comment(string_view);
+		void internal_set_update_url(string_view);
+		void internal_set_originator(string_view);
 
 #if TORRENT_ABI_VERSION <= 2
 		// support for BEP 30 merkle torrents has been removed
@@ -746,6 +759,12 @@ TORRENT_VERSION_NAMESPACE_3
 		// if a comment is found in the torrent file
 		// this will be set to that comment
 		std::string m_comment;
+
+		// The feed URL from a BEP 39 torrent info dict.
+		std::string m_update_url;
+
+		// The originator certificate from a BEP 39 torrent info dict.
+		std::string m_originator;
 
 		// an optional string naming the software used
 		// to create the torrent file

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -522,6 +522,8 @@ namespace {
 
 		if (!ti.creator().empty()) set_creator(ti.creator().c_str());
 		if (!ti.comment().empty()) set_comment(ti.comment().c_str());
+		if (!ti.update_url().empty()) set_update_url(ti.update_url().c_str());
+		if (!ti.originator().empty()) set_originator(ti.originator().c_str());
 
 		for (auto const& n : ti.nodes())
 			add_node(n);
@@ -798,6 +800,12 @@ namespace {
 		if (!m_root_cert.empty())
 			info["ssl-cert"] = m_root_cert;
 
+		if (!m_update_url.empty())
+			info["update-url"] = m_update_url;
+
+		if (!m_originator.empty())
+			info["originator"] = m_originator;
+
 		if (m_private) info["private"] = 1;
 
 		if (make_v1)
@@ -1035,6 +1043,18 @@ namespace {
 	{
 		if (str == nullptr) m_created_by.clear();
 		else m_created_by = str;
+	}
+
+	void create_torrent::set_update_url(char const* str)
+	{
+		if (str == nullptr) m_update_url.clear();
+		else m_update_url = str;
+	}
+
+	void create_torrent::set_originator(char const* str)
+	{
+		if (str == nullptr) m_originator.clear();
+		else m_originator = str;
 	}
 
 	void create_torrent::set_creation_date(std::time_t timestamp)

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1422,6 +1422,9 @@ namespace {
 					, str.string_length());
 			}
 		}
+
+		m_update_url = info.dict_find_string_value("update-url").to_string();
+		m_originator = info.dict_find_string_value("originator").to_string();
 #endif // TORRENT_DISABLE_MUTABLE_TORRENTS
 
 		if (info.dict_find_string("ssl-cert"))
@@ -1547,6 +1550,12 @@ namespace {
 
 	void torrent_info::internal_set_comment(string_view const s)
 	{ m_comment = std::string(s); }
+
+	void torrent_info::internal_set_update_url(string_view const u)
+	{ m_update_url = std::string(u); }
+
+	void torrent_info::internal_set_originator(string_view const o)
+	{ m_originator = std::string(o); }
 
 	bdecode_node torrent_info::info(char const* key) const
 	{

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1551,12 +1551,6 @@ namespace {
 	void torrent_info::internal_set_comment(string_view const s)
 	{ m_comment = std::string(s); }
 
-	void torrent_info::internal_set_update_url(string_view const u)
-	{ m_update_url = std::string(u); }
-
-	void torrent_info::internal_set_originator(string_view const o)
-	{ m_originator = std::string(o); }
-
 	bdecode_node torrent_info::info(char const* key) const
 	{
 		if (m_info_dict.type() == bdecode_node::none_t)

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -638,7 +638,7 @@ TORRENT_TEST(originator)
 TORRENT_TEST(dht_nodes)
 {
 	auto info = test_field([](lt::create_torrent& t){
-		t.add_node({std::string("foobar"), 1337});
+		t.add_node({"foobar"s, 1337});
 	});
 	using nodes = std::vector<std::pair<std::string, int>>;
 	TEST_CHECK((info.nodes() == nodes{{"foobar", 1337}}));

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -619,10 +619,26 @@ TORRENT_TEST(creator)
 	TEST_EQUAL(info.creator(), "foobar");
 }
 
+TORRENT_TEST(update_url)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_update_url("http://example.com/update");
+	});
+	TEST_EQUAL(info.update_url(), "http://example.com/update");
+}
+
+TORRENT_TEST(originator)
+{
+	auto info = test_field([](lt::create_torrent& t){
+		t.set_originator("cert-bytes");
+	});
+	TEST_EQUAL(info.originator(), "cert-bytes");
+}
+
 TORRENT_TEST(dht_nodes)
 {
 	auto info = test_field([](lt::create_torrent& t){
-		t.add_node({"foobar"s, 1337});
+		t.add_node({std::string("foobar"), 1337});
 	});
 	using nodes = std::vector<std::pair<std::string, int>>;
 	TEST_CHECK((info.nodes() == nodes{{"foobar", 1337}}));


### PR DESCRIPTION
## Summary

Implements [BEP 39](http://www.bittorrent.org/beps/bep_0039.html) update feed fields for torrents.

- Adds  and  setters to 
- Adds  and  const accessors to 
- Adds  /  internal setters
- Serializes  and  keys into the info dict when non-empty
- Parses both fields from the info dict during torrent loading
- Propagates both fields when constructing  from an existing 

## Test plan

- [ ]  — round-trips  through create/parse
- [ ]  — round-trips  through create/parse
- [ ] Existing  suite passes without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)