### PR TITLE
I2p flag

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,13 @@
+# Auto-generated source files; do not reformat them.
+# These are produced by code-generation scripts and must match the generator
+# output exactly, so clang-format must leave them untouched. This file is
+# honored by a direct `clang-format` / `clang-format -i` run (e.g. from an
+# editor). NOTE: git-clang-format does NOT understand .clang-format-ignore --
+# it reads the empty output for an ignored file as "make the file empty" -- so
+# these same files are also excluded from the git-clang-format pre-commit hook
+# in .pre-commit-config.yaml. Keep the two lists in sync.
+bindings/c/include/libtorrent_settings.h
+bindings/c/include/libtorrent_alerts.h
+bindings/c/src/settings.cpp
+include/libtorrent/libtorrent.hpp
+include/libtorrent/fwd.hpp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -218,6 +218,17 @@ repos:
   - id: git-clang-format
     name: git-clang-format
     language: system
-    entry: git-clang-format-18 --binary clang-format-18 --force
-    pass_filenames: false
+    entry: git-clang-format-18 --binary clang-format-18 --force --
+    pass_filenames: true
     files: \.(cpp|hpp)$
+    # Auto-generated sources must match their generator output, so
+    # clang-format must never touch them. The .h generated headers
+    # (bindings/c/include/libtorrent_*.h) are already skipped because they
+    # do not match the .cpp/.hpp filter above; the generated .cpp/.hpp
+    # sources are excluded explicitly here.
+    exclude: |
+      (?x)^(
+        bindings/c/src/settings\.cpp|
+        include/libtorrent/libtorrent\.hpp|
+        include/libtorrent/fwd\.hpp
+      )$

