### PR TITLE
hash_picker: stop retrying accepted piece-layer hashes

### DIFF
--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -289,6 +289,27 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 		ret.hash_failed = std::move(results->failed);
 		ret.hash_passed = std::move(results->passed);
 
+		if (req.base == m_piece_layer)
+		{
+			// Piece-layer hash requests are tracked in 512-piece buckets.
+			// Once the response has been validated and inserted into the merkle
+			// tree, mark the bucket as complete so pick_hashes() does not retry
+			// the same range after min_request_interval.
+			TORRENT_ASSERT(req.index % 512 == 0);
+			TORRENT_ASSERT(req.count <= 512);
+			int const request_index = req.index / 512;
+			if (req.index % 512 == 0
+				&& req.count <= 512
+				&& request_index >= 0
+				&& request_index < int(m_piece_hash_requested[req.file].size()))
+			{
+				auto& piece_hash_req = m_piece_hash_requested[req.file][request_index];
+				piece_hash_req.have = true;
+				piece_hash_req.last_request = min_time();
+				piece_hash_req.num_requests = 0;
+			}
+		}
+
 		return ret;
 	}
 

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -271,6 +271,43 @@ TORRENT_TEST(add_piece_hashes)
 	TEST_CHECK(std::equal(cmp.begin(), cmp.begin() + merkle_num_nodes(1024), full_tree.begin()));
 }
 
+TORRENT_TEST(add_piece_hashes_marks_request_complete)
+{
+	file_storage fs;
+	fs.set_piece_length(4 * 16 * 1024);
+
+	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const full_tree = build_tree(4 * 512);
+	sha256_hash const root = full_tree[0];
+	trees.emplace_back(4 * 512, 4, root.data());
+
+	hash_picker picker(fs, trees);
+
+	typed_bitfield<piece_index_t> const pieces(512, true);
+
+	hash_request const picked = picker.pick_hashes(pieces);
+	TEST_EQUAL(picked.file, 0_file);
+	TEST_EQUAL(picked.base, 2);
+	TEST_EQUAL(picked.index, 0);
+	TEST_EQUAL(picked.count, 512);
+
+	// Make the same request immediately eligible again. This simulates the
+	// retry interval expiring before the valid response is processed.
+	picker.hashes_rejected(picked);
+
+	auto pieces_start = full_tree.begin() + merkle_num_nodes(512) - 512;
+
+	std::vector<sha256_hash> hashes;
+	std::copy(pieces_start, pieces_start + 512, std::back_inserter(hashes));
+	add_hashes_result const result = picker.add_hashes(picked, hashes);
+	TEST_CHECK(result.valid);
+
+	hash_request const picked2 = picker.pick_hashes(pieces);
+	TEST_EQUAL(picked2.count, 0);
+}
+
 TORRENT_TEST(add_piece_hashes_padded)
 {
 	file_storage fs;
@@ -682,4 +719,3 @@ TORRENT_TEST(validate_hash_request_single_block_file)
 
 	TEST_CHECK(!validate_hash_request(hash_request(file_index_t{0}, 0, 0, 1, 0), fs));
 }
-


### PR DESCRIPTION
## Summary

`hash_picker::add_hashes()` validates and inserts accepted BEP52 piece-layer hash responses into the file merkle tree, but it did not update the per-512-piece request bookkeeping used by `pick_hashes()`.

That leaves `m_piece_hash_requested[].have` false after a successful response. Once the retry interval expires, `pick_hashes()` may select the same piece-layer range again, causing repeated `HASH_REQUEST` / `HASHES` exchanges with peers that already served valid hashes.

This marks the corresponding piece-layer request bucket complete after a valid response is accepted.

## Test

Added `add_piece_hashes_marks_request_complete` to `test_hash_picker.cpp`. The test makes a previously requested piece-layer range eligible again, accepts a valid hash response, and verifies `pick_hashes()` does not select the same range again.

## Local validation

- `git diff --check`
- `clang++ -std=c++14 -Iinclude -I/opt/homebrew/include -DTORRENT_BUILDING_LIBRARY -DTORRENT_USE_OPENSSL=1 -fsyntax-only src/hash_picker.cpp`
- `clang++ -std=c++14 -Iinclude -Itest -I/opt/homebrew/include -DTORRENT_USE_OPENSSL=1 -fsyntax-only test/test_hash_picker.cpp`

`make check` could not run locally because Boost.Build (`b2`) is not installed in this environment.
