### PR TITLE
improve tools/run_benchmark.py

### DIFF
--- a/tools/disk_latency.py
+++ b/tools/disk_latency.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+
+"""Summarize disk read-job latency over time from a libtorrent session-stats
+log (the file written by ``client_test -O``, the same format
+parse_session_stats.py reads).
+
+libtorrent records read-job latency (queue wait + execution + completion-queue
+wait, measured on the network thread) as a histogram of monotonic counters
+named ``disk.disk_read_latency1`` .. ``disk.disk_read_latency20``, linear in
+30 ms steps: ``disk_read_latencyN`` counts read jobs whose latency fell in
+[30*(N-1), 30*N) ms, and the last counter (latency20) is the catch-all for
+>= 570 ms. These are only populated in disk-latency-stats builds; without that
+build flag the buckets stay zero and there is nothing to plot.
+
+This tool diffs the cumulative buckets between samples, groups the resulting
+per-job counts into fixed wall-clock intervals (5 s by default), and from each
+interval's histogram estimates the median, mean, and 95th-percentile latency,
+reported in milliseconds. collect_latency() returns those series plus a single
+representative number for the whole run -- the peak interval p95 -- which
+run_benchmark.py drops into its results table.
+"""
+
+from argparse import ArgumentParser
+from collections.abc import Iterator
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+import re
+
+# number of disk_read_latency buckets exposed by libtorrent (see
+# performance_counters.hpp: disk_read_latency1 .. disk_read_latency20), linear
+# in 30 ms steps.
+NUM_BUCKETS = 20
+# width of each linear bucket, in milliseconds
+BUCKET_STEP_MS = 30
+# counter-name prefix in the session-stats header (category "disk"); the
+# counters are 1-indexed (latency1 .. latency20), so the first index is 1.
+BUCKET_PREFIX = "disk.disk_read_latency"
+BUCKET_FIRST = 1
+
+# leading "[<ms>]" timestamp client_test writes on every stats line
+_TS_RE = re.compile(r"^\[(\d+)\]")
+
+
+def bucket_rep_ms(i: int) -> float:
+    """Representative latency, in milliseconds, for histogram bucket `i`
+    (0-based; bucket i is the counter disk_read_latency{i+1}).
+
+    Bucket i covers [30*i, 30*(i+1)) ms, so we use its midpoint, 30*i + 15 ms.
+    For the open-ended top bucket this is just the midpoint of its first 30 ms
+    step, an approximate lower bound.
+    """
+    return BUCKET_STEP_MS * i + BUCKET_STEP_MS / 2.0
+
+
+@dataclass
+class LatencySeries:
+    """Per-interval disk read-latency summary plus a single run-level number."""
+
+    # interval midpoint, in seconds since the start of the run
+    times: list[float] = field(default_factory=list)
+    # per-interval latency statistics, in milliseconds
+    median_ms: list[float] = field(default_factory=list)
+    mean_ms: list[float] = field(default_factory=list)
+    p95_ms: list[float] = field(default_factory=list)
+    # number of read jobs observed in each interval
+    counts: list[int] = field(default_factory=list)
+    # representative latency for the whole run (ms): the worst (peak) interval
+    # p95. 0.0 when no read-latency samples were recorded -- e.g. a build
+    # without disk-latency-stats, or the posix backend (no disk job queue).
+    peak_p95_ms: float = 0.0
+
+
+def _parse_samples(path: Path) -> Iterator[tuple[float, list[int]]]:
+    """Yield (time_s, counts) for each session-stats sample in `path`, where
+    counts is a list of the NUM_BUCKETS cumulative latency-bucket values. The
+    leading "[<ms>]" timestamp gives wall-clock time; without it we fall back
+    to the sample index (assuming 1 s spacing). Yields nothing if the file is
+    unreadable or its header has no latency columns.
+    """
+    try:
+        f = open(path, encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    with f:
+        # find the header and locate the latency columns
+        cols = None
+        for line in f:
+            if "session stats header:" in line:
+                keys = line.split("session stats header:")[1].strip().split(", ")
+                cols = []
+                for n in range(NUM_BUCKETS):
+                    try:
+                        cols.append(keys.index(f"{BUCKET_PREFIX}{BUCKET_FIRST + n}"))
+                    except ValueError:
+                        return  # this log has no latency columns
+                break
+        if not cols:
+            return
+
+        idx = 0
+        for line in f:
+            if "session stats (" not in line:
+                continue
+            try:
+                values = line.split(" values): ")[1].strip().split(", ")
+                counts = [int(values[c]) for c in cols]
+            except (IndexError, ValueError):
+                continue
+            m = _TS_RE.match(line)
+            t_s = (int(m.group(1)) / 1000.0) if m else float(idx)
+            idx += 1
+            yield t_s, counts
+
+
+def _percentile(hist: list[int], frac: float, total: int) -> float:
+    """The `frac` quantile (e.g. 0.95) of a bucketed histogram, returned as the
+    representative latency (ms) of the bucket the quantile falls in.
+    """
+    threshold = frac * total
+    cum = 0
+    for i, c in enumerate(hist):
+        cum += c
+        if cum >= threshold:
+            return bucket_rep_ms(i)
+    return bucket_rep_ms(len(hist) - 1)
+
+
+def collect_latency(path: str | Path, interval_s: float = 5.0) -> LatencySeries:
+    """Parse `path` and return a LatencySeries: per-interval median/mean/p95
+    disk read latency (ms) over `interval_s`-second wall-clock windows, plus
+    the peak interval p95 as a single representative number for the run.
+
+    The buckets are cumulative counters, so each sample contributes its delta
+    from the previous sample; those deltas are accumulated into the interval
+    the sample falls in. The first sample is taken as a baseline (counters may
+    already be nonzero when logging starts, and attributing that backlog to
+    interval 0 would distort it).
+    """
+    by_interval: dict[int, list[int]] = {}
+    prev: list[int] | None = None
+    for t_s, counts in _parse_samples(Path(path)):
+        if prev is None:
+            prev = counts
+            continue
+        # guard against counter resets / out-of-order lines with max(0, .)
+        delta = [max(0, counts[i] - prev[i]) for i in range(NUM_BUCKETS)]
+        prev = counts
+        acc = by_interval.setdefault(int(t_s // interval_s), [0] * NUM_BUCKETS)
+        for i in range(NUM_BUCKETS):
+            acc[i] += delta[i]
+
+    series = LatencySeries()
+    for k in sorted(by_interval):
+        hist = by_interval[k]
+        n = sum(hist)
+        if n == 0:
+            continue
+        p95 = _percentile(hist, 0.95, n)
+        series.times.append((k + 0.5) * interval_s)
+        series.median_ms.append(_percentile(hist, 0.5, n))
+        series.mean_ms.append(sum(c * bucket_rep_ms(i) for i, c in enumerate(hist)) / n)
+        series.p95_ms.append(p95)
+        series.counts.append(n)
+        series.peak_p95_ms = max(series.peak_p95_ms, p95)
+    return series
+
+
+def plot_latency(
+    series: LatencySeries, out_path: Path, title: str = "disk read latency"
+) -> bool:
+    """Plot median / average / p95 read latency over time to `out_path` (PNG).
+    Returns True on success, False if matplotlib is missing or there is no
+    data to plot (so callers can skip referencing the image).
+    """
+    if not series.times:
+        return False
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")  # headless backend; no display required
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return False
+
+    fig, ax = plt.subplots(figsize=(10.0, 4.0))
+    ax.plot(series.times, series.median_ms, label="median")
+    ax.plot(series.times, series.mean_ms, label="average")
+    ax.plot(series.times, series.p95_ms, label="95th percentile")
+    # linear y-axis in milliseconds, for readable tick marks
+    ax.set_ylim(bottom=0)
+    ax.set_xlabel("time (s)")
+    ax.set_ylabel("read latency (ms)")
+    ax.set_title(title)
+    ax.grid(True, which="both", linewidth=0.3, alpha=0.5)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=100)
+    plt.close(fig)
+    return True
+
+
+def main(
+    input_file: str | Path, output_dir: str | Path, interval_s: float = 5.0
+) -> float:
+    """Parse `input_file`, write disk_read_latency.png into `output_dir`, and
+    return the run's representative latency (peak interval p95, ms).
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    series = collect_latency(input_file, interval_s)
+    out_png = output_dir / "disk_read_latency.png"
+    if plot_latency(series, out_png):
+        print(f"wrote {out_png}")
+    elif not series.times:
+        print(
+            "no disk read-latency samples found" " (needs a disk-latency-stats build)"
+        )
+    else:
+        print("matplotlib not installed; skipped latency plot")
+    print(f"peak interval p95 read latency: {series.peak_p95_ms:.3f} ms")
+    return series.peak_p95_ms
+
+
+if __name__ == "__main__":
+    p = ArgumentParser(description=__doc__)
+    p.add_argument(
+        "input",
+        type=Path,
+        help="session-stats log to parse (client_test -O output)",
+    )
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("."),
+        help="directory to write disk_read_latency.png to",
+    )
+    p.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="bucket interval in seconds (default: 5)",
+    )
+    args = p.parse_args()
+    main(args.input, args.output_dir, args.interval)

--- a/tools/perf_call_tree.py
+++ b/tools/perf_call_tree.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+
+# Copyright (c) 2026, Arvid Norberg
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the distribution.
+#     * Neither the name of the author nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# this script processes a perf.data file (recorded by 'perf record') and
+# generates a single self-contained HTML page displaying the aggregated call
+# tree. the tree is navigable with the keyboard: up/down move the selection,
+# left collapses a subtree (or steps to the parent), right expands it (or steps
+# to the first child). every level is collapsed by default.
+
+from argparse import ArgumentParser
+from functools import lru_cache
+import html
+from pathlib import Path
+import re
+import subprocess
+from typing import Optional
+
+
+# a node in the calling-context tree. "count" is the number of samples whose
+# stack passes through this node along this exact path (inclusive count).
+class Node:
+    __slots__ = ("name", "count", "children")
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.count = 0
+        self.children: dict[str, "Node"] = {}
+
+    def child(self, name: str) -> "Node":
+        node = self.children.get(name)
+        if node is None:
+            node = Node(name)
+            self.children[name] = node
+        return node
+
+
+def run_perf_script(perf_data: Path) -> str:
+    """Run 'perf script' on perf_data and return its stdout. Exits with a clear
+    message if perf is missing or fails."""
+    cmd = ["perf", "script", "-i", str(perf_data)]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        raise SystemExit(
+            "ERROR: 'perf' is not installed or not in PATH.\n"
+            "  Debian/Ubuntu: sudo apt install linux-perf (or linux-tools-*)\n"
+            "  Fedora/RHEL:   sudo dnf install perf"
+        )
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            f"ERROR: '{' '.join(cmd)}' exited with code {e.returncode}\n\n"
+            f"perf output:\n{e.stderr.strip()}"
+        )
+    return result.stdout
+
+
+# a stack frame line from 'perf script' looks like:
+#             ffffffff8100a1b2 some_function+0x12 (/path/to/dso)
+# capture the leading hex address and the rest (symbol + "+0xoffset" + "(dso)").
+_FRAME_RE = re.compile(r"^\s+([0-9a-fA-F]+)\s+(.*)$")
+
+# the per-sample header line (non-indented) that precedes each stack looks like:
+#   client_test 12345/12348 [001] 9043.123456: 1000000 cycles:ppp:
+#   ^comm        ^pid ^tid    ^cpu  ^timestamp
+# comm may itself contain spaces, so anchor on the "pid[/tid] [cpu] time:" tail
+# and let comm absorb everything before it. the cpu field is optional.
+_HEADER_RE = re.compile(
+    r"^(?P<comm>.+?)\s+(?P<pid>\d+)(?:/(?P<tid>\d+))?\s+" r"(?:\[\d+\]\s+)?[\d.]+:"
+)
+
+# trailing cv/ref/exception qualifiers that 'perf' (via c++filt) appends after
+# the parameter list of a member function, e.g. "foo(int) const noexcept".
+_TRAILING_QUALS = (" const", " volatile", " noexcept", " &&", " &")
+
+
+# the same symbols recur across millions of stack frames, so cache the result
+# per distinct symbol -- the scans below then run only once per unique name.
+@lru_cache(maxsize=None)
+def strip_return_type(sym: str) -> str:
+    """Strip the leading return type from a demangled C++ signature.
+
+    The Itanium ABI only encodes a return type for template instantiations, so
+    most frames (plain functions) have nothing to strip and are returned
+    unchanged. For the template case the return type is the leading token,
+    separated from the qualified function name by a depth-0 space:
+
+        std::pair<a, b> ns::foo<int>(int)  ->  ns::foo<int>(int)
+
+    The split point is the last space that sits outside any '<>' or '()'
+    nesting and before the parameter list. '(anonymous namespace)' segments and
+    'operator' names are handled so their internal spaces/parens do not fool the
+    scan. Conversion operators ('operator bool()') and other exotic forms are
+    left untouched rather than mangled."""
+    # find the parameter-list '(' by matching the final ')' from the right.
+    # peel off trailing qualifiers first so the final ')' is the arg list.
+    body = sym
+    changed = True
+    while changed:
+        changed = False
+        for q in _TRAILING_QUALS:
+            if body.endswith(q):
+                body = body[: -len(q)]
+                changed = True
+    close = body.rfind(")")
+    if close == -1:
+        # not a function signature (data symbol, mangled name, C function)
+        return sym
+    depth = 0
+    open_paren = -1
+    for k in range(close, -1, -1):
+        c = body[k]
+        if c == ")":
+            depth += 1
+        elif c == "(":
+            depth -= 1
+            if depth == 0:
+                open_paren = k
+                break
+    if open_paren == -1:
+        return sym
+    prefix = body[:open_paren]
+    # the return type ends at the last depth-0 space in the prefix (depth here
+    # counts both '<>' and '()' so anonymous-namespace parens are skipped).
+    angle = paren = 0
+    boundary = -1
+    for j, c in enumerate(prefix):
+        if c == "<":
+            angle += 1
+        elif c == ">":
+            angle -= 1
+        elif c == "(":
+            paren += 1
+        elif c == ")":
+            paren -= 1
+        elif c == " " and angle == 0 and paren == 0:
+            boundary = j
+    if boundary == -1:
+        return sym
+    # a trailing 'operator' before the space means this is a conversion operator
+    # ('operator bool'), not a return type plus a name; leave it alone.
+    if prefix[:boundary].endswith("operator"):
+        return sym
+    return sym[boundary + 1 :]
+
+
+# the set of characters that make up a symbolic operator name ('operator<<',
+# 'operator<=>', 'operator->'). used to skip past such names so their angle
+# brackets are not mistaken for template-argument brackets.
+_OP_CHARS = frozenset("<>=!+-*/%^&|~")
+
+
+@lru_cache(maxsize=None)
+def collapse_templates(sym: str) -> str:
+    """Replace every top-level template argument list with '<...>'.
+
+    Matching pairs of '<' and '>' are folded so that, e.g.
+
+        std::map<int, std::vector<foo>>::find(char const*) const
+        ->  std::map<...>::find(char const*) const
+
+    Only outermost (depth-0) '<>' pairs are emitted as '<...>'; anything nested
+    inside them is dropped. Symbolic operators whose name contains '<' or '>'
+    ('operator<<', 'operator<=>', 'operator->') are copied verbatim so they do
+    not start a spurious bracket group."""
+    out: list[str] = []
+    i = 0
+    n = len(sym)
+    depth = 0
+    while i < n:
+        # at depth 0, detect an 'operator' token whose symbolic name may
+        # contain '<' or '>' characters that must not be treated as brackets
+        if (
+            depth == 0
+            and sym.startswith("operator", i)
+            and (i == 0 or not (sym[i - 1].isalnum() or sym[i - 1] == "_"))
+        ):
+            out.append("operator")
+            j = i + len("operator")
+            # symbolic operators follow immediately; copy the run of operator
+            # characters verbatim (e.g. '<<', '<=>', '->')
+            while j < n and sym[j] in _OP_CHARS:
+                out.append(sym[j])
+                j += 1
+            i = j
+            continue
+        c = sym[i]
+        if c == "<":
+            if depth == 0:
+                out.append("<...>")
+            depth += 1
+        elif c == ">":
+            if depth > 0:
+                depth -= 1
+        elif depth == 0:
+            out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def frame_symbol(
+    addr: str,
+    payload: str,
+    strip_ret: bool = True,
+    collapse_tmpl: bool = True,
+    abbrev_ns: bool = True,
+) -> str:
+    """Build a merge key (function name only) from a frame line. Strips the
+    trailing '+0xoffset' and '(dso)'. Frames whose symbol is unresolved
+    ('[unknown]') are kept distinct by address so unrelated functions do not
+    collapse into a single tree node. When strip_ret is set, the leading return
+    type of demangled C++ template signatures is also removed. When
+    collapse_tmpl is set, top-level template argument lists are folded to
+    '<...>'. When abbrev_ns is set, the 'libtorrent::' namespace prefix is
+    abbreviated to 'lt::'."""
+    payload = payload.strip()
+    dso: Optional[str] = None
+    # split off the trailing "(/path/to/dso)" if present
+    if payload.endswith(")"):
+        open_paren = payload.rfind(" (")
+        if open_paren != -1:
+            dso = payload[open_paren + 2 : -1]
+            payload = payload[:open_paren].rstrip()
+    # drop a trailing "+0x..." offset
+    plus = payload.rfind("+0x")
+    if plus != -1:
+        payload = payload[:plus].rstrip()
+    if payload == "" or payload == "[unknown]":
+        base = dso.rsplit("/", 1)[-1] if dso else "?"
+        return f"[unknown] 0x{addr} ({base})"
+    if strip_ret:
+        payload = strip_return_type(payload)
+    if collapse_tmpl:
+        payload = collapse_templates(payload)
+    if abbrev_ns:
+        payload = payload.replace("libtorrent::", "lt::")
+    return payload
+
+
+def parse_samples(
+    text: str,
+    strip_ret: bool = True,
+    collapse_tmpl: bool = True,
+    abbrev_ns: bool = True,
+) -> list[list[str]]:
+    """Parse 'perf script' output into a list of call stacks. Each stack is a
+    list of function names ordered root -> leaf. A synthetic frame identifying
+    the originating thread (comm + tid) is prepended to every stack, so each
+    thread gets its own root in the resulting tree."""
+    samples: list[list[str]] = []
+    frames: list[str] = []
+    have_record = False
+    thread: Optional[str] = None
+
+    def flush() -> None:
+        nonlocal frames, have_record
+        if have_record and frames:
+            # perf prints leaf first; reverse to root -> leaf
+            frames.reverse()
+            frames.insert(0, thread if thread is not None else "[unknown thread]")
+            samples.append(frames)
+        frames = []
+        have_record = False
+
+    for line in text.splitlines():
+        if line.strip() == "":
+            flush()
+            continue
+        m = _FRAME_RE.match(line)
+        if m is None:
+            # a non-indented line is the per-sample header (comm/pid/tid/event).
+            # it begins a new record; flush the previous one first, then capture
+            # the thread identity this record's frames belong to.
+            flush()
+            have_record = True
+            hm = _HEADER_RE.match(line)
+            if hm is not None:
+                tid = hm.group("tid") or hm.group("pid")
+                thread = f"{hm.group('comm').strip()} (tid {tid})"
+            else:
+                thread = "[unknown thread]"
+            continue
+        frames.append(
+            frame_symbol(m.group(1), m.group(2), strip_ret, collapse_tmpl, abbrev_ns)
+        )
+    flush()
+    return samples
+
+
+def build_tree(samples: list[list[str]]) -> Node:
+    """Fold call stacks into a calling-context tree with inclusive counts."""
+    root = Node("[root]")
+    for stack in samples:
+        root.count += 1
+        node = root
+        for name in stack:
+            node = node.child(name)
+            node.count += 1
+    return root
+
+
+def prune(node: Node, min_count: float) -> None:
+    """Drop children below min_count samples, depth first."""
+    for name in list(node.children.keys()):
+        child = node.children[name]
+        if child.count < min_count:
+            del node.children[name]
+        else:
+            prune(child, min_count)
+
+
+def sorted_children(node: Node) -> list[Node]:
+    return sorted(node.children.values(), key=lambda n: n.count, reverse=True)
+
+
+def render_node(node: Node, total: int, parts: list[str]) -> None:
+    """Append the <li> for node (and its subtree) to parts."""
+    children = sorted_children(node)
+    has_children = len(children) > 0
+    pct = (100.0 * node.count / total) if total else 0.0
+    cls = "has-children" if has_children else "leaf"
+    label = (
+        f'<span class="pct">{pct:6.2f}%</span>'
+        f'<span class="count">{node.count}</span>'
+        f'<span class="name">{html.escape(node.name)}</span>'
+    )
+    parts.append(f'<li class="{cls}">')
+    parts.append(f'<div class="node" tabindex="-1">{label}</div>')
+    if has_children:
+        # children hidden by default -> every level starts collapsed
+        parts.append('<ul class="children" hidden>')
+        for child in children:
+            render_node(child, total, parts)
+        parts.append("</ul>")
+    parts.append("</li>")
+
+
+PAGE_CSS = """
+body { font-family: monospace; font-size: 13px; margin: 1em; color: #222; }
+h1 { font-size: 1.1em; }
+ul { list-style: none; margin: 0; padding-left: 1.4em; }
+ul.tree { padding-left: 0; }
+li { margin: 0; }
+/* inline-block so the box (and the selection highlight) grows to the full
+   width of the text rather than being clipped at the viewport edge; min-width
+   keeps short rows highlighted out to at least the window border */
+.node { display: inline-block; min-width: 100%; white-space: pre;
+        cursor: default; padding: 1px 2px; border-radius: 3px;
+        box-sizing: border-box; }
+li.has-children > .node { cursor: pointer; }
+/* caret: filled triangle that rotates when expanded */
+li.has-children > .node::before { content: "\\25B6 "; color: #888; }
+li.has-children.expanded > .node::before { content: "\\25BC "; color: #888; }
+li.leaf > .node::before { content: "\\2003 "; }
+.node.selected { background: #2b6cb0; color: #fff; outline: none; }
+.node.selected .pct, .node.selected .count { color: #cfe3ff; }
+.pct { color: #b04000; display: inline-block; width: 7ch; text-align: right; }
+.count { color: #888; display: inline-block; width: 9ch; text-align: right;
+         padding-right: 1ch; }
+.name { color: inherit; }
+"""
+
+PAGE_JS = """
+(function () {
+  var nodes = Array.prototype.slice.call(document.querySelectorAll('.node'));
+  var selected = null;
+
+  function liOf(node) { return node.parentNode; }
+  function hasChildren(node) { return liOf(node).classList.contains('has-children'); }
+  function isExpanded(node) { return liOf(node).classList.contains('expanded'); }
+
+  function childList(node) { return liOf(node).querySelector(':scope > ul.children'); }
+
+  function expand(node) {
+    if (!hasChildren(node)) return;
+    liOf(node).classList.add('expanded');
+    var ul = childList(node);
+    ul.hidden = false;
+    // collapse degenerate chains: if there is exactly one child, expand it
+    // too, recursively, until we reach a node with 0 or more than 1 children
+    var childLis = ul.querySelectorAll(':scope > li');
+    if (childLis.length === 1) {
+      expand(childLis[0].querySelector(':scope > .node'));
+    }
+  }
+  function collapse(node) {
+    if (!hasChildren(node)) return;
+    liOf(node).classList.remove('expanded');
+    childList(node).hidden = true;
+  }
+
+  function firstChild(node) {
+    var ul = childList(node);
+    if (!ul) return null;
+    var li = ul.querySelector(':scope > li');
+    return li ? li.querySelector(':scope > .node') : null;
+  }
+  function parentNodeOf(node) {
+    var li = liOf(node);
+    var ul = li.parentNode;
+    if (!ul || !ul.classList.contains('children')) return null;
+    return ul.parentNode.querySelector(':scope > .node');
+  }
+
+  // visible nodes in document order (skipping collapsed subtrees)
+  function visibleNodes() {
+    return nodes.filter(function (n) {
+      var el = liOf(n);
+      while (el && el.parentNode) {
+        var ul = el.parentNode;
+        if (ul.classList && ul.classList.contains('children') && ul.hidden)
+          return false;
+        el = ul.closest ? ul.closest('li') : null;
+      }
+      return true;
+    });
+  }
+
+  function select(node) {
+    if (!node) return;
+    if (selected) selected.classList.remove('selected');
+    selected = node;
+    selected.classList.add('selected');
+    // only scroll vertically: the rows are wider than the viewport (min-width
+    // 100% plus per-level indentation), so letting scrollIntoView touch the
+    // inline axis would scroll the page to the right on every selection
+    var x = window.scrollX;
+    selected.scrollIntoView({ block: 'nearest' });
+    if (window.scrollX !== x) window.scrollTo(x, window.scrollY);
+  }
+
+  function move(delta) {
+    var vis = visibleNodes();
+    var idx = vis.indexOf(selected);
+    if (idx === -1) { select(vis[0]); return; }
+    var next = idx + delta;
+    if (next >= 0 && next < vis.length) select(vis[next]);
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (!selected) return;
+    switch (e.key) {
+      case 'ArrowDown': move(1); e.preventDefault(); break;
+      case 'ArrowUp': move(-1); e.preventDefault(); break;
+      case 'ArrowRight':
+        if (hasChildren(selected)) {
+          if (!isExpanded(selected)) expand(selected);
+          else select(firstChild(selected));
+        }
+        e.preventDefault();
+        break;
+      case 'ArrowLeft':
+        if (hasChildren(selected) && isExpanded(selected)) collapse(selected);
+        else select(parentNodeOf(selected));
+        e.preventDefault();
+        break;
+    }
+  });
+
+  // click toggles expand/collapse and selects
+  nodes.forEach(function (node) {
+    node.addEventListener('click', function () {
+      select(node);
+      if (hasChildren(node)) {
+        if (isExpanded(node)) collapse(node); else expand(node);
+      }
+    });
+  });
+
+  // start with the first (hottest) top-level node selected
+  if (nodes.length) select(nodes[0]);
+})();
+"""
+
+
+def gen_html(root: Node, total: int, title: str) -> str:
+    parts: list[str] = []
+    parts.append("<!doctype html>")
+    parts.append('<html><head><meta charset="utf-8">')
+    parts.append(f"<title>{html.escape(title)}</title>")
+    parts.append(f"<style>{PAGE_CSS}</style>")
+    parts.append("</head><body>")
+    parts.append(f"<h1>{html.escape(title)}</h1>")
+    parts.append(
+        f"<p>{total} samples. "
+        "Navigate with the arrow keys: up/down move, right expands, "
+        "left collapses.</p>"
+    )
+    parts.append('<ul class="tree">')
+    # render the real top-level frames, not the synthetic root. each top-level
+    # node is a thread, so percentages are computed relative to that thread's
+    # own sample count -- every thread root reads 100%.
+    for child in sorted_children(root):
+        render_node(child, child.count, parts)
+    parts.append("</ul>")
+    parts.append(f"<script>{PAGE_JS}</script>")
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+def main(
+    perf_data: Path,
+    output: Path,
+    threshold: float,
+    strip_ret: bool = True,
+    collapse_tmpl: bool = True,
+    abbrev_ns: bool = True,
+) -> None:
+    text = run_perf_script(perf_data)
+    samples = parse_samples(text, strip_ret, collapse_tmpl, abbrev_ns)
+    if not samples:
+        raise SystemExit(
+            f"ERROR: no call-stack samples found in {perf_data}.\n"
+            "  was it recorded with call graphs, e.g."
+            " 'perf record --call-graph dwarf'?"
+        )
+    root = build_tree(samples)
+    total = root.count
+    prune(root, total * threshold / 100.0)
+    page = gen_html(root, total, f"call tree: {perf_data.name}")
+    output.write_text(page)
+    print(f"wrote {output} ({total} samples)")
+
+
+if __name__ == "__main__":
+    p = ArgumentParser(description="generate an HTML call tree from a perf.data file")
+    p.add_argument("perf_data", type=Path, help="the perf.data file to process")
+    p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("perf-call-tree.html"),
+        help="output HTML file (default: perf-call-tree.html)",
+    )
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=0.1,
+        help="prune subtrees below this percent of total samples" " (default: 0.1)",
+    )
+    p.add_argument(
+        "--raw-symbols",
+        action="store_true",
+        help="keep the leading return type on demangled C++ template"
+        " signatures (by default it is stripped)",
+    )
+    p.add_argument(
+        "--full-templates",
+        action="store_true",
+        help="keep full template argument lists in symbol names (by default"
+        " each top-level '<...>' is collapsed for readability)",
+    )
+    p.add_argument(
+        "--full-namespaces",
+        action="store_true",
+        help="keep the full 'libtorrent::' namespace prefix (by default it is"
+        " abbreviated to 'lt::')",
+    )
+    args = p.parse_args()
+    main(
+        args.perf_data,
+        args.output,
+        args.threshold,
+        not args.raw_symbols,
+        not args.full_templates,
+        not args.full_namespaces,
+    )

--- a/tools/run_benchmark.py
+++ b/tools/run_benchmark.py
@@ -8,6 +8,8 @@ import shutil
 import signal
 import subprocess
 import parse_session_stats
+import perf_call_tree
+import disk_latency
 from pathlib import Path
 from argparse import ArgumentParser
 
@@ -28,6 +30,12 @@ VARIANT_FLAGS = {"v1": "1", "v2": "2", "hybrid": "h"}
 
 # disk I/O backends to exercise. Passed to client_test via "-i".
 IO_BACKENDS = ["mmap", "pread", "posix"]
+
+# fixed properties of the generated test torrents. connection_tester's
+# gen-torrent uses a 1 MiB piece size (the "-s" flag is the piece count, not
+# the piece size), and we always generate this many files per torrent.
+PIECE_SIZE_MIB = 1
+NUM_FILES = 15
 
 if platform.system() == "Windows":
     exe = ".exe"
@@ -74,7 +82,11 @@ def drop_file_cache(path: Path) -> None:
 
     Linux: posix_fadvise(POSIX_FADV_DONTNEED) per file, after fdatasync to
         flush any dirty pages first (only clean pages can be dropped). No
-        root required; targeted to just these files.
+        root required; targeted to just these files. NOTE: this only evicts
+        the Linux page cache, which is not enough on every filesystem: ZFS
+        serves normal reads from its own ARC (fadvise cannot touch it) and
+        tmpfs is RAM-backed (nothing to evict to). A warning is printed when
+        the target is on one of those; see _warn_if_ineffective_drop().
     macOS: posix_fadvise is not implemented in Darwin's libc, so
         os.posix_fadvise is not defined on Python/macOS. Falls back to the
         Apple-supplied 'purge' command, which flushes the entire system
@@ -104,6 +116,7 @@ def drop_file_cache(path: Path) -> None:
                 os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
             finally:
                 os.close(fd)
+        _warn_if_ineffective_drop(path)
         return
 
     if system == "Darwin":
@@ -147,69 +160,72 @@ def _walk_files(root: Path):
             yield entry
 
 
-def compact_indent(line: str) -> str:
-    """Compact a perf '--call-graph graph' tree line: each 11-column tree
-    level shrinks to 2 columns so deep trees fit on screen.
-
-    Approach: split the indent prefix at each '|' and shrink each interior
-    space run proportionally. perf renders each tree level as 11 columns,
-    so 10 spaces between pipes (the body of one `|          ` unit) become
-    1 space. The 15-space baseline (the Children% column) becomes 5 spaces,
-    with each additional 11-col last-sibling unit (11 spaces, no pipe)
-    contributing 2 more. Content past the indent (`|--12.34%-- foo`,
-    ` --12.34%-- foo`, a function name, or nothing for a pure
-    sibling-separator line) is preserved unchanged.
-
-    A `|` belongs to the indent only when followed by whitespace or
-    end-of-line. A `|` immediately followed by `-` is the content marker
-    `|--XX.XX%--`, so the scan stops before it.
-
-    Pure sibling-separator lines (e.g. `               |          |`) get
-    the same treatment so the tree's branching structure is preserved.
-
-    The first child of a top-level entry is rendered as
-    `<12 spaces>---name` (no percentage) and is handled separately.
+def _filesystem_type(path: Path) -> str | None:
+    """Linux only. Return the filesystem type (e.g. 'zfs', 'ext4') backing
+    `path` by matching it against the longest mount point in /proc/mounts.
+    Returns None if it can't be determined.
     """
-    if line.startswith("            ---"):
-        return "  " + line[12:]
-    if not line.startswith("               "):  # 15-space Children% baseline
-        return line
+    try:
+        target = path.resolve()
+    except OSError:
+        return None
+    best_len = -1
+    best_fstype = None
+    try:
+        with open("/proc/mounts", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                # mount points with spaces etc. are octal-escaped (\040)
+                mount_point = parts[1].encode("latin-1").decode(
+                    "unicode_escape"
+                )
+                fstype = parts[2]
+                try:
+                    target.relative_to(mount_point)
+                except ValueError:
+                    continue
+                if len(mount_point) > best_len:
+                    best_len = len(mount_point)
+                    best_fstype = fstype
+    except OSError:
+        return None
+    return best_fstype
 
-    stripped = line.rstrip("\n")
-    nl = line[len(stripped):]
 
-    # find the end of the indent prefix: a leading run of ' ' and 'indent'
-    # pipes. anything past it is content (or nothing for a sibling
-    # separator).
-    i = 0
-    while i < len(stripped):
-        c = stripped[i]
-        if c == " ":
-            i += 1
-        elif c == "|":
-            nxt = stripped[i + 1] if i + 1 < len(stripped) else ""
-            if nxt == "" or nxt == " ":
-                i += 1
-            else:
-                break
-        else:
-            break
-    indent, rest = stripped[:i], stripped[i:]
+def _warn_if_ineffective_drop(path: Path) -> None:
+    """Linux only. POSIX_FADV_DONTNEED only evicts the Linux page cache.
+    Warn when the drop target lives on a filesystem where that is not enough
+    to give a cold cache for the next benchmark run:
 
-    pieces = indent.split("|")
-    out = []
-    for idx, p in enumerate(pieces):
-        if idx == 0:
-            # baseline (15) -> 5; each extra 11-col last-sibling unit -> 2.
-            # anything left over (off-by-one whitespace) is kept verbatim.
-            extra = len(p) - 15
-            out.append(" " * (5 + 2 * (extra // 11) + extra % 11))
-        else:
-            # 10 spaces inside one `|          ` unit -> 1 space; round
-            # other widths proportionally.
-            out.append(" " * round(len(p) / 10))
+    - ZFS: normal reads go through its own ARC, which fadvise cannot touch,
+      so the data stays warm.
+    - tmpfs: RAM-backed, so there is no backing store to evict to and
+      fadvise is a no-op; the data is always warm.
 
-    return "|".join(out) + rest + nl
+    Native page-cache filesystems (ext4, xfs, btrfs, ...) drop correctly and
+    get no warning.
+    """
+    fstype = _filesystem_type(path)
+    if fstype == "zfs":
+        print(
+            f"warning: {path} is on ZFS. POSIX_FADV_DONTNEED does not evict"
+            " the ZFS ARC, so the data stays cached and 'cold-cache' runs"
+            " are effectively warm-cache. For cold reads, set 'zfs set"
+            " primarycache=metadata <dataset>' (needs root), shrink"
+            " zfs_arc_max, or point --save-path at a non-ZFS filesystem."
+            " Run 'df -hT' to find alternative volumes to test on."
+        )
+    elif fstype == "tmpfs":
+        print(
+            f"warning: {path} is on tmpfs (RAM-backed). POSIX_FADV_DONTNEED"
+            " is a no-op there -- there is no backing store to evict to, so"
+            " the data is always warm and 'cold-cache' runs are effectively"
+            " warm-cache. Point --save-path at a real on-disk, non-ZFS"
+            " filesystem (ext4/xfs/btrfs) for cold reads. Run 'df -hT' to"
+            " find alternative volumes to test on."
+        )
 
 
 RATE_LINE_RE = re.compile(
@@ -218,10 +234,11 @@ RATE_LINE_RE = re.compile(
 
 
 def parse_test_out(path: Path) -> tuple[float, float]:
-    """Return (sent_MB, received_MB) parsed from connection_tester's summary.
-    The 'MB/s' label in connection_tester's output is misleading -- the
-    printed value is total bytes / 1e6, not divided by runtime. Caller
-    converts to a real rate using its own runtime measurement.
+    """Return (sent_rate, received_rate) in MB/s parsed from connection_tester's
+    'rate sent: X MB/s received: Y MB/s' summary line. connection_tester
+    computes this against its own transfer window, which excludes the startup
+    spent building v2 merkle trees, so it is a real throughput rate usable
+    as-is (no further division by runtime).
     """
     try:
         text = path.read_text(errors="replace")
@@ -233,15 +250,54 @@ def parse_test_out(path: Path) -> tuple[float, float]:
     return float(m.group(1)), float(m.group(2))
 
 
+def parse_max_rss(path: Path) -> float:
+    """Scan a memory_stats.log (written by vmstat.print_output_to_file) and
+    return the peak RSS in bytes reached during the run. The file is a
+    whitespace-separated table whose first line names the columns; the 'rss'
+    column holds resident set size in bytes. Returns 0.0 if the file or the
+    column is missing.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            header = f.readline().split()
+            if "rss" not in header:
+                return 0.0
+            col = header.index("rss")
+            peak = 0.0
+            for line in f:
+                fields = line.split()
+                if len(fields) <= col:
+                    continue
+                try:
+                    val = float(fields[col])
+                except ValueError:
+                    continue
+                peak = max(peak, val)
+            return peak
+    except OSError:
+        return 0.0
+
+
 # stable display order: backends are table rows, variants are columns
 _VARIANT_ORDER = {"v1": 0, "v2": 1, "hybrid": 2}
 _BACKEND_ORDER = {"mmap": 0, "pread": 1, "posix": 2}
 
 
-def render_pivot(mode_results: list[dict], rate_field: str) -> str:
+def render_pivot(
+    mode_results: list[dict], rate_field: str, transfer_mode: str
+) -> str:
     """Render a `disk_io_backend X torrent_variant` matrix of `rate_field`
     as an RST simple table. Backends not yet tested in this mode are
     omitted; cells for untested (backend, variant) pairs show '-'.
+
+    Each rate cell is an anonymous hyperlink reference (`120.00`__) to that
+    test's summary page (`<transfer_mode>-<variant>-<backend>/summary.html`,
+    written by write_test_summary). The matching anonymous targets are
+    emitted after the table to keep the cells (and thus the column widths)
+    narrow. Anonymous references resolve against anonymous targets in
+    document order, so the targets are listed in the same row-major order
+    the references appear in; duplicate URLs (the two dual-mode tables both
+    point at the same test dir) are fine.
     """
     backends = sorted(
         {r["io_backend"] for r in mode_results},
@@ -258,11 +314,16 @@ def render_pivot(mode_results: list[dict], rate_field: str) -> str:
 
     headers = ["Backend"] + variants
     body = []
+    targets = []  # anonymous hyperlink targets, in reference (row-major) order
     for b in backends:
         row = [b]
         for v in variants:
             rate = by_key.get((b, v))
-            row.append(f"{rate:.2f}" if rate is not None else "-")
+            if rate is None:
+                row.append("-")
+            else:
+                row.append(f"`{rate:.2f}`__")
+                targets.append(f"__ {transfer_mode}-{v}-{b}/summary.html")
         body.append(row)
 
     widths = [len(h) for h in headers]
@@ -279,7 +340,127 @@ def render_pivot(mode_results: list[dict], rate_field: str) -> str:
     for row in body:
         lines.append(fmt(row))
     lines.append(sep)
-    return "\n".join(lines) + "\n"
+    table = "\n".join(lines) + "\n"
+    if targets:
+        table += "\n" + "\n".join(targets) + "\n"
+    return table
+
+
+def render_chart(
+    mode_results: list[dict],
+    rate_field: str,
+    title: str,
+    out_path: Path,
+    ylabel: str = "MB/s",
+    *,
+    palette: str | None = None,
+    baseline: float | None = None,
+) -> bool:
+    """Render a grouped bar chart of `rate_field` (backends along the x
+    axis, one bar per torrent variant within each group) to `out_path` as
+    a PNG. Mirrors render_pivot's stable ordering. Returns True on success,
+    False if matplotlib is not installed -- in which case the caller skips
+    emitting the image so the report stays valid without the dependency.
+
+    `palette` names a matplotlib colormap to draw the per-variant bar colors
+    from (defaults to matplotlib's property-cycle colors).
+    `baseline`, when set, pins the y-axis lower limit (the bars are drawn
+    from 0 but clipped to this limit, so they appear anchored to it instead
+    of to matplotlib's autoscaled floor).
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")  # headless backend; no display required
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return False
+
+    backends = sorted(
+        {r["io_backend"] for r in mode_results},
+        key=lambda b: _BACKEND_ORDER.get(b, 99),
+    )
+    variants = sorted(
+        {r["variant"] for r in mode_results},
+        key=lambda v: _VARIANT_ORDER.get(v, 99),
+    )
+    by_key = {
+        (r["io_backend"], r["variant"]): r[rate_field]
+        for r in mode_results
+    }
+
+    n_variants = max(len(variants), 1)
+    group_width = 0.8
+    bar_width = group_width / n_variants
+    x_base = list(range(len(backends)))
+
+    # draw the per-variant colors from `palette` when given, sampling it
+    # evenly across the variants; otherwise fall back to matplotlib's
+    # default property-cycle colors.
+    cmap = plt.get_cmap(palette) if palette else None
+
+    fig, ax = plt.subplots(figsize=(max(6.0, len(backends) * 1.6), 4.0))
+    for i, variant in enumerate(variants):
+        offsets = [
+            x + (i - (n_variants - 1) / 2) * bar_width for x in x_base
+        ]
+        heights = [by_key.get((b, variant)) or 0.0 for b in backends]
+        color = cmap((i + 0.5) / n_variants) if cmap else None
+        bars = ax.bar(offsets, heights, bar_width, label=variant, color=color)
+        # blank labels on absent (or zero) cells, matching the table's '-'
+        if hasattr(ax, "bar_label"):
+            labels = [f"{h:.1f}" if h else "" for h in heights]
+            ax.bar_label(bars, labels=labels, padding=2, fontsize=7)
+
+    if baseline is not None:
+        ax.set_ylim(bottom=baseline)
+
+    ax.set_xticks(x_base)
+    ax.set_xticklabels(backends)
+    ax.set_xlabel("disk I/O backend")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.legend(title="variant")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=100)
+    plt.close(fig)
+    return True
+
+
+def build_config_header(
+    save_path: Path,
+    download_peers: int,
+    upload_peers: int,
+    num_pieces: int,
+    disk_cache_mib: int,
+    aio_threads: int,
+    hasher_threads: int,
+) -> str:
+    """Render an RST field list describing the benchmark configuration, so
+    results.rst is self-describing. The filesystem reported is the one
+    backing the payload (save_path), since that is what the disk I/O hits.
+    """
+    fstype = _filesystem_type(save_path) or "unknown"
+    try:
+        resolved = save_path.resolve()
+    except OSError:
+        resolved = save_path
+    total_mib = num_pieces * PIECE_SIZE_MIB
+    lines = [
+        "Benchmark configuration",
+        "=======================",
+        "",
+        f":Filesystem: {fstype} ({resolved})",
+        f":Download peers: {download_peers}",
+        f":Upload peers: {upload_peers}",
+        f":Torrent size: {total_mib} MiB ({num_pieces} pieces x"
+        f" {PIECE_SIZE_MIB} MiB, {NUM_FILES} files)",
+        f":Disk cache: {disk_cache_mib} MiB (max_queued_disk_bytes)",
+        f":AIO threads: {aio_threads} (aio_threads)",
+        f":Hasher threads: {hasher_threads} (hashing_threads)",
+        "",
+        "",
+    ]
+    return "\n".join(lines)
 
 
 def update_results(
@@ -290,6 +471,9 @@ def update_results(
     io_backend: str,
     upload_rate: float,
     download_rate: float,
+    max_rss_bytes: float,
+    read_latency_p95_ms: float,
+    config_header: str,
 ) -> None:
     """Record one test's result into `results` (mutated in place) and
     re-render the RST summary table -- plus its HTML rendering, when
@@ -311,6 +495,8 @@ def update_results(
         "io_backend": io_backend,
         "upload_rate_mbps": upload_rate,
         "download_rate_mbps": download_rate,
+        "max_rss_mib": max_rss_bytes / (1024 * 1024),
+        "read_latency_p95_ms": read_latency_p95_ms,
     })
 
     by_mode: dict[str, list[dict]] = {}
@@ -321,17 +507,17 @@ def update_results(
     # upload-only modes get a single matrix for the rate that mode
     # actually exercises; dual mode gets one matrix per direction.
     sections = [
-        ("download", "Download mode",
-         [(None, "download_rate_mbps")]),
-        ("upload", "Upload mode",
-         [(None, "upload_rate_mbps")]),
-        ("dual", "Dual mode", [
+        ("download", "Download only",
+         [("Download rate (MB/s)", "download_rate_mbps")]),
+        ("upload", "Upload only",
+         [("Upload rate (MB/s)", "upload_rate_mbps")]),
+        ("dual", "Upload & Download", [
             ("Download rate (MB/s)", "download_rate_mbps"),
             ("Upload rate (MB/s)", "upload_rate_mbps"),
         ]),
     ]
 
-    doc_parts: list[str] = []
+    doc_parts: list[str] = [config_header]
     for mode_key, heading, subs in sections:
         mode_results = by_mode.get(mode_key, [])
         if not mode_results:
@@ -342,8 +528,48 @@ def update_results(
                 doc_parts.append(
                     f"{sub_heading}\n{'-' * len(sub_heading)}\n\n"
                 )
-            doc_parts.append(render_pivot(mode_results, rate_field))
+            doc_parts.append(render_pivot(mode_results, rate_field, mode_key))
             doc_parts.append("\n")
+            # a single-direction mode (download/upload) needs no direction
+            # suffix; dual mode has two charts, so disambiguate by direction.
+            direction = rate_field[: -len("_rate_mbps")]
+            slug = mode_key if len(subs) == 1 else f"{mode_key}_{direction}"
+            chart_name = f"chart_{slug}.png"
+            if render_chart(
+                mode_results, rate_field, sub_heading,
+                benchmarks_dir / chart_name,
+            ):
+                doc_parts.append(
+                    f".. image:: {chart_name}\n"
+                    f"   :alt: {sub_heading}\n\n"
+                )
+        # peak RSS matrix for this mode -- memory rather than throughput.
+        mem_heading = "Max memory usage (MiB RSS)"
+        doc_parts.append(f"{mem_heading}\n{'-' * len(mem_heading)}\n\n")
+        doc_parts.append(render_pivot(mode_results, "max_rss_mib", mode_key))
+        doc_parts.append("\n")
+        mem_title = f"{heading}: {mem_heading}"
+        mem_chart = f"chart_{mode_key}_rss.png"
+        if render_chart(
+            mode_results, "max_rss_mib", mem_title,
+            benchmarks_dir / mem_chart, ylabel="MiB",
+            palette="viridis", baseline=1.0,
+        ):
+            doc_parts.append(
+                f".. image:: {mem_chart}\n"
+                f"   :alt: {mem_title}\n\n"
+            )
+        # disk read-latency matrix for this mode. The cell value is the peak
+        # interval p95 read latency (from disk_latency.collect_latency); it is
+        # only nonzero for disk-latency-stats builds and backends that have a
+        # disk job queue (mmap, pread -- not posix).
+        lat_heading = "Disk read latency (peak p95, ms)"
+        doc_parts.append(f"{lat_heading}\n{'-' * len(lat_heading)}\n\n")
+        doc_parts.append(
+            render_pivot(mode_results, "read_latency_p95_ms", mode_key)
+        )
+        doc_parts.append("\n")
+
     rst_text = "".join(doc_parts)
 
     rst_path = benchmarks_dir / "results.rst"
@@ -363,7 +589,7 @@ def update_results(
 
 
 def check_perf_environment() -> None:
-    """Warn early about sysctls that prevent perf record / perf report from
+    """Warn early about sysctls that prevent perf record / perf script from
     producing useful output. Linux only; no-op elsewhere.
     """
     if platform.system() != "Linux":
@@ -380,7 +606,7 @@ def check_perf_environment() -> None:
     if kptr is not None and kptr != "0":
         warnings.append(
             f"  kernel.kptr_restrict = {kptr} -- kernel symbols will not"
-            " resolve in perf report.\n"
+            " resolve in perf script.\n"
             "    fix: sudo sysctl kernel.kptr_restrict=0"
         )
 
@@ -409,6 +635,21 @@ def check_perf_environment() -> None:
         print()
 
 
+def check_matplotlib() -> None:
+    """Warn once, up front, if matplotlib is missing. Without it render_chart
+    silently skips the per-mode bar charts; the RST/HTML tables are still
+    produced. find_spec avoids importing the (heavy) module just to probe.
+    """
+    import importlib.util
+    if importlib.util.find_spec("matplotlib") is None:
+        print(
+            "warning: matplotlib is not installed; result charts will not be"
+            " generated (the tables in results.rst/results.html are still"
+            " produced).\n"
+            "    install it with: pip install matplotlib\n"
+        )
+
+
 def main() -> None:
     p = ArgumentParser()
     p.add_argument("--toolset", default="")
@@ -423,6 +664,15 @@ def main() -> None:
         default=".",
         type=Path,
         help="The directory to download to or upload from",
+    )
+    p.add_argument(
+        "--results-path",
+        default=".",
+        type=Path,
+        help="Directory to write benchmark results and per-test logs to"
+        " (in a 'benchmarks' subdirectory). Defaults to the current working"
+        " directory, independent of --save-path -- so the payload data can"
+        " live on a fast/non-ZFS volume while results stay in the repo.",
     )
     p.add_argument(
         "--variants",
@@ -443,14 +693,37 @@ def main() -> None:
     p.add_argument(
         "--num-pieces",
         type=int,
-        default=1000,
+        default=10000,
         help="Number of pieces in the generated test torrent."
         " Piece size is 1 MiB, so total size is num_pieces MiB.",
+    )
+    p.add_argument(
+        "--disk-cache-size",
+        type=int,
+        default=100,
+        help="Disk write cache size in MiB -- libtorrent's"
+        " max_queued_disk_bytes setting (the max bytes queued for write"
+        " before the download rate is throttled).",
+    )
+    p.add_argument(
+        "--aio-threads",
+        type=int,
+        default=5,
+        help="Number of disk I/O threads -- libtorrent's aio_threads"
+        " setting.",
+    )
+    p.add_argument(
+        "--hasher-threads",
+        type=int,
+        default=2,
+        help="Number of disk threads used for piece hashing -- libtorrent's"
+        " hashing_threads setting.",
     )
 
     args = p.parse_args()
 
     check_perf_environment()
+    check_matplotlib()
 
     subprocess.check_call(
         [
@@ -458,6 +731,7 @@ def main() -> None:
             "release",
             "debug-symbols=on",
             "cxxflags=-fno-omit-frame-pointer",
+            "disk-latency-stats=on",
             args.toolset,
             "stage_client_test",
         ],
@@ -476,7 +750,7 @@ def main() -> None:
                     "-s",  # num pieces
                     str(args.num_pieces),
                     "-n",  # num files
-                    "15",
+                    str(NUM_FILES),
                     "-V",  # metadata version
                     VARIANT_FLAGS[variant],
                     "-t",  # output torrent file
@@ -487,6 +761,13 @@ def main() -> None:
     rm_file_or_dir(Path("t"))
 
     results: list[dict] = []
+
+    config_header = build_config_header(
+        args.save_path, args.download_peers, args.upload_peers,
+        args.num_pieces, args.disk_cache_size, args.aio_threads,
+        args.hasher_threads,
+    )
+    max_queued_disk_bytes = args.disk_cache_size * 1024 * 1024
 
     for variant in args.variants:
         torrent = torrent_path(variant, args.num_pieces)
@@ -502,6 +783,11 @@ def main() -> None:
                 torrent,
                 data_dir,
                 results=results,
+                results_path=args.results_path,
+                config_header=config_header,
+                max_queued_disk_bytes=max_queued_disk_bytes,
+                aio_threads=args.aio_threads,
+                hasher_threads=args.hasher_threads,
                 transfer_mode="download",
                 variant=variant,
                 io_backend=io_backend,
@@ -516,6 +802,11 @@ def main() -> None:
                 torrent,
                 data_dir,
                 results=results,
+                results_path=args.results_path,
+                config_header=config_header,
+                max_queued_disk_bytes=max_queued_disk_bytes,
+                aio_threads=args.aio_threads,
+                hasher_threads=args.hasher_threads,
                 transfer_mode="dual",
                 variant=variant,
                 io_backend=io_backend,
@@ -536,6 +827,11 @@ def main() -> None:
                 torrent,
                 data_dir,
                 results=results,
+                results_path=args.results_path,
+                config_header=config_header,
+                max_queued_disk_bytes=max_queued_disk_bytes,
+                aio_threads=args.aio_threads,
+                hasher_threads=args.hasher_threads,
                 transfer_mode="upload",
                 variant=variant,
                 io_backend=io_backend,
@@ -552,11 +848,16 @@ def run_test(
     data_dir: Path,
     *,
     results: list[dict],
+    results_path: Path,
+    config_header: str,
+    max_queued_disk_bytes: int,
+    aio_threads: int,
+    hasher_threads: int,
     transfer_mode: str,
     variant: str,
     io_backend: str,
 ) -> None:
-    benchmarks_dir = (save_path / "benchmarks").resolve()
+    benchmarks_dir = (results_path / "benchmarks").resolve()
     output_dir = benchmarks_dir / name
 
     rm_file_or_dir(output_dir)
@@ -589,6 +890,11 @@ def run_test(
         "--enable_natpmp=0",
         "--allow_multiple_connections_per_ip=1",
         f"--connections_limit={num_peers*2}",
+        # these come after "-k" on the command line, so they override the
+        # high-performance-seed preset's values.
+        f"--max_queued_disk_bytes={max_queued_disk_bytes}",
+        f"--aio_threads={aio_threads}",
+        f"--hashing_threads={hasher_threads}",
         "--alert_mask=error,status,connect,performance_warning,storage,peer",
     ] + client_arg
 
@@ -706,7 +1012,6 @@ def run_test(
                 )
 
         print(f"test_cmd: \"{' '.join(test_cmd)}\"")
-        test_start = time.monotonic()
         t = subprocess.Popen(test_cmd, stdout=test_out, stderr=test_out)
 
         out: dict[str, list[float]] = {}
@@ -715,7 +1020,6 @@ def run_test(
             time.sleep(0.1)
             t.poll()
         end = time.monotonic()
-        test_runtime = end - test_start
 
         if profiler is not None:
             profiler.send_signal(signal.SIGINT)
@@ -736,41 +1040,91 @@ def run_test(
 
     print(f"runtime {end-start:0.2f} seconds")
 
-    sent_mb, recv_mb = parse_test_out(output_dir / "test.out")
-    # connection_tester reports totals from its own perspective: it `sent` to
-    # the client (so client downloaded) and `received` from it (so client
-    # uploaded). Convert to rates against the test-only runtime.
-    download_rate = sent_mb / test_runtime if test_runtime > 0 else 0.0
-    upload_rate = recv_mb / test_runtime if test_runtime > 0 else 0.0
+    sent_rate, recv_rate = parse_test_out(output_dir / "test.out")
+    # connection_tester reports rates from its own perspective: bytes it sent
+    # are what the client downloaded, bytes it received are what the client
+    # uploaded. The rate already excludes connection_tester's startup (the v2
+    # merkle-tree build), so use it directly.
+    download_rate = sent_rate
+    upload_rate = recv_rate
+    max_rss_bytes = parse_max_rss(output_dir / "memory_stats.log")
+    # summarize disk read-job latency over the run and render the per-test
+    # median/avg/p95 plot (embedded in summary.html). The peak interval p95 is
+    # the single number that goes into the results latency table.
+    latency = disk_latency.collect_latency(output_dir / "counters.log")
+    disk_latency.plot_latency(
+        latency, output_dir / "disk_read_latency.png",
+        title=f"{name}: disk read latency",
+    )
     update_results(
         results, benchmarks_dir, transfer_mode, variant, io_backend,
-        upload_rate, download_rate,
+        upload_rate, download_rate, max_rss_bytes, latency.peak_p95_ms,
+        config_header,
     )
 
     # perf-based profiling is Linux only
     if platform.system() == "Linux":
         print("generating call tree report...")
-        raw_report = subprocess.check_output(
-            [
-                "perf", "report",
-                "-i", str(output_dir / "perf.data"),
-                "--stdio",
-                "--no-header",
-                "--children",
-                "--sort", "symbol",
-                "-g", "graph,0.5,caller",
-                "--percent-limit", "0.5",
-            ],
-            text=True,
+        perf_call_tree.main(
+            output_dir / "perf.data", output_dir / "profile.html", 0.1
         )
-        # collapse each 11-column tree level to 2 columns so deep trees
-        # fit on screen. sibling-separator lines (whitespace plus `|`)
-        # are kept because they show where the tree's branching happens.
-        with open(output_dir / "perf.report", "w") as perf_report:
-            for line in raw_report.splitlines(keepends=True):
-                perf_report.write(compact_indent(line))
 
     parse_session_stats.main(output_dir / "counters.log", 8, output_dir)
+
+    # write the per-test summary page that results.rst links to. Done last so
+    # the artifacts it references (index.html, vmstat plots, profile.html)
+    # already exist.
+    write_test_summary(output_dir, name)
+
+
+def write_test_summary(output_dir: Path, name: str) -> None:
+    """Write summary.html into a test run's output_dir. It links the session
+    stats page (index.html, from parse_session_stats), embeds the vmstat
+    plots, and links the raw logs. results.rst points each rate cell here.
+    Artifacts that are absent (e.g. plots when gnuplot is missing, or
+    profile.html off Linux) are simply skipped.
+    """
+    parts = [
+        "<!doctype html>",
+        "<html><head><meta charset='utf-8'>",
+        f"<title>{name}</title></head><body>",
+        f"<h1>{name}</h1>",
+    ]
+
+    links = []
+    if (output_dir / "index.html").exists():
+        links.append(("index.html", "session stats"))
+    for fname, label in (
+        ("events.log", "events.log (libtorrent alerts)"),
+        ("test.out", "test.out (connection_tester output)"),
+        ("profile.html", "profile.html (call tree)"),
+    ):
+        if (output_dir / fname).exists():
+            links.append((fname, label))
+    if links:
+        parts.append("<ul>")
+        parts += [f'<li><a href="{href}">{label}</a></li>' for href, label in links]
+        parts.append("</ul>")
+
+    # vmstat plots, embedded (see plot_output() in vmstat.py for the names),
+    # plus the disk read-latency plot (from disk_latency.plot_latency)
+    plots = [
+        ("disk_read_latency.png", "disk read latency (median/avg/p95)"),
+        ("memory_stats.log-memory.png", "memory usage"),
+        ("memory_stats.log-vm.png", "vm stats"),
+        ("memory_stats.log-read.png", "disk read"),
+        ("memory_stats.log-write.png", "disk write"),
+    ]
+    imgs = [(img, alt) for img, alt in plots if (output_dir / img).exists()]
+    if imgs:
+        parts.append("<h2>resource usage</h2>")
+        parts += [
+            f'<p><img src="{img}" alt="{alt}" style="max-width:100%"></p>'
+            for img, alt in imgs
+        ]
+
+    parts.append("</body></html>")
+    (output_dir / "summary.html").write_text("\n".join(parts))
 
 
 def rm_file_or_dir(path: Path) -> None:


### PR DESCRIPTION
detect and warn if the benchmark is run in ZFS (where we can't clear the cache)
save results separately from the test volume
render plots for benchmark
make disk cache and thread counts configurable on the command line tool to process a perf profiles