### PR TITLE
Fix mmap disk jobs stranded behind fences

### DIFF
--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -1368,7 +1368,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			m_generic_io_jobs.m_queued_jobs.push_back(j);
 			l.unlock();
 
-			if (num_threads() == 0 && user_add)
+			if (pool_for_job(j).max_threads() == 0 && user_add)
 				immediate_execute();
 
 			return;
@@ -1432,9 +1432,12 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 	void mmap_disk_io::immediate_execute()
 	{
-		while (!m_generic_io_jobs.m_queued_jobs.empty())
+		for (;;)
 		{
+			std::unique_lock<std::mutex> l(m_job_mutex);
+			if (m_generic_io_jobs.m_queued_jobs.empty()) return;
 			aux::mmap_disk_job* j = m_generic_io_jobs.m_queued_jobs.pop_front();
+			l.unlock();
 			execute_job(j);
 		}
 	}
@@ -1687,8 +1690,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 	aux::disk_io_thread_pool& mmap_disk_io::pool_for_job(aux::mmap_disk_job* j)
 	{
-		if (m_hash_threads.max_threads() > 0
-			&& (j->action == aux::job_action_t::hash || j->action == aux::job_action_t::hash2))
+		if (&queue_for_job(j) == &m_hash_io_jobs)
 			return m_hash_threads;
 		else
 			return m_generic_threads;
@@ -1745,6 +1747,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		m_stats_counters.inc_stats_counter(counters::blocked_disk_jobs, -ret);
 		TORRENT_ASSERT(int(m_stats_counters[counters::blocked_disk_jobs]) >= 0);
 
+		jobqueue_t execute_now;
 		if (m_abort.load())
 		{
 			while (!new_jobs.empty())
@@ -1760,28 +1763,56 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		{
 			if (!new_jobs.empty())
 			{
+				std::lock_guard<std::mutex> l(m_job_mutex);
+				bool queue_generic = false;
+				bool queue_hash = false;
+				while (!new_jobs.empty())
 				{
-					std::lock_guard<std::mutex> l(m_job_mutex);
-					m_generic_io_jobs.m_queued_jobs.append(std::move(new_jobs));
+					aux::mmap_disk_job* j = new_jobs.pop_front();
+					if (pool_for_job(j).max_threads() == 0)
+					{
+						execute_now.push_back(j);
+						continue;
+					}
+
+					job_queue& q = queue_for_job(j);
+					q.m_queued_jobs.push_back(j);
+					if (&q == &m_hash_io_jobs)
+						queue_hash = true;
+					else
+						queue_generic = true;
 				}
 
+				if (queue_generic)
 				{
-					std::lock_guard<std::mutex> l(m_job_mutex);
 					m_generic_io_jobs.m_job_cond.notify_all();
 					m_generic_threads.job_queued(m_generic_io_jobs.m_queued_jobs.size());
+				}
+				if (queue_hash)
+				{
+					m_hash_io_jobs.m_job_cond.notify_all();
+					m_hash_threads.job_queued(m_hash_io_jobs.m_queued_jobs.size());
 				}
 			}
 		}
 
-		std::lock_guard<std::mutex> l(m_completed_jobs_mutex);
-		m_completed_jobs.append(std::move(jobs));
-
-		if (!m_job_completions_in_flight)
 		{
-			DLOG("posting job handlers (%d)\n", m_completed_jobs.size());
+			std::lock_guard<std::mutex> l(m_completed_jobs_mutex);
+			m_completed_jobs.append(std::move(jobs));
 
-			post(m_ios, [this] { this->call_job_handlers(); });
-			m_job_completions_in_flight = true;
+			if (!m_job_completions_in_flight)
+			{
+				DLOG("posting job handlers (%d)\n", m_completed_jobs.size());
+
+				post(m_ios, [this] { this->call_job_handlers(); });
+				m_job_completions_in_flight = true;
+			}
+		}
+
+		while (!execute_now.empty())
+		{
+			aux::mmap_disk_job* j = execute_now.pop_front();
+			execute_job(j);
 		}
 	}
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -1432,6 +1432,8 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 	void mmap_disk_io::immediate_execute()
 	{
+		// Hash threads can lower fences and touch the generic queue while
+		// there are no generic disk threads.
 		for (;;)
 		{
 			std::unique_lock<std::mutex> l(m_job_mutex);

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -1368,7 +1368,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			m_generic_io_jobs.m_queued_jobs.push_back(j);
 			l.unlock();
 
-			if (pool_for_job(j).max_threads() == 0 && user_add)
+			if (m_generic_threads.max_threads() == 0 && user_add)
 				immediate_execute();
 
 			return;

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -767,46 +767,43 @@ void test_check_files(check_files_flag_t const flags
 		run_until(ios, done);
 	}
 
-	if (aio_threads == 0 && hashing_threads > 0)
+	int outstanding = 3;
+	int hashes_done = 0;
+	bool release_done = false;
+	sha1_hash const expected_hash = hasher(piece0).final();
+	auto hash_handler = [&](piece_index_t const piece
+		, sha1_hash const& hash, storage_error const& error)
 	{
-		int outstanding = 3;
-		int hashes_done = 0;
-		bool release_done = false;
-		sha1_hash const expected_hash = hasher(piece0).final();
-		auto hash_handler = [&](piece_index_t const piece
-			, sha1_hash const& hash, storage_error const& error)
-		{
-			TEST_EQUAL(piece, 0_piece);
-			TEST_CHECK(!error);
-			TEST_EQUAL(hash, expected_hash);
-			++hashes_done;
-			--outstanding;
-		};
+		TEST_EQUAL(piece, 0_piece);
+		TEST_CHECK(!error);
+		TEST_EQUAL(hash, expected_hash);
+		++hashes_done;
+		--outstanding;
+	};
 
-		io->async_hash(st, 0_piece, {}
-			, disk_interface::sequential_access | disk_interface::volatile_read | disk_interface::v1_hash
-			, hash_handler);
-		io->async_release_files(st, [&]
-		{
-			release_done = true;
-			--outstanding;
-		});
-		io->async_hash(st, 0_piece, {}
-			, disk_interface::sequential_access | disk_interface::volatile_read | disk_interface::v1_hash
-			, hash_handler);
-		io->submit_jobs();
+	io->async_hash(st, 0_piece, {}
+		, disk_interface::sequential_access | disk_interface::volatile_read | disk_interface::v1_hash
+		, hash_handler);
+	io->async_release_files(st, [&]
+	{
+		release_done = true;
+		--outstanding;
+	});
+	io->async_hash(st, 0_piece, {}
+		, disk_interface::sequential_access | disk_interface::volatile_read | disk_interface::v1_hash
+		, hash_handler);
+	io->submit_jobs();
 
-		time_point const end_time = clock_type::now() + seconds(10);
-		while (outstanding > 0 && clock_type::now() < end_time)
-		{
-			ios.run_one_for(milliseconds(100));
-			ios.restart();
-		}
-
-		TEST_EQUAL(outstanding, 0);
-		TEST_EQUAL(hashes_done, 2);
-		TEST_CHECK(release_done);
+	time_point const end_time = clock_type::now() + seconds(10);
+	while (outstanding > 0 && clock_type::now() < end_time)
+	{
+		ios.run_one_for(milliseconds(100));
+		ios.restart();
 	}
+
+	TEST_EQUAL(outstanding, 0);
+	TEST_EQUAL(hashes_done, 2);
+	TEST_CHECK(release_done);
 
 	io->abort(true);
 }

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -678,7 +678,9 @@ constexpr check_files_flag_t test_oversized = 1_bit;
 constexpr check_files_flag_t zero_prio = 2_bit;
 
 void test_check_files(check_files_flag_t const flags
-	, lt::disk_io_constructor_type const disk_constructor)
+	, lt::disk_io_constructor_type const disk_constructor
+	, int const aio_threads = 1
+	, int const hashing_threads = 0)
 {
 	std::string const test_path = current_working_directory();
 	std::shared_ptr<torrent_info> info;
@@ -721,7 +723,8 @@ void test_check_files(check_files_flag_t const flags
 	counters cnt;
 
 	aux::session_settings sett;
-	sett.set_int(settings_pack::aio_threads, 1);
+	sett.set_int(settings_pack::aio_threads, aio_threads);
+	sett.set_int(settings_pack::hashing_threads, hashing_threads);
 	std::unique_ptr<disk_interface> io = disk_constructor(ios, sett, cnt);
 
 	aux::vector<download_priority_t, file_index_t> priorities;
@@ -762,6 +765,47 @@ void test_check_files(check_files_flag_t const flags
 		io->submit_jobs();
 		ios.restart();
 		run_until(ios, done);
+	}
+
+	if (aio_threads == 0 && hashing_threads > 0)
+	{
+		int outstanding = 3;
+		int hashes_done = 0;
+		bool release_done = false;
+		sha1_hash const expected_hash = hasher(piece0).final();
+		auto hash_handler = [&](piece_index_t const piece
+			, sha1_hash const& hash, storage_error const& error)
+		{
+			TEST_EQUAL(piece, 0_piece);
+			TEST_CHECK(!error);
+			TEST_EQUAL(hash, expected_hash);
+			++hashes_done;
+			--outstanding;
+		};
+
+		io->async_hash(st, 0_piece, {}
+			, disk_interface::sequential_access | disk_interface::volatile_read | disk_interface::v1_hash
+			, hash_handler);
+		io->async_release_files(st, [&]
+		{
+			release_done = true;
+			--outstanding;
+		});
+		io->async_hash(st, 0_piece, {}
+			, disk_interface::sequential_access | disk_interface::volatile_read | disk_interface::v1_hash
+			, hash_handler);
+		io->submit_jobs();
+
+		time_point const end_time = clock_type::now() + seconds(10);
+		while (outstanding > 0 && clock_type::now() < end_time)
+		{
+			ios.run_one_for(milliseconds(100));
+			ios.restart();
+		}
+
+		TEST_EQUAL(outstanding, 0);
+		TEST_EQUAL(hashes_done, 2);
+		TEST_CHECK(release_done);
 	}
 
 	io->abort(true);
@@ -828,21 +872,25 @@ void run_test()
 TORRENT_TEST(check_files_sparse_mmap)
 {
 	test_check_files(sparse | zero_prio, lt::mmap_disk_io_constructor);
+	test_check_files(sparse | zero_prio, lt::mmap_disk_io_constructor, 0, 1);
 }
 
 TORRENT_TEST(check_files_oversized_mmap_zero_prio)
 {
 	test_check_files(sparse | zero_prio | test_oversized, lt::mmap_disk_io_constructor);
+	test_check_files(sparse | zero_prio | test_oversized, lt::mmap_disk_io_constructor, 0, 1);
 }
 
 TORRENT_TEST(check_files_oversized_mmap)
 {
 	test_check_files(sparse | test_oversized, lt::mmap_disk_io_constructor);
+	test_check_files(sparse | test_oversized, lt::mmap_disk_io_constructor, 0, 1);
 }
 
 TORRENT_TEST(check_files_allocate_mmap)
 {
 	test_check_files(zero_prio, lt::mmap_disk_io_constructor);
+	test_check_files(zero_prio, lt::mmap_disk_io_constructor, 0, 1);
 }
 
 TORRENT_TEST(test_pre_allocate_mmap)
@@ -1729,93 +1777,6 @@ void test_unaligned_read(lt::disk_io_constructor_type constructor, Fun fun)
 	t.reset();
 	disk_io->abort(true);
 }
-
-#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
-TORRENT_TEST(mmap_fenced_hash_zero_aio_threads)
-{
-	lt::io_context ioc;
-	lt::counters cnt;
-	lt::settings_pack pack;
-	pack.set_int(lt::settings_pack::aio_threads, 0);
-	pack.set_int(lt::settings_pack::hashing_threads, 1);
-	pack.set_int(lt::settings_pack::file_pool_size, 2);
-
-	std::unique_ptr<lt::disk_interface> disk_io
-		= lt::mmap_disk_io_constructor(ioc, pack, cnt);
-
-	lt::file_storage fs;
-	fs.add_file(combine_path("fenced_hash", "test"), lt::default_block_size);
-	fs.set_num_pieces(1);
-	fs.set_piece_length(lt::default_block_size);
-
-	std::string const save_path = complete("fenced_hash_save");
-	delete_dirs(save_path);
-
-	lt::aux::vector<lt::download_priority_t, lt::file_index_t> prios;
-	lt::storage_params params(fs, nullptr
-		, save_path
-		, lt::storage_mode_sparse
-		, prios
-		, lt::sha1_hash("01234567890123456789"));
-
-	lt::storage_holder t = disk_io->new_torrent(params, {});
-
-	std::vector<char> write_buffer(lt::default_block_size);
-	aux::random_bytes(write_buffer);
-	lt::sha1_hash const expected_hash = lt::hasher(write_buffer).final();
-
-	int outstanding = 1;
-	lt::peer_request const req{0_piece, 0, lt::default_block_size};
-	disk_io->async_write(t, req, write_buffer.data(), {}
-		, [&](lt::storage_error const& ec)
-		{
-			TEST_CHECK(!ec);
-			--outstanding;
-		});
-	disk_io->submit_jobs();
-	sync(ioc, outstanding);
-
-	int hashes_done = 0;
-	bool release_done = false;
-	outstanding = 3;
-	auto hash_handler = [&](lt::piece_index_t const piece
-		, lt::sha1_hash const& hash, lt::storage_error const& ec)
-	{
-		TEST_EQUAL(piece, 0_piece);
-		TEST_CHECK(!ec);
-		TEST_EQUAL(hash, expected_hash);
-		++hashes_done;
-		--outstanding;
-	};
-
-	disk_io->async_hash(t, 0_piece, {}
-		, lt::disk_interface::sequential_access | lt::disk_interface::v1_hash
-		, hash_handler);
-	disk_io->async_release_files(t, [&]
-	{
-		release_done = true;
-		--outstanding;
-	});
-	disk_io->async_hash(t, 0_piece, {}
-		, lt::disk_interface::sequential_access | lt::disk_interface::v1_hash
-		, hash_handler);
-	disk_io->submit_jobs();
-
-	time_point const end_time = clock_type::now() + seconds(10);
-	while (outstanding > 0 && clock_type::now() < end_time)
-	{
-		ioc.run_one_for(milliseconds(100));
-		ioc.restart();
-	}
-
-	TEST_EQUAL(outstanding, 0);
-	TEST_EQUAL(hashes_done, 2);
-	TEST_CHECK(release_done);
-
-	t.reset();
-	disk_io->abort(true);
-}
-#endif
 
 struct write_handler
 {

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -61,8 +61,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 #include <functional> // for bind
-#include <thread>
-
 #include <iostream>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
@@ -1803,11 +1801,11 @@ TORRENT_TEST(mmap_fenced_hash_zero_aio_threads)
 		, hash_handler);
 	disk_io->submit_jobs();
 
-	for (int i = 0; i < 200 && outstanding > 0; ++i)
+	time_point const end_time = clock_type::now() + seconds(10);
+	while (outstanding > 0 && clock_type::now() < end_time)
 	{
-		ioc.poll();
+		ioc.run_one_for(milliseconds(100));
 		ioc.restart();
-		std::this_thread::sleep_for(lt::milliseconds(10));
 	}
 
 	TEST_EQUAL(outstanding, 0);

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -869,28 +869,31 @@ void run_test()
 }
 
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
+void test_check_files_mmap(check_files_flag_t const flags)
+{
+	test_check_files(flags, lt::mmap_disk_io_constructor);
+	test_check_files(flags, lt::mmap_disk_io_constructor, 0, 1);
+	test_check_files(flags, lt::mmap_disk_io_constructor, 0, 2);
+}
+
 TORRENT_TEST(check_files_sparse_mmap)
 {
-	test_check_files(sparse | zero_prio, lt::mmap_disk_io_constructor);
-	test_check_files(sparse | zero_prio, lt::mmap_disk_io_constructor, 0, 1);
+	test_check_files_mmap(sparse | zero_prio);
 }
 
 TORRENT_TEST(check_files_oversized_mmap_zero_prio)
 {
-	test_check_files(sparse | zero_prio | test_oversized, lt::mmap_disk_io_constructor);
-	test_check_files(sparse | zero_prio | test_oversized, lt::mmap_disk_io_constructor, 0, 1);
+	test_check_files_mmap(sparse | zero_prio | test_oversized);
 }
 
 TORRENT_TEST(check_files_oversized_mmap)
 {
-	test_check_files(sparse | test_oversized, lt::mmap_disk_io_constructor);
-	test_check_files(sparse | test_oversized, lt::mmap_disk_io_constructor, 0, 1);
+	test_check_files_mmap(sparse | test_oversized);
 }
 
 TORRENT_TEST(check_files_allocate_mmap)
 {
-	test_check_files(zero_prio, lt::mmap_disk_io_constructor);
-	test_check_files(zero_prio, lt::mmap_disk_io_constructor, 0, 1);
+	test_check_files_mmap(zero_prio);
 }
 
 TORRENT_TEST(test_pre_allocate_mmap)

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -61,6 +61,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 #include <functional> // for bind
+#include <thread>
 
 #include <iostream>
 
@@ -1730,6 +1731,93 @@ void test_unaligned_read(lt::disk_io_constructor_type constructor, Fun fun)
 	t.reset();
 	disk_io->abort(true);
 }
