### PR TITLE
Tighten HTTP tracker peer parsing

### DIFF
--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -46,7 +46,7 @@ namespace libtorrent::aux {
 		bool valid_compact_peer_list(int const len, int const entry_size)
 		{
 			TORRENT_ASSERT(entry_size > 0);
-			return len % entry_size == 0;
+			return len >= 0 && len % entry_size == 0;
 		}
 
 	}

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -25,6 +25,7 @@ see LICENSE file.
 #include <algorithm>
 #include <cstdio> // for snprintf
 #include <cinttypes> // for PRId64 et.al.
+#include <limits>
 
 #include "libtorrent/aux_/http_tracker_connection.hpp"
 #include "libtorrent/aux_/http_connection.hpp"
@@ -39,6 +40,16 @@ see LICENSE file.
 #include "libtorrent/aux_/array.hpp"
 
 namespace libtorrent::aux {
+
+	namespace {
+
+		bool valid_compact_peer_list(int const len, int const entry_size)
+		{
+			TORRENT_ASSERT(entry_size > 0);
+			return len % entry_size == 0;
+		}
+
+	}
 
 	http_tracker_connection::http_tracker_connection(
 		io_context& ios
@@ -492,7 +503,14 @@ namespace libtorrent::aux {
 			ec = errors::invalid_tracker_response;
 			return false;
 		}
-		ret.port = std::uint16_t(i.int_value());
+
+		auto const port = i.int_value();
+		if (port < 0 || port > std::numeric_limits<std::uint16_t>::max())
+		{
+			ec = errors::invalid_tracker_response;
+			return false;
+		}
+		ret.port = std::uint16_t(port);
 
 		return true;
 	}
@@ -573,9 +591,13 @@ namespace libtorrent::aux {
 #if TORRENT_USE_I2P
 			if (flags & tracker_request::i2p)
 			{
+				if (!valid_compact_peer_list(len, 32))
+				{
+					ec = errors::invalid_peers_entry;
+					return resp;
+				}
 				for (int i = 0; i < len; i += 32)
 				{
-					if (len - i < 32) break;
 					i2p_peer_entry p;
 					std::memcpy(p.destination.data(), peers + i, 32);
 					resp.i2p_peers.push_back(p);
@@ -584,11 +606,14 @@ namespace libtorrent::aux {
 			else
 #endif
 			{
+				if (!valid_compact_peer_list(len, 6))
+				{
+					ec = errors::invalid_peers_entry;
+					return resp;
+				}
 				resp.peers4.reserve(std::size_t(len / 6));
 				for (int i = 0; i < len; i += 6)
 				{
-					if (len - i < 6) break;
-
 					ipv4_peer_entry p;
 					p.ip = aux::read_v4_address(peers).to_bytes();
 					p.port = aux::read_uint16(peers);
@@ -626,11 +651,14 @@ namespace libtorrent::aux {
 		{
 			char const* peers = ipv6_peers.string_ptr();
 			int const len = ipv6_peers.string_length();
+			if (!valid_compact_peer_list(len, 18))
+			{
+				ec = errors::invalid_peers_entry;
+				return resp;
+			}
 			resp.peers6.reserve(std::size_t(len / 18));
 			for (int i = 0; i < len; i += 18)
 			{
-				if (len - i < 18) break;
-
 				ipv6_peer_entry p;
 				p.ip = aux::read_v6_address(peers).to_bytes();
 				p.port = aux::read_uint16(peers);

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -39,7 +39,6 @@ see LICENSE file.
 using namespace lt;
 
 // TODO: test scrape requests
-// TODO: test parse peers6
 // TODO: test parse tracker-id
 // TODO: test parse failure-reason
 // TODO: test all failure paths, including
@@ -106,6 +105,37 @@ TORRENT_TEST(parse_peers4_invalid_length)
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
 	TEST_EQUAL(resp.peers4.size(), 0);
+}
+
+TORRENT_TEST(parse_peers6)
+{
+	std::string response = "d6:peers636:";
+	auto const ip0 = addr6("2001:db8::1").to_bytes();
+	response.append(reinterpret_cast<char const*>(ip0.data()), ip0.size());
+	response.push_back(char(0x30));
+	response.push_back(char(0x10));
+	auto const ip1 = addr6("2001:db8::2").to_bytes();
+	response.append(reinterpret_cast<char const*>(ip1.data()), ip1.size());
+	response.push_back(char(0x20));
+	response.push_back(char(0x10));
+	response += 'e';
+
+	error_code ec;
+	tracker_response resp = parse_tracker_response(response
+		, ec, {}, sha1_hash());
+
+	TEST_EQUAL(ec, error_code());
+	TEST_EQUAL(resp.peers6.size(), 2);
+	if (resp.peers6.size() == 2)
+	{
+		ipv6_peer_entry const& e0 = resp.peers6[0];
+		ipv6_peer_entry const& e1 = resp.peers6[1];
+		TEST_CHECK(e0.ip == addr6("2001:db8::1").to_bytes());
+		TEST_EQUAL(e0.port, 0x3010);
+
+		TEST_CHECK(e1.ip == addr6("2001:db8::2").to_bytes());
+		TEST_EQUAL(e1.port, 0x2010);
+	}
 }
 
 TORRENT_TEST(parse_peers6_invalid_length)

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -97,6 +97,31 @@ TORRENT_TEST(parse_peers4)
 	}
 }
 
+TORRENT_TEST(parse_peers4_invalid_length)
+{
+	char const response[] = "d5:peers7:\x01\x02\x03\x04\x30\x10\x01" "e";
+	error_code ec;
+	tracker_response resp = parse_tracker_response(response
+		, ec, {}, sha1_hash());
+
+	TEST_EQUAL(ec, errors::invalid_peers_entry);
+	TEST_EQUAL(resp.peers4.size(), 0);
+}
+
+TORRENT_TEST(parse_peers6_invalid_length)
+{
+	std::string response = "d6:peers619:";
+	response.append(19, '\1');
+	response += 'e';
+
+	error_code ec;
+	tracker_response resp = parse_tracker_response(response
+		, ec, {}, sha1_hash());
+
+	TEST_EQUAL(ec, errors::invalid_peers_entry);
+	TEST_EQUAL(resp.peers6.size(), 0);
+}
+
 #if TORRENT_USE_I2P
 TORRENT_TEST(parse_i2p_peers)
 {
@@ -306,6 +331,18 @@ TORRENT_TEST(extract_peer_missing_port)
 {
 	// missing port
 	aux::peer_entry result = extract_peer("d7:peer id20:abababababababababab2:ip4:abcde"
+		, errors::invalid_tracker_response, false);
+}
+
+TORRENT_TEST(extract_peer_negative_port)
+{
+	peer_entry result = extract_peer("d2:ip11:example.com4:porti-1ee"
+		, errors::invalid_tracker_response, false);
+}
+
+TORRENT_TEST(extract_peer_port_overflow)
+{
+	peer_entry result = extract_peer("d2:ip11:example.com4:porti65536ee"
 		, errors::invalid_tracker_response, false);
 }
 

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -98,9 +98,12 @@ TORRENT_TEST(parse_peers4)
 
 TORRENT_TEST(parse_peers4_invalid_length)
 {
-	char const response[] = "d5:peers7:\x01\x02\x03\x04\x30\x10\x01" "e";
+	std::string response = "d5:peers7:";
+	response.append("\x01\x02\x03\x04\x30\x10\x01", 7);
+	response += 'e';
+
 	error_code ec;
-	tracker_response resp = parse_tracker_response(response
+	aux::tracker_response resp = aux::parse_tracker_response(response
 		, ec, {}, sha1_hash());
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
@@ -121,15 +124,15 @@ TORRENT_TEST(parse_peers6)
 	response += 'e';
 
 	error_code ec;
-	tracker_response resp = parse_tracker_response(response
+	aux::tracker_response resp = aux::parse_tracker_response(response
 		, ec, {}, sha1_hash());
 
 	TEST_EQUAL(ec, error_code());
 	TEST_EQUAL(resp.peers6.size(), 2);
 	if (resp.peers6.size() == 2)
 	{
-		ipv6_peer_entry const& e0 = resp.peers6[0];
-		ipv6_peer_entry const& e1 = resp.peers6[1];
+		aux::ipv6_peer_entry const& e0 = resp.peers6[0];
+		aux::ipv6_peer_entry const& e1 = resp.peers6[1];
 		TEST_CHECK(e0.ip == addr6("2001:db8::1").to_bytes());
 		TEST_EQUAL(e0.port, 0x3010);
 
@@ -145,7 +148,7 @@ TORRENT_TEST(parse_peers6_invalid_length)
 	response += 'e';
 
 	error_code ec;
-	tracker_response resp = parse_tracker_response(response
+	aux::tracker_response resp = aux::parse_tracker_response(response
 		, ec, {}, sha1_hash());
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
@@ -237,8 +240,8 @@ TORRENT_TEST(parse_i2p_peers_invalid_length)
 	response += 'e';
 
 	error_code ec;
-	tracker_response resp = parse_tracker_response(response
-		, ec, tracker_request::i2p, sha1_hash());
+	aux::tracker_response resp = aux::parse_tracker_response(response
+		, ec, aux::tracker_request::i2p, sha1_hash());
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
 	TEST_EQUAL(resp.i2p_peers.size(), 0);
@@ -375,33 +378,33 @@ TORRENT_TEST(extract_peer_hostname)
 TORRENT_TEST(extract_peer_not_a_dictionary)
 {
 	// not a dictionary
-	aux::peer_entry result = extract_peer("2:ip11:example.com"
+	extract_peer("2:ip11:example.com"
 		, errors::invalid_peer_dict, false);
 }
 
 TORRENT_TEST(extract_peer_missing_ip)
 {
 	// missing IP
-	aux::peer_entry result = extract_peer("d7:peer id20:abababababababababab4:porti1337ee"
+	extract_peer("d7:peer id20:abababababababababab4:porti1337ee"
 		, errors::invalid_tracker_response, false);
 }
 
 TORRENT_TEST(extract_peer_missing_port)
 {
 	// missing port
-	aux::peer_entry result = extract_peer("d7:peer id20:abababababababababab2:ip4:abcde"
+	extract_peer("d7:peer id20:abababababababababab2:ip4:abcde"
 		, errors::invalid_tracker_response, false);
 }
 
 TORRENT_TEST(extract_peer_negative_port)
 {
-	peer_entry result = extract_peer("d2:ip11:example.com4:porti-1ee"
+	extract_peer("d2:ip11:example.com4:porti-1ee"
 		, errors::invalid_tracker_response, false);
 }
 
 TORRENT_TEST(extract_peer_port_overflow)
 {
-	peer_entry result = extract_peer("d2:ip11:example.com4:porti65536ee"
+	extract_peer("d2:ip11:example.com4:porti65536ee"
 		, errors::invalid_tracker_response, false);
 }
 

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -103,8 +103,7 @@ TORRENT_TEST(parse_peers4_invalid_length)
 	response += 'e';
 
 	error_code ec;
-	aux::tracker_response resp = aux::parse_tracker_response(response
-		, ec, {}, sha1_hash());
+	aux::tracker_response resp = aux::parse_tracker_response(response, ec, {}, sha1_hash());
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
 	TEST_EQUAL(resp.peers4.size(), 0);
@@ -124,8 +123,7 @@ TORRENT_TEST(parse_peers6)
 	response += 'e';
 
 	error_code ec;
-	aux::tracker_response resp = aux::parse_tracker_response(response
-		, ec, {}, sha1_hash());
+	aux::tracker_response resp = aux::parse_tracker_response(response, ec, {}, sha1_hash());
 
 	TEST_EQUAL(ec, error_code());
 	TEST_EQUAL(resp.peers6.size(), 2);
@@ -148,8 +146,7 @@ TORRENT_TEST(parse_peers6_invalid_length)
 	response += 'e';
 
 	error_code ec;
-	aux::tracker_response resp = aux::parse_tracker_response(response
-		, ec, {}, sha1_hash());
+	aux::tracker_response resp = aux::parse_tracker_response(response, ec, {}, sha1_hash());
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
 	TEST_EQUAL(resp.peers6.size(), 0);
@@ -213,10 +210,10 @@ TORRENT_TEST(parse_i2p_peers)
 	{
 		bdecode_node decoded;
 		error_code decode_ec;
-		int const decode_result = bdecode(
-			reinterpret_cast<char const*>(response)
-			, reinterpret_cast<char const*>(response + sizeof(response))
-			, decoded, decode_ec);
+		int const decode_result = bdecode(reinterpret_cast<char const*>(response),
+			reinterpret_cast<char const*>(response + sizeof(response)),
+			decoded,
+			decode_ec);
 		TEST_EQUAL(decode_ec, error_code());
 		TEST_EQUAL(decode_result, 0);
 
@@ -225,8 +222,7 @@ TORRENT_TEST(parse_i2p_peers)
 		if (peers)
 		{
 			TEST_EQUAL(peers.string_length(), 11 * int(sha256_hash::size()));
-			TEST_CHECK(resp.i2p_peers[0].destination
-				== sha256_hash(peers.string_ptr()));
+			TEST_CHECK(resp.i2p_peers[0].destination == sha256_hash(peers.string_ptr()));
 			TEST_CHECK(resp.i2p_peers[10].destination
 				== sha256_hash(peers.string_ptr() + 10 * sha256_hash::size()));
 		}
@@ -240,8 +236,8 @@ TORRENT_TEST(parse_i2p_peers_invalid_length)
 	response += 'e';
 
 	error_code ec;
-	aux::tracker_response resp = aux::parse_tracker_response(response
-		, ec, aux::tracker_request::i2p, sha1_hash());
+	aux::tracker_response resp =
+		aux::parse_tracker_response(response, ec, aux::tracker_request::i2p, sha1_hash());
 
 	TEST_EQUAL(ec, errors::invalid_peers_entry);
 	TEST_EQUAL(resp.i2p_peers.size(), 0);
@@ -378,34 +374,31 @@ TORRENT_TEST(extract_peer_hostname)
 TORRENT_TEST(extract_peer_not_a_dictionary)
 {
 	// not a dictionary
-	extract_peer("2:ip11:example.com"
-		, errors::invalid_peer_dict, false);
+	extract_peer("2:ip11:example.com", errors::invalid_peer_dict, false);
 }
 
 TORRENT_TEST(extract_peer_missing_ip)
 {
 	// missing IP
-	extract_peer("d7:peer id20:abababababababababab4:porti1337ee"
-		, errors::invalid_tracker_response, false);
+	extract_peer(
+		"d7:peer id20:abababababababababab4:porti1337ee", errors::invalid_tracker_response, false);
 }
 
 TORRENT_TEST(extract_peer_missing_port)
 {
 	// missing port
-	extract_peer("d7:peer id20:abababababababababab2:ip4:abcde"
-		, errors::invalid_tracker_response, false);
+	extract_peer(
+		"d7:peer id20:abababababababababab2:ip4:abcde", errors::invalid_tracker_response, false);
 }
 
 TORRENT_TEST(extract_peer_negative_port)
 {
-	extract_peer("d2:ip11:example.com4:porti-1ee"
-		, errors::invalid_tracker_response, false);
+	extract_peer("d2:ip11:example.com4:porti-1ee", errors::invalid_tracker_response, false);
 }
 
 TORRENT_TEST(extract_peer_port_overflow)
 {
-	extract_peer("d2:ip11:example.com4:porti65536ee"
-		, errors::invalid_tracker_response, false);
+	extract_peer("d2:ip11:example.com4:porti65536ee", errors::invalid_tracker_response, false);
 }
 
 namespace {

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -215,6 +215,20 @@ TORRENT_TEST(parse_i2p_peers)
 			== sha256_hash(reinterpret_cast<char const*>(peers + 10 * 32)));
 	}
 }
+
+TORRENT_TEST(parse_i2p_peers_invalid_length)
+{
+	std::string response = "d5:peers33:";
+	response.append(33, '\1');
+	response += 'e';
+
+	error_code ec;
+	tracker_response resp = parse_tracker_response(response
+		, ec, tracker_request::i2p, sha1_hash());
+
+	TEST_EQUAL(ec, errors::invalid_peers_entry);
+	TEST_EQUAL(resp.i2p_peers.size(), 0);
+}
 #endif // TORRENT_USE_I2P
 
 TORRENT_TEST(parse_interval)

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -208,11 +208,25 @@ TORRENT_TEST(parse_i2p_peers)
 
 	if (resp.i2p_peers.size() == 11)
 	{
-		std::uint8_t const* peers = response + 57;
-		TEST_CHECK(resp.i2p_peers[0].destination
-			== sha256_hash(reinterpret_cast<char const*>(peers)));
-		TEST_CHECK(resp.i2p_peers[10].destination
-			== sha256_hash(reinterpret_cast<char const*>(peers + 10 * 32)));
+		bdecode_node decoded;
+		error_code decode_ec;
+		int const decode_result = bdecode(
+			reinterpret_cast<char const*>(response)
+			, reinterpret_cast<char const*>(response + sizeof(response))
+			, decoded, decode_ec);
+		TEST_EQUAL(decode_ec, error_code());
+		TEST_EQUAL(decode_result, 0);
+
+		bdecode_node const peers = decoded.dict_find_string("peers");
+		TEST_CHECK(peers);
+		if (peers)
+		{
+			TEST_EQUAL(peers.string_length(), 11 * int(sha256_hash::size()));
+			TEST_CHECK(resp.i2p_peers[0].destination
+				== sha256_hash(peers.string_ptr()));
+			TEST_CHECK(resp.i2p_peers[10].destination
+				== sha256_hash(peers.string_ptr() + 10 * sha256_hash::size()));
+		}
 	}
 }
 

--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -85,7 +85,7 @@ TORRENT_TEST(parse_peers4)
 
 	TEST_EQUAL(ec, error_code());
 	TEST_EQUAL(resp.peers4.size(), 2);
-	if (resp.peers.size() == 2)
+	if (resp.peers4.size() == 2)
 	{
 		aux::ipv4_peer_entry const& e0 = resp.peers4[0];
 		aux::ipv4_peer_entry const& e1 = resp.peers4[1];
@@ -176,12 +176,13 @@ TORRENT_TEST(parse_i2p_peers)
 	TEST_EQUAL(ec, error_code());
 	TEST_EQUAL(resp.i2p_peers.size(), 11);
 
-	if (resp.peers.size() == 11)
+	if (resp.i2p_peers.size() == 11)
 	{
-		TEST_EQUAL(resp.peers[0].hostname
-			, "wgcobfq73pzmtmcttiy2knon5bm2a7gn6j6idaiccf53ikwrecdq.b32.i2p");
-		TEST_EQUAL(resp.peers[10].hostname
-			, "ufunemgwuun5t2sn3oay4zv7jvwdezwcrirgwr6b2fjgczvaowvq.b32.i2p");
+		std::uint8_t const* peers = response + 57;
+		TEST_CHECK(resp.i2p_peers[0].destination
+			== sha256_hash(reinterpret_cast<char const*>(peers)));
+		TEST_CHECK(resp.i2p_peers[10].destination
+			== sha256_hash(reinterpret_cast<char const*>(peers + 10 * 32)));
 	}
 }
 #endif // TORRENT_USE_I2P


### PR DESCRIPTION
Reject malformed compact tracker peer lists instead of silently dropping trailing bytes.

Reject dictionary peer ports outside the uint16 range before they can wrap into valid endpoints.

Add focused tracker parser coverage for IPv4, IPv6, I2P, and dictionary peer ports.

Validated with git diff --check, pre-commit for touched files, Boost.Build test_tracker build, and focused parser test_tracker cases.