--- a/bindings/c/include/libtorrent_settings.h
+++ b/bindings/c/include/libtorrent_settings.h
@@ -32,7 +32,6 @@ enum settings_tags_t {
 	SET_ANNOUNCE_TO_ALL_TRACKERS, // int (0 or 1)
 	SET_PREFER_UDP_TRACKERS, // int (0 or 1)
 	SET_DISABLE_HASH_CHECKS, // int (0 or 1)
-	SET_ALLOW_I2P_MIXED, // int (0 or 1)
 	SET_NO_ATIME_STORAGE, // int (0 or 1)
 	SET_INCOMING_STARTS_QUEUED_TORRENTS, // int (0 or 1)
 	SET_REPORT_TRUE_DOWNLOADED, // int (0 or 1)

--- a/bindings/c/src/settings.cpp
+++ b/bindings/c/src/settings.cpp
@@ -37,7 +37,6 @@ int settings_key(int const tag)
 		case SET_ANNOUNCE_TO_ALL_TRACKERS: return sp::announce_to_all_trackers;
 		case SET_PREFER_UDP_TRACKERS: return sp::prefer_udp_trackers;
 		case SET_DISABLE_HASH_CHECKS: return sp::disable_hash_checks;
-		case SET_ALLOW_I2P_MIXED: return sp::allow_i2p_mixed;
 		case SET_NO_ATIME_STORAGE: return sp::no_atime_storage;
 		case SET_INCOMING_STARTS_QUEUED_TORRENTS: return sp::incoming_starts_queued_torrents;
 		case SET_REPORT_TRUE_DOWNLOADED: return sp::report_true_downloaded;

--- a/docs/gen_settings_doc.py
+++ b/docs/gen_settings_doc.py
@@ -95,6 +95,8 @@ for line in f:
         mode += "skip"
     if "#if TORRENT_ABI_VERSION <= 3" in line:
         mode += "skip"
+    if "#if TORRENT_ABI_VERSION < 4" in line:
+        mode += "skip"
     if "#endif" in line:
         mode = mode[0:-4]
 
@@ -134,6 +136,9 @@ for line in f:
         line = line[:-1]  # strip trailing comma
         if "=" in line:
             line = line.split("=")[0].strip()
+        # strip a trailing deprecation marker, e.g. "name TORRENT_DEPRECATED_ENUM"
+        if line.endswith("TORRENT_DEPRECATED_ENUM"):
+            line = line[: -len("TORRENT_DEPRECATED_ENUM")].strip()
         if line.endswith("_internal"):
             continue
 

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -836,6 +836,7 @@ namespace aux {
 			void update_dht_upload_rate_limit();
 			void update_proxy();
 			void update_i2p_bridge();
+			void update_allow_i2p_mixed();
 			void update_peer_dscp();
 			void update_user_agent();
 			void update_unchoke_limit();

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -964,8 +964,10 @@ namespace libtorrent::aux {
 		void on_i2p_resolve(error_code const& ec, char const* dest, peer_source_flags_t const source);
 		void add_i2p_peer(sha256_hash const& dest, peer_source_flags_t source);
 		bool is_i2p() const { return m_i2p; }
+		bool only_i2p_peers() const { return m_only_i2p_peers; }
 #else
 		bool is_i2p() const { return false; }
+		bool only_i2p_peers() const { return false; }
 #endif
 
 		// this is the asio callback that is called when a name
@@ -1686,6 +1688,10 @@ namespace libtorrent::aux {
 		bool m_enable_lsd:1;
 
 		bool m_i2p:1;
+
+		// when set, only i2p peers are allowed for this torrent; regular peers
+		// are never added. See torrent_flags::only_i2p_peers.
+		bool m_only_i2p_peers : 1;
 
 		// set once at construct_storage() time when disable_v1_hashes is
 		// enabled. locked in at that point so that changing the setting later

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -556,12 +556,24 @@ namespace aux {
 			// combined with disabled_storage)
 			disable_hash_checks,
 
+#if TORRENT_ABI_VERSION < 4
 			// if this is true, i2p torrents are allowed to also get peers from
 			// other sources than the tracker, and connect to regular IPs, not
 			// providing any anonymization. This may be useful if the user is not
 			// interested in the anonymization of i2p, but still wants to be able
 			// to connect to i2p peers.
-			allow_i2p_mixed,
+			// This is a global override of the per-torrent
+			// ``torrent_flags::only_i2p_peers`` flag: enabling it clears that
+			// flag on all torrents (and prevents it from being set), while
+			// disabling it restores i2p-only behavior for i2p torrents.
+			//
+			// This setting is deprecated. For finer-grained control, leave it
+			// at its default (disabled) and manage the per-torrent
+			// ``torrent_flags::only_i2p_peers`` flag instead.
+			allow_i2p_mixed TORRENT_DEPRECATED_ENUM,
+#else
+			deprecated_allow_i2p_mixed,
+#endif
 
 #if TORRENT_ABI_VERSION == 1
 			// ``low_prio_disk`` determines if the disk I/O should use a normal or

--- a/include/libtorrent/torrent_flags.hpp
+++ b/include/libtorrent/torrent_flags.hpp
@@ -282,9 +282,10 @@ namespace torrent_flags {
 	// (dont_download).
 	constexpr torrent_flags_t default_dont_download = 23_bit;
 
-	// this flag makes the torrent be considered an "i2p torrent" for purposes
-	// of the allow_i2p_mixed setting. When mixing regular peers and i2p peers
-	// is disabled, i2p torrents won't add normal peers to its peer list.
+#if TORRENT_ABI_VERSION < 4
+	// this flag makes the torrent be considered an "i2p torrent". i2p torrents
+	// exchange peers over i2p (via the i2p_pex extension) and can connect to
+	// peers reachable through the session's SAM connection.
 	// Note that non i2p torrents may still allow i2p peers (on the off-chance
 	// that a tracker return them and the session is configured with a SAM
 	// connection).
@@ -292,7 +293,20 @@ namespace torrent_flags {
 	// one tracker whose hostname ends with .i2p.
 	// It's also set by parse_magnet_uri() if the tracker list contains such
 	// URL.
-	constexpr torrent_flags_t i2p_torrent = 24_bit;
+	// Whether regular (non-i2p) peers are allowed is controlled separately by
+	// the only_i2p_peers flag.
+	//
+	// This flag is deprecated. It is set automatically for i2p torrents (those
+	// with a .i2p tracker), so setting it explicitly should not be necessary.
+	// To control whether regular (non-i2p) peers are allowed, use the
+	// only_i2p_peers flag instead.
+	TORRENT_DEPRECATED constexpr torrent_flags_t i2p_torrent = 24_bit;
+#endif
+
+	// hidden
+	// internal, non-deprecated alias for i2p_torrent, used by the library and
+	// tests in place of the deprecated public name
+	constexpr torrent_flags_t deprecated_i2p_torrent = 24_bit;
 
 	// For hybrid (v1+v2) torrents, skip SHA-1 (v1) piece hash validation and
 	// only verify SHA-256 (v2) hashes. Saves CPU and disk I/O by avoiding the
@@ -300,6 +314,15 @@ namespace torrent_flags {
 	// validation alone is sufficient. Has no effect on v1-only or v2-only
 	// torrents. Cannot be changed after the torrent is added.
 	constexpr torrent_flags_t disable_v1_hashes = 25_bit;
+
+	// when set, this torrent only connects to and exchanges i2p peers; regular
+	// (non-i2p) peers are never added to the peer list, and the torrent is not
+	// announced to regular trackers, the DHT or local service discovery. This
+	// is the per-torrent equivalent of disabling the global allow_i2p_mixed
+	// setting. It is set automatically for i2p torrents (see i2p_torrent),
+	// unless allow_i2p_mixed is enabled. Clearing the i2p_torrent flag also
+	// clears this flag.
+	constexpr torrent_flags_t only_i2p_peers = 26_bit;
 
 	// all torrent flags combined. Can conveniently be used when creating masks
 	// for flags

--- a/src/load_torrent.cpp
+++ b/src/load_torrent.cpp
@@ -238,7 +238,14 @@ namespace aux {
 					string_view const url = aux::ltrim(tier.list_string_value_at(k));
 					if (!aux::is_valid_tracker_url(url)) continue;
 #if TORRENT_USE_I2P
-					if (aux::is_i2p_url(url)) out.flags |= torrent_flags::i2p_torrent;
+					if (aux::is_i2p_url(url))
+					{
+						// fail closed: an .i2p tracker makes this an i2p-only
+						// torrent. The session relaxes this when allow_i2p_mixed
+						// is enabled.
+						out.flags |= torrent_flags::deprecated_i2p_torrent;
+						out.flags |= torrent_flags::only_i2p_peers;
+					}
 #endif
 					out.trackers.emplace_back(url);
 					out.tracker_tiers.push_back(j);
@@ -252,7 +259,14 @@ namespace aux {
 			if (aux::is_valid_tracker_url(url))
 			{
 #if TORRENT_USE_I2P
-				if (aux::is_i2p_url(url)) out.flags |= torrent_flags::i2p_torrent;
+				if (aux::is_i2p_url(url))
+				{
+					// fail closed: an .i2p tracker makes this an i2p-only
+					// torrent. The session relaxes this when allow_i2p_mixed
+					// is enabled.
+					out.flags |= torrent_flags::deprecated_i2p_torrent;
+					out.flags |= torrent_flags::only_i2p_peers;
+				}
 #endif
 				out.trackers.emplace_back(url);
 				out.tracker_tiers.push_back(0);

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -322,8 +322,14 @@ namespace libtorrent {
 				if (!e && lt::aux::is_valid_tracker_url(tracker))
 				{
 #if TORRENT_USE_I2P
-					if (!(p.flags & torrent_flags::i2p_torrent) && aux::is_i2p_url(tracker))
-						p.flags |= torrent_flags::i2p_torrent;
+					if (!(p.flags & torrent_flags::deprecated_i2p_torrent)
+						&& aux::is_i2p_url(tracker))
+					{
+						p.flags |= torrent_flags::deprecated_i2p_torrent;
+						// fail closed: restrict to i2p peers. The session relaxes
+						// this when allow_i2p_mixed is enabled.
+						p.flags |= torrent_flags::only_i2p_peers;
+					}
 #endif
 
 					p.trackers.push_back(std::move(tracker));

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1344,12 +1344,10 @@ namespace {
 		}
 
 #if TORRENT_USE_I2P
-		if (!aux::is_i2p(m_socket)
-			&& t->is_i2p()
-			&& !m_settings.get_bool(settings_pack::allow_i2p_mixed))
+		if (!aux::is_i2p(m_socket) && t->only_i2p_peers())
 		{
-			// the torrent is an i2p torrent, the peer is a regular peer
-			// and we don't allow mixed mode. Disconnect the peer.
+			// the torrent only allows i2p peers and this is a regular peer.
+			// Disconnect the peer.
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, peer_log_alert::attach, "rejected regular connection to i2p torrent");
 #endif

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -249,7 +249,7 @@ namespace {
 		apply_flag(ret.flags, rd, "super_seeding", torrent_flags::super_seeding);
 #endif
 #if TORRENT_USE_I2P
-		apply_flag(ret.flags, rd, "i2p", torrent_flags::i2p_torrent);
+		apply_flag(ret.flags, rd, "i2p", torrent_flags::deprecated_i2p_torrent);
 #endif
 		apply_flag(ret.flags, rd, "sequential_download", torrent_flags::sequential_download);
 		apply_flag(ret.flags, rd, "stop_when_ready", torrent_flags::stop_when_ready);
@@ -326,7 +326,8 @@ namespace {
 					ret.trackers.emplace_back(tier_list.list_string_value_at(j));
 					ret.tracker_tiers.push_back(tier);
 #if TORRENT_USE_I2P
-					if (aux::is_i2p_url(ret.trackers.back())) ret.flags |= torrent_flags::i2p_torrent;
+					if (aux::is_i2p_url(ret.trackers.back()))
+						ret.flags |= torrent_flags::deprecated_i2p_torrent;
 #endif
 				}
 				++tier;
@@ -453,6 +454,19 @@ namespace {
 					bitmask.string_ptr(), bitmask.string_length() * CHAR_BIT);
 			}
 		}
+
+#if TORRENT_USE_I2P
+		// the only_i2p_peers flag controls whether regular (non-i2p) peers are
+		// allowed. If the resume data carries it explicitly, honor that value.
+		// Older resume data (written before this flag existed) has no such key:
+		// in that case fail closed and derive it from the i2p flag (which may
+		// have been set from the "i2p" key or from an .i2p tracker URL), so a
+		// torrent that used to be restricted to i2p peers stays restricted.
+		if (rd.dict_find("only_i2p_peers"))
+			apply_flag(ret.flags, rd, "only_i2p_peers", torrent_flags::only_i2p_peers);
+		else if (ret.flags & torrent_flags::deprecated_i2p_torrent)
+			ret.flags |= torrent_flags::only_i2p_peers;
+#endif
 
 		// we're loading this torrent from resume data. There's no need to
 		// re-save the resume data immediately.

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2378,6 +2378,31 @@ retry:
 #endif
 	}
 
+	void session_impl::update_allow_i2p_mixed()
+	{
+#if TORRENT_USE_I2P && TORRENT_ABI_VERSION < 4
+		// the global allow_i2p_mixed setting is preserved as an override of
+		// the per-torrent only_i2p_peers flag. Keep the invariant
+		// only_i2p_peers == (i2p_torrent && !allow_i2p_mixed) for all torrents
+		// that don't manage only_i2p_peers themselves. This callback fires only
+		// when the setting actually changes.
+		bool const mixed = m_settings.get_bool(settings_pack::allow_i2p_mixed);
+		for (auto const& t : m_torrents)
+		{
+			if (mixed)
+			{
+				// mixing enabled: allow regular peers everywhere
+				t->set_flags(torrent_flags_t{}, torrent_flags::only_i2p_peers);
+			}
+			else if (t->is_i2p())
+			{
+				// mixing disabled again: restore i2p-only for i2p torrents
+				t->set_flags(torrent_flags::only_i2p_peers, torrent_flags::only_i2p_peers);
+			}
+		}
+#endif
+	}
+
 #ifndef TORRENT_DISABLE_DHT
 	int session_impl::external_udp_port(address const& local_address) const
 	{
@@ -5797,9 +5822,8 @@ retry:
 
 		std::shared_ptr<torrent> t = find_torrent(info_hash_t(ih)).lock();
 		if (!t) return;
-		// don't add peers from lsd to private torrents
-		if (t->torrent_file().priv() || (t->is_i2p()
-			&& !m_settings.get_bool(settings_pack::allow_i2p_mixed))) return;
+		// don't add peers from lsd to private or i2p-only torrents
+		if (t->torrent_file().priv() || t->only_i2p_peers()) return;
 
 		protocol_version const v = ih == t->torrent_file().info_hashes().v1
 			? protocol_version::V1 : protocol_version::V2;

--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -86,6 +86,18 @@ namespace libtorrent {
 #define DEPRECATED2_SET(name, default_value, fun) { "", nullptr, 0 }
 #endif
 
+#if TORRENT_ABI_VERSION < 4
+#define DEPRECATED4_SET(name, default_value, fun) \
+	{ \
+		#name, fun, default_value \
+	}
+#else
+#define DEPRECATED4_SET(name, default_value, fun) \
+	{ \
+		"", nullptr, 0 \
+	}
+#endif
+
 #ifdef TORRENT_WINDOWS
 constexpr int CLOSE_FILE_INTERVAL = 240;
 #else
@@ -129,10 +141,11 @@ namespace {
 	}});
 
 	CONSTEXPR_SETTINGS
-	aux::array<bool_setting_entry_t, settings_pack::num_bool_settings> const bool_settings
-	({{
+	aux::array<bool_setting_entry_t, settings_pack::num_bool_settings> const bool_settings({{
 		SET(allow_multiple_connections_per_ip, false, nullptr),
-		DEPRECATED_SET(ignore_limits_on_local_network, true, &session_impl::update_ignore_rate_limits_on_local_network),
+		DEPRECATED_SET(ignore_limits_on_local_network,
+			true,
+			&session_impl::update_ignore_rate_limits_on_local_network),
 		SET(send_redundant_have, true, nullptr),
 		DEPRECATED_SET(lazy_bitfields, false, nullptr),
 		SET(use_dht_as_fallback, false, nullptr),
@@ -154,7 +167,7 @@ namespace {
 		DEPRECATED_SET(strict_super_seeding, false, nullptr),
 		DEPRECATED_SET(lock_disk_cache, false, nullptr),
 		SET(disable_hash_checks, false, nullptr),
-		SET(allow_i2p_mixed, false, nullptr),
+		DEPRECATED4_SET(allow_i2p_mixed, false, &session_impl::update_allow_i2p_mixed),
 		DEPRECATED_SET(low_prio_disk, true, nullptr),
 		DEPRECATED2_SET(volatile_read_cache, false, nullptr),
 		DEPRECATED_SET(guided_read_cache, false, nullptr),

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -208,10 +208,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		, m_state(torrent_status::checking_resume_data)
 	{}
 
-	torrent::torrent(
-		aux::session_interface& ses
-		, bool const session_paused
-		, add_torrent_params&& p)
+	torrent::torrent(aux::session_interface& ses, bool const session_paused, add_torrent_params&& p)
 		: torrent_hot_members(ses, p, session_paused)
 		, m_total_uploaded(p.total_uploaded)
 		, m_total_downloaded(p.total_downloaded)
@@ -248,7 +245,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		, m_stop_when_ready(p.flags & torrent_flags::stop_when_ready)
 		, m_enable_dht(!bool(p.flags & torrent_flags::disable_dht))
 		, m_enable_lsd(!bool(p.flags & torrent_flags::disable_lsd))
-		, m_i2p(bool(p.flags & torrent_flags::i2p_torrent))
+		, m_i2p(bool(p.flags & torrent_flags::deprecated_i2p_torrent))
+		, m_only_i2p_peers(bool(p.flags & torrent_flags::only_i2p_peers))
 		, m_disable_v1_hashes(false)
 		, m_max_uploads((1 << 24) - 1)
 		, m_num_uploads(0)
@@ -258,7 +256,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 #if TORRENT_ABI_VERSION < 4
 		, m_v2_piece_layers_validated(false)
 #endif
-		, m_connect_boost_counter(static_cast<std::uint8_t>(settings().get_int(settings_pack::torrent_connect_boost)))
+		, m_connect_boost_counter(
+			  static_cast<std::uint8_t>(settings().get_int(settings_pack::torrent_connect_boost)))
 		, m_incomplete(0xffffff)
 		, m_announce_to_dht(!(p.flags & torrent_flags::paused))
 		, m_ssl_torrent(false)
@@ -313,7 +312,23 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 #if TORRENT_USE_I2P
 		if (m_torrent_file->is_i2p())
+		{
+			bool const was_i2p = m_i2p;
 			m_i2p = true;
+			// if the torrent's i2p nature was only discovered from the metadata
+			// (i.e. it was not flagged via add_torrent_params or resume data,
+			// both of which also set only_i2p_peers), fail closed and restrict
+			// to i2p peers only. When the flag was set by a loader, magnet link
+			// or resume data, only_i2p_peers carries the authoritative decision
+			// (including a deliberate "mixed" choice) and is honored as-is.
+			if (!was_i2p) m_only_i2p_peers = true;
+		}
+#if TORRENT_ABI_VERSION < 4
+		// honor the deprecated global mixed-mode override: when the user has
+		// explicitly enabled mixing i2p and regular peers, never restrict to
+		// i2p-only.
+		if (settings().get_bool(settings_pack::allow_i2p_mixed)) m_only_i2p_peers = false;
+#endif
 #endif
 
 		if (m_torrent_file->is_valid())
@@ -739,10 +754,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (!m_ses.announce_dht()) return false;
 
 #if TORRENT_USE_I2P
-		// i2p torrents don't announced on the DHT
-		// unless we allow mixed swarms
-		if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
-			return false;
+		// i2p-only torrents are not announced on the DHT
+		if (only_i2p_peers()) return false;
 #endif
 
 		if (!m_ses.dht()) return false;
@@ -947,8 +960,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 			ret |= torrent_flags::disable_lsd;
 		if (!m_enable_pex)
 			ret |= torrent_flags::disable_pex;
-		if (m_i2p)
-			ret |= torrent_flags::i2p_torrent;
+		if (m_i2p) ret |= torrent_flags::deprecated_i2p_torrent;
+		if (m_only_i2p_peers) ret |= torrent_flags::only_i2p_peers;
 		if (m_disable_v1_hashes)
 			ret |= torrent_flags::disable_v1_hashes;
 		return ret;
@@ -957,9 +970,28 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 	void torrent::set_flags(torrent_flags_t const flags
 		, torrent_flags_t const mask)
 	{
-		if (mask & torrent_flags::i2p_torrent)
+		if (mask & torrent_flags::deprecated_i2p_torrent)
 		{
-			m_i2p = bool(flags & torrent_flags::i2p_torrent);
+			bool const new_i2p = bool(flags & torrent_flags::deprecated_i2p_torrent);
+			m_i2p = new_i2p;
+			// backward compatibility: toggling the i2p_torrent flag also
+			// adjusts only_i2p_peers. Setting i2p_torrent fails closed
+			// (i2p-only); clearing it allows regular peers again.
+#if TORRENT_ABI_VERSION < 4
+			// while the deprecated allow_i2p_mixed setting exists, it overrides
+			// the fail-closed default, preserving the legacy behavior where
+			// i2p_torrent combined with !allow_i2p_mixed controlled whether
+			// regular peers were allowed.
+			m_only_i2p_peers = new_i2p && !settings().get_bool(settings_pack::allow_i2p_mixed);
+#else
+			m_only_i2p_peers = new_i2p;
+#endif
+		}
+		// applied after the i2p_torrent shim so an explicit only_i2p_peers in
+		// the same call takes precedence.
+		if (mask & torrent_flags::only_i2p_peers)
+		{
+			m_only_i2p_peers = bool(flags & torrent_flags::only_i2p_peers);
 		}
 		if ((mask & torrent_flags::seed_mode)
 			&& !(flags & torrent_flags::seed_mode))
@@ -2867,10 +2899,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (m_torrent_file->is_valid() && m_torrent_file->priv()) return;
 
 #if TORRENT_USE_I2P
-		// i2p torrents are also never announced on LSD
-		// unless we allow mixed swarms
-		if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
-			return;
+		// i2p-only torrents are also never announced on LSD
+		if (only_i2p_peers()) return;
 #endif
 
 		if (is_paused()) return;
@@ -2911,8 +2941,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 			if (should_log())
 			{
 #if TORRENT_USE_I2P
-				if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
-					debug_log("DHT: i2p torrent (and mixed peers not allowed)");
+				if (only_i2p_peers())
+					debug_log("DHT: i2p-only torrent (regular peers not allowed)");
 #endif
 				if (!m_ses.announce_dht())
 					debug_log("DHT: no listen sockets");
@@ -3007,7 +3037,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		}
 
 #if TORRENT_USE_I2P
-		if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed)) return;
+		if (only_i2p_peers()) return;
 #endif
 
 		if (torrent_file().priv()) return;
@@ -3308,10 +3338,10 @@ namespace {
 			{
 				req.kind |= tracker_request::i2p;
 			}
-			else if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+			else if (only_i2p_peers())
 			{
-				// if we don't allow mixing normal peers into this i2p
-				// torrent, skip this announce
+				// if this is an i2p-only torrent, skip announcing to this
+				// regular tracker
 				continue;
 			}
 #endif
@@ -3524,7 +3554,7 @@ namespace {
 #if TORRENT_USE_I2P
 		if (ae.i2p)
 			req.kind |= tracker_request::i2p;
-		else if (is_i2p() && !settings().get_bool(settings_pack::allow_i2p_mixed))
+		else if (only_i2p_peers())
 			return;
 #endif
 		refresh_endpoint_list(m_ses, is_ssl_torrent(), bool(m_complete_sent), ae);
@@ -11535,9 +11565,8 @@ namespace {
 		}
 
 #if TORRENT_USE_I2P
-		// if this is an i2p torrent, and we don't allow mixed mode
-		// no regular peers should ever be added!
-		if (!settings().get_bool(settings_pack::allow_i2p_mixed) && is_i2p())
+		// if this is an i2p-only torrent, no regular peers should ever be added!
+		if (only_i2p_peers())
 		{
 			if (alerts().should_post<peer_blocked_alert>())
 				alerts().emplace_alert<peer_blocked_alert>(get_handle()

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1542,7 +1542,7 @@ TORRENT_VERSION_NAMESPACE_4
 			m_urls.push_back(std::move(ent));
 		}
 
-		if (atp.flags & torrent_flags::i2p_torrent)
+		if (atp.flags & torrent_flags::deprecated_i2p_torrent)
 		{
 			m_flags |= i2p;
 		}

--- a/src/ut_pex.cpp
+++ b/src/ut_pex.cpp
@@ -602,8 +602,7 @@ namespace libtorrent {
 	std::shared_ptr<torrent_plugin> create_ut_pex_plugin(torrent_handle const& th, client_data_t)
 	{
 		aux::torrent* t = th.native_handle().get();
-		if (t->torrent_file().priv() || (t->is_i2p()
-			&& !t->settings().get_bool(settings_pack::allow_i2p_mixed)))
+		if (t->torrent_file().priv() || t->only_i2p_peers())
 		{
 			return {};
 		}

--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -93,7 +93,8 @@ namespace {
 		ret["super_seeding"] = bool(atp.flags & torrent_flags::super_seeding);
 #endif
 #if TORRENT_USE_I2P
-		ret["i2p"] = bool(atp.flags & torrent_flags::i2p_torrent);
+		ret["i2p"] = bool(atp.flags & torrent_flags::deprecated_i2p_torrent);
+		ret["only_i2p_peers"] = bool(atp.flags & torrent_flags::only_i2p_peers);
 #endif
 		ret["sequential_download"] = bool(atp.flags & torrent_flags::sequential_download);
 		ret["stop_when_ready"] = bool(atp.flags & torrent_flags::stop_when_ready);

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -363,10 +363,13 @@ TORRENT_TEST(parse_i2p_tracker)
 {
 	add_torrent_params p = parse_magnet_uri("magnet:?xt=urn:btih:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
 		"&tr=https://test.i2p/announce");
-	TEST_CHECK(p.flags & torrent_flags::i2p_torrent);
+	TEST_CHECK(p.flags & torrent_flags::deprecated_i2p_torrent);
+	// an .i2p tracker also fails closed to i2p-only peers
+	TEST_CHECK(p.flags & torrent_flags::only_i2p_peers);
 	p = parse_magnet_uri("magnet:?xt=urn:btih:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
 		"&tr=https://test.com/announce");
-	TEST_CHECK(!(p.flags & torrent_flags::i2p_torrent));
+	TEST_CHECK(!(p.flags & torrent_flags::deprecated_i2p_torrent));
+	TEST_CHECK(!(p.flags & torrent_flags::only_i2p_peers));
 }
 #endif
 

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -72,13 +72,9 @@ TORRENT_TEST(read_resume)
 	TEST_EQUAL(atp.max_connections, 1345);
 	TEST_EQUAL(atp.max_uploads, 1346);
 
-	torrent_flags_t const flags_mask
-		= torrent_flags::seed_mode
-		| torrent_flags::super_seeding
-		| torrent_flags::auto_managed
-		| torrent_flags::paused
-		| torrent_flags::i2p_torrent
-		| torrent_flags::sequential_download;
+	torrent_flags_t const flags_mask = torrent_flags::seed_mode | torrent_flags::super_seeding
+		| torrent_flags::auto_managed | torrent_flags::paused
+		| torrent_flags::deprecated_i2p_torrent | torrent_flags::sequential_download;
 
 	TEST_CHECK(!(atp.flags & flags_mask));
 	TEST_EQUAL(atp.added_time, 1347);
@@ -386,7 +382,7 @@ TORRENT_TEST(round_trip_flags)
 		torrent_flags::disable_lsd,
 		torrent_flags::disable_pex,
 #if TORRENT_USE_I2P
-		torrent_flags::i2p_torrent,
+		torrent_flags::deprecated_i2p_torrent,
 #endif
 	};
 

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -45,64 +45,57 @@ using namespace lt;
 
 namespace {
 
-torrent_flags_t const flags_mask
-	= torrent_flags::sequential_download
-	| torrent_flags::paused
-	| torrent_flags::auto_managed
-	| torrent_flags::seed_mode
-	| torrent_flags::super_seeding
-	| torrent_flags::share_mode
-	| torrent_flags::upload_mode
-	| torrent_flags::apply_ip_filter
-	| torrent_flags::i2p_torrent;
+	torrent_flags_t const flags_mask = torrent_flags::sequential_download | torrent_flags::paused
+		| torrent_flags::auto_managed | torrent_flags::seed_mode | torrent_flags::super_seeding
+		| torrent_flags::share_mode | torrent_flags::upload_mode | torrent_flags::apply_ip_filter
+		| torrent_flags::deprecated_i2p_torrent;
 
-std::vector<char> generate_resume_data(torrent_info const* ti
-	, char const* file_priorities = "")
-{
-	entry rd;
-
-	rd["file-format"] = "libtorrent resume file";
-	rd["file-version"] = 1;
-	rd["info-hash"] = ti->info_hashes().v1.to_string();
-	rd["blocks per piece"] = std::max(1, ti->piece_length() / 0x4000);
-	rd["pieces"] = std::string(std::size_t(ti->num_pieces()), '\x01');
-
-	rd["total_uploaded"] = 1337;
-	rd["total_downloaded"] = 1338;
-	rd["active_time"] = 1339;
-	rd["seeding_time"] = 1340;
-	rd["upload_rate_limit"] = 1343;
-	rd["download_rate_limit"] = 1344;
-	rd["max_connections"] = 1345;
-	rd["max_uploads"] = 1346;
-	rd["seed_mode"] = 0;
-	rd["i2p"] = 0;
-	rd["super_seeding"] = 0;
-	rd["added_time"] = 1347;
-	rd["completed_time"] = 1348;
-	rd["last_download"] = time(nullptr) - 1350;
-	rd["last_upload"] = time(nullptr) - 1351;
-	rd["finished_time"] = 1352;
-	rd["last_seen_complete"] = 1353;
-	if (file_priorities && file_priorities[0])
+	std::vector<char> generate_resume_data(torrent_info const* ti, char const* file_priorities = "")
 	{
-		entry::list_type& file_prio = rd["file_priority"].list();
-		for (int i = 0; file_priorities[i]; ++i)
-			file_prio.push_back(entry(file_priorities[i] - '0'));
-	}
+		entry rd;
 
-	rd["piece_priority"] = std::string(std::size_t(ti->num_pieces()), '\x01');
-	rd["auto_managed"] = 0;
-	rd["sequential_download"] = 0;
-	rd["paused"] = 0;
-	entry::list_type& trackers = rd["trackers"].list();
-	trackers.push_back(entry(entry::list_t));
-	trackers.back().list().push_back(entry("http://resume-data-tracker.com/announce"));
-	entry::list_type& url_list = rd["url-list"].list();
-	url_list.push_back(entry("http://resume-data-url-seed.com"));
+		rd["file-format"] = "libtorrent resume file";
+		rd["file-version"] = 1;
+		rd["info-hash"] = ti->info_hashes().v1.to_string();
+		rd["blocks per piece"] = std::max(1, ti->piece_length() / 0x4000);
+		rd["pieces"] = std::string(std::size_t(ti->num_pieces()), '\x01');
 
-	entry::list_type& httpseeds = rd["httpseeds"].list();
-	httpseeds.push_back(entry("http://resume-data-http-seed.com"));
+		rd["total_uploaded"] = 1337;
+		rd["total_downloaded"] = 1338;
+		rd["active_time"] = 1339;
+		rd["seeding_time"] = 1340;
+		rd["upload_rate_limit"] = 1343;
+		rd["download_rate_limit"] = 1344;
+		rd["max_connections"] = 1345;
+		rd["max_uploads"] = 1346;
+		rd["seed_mode"] = 0;
+		rd["i2p"] = 0;
+		rd["super_seeding"] = 0;
+		rd["added_time"] = 1347;
+		rd["completed_time"] = 1348;
+		rd["last_download"] = time(nullptr) - 1350;
+		rd["last_upload"] = time(nullptr) - 1351;
+		rd["finished_time"] = 1352;
+		rd["last_seen_complete"] = 1353;
+		if (file_priorities && file_priorities[0])
+		{
+			entry::list_type& file_prio = rd["file_priority"].list();
+			for (int i = 0; file_priorities[i]; ++i)
+				file_prio.push_back(entry(file_priorities[i] - '0'));
+		}
+
+		rd["piece_priority"] = std::string(std::size_t(ti->num_pieces()), '\x01');
+		rd["auto_managed"] = 0;
+		rd["sequential_download"] = 0;
+		rd["paused"] = 0;
+		entry::list_type& trackers = rd["trackers"].list();
+		trackers.push_back(entry(entry::list_t));
+		trackers.back().list().push_back(entry("http://resume-data-tracker.com/announce"));
+		entry::list_type& url_list = rd["url-list"].list();
+		url_list.push_back(entry("http://resume-data-url-seed.com"));
+
+		entry::list_type& httpseeds = rd["httpseeds"].list();
+		httpseeds.push_back(entry("http://resume-data-http-seed.com"));
 
 #ifdef TORRENT_WINDOWS
 	rd["save_path"] = "c:\\resume_data save_path";
@@ -1137,6 +1130,55 @@ TORRENT_TEST(resume_info_dict)
 	add_torrent_params atp = read_resume_data(resume_data, ec);
 	TEST_CHECK(atp.ti->info_hashes() == p.ti->info_hashes());
 }
+
+#if TORRENT_USE_I2P
+TORRENT_TEST(only_i2p_peers_resume_migration)
+{
+	// the only_i2p_peers flag controls whether regular peers are allowed.
+	// Verify it round-trips, and that resume data predating the flag (no
+	// "only_i2p_peers" key) fails closed by deriving it from the i2p flag.
+	auto make_resume = [](bool const set_i2p, int const i2p, bool const set_only, int const only) {
+		entry rd;
+		rd["file-format"] = "libtorrent resume file";
+		rd["file-version"] = 1;
+		rd["info-hash"] = "abcdefghij0123456789";
+		if (set_i2p) rd["i2p"] = i2p;
+		if (set_only) rd["only_i2p_peers"] = only;
+		return bencode(rd);
+	};
+
+	auto flags_of = [](std::vector<char> const& buf) {
+		error_code ec;
+		add_torrent_params atp = read_resume_data(buf, ec);
+		TEST_CHECK(!ec);
+		return atp.flags;
+	};
+
+	// old resume data, i2p torrent, no only_i2p_peers key -> fail closed
+	{
+		auto const f = flags_of(make_resume(true, 1, false, 0));
+		TEST_CHECK(f & torrent_flags::deprecated_i2p_torrent);
+		TEST_CHECK(f & torrent_flags::only_i2p_peers);
+	}
+	// old resume data, non-i2p torrent -> not restricted
+	{
+		auto const f = flags_of(make_resume(true, 0, false, 0));
+		TEST_CHECK(!(f & torrent_flags::only_i2p_peers));
+	}
+	// new resume data, explicit only_i2p_peers=1 -> restricted
+	{
+		auto const f = flags_of(make_resume(true, 1, true, 1));
+		TEST_CHECK(f & torrent_flags::only_i2p_peers);
+	}
+	// new resume data, explicit only_i2p_peers=0 on an i2p torrent is honored
+	// (the torrent was deliberately put in mixed mode)
+	{
+		auto const f = flags_of(make_resume(true, 1, true, 0));
+		TEST_CHECK(f & torrent_flags::deprecated_i2p_torrent);
+		TEST_CHECK(!(f & torrent_flags::only_i2p_peers));
+	}
+}
+#endif
 
 TORRENT_TEST(zero_file_prio)
 {

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -290,6 +290,105 @@ TORRENT_TEST(added_peers)
 	if (ra) TEST_EQUAL(ra->params.peers.size(), 2);
 }
 
+// this test exercises the deprecated allow_i2p_mixed setting, which only
+// exists for TORRENT_ABI_VERSION < 4. The per-torrent only_i2p_peers flag is
+// covered for all ABIs by test_resume and test_magnet.
+#if TORRENT_USE_I2P && TORRENT_ABI_VERSION < 4
+namespace {
+// suppress the deprecation warning for the allow_i2p_mixed setting, which this
+// test deliberately exercises for backward-compatibility coverage
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+	std::unique_ptr<lt::session> make_i2p_mixed_session(bool const mixed)
+	{
+		settings_pack pack = settings();
+		pack.set_str(settings_pack::listen_interfaces, test_listen_interface());
+		pack.set_int(settings_pack::max_retry_port_bind, 10);
+		pack.set_bool(settings_pack::allow_i2p_mixed, mixed);
+		return std::make_unique<lt::session>(pack);
+	}
+
+	void set_allow_i2p_mixed(lt::session& ses, bool const mixed)
+	{
+		settings_pack pack;
+		pack.set_bool(settings_pack::allow_i2p_mixed, mixed);
+		ses.apply_settings(pack);
+	}
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+	torrent_handle add_i2p_torrent(lt::session& ses, bool const i2p)
+	{
+		add_torrent_params atp = generate_torrent();
+		atp.save_path = ".";
+		// mimic what the loaders (load_torrent / parse_magnet_uri) produce for an
+		// i2p torrent: both the i2p_torrent flag and the fail-closed only_i2p_peers
+		// flag are set. The session reconciles only_i2p_peers with allow_i2p_mixed.
+		if (i2p) atp.flags |= torrent_flags::deprecated_i2p_torrent | torrent_flags::only_i2p_peers;
+		return ses.add_torrent(std::move(atp));
+	}
+} // anonymous namespace
+
+// this exercises the per-torrent only_i2p_peers flag (which controls whether
+// regular peers are allowed) and its backward-compatible reconciliation with
+// the i2p_torrent flag and the deprecated allow_i2p_mixed setting. It does not
+// require an i2p router, since it only inspects flag state via the public API.
+TORRENT_TEST(only_i2p_peers_flag)
+{
+	// default (allow_i2p_mixed = false): an i2p torrent fails closed to i2p-only
+	{
+		auto ses = make_i2p_mixed_session(false);
+		torrent_handle h = add_i2p_torrent(*ses, true);
+		TEST_CHECK(h.flags() & torrent_flags::only_i2p_peers);
+	}
+
+	// a non-i2p torrent is never restricted
+	{
+		auto ses = make_i2p_mixed_session(false);
+		torrent_handle h = add_i2p_torrent(*ses, false);
+		TEST_CHECK(!(h.flags() & torrent_flags::only_i2p_peers));
+	}
+
+	// allow_i2p_mixed = true at add time: regular peers are allowed
+	{
+		auto ses = make_i2p_mixed_session(true);
+		torrent_handle h = add_i2p_torrent(*ses, true);
+		TEST_CHECK(!(h.flags() & torrent_flags::only_i2p_peers));
+	}
+
+	// toggling allow_i2p_mixed at runtime reconciles existing i2p torrents in
+	// both directions
+	{
+		auto ses = make_i2p_mixed_session(false);
+		torrent_handle h = add_i2p_torrent(*ses, true);
+		TEST_CHECK(h.flags() & torrent_flags::only_i2p_peers);
+
+		set_allow_i2p_mixed(*ses, true);
+		TEST_CHECK(!(h.flags() & torrent_flags::only_i2p_peers));
+
+		set_allow_i2p_mixed(*ses, false);
+		TEST_CHECK(h.flags() & torrent_flags::only_i2p_peers);
+	}
+
+	// the set_flags compatibility shim: toggling the (deprecated) i2p_torrent
+	// flag also adjusts only_i2p_peers
+	{
+		auto ses = make_i2p_mixed_session(false);
+		torrent_handle h = add_i2p_torrent(*ses, false);
+		TEST_CHECK(!(h.flags() & torrent_flags::only_i2p_peers));
+
+		h.set_flags(torrent_flags::deprecated_i2p_torrent, torrent_flags::deprecated_i2p_torrent);
+		TEST_CHECK(h.flags() & torrent_flags::only_i2p_peers);
+
+		h.unset_flags(torrent_flags::deprecated_i2p_torrent);
+		TEST_CHECK(!(h.flags() & torrent_flags::only_i2p_peers));
+	}
+}
+#endif // TORRENT_USE_I2P && TORRENT_ABI_VERSION < 4
+
 TORRENT_TEST(mismatching_info_hash)
 {
 	std::vector<lt::create_file_entry> fs;


### PR DESCRIPTION
perhaps this is better targeting `master`.

The idea is to simplify the control of i2p torrents with a single flag `allow_i2p_peers`, instead of the `allow_i2p_mixed` settings and the `i2p_torrent` flag.