+
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
+TORRENT_TEST(mmap_fenced_hash_zero_aio_threads)
+{
+	lt::io_context ioc;
+	lt::counters cnt;
+	lt::settings_pack pack;
+	pack.set_int(lt::settings_pack::aio_threads, 0);
+	pack.set_int(lt::settings_pack::hashing_threads, 1);
+	pack.set_int(lt::settings_pack::file_pool_size, 2);
+
+	std::unique_ptr<lt::disk_interface> disk_io
+		= lt::mmap_disk_io_constructor(ioc, pack, cnt);
+
+	lt::file_storage fs;
+	fs.add_file(combine_path("fenced_hash", "test"), lt::default_block_size);
+	fs.set_num_pieces(1);
+	fs.set_piece_length(lt::default_block_size);
+
+	std::string const save_path = complete("fenced_hash_save");
+	delete_dirs(save_path);
+
+	lt::aux::vector<lt::download_priority_t, lt::file_index_t> prios;
+	lt::storage_params params(fs, nullptr
+		, save_path
+		, lt::storage_mode_sparse
+		, prios
+		, lt::sha1_hash("01234567890123456789"));
+
+	lt::storage_holder t = disk_io->new_torrent(params, {});
+
+	std::vector<char> write_buffer(lt::default_block_size);
+	aux::random_bytes(write_buffer);
+	lt::sha1_hash const expected_hash = lt::hasher(write_buffer).final();
+
+	int outstanding = 1;
+	lt::peer_request const req{0_piece, 0, lt::default_block_size};
+	disk_io->async_write(t, req, write_buffer.data(), {}
+		, [&](lt::storage_error const& ec)
+		{
+			TEST_CHECK(!ec);
+			--outstanding;
+		});
+	disk_io->submit_jobs();
+	sync(ioc, outstanding);
+
+	int hashes_done = 0;
+	bool release_done = false;
+	outstanding = 3;
+	auto hash_handler = [&](lt::piece_index_t const piece
+		, lt::sha1_hash const& hash, lt::storage_error const& ec)
+	{
+		TEST_EQUAL(piece, 0_piece);
+		TEST_CHECK(!ec);
+		TEST_EQUAL(hash, expected_hash);
+		++hashes_done;
+		--outstanding;
+	};
+
+	disk_io->async_hash(t, 0_piece, {}
+		, lt::disk_interface::sequential_access | lt::disk_interface::v1_hash
+		, hash_handler);
+	disk_io->async_release_files(t, [&]
+	{
+		release_done = true;
+		--outstanding;
+	});
+	disk_io->async_hash(t, 0_piece, {}
+		, lt::disk_interface::sequential_access | lt::disk_interface::v1_hash
+		, hash_handler);
+	disk_io->submit_jobs();
+
+	for (int i = 0; i < 200 && outstanding > 0; ++i)
+	{
+		ioc.poll();
+		ioc.restart();
+		std::this_thread::sleep_for(lt::milliseconds(10));
+	}
+
+	TEST_EQUAL(outstanding, 0);
+	TEST_EQUAL(hashes_done, 2);
+	TEST_CHECK(release_done);
+
+	t.reset();
+	disk_io->abort(true);
+}
+#endif
 
 struct write_handler
 {


### PR DESCRIPTION
Fixes an mmap disk I/O scheduling case where jobs unblocked by a fence could be put back on the generic queue even when no generic disk threads were running.

This could stall configs with aio_threads=0 and hashing_threads>0 after a fenced job, because follow-up work was not always routed to an active queue or executed inline.

The change keeps job queue and thread-pool selection consistent, routes unblocked fence jobs back to the right queue, and executes unblocked jobs inline when their target pool has no threads.

Added a regression test for fenced mmap hashing with zero aio threads.

Tested with test_storage and test_fence.