### PR TITLE
Mmap v2 block hashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ set(libtorrent_aux_include_files
 	merkle.hpp
 	merkle_tree.hpp
 	mmap_storage.hpp
+	precomputed_block_hashes.hpp
 	netlink.hpp
 	netlink_utils.hpp
 	noexcept_movable.hpp
@@ -376,6 +377,7 @@ set(sources
 	mmap_disk_io.cpp
 	disk_job.cpp
 	mmap_storage.cpp
+	precomputed_block_hashes.cpp
 	natpmp.cpp
 	packet_buffer.cpp
 	parse_url.cpp

--- a/Jamfile
+++ b/Jamfile
@@ -929,6 +929,7 @@ SOURCES =
 	mmap
 	mmap_disk_io
 	mmap_storage
+	precomputed_block_hashes
 	pread_disk_io
 	pread_storage
 	posix_disk_io

--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,7 @@ SOURCES = \
   mmap_disk_io.cpp                \
   disk_job.cpp                    \
   mmap_storage.cpp                \
+  precomputed_block_hashes.cpp    \
   natpmp.cpp                      \
   packet_buffer.cpp               \
   parse_url.cpp                   \
@@ -612,6 +613,7 @@ HEADERS = \
   aux_/merkle_tree.hpp              \
   aux_/mmap.hpp                     \
   aux_/mmap_storage.hpp             \
+  aux_/precomputed_block_hashes.hpp \
   aux_/mmap_disk_job.hpp            \
   aux_/disk_job.hpp                 \
   aux_/netlink.hpp                  \
@@ -1004,6 +1006,7 @@ TEST_SOURCES = \
   test_web_seed_socks5_no_peers.cpp \
   test_web_seed_socks5_pw.cpp \
   test_xml.cpp \
+  test_precomputed_block_hashes.cpp \
   \
   main.cpp \
   broadcast_socket.cpp \

--- a/include/libtorrent/aux_/mmap_storage.hpp
+++ b/include/libtorrent/aux_/mmap_storage.hpp
@@ -29,11 +29,13 @@ see LICENSE file.
 #include "libtorrent/aux_/stat_cache.hpp"
 #include "libtorrent/bitfield.hpp"
 #include "libtorrent/span.hpp"
+#include "libtorrent/sha1_hash.hpp" // for sha256_hash
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/open_mode.hpp" // for aux::open_mode_t
 #include "libtorrent/disk_interface.hpp" // for disk_job_flags_t
 #include "libtorrent/aux_/mmap.hpp"
 #include "libtorrent/aux_/file_view_pool.hpp"
+#include "libtorrent/aux_/precomputed_block_hashes.hpp"
 
 namespace libtorrent::aux {
 
@@ -115,6 +117,20 @@ namespace libtorrent::aux {
 		storage_index_t storage_index() const { return m_storage_index; }
 		void set_storage_index(storage_index_t st) { m_storage_index = st; }
 
+		bool v1() const { return m_v1; }
+		bool v2() const { return m_v2; }
+
+		// SHA-256 block hashes computed inline during write jobs (see
+		// m_precomputed_v2). Consumed by hash/hash2 jobs to avoid re-reading the
+		// block from disk just to hash it. A block whose hash hasn't been
+		// computed reads as an all-zero hash (a SHA-256 over a non-empty block
+		// is never all zeros), so no separate "present" bitfield is needed.
+		void store_precomputed_v2(piece_index_t piece, int block, sha256_hash const& h);
+		// the piece's block hashes (indexed by block); empty if none.
+		aux::vector<sha256_hash> take_precomputed_v2(piece_index_t piece);
+		std::optional<sha256_hash> take_precomputed_v2_block(piece_index_t piece, int block);
+		void drop_precomputed_v2(piece_index_t piece);
+
 	private:
 
 		bool m_need_tick = false;
@@ -195,6 +211,20 @@ namespace libtorrent::aux {
 #endif
 
 		bool m_allocate_files;
+
+		// whether this torrent has v1 and/or v2 piece hashes
+		bool m_v1;
+		bool m_v2;
+
+		// SHA-256 block hashes computed during write jobs. An entry is added
+		// when the first block of a piece is written and removed by
+		// take_precomputed_v2() (full-piece hash), take_precomputed_v2_block()
+		// (single-block hash2) or drop_precomputed_v2() (clear_piece). An entry
+		// for a piece that is written but never hashed or cleared lives until
+		// the storage is destroyed; it is therefore bounded by the number of
+		// pieces with blocks written but not yet hashed, i.e. the in-flight
+		// pieces the piece picker keeps open.
+		precomputed_block_hashes m_precomputed_v2;
 	};
 
 }

--- a/include/libtorrent/aux_/precomputed_block_hashes.hpp
+++ b/include/libtorrent/aux_/precomputed_block_hashes.hpp
@@ -1,0 +1,56 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#ifndef TORRENT_PRECOMPUTED_BLOCK_HASHES_HPP
+#define TORRENT_PRECOMPUTED_BLOCK_HASHES_HPP
+
+#include <unordered_map>
+#include <mutex>
+#include <optional>
+
+#include "libtorrent/units.hpp" // for piece_index_t
+#include "libtorrent/sha1_hash.hpp" // for sha256_hash
+#include "libtorrent/aux_/vector.hpp"
+#include "libtorrent/aux_/export.hpp" // for TORRENT_EXTRA_EXPORT
+
+namespace libtorrent::aux {
+
+	// A thread-safe cache of SHA-256 block hashes computed inline while writing
+	// blocks to disk, so a later hash/hash2 job doesn't have to re-read the block
+	// just to hash it. Keyed by piece, then indexed by block within the piece.
+	//
+	// A block whose hash has not been computed reads as an all-zero hash. A
+	// SHA-256 over a (non-empty) block is never all zeros, so this doubles as the
+	// "not present" sentinel and avoids a separate bitfield.
+	struct TORRENT_EXTRA_EXPORT precomputed_block_hashes
+	{
+		// store the SHA-256 of a single block. num_blocks is the number of blocks
+		// in the piece; it sizes the per-piece array the first time a block of the
+		// piece is stored.
+		void store(piece_index_t piece, int block, int num_blocks, sha256_hash const& h);
+
+		// remove and return all of a piece's block hashes (indexed by block).
+		// Returns an empty vector if the piece has none. Blocks that were never
+		// stored read as all-zero.
+		aux::vector<sha256_hash> take(piece_index_t piece);
+
+		// remove and return a single block's hash, or nullopt if it wasn't stored.
+		std::optional<sha256_hash> take_block(piece_index_t piece, int block);
+
+		// discard all of a piece's hashes (e.g. on clear_piece / re-download).
+		void drop(piece_index_t piece);
+
+	private:
+		mutable std::mutex m_mutex;
+		std::unordered_map<piece_index_t, aux::vector<sha256_hash>> m_hashes;
+	};
+
+}
+
+#endif

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -502,6 +502,22 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			m_stats_counters.inc_stats_counter(counters::disk_job_time, write_time);
 		}
 
+		// for v2 / hybrid torrents the block is still in RAM; compute the
+		// SHA-256 hash now and stash it on the storage so the later hash job
+		// doesn't have to re-read the block from disk. v2 pieces don't span
+		// file boundaries, so for hybrid torrents the block may extend past
+		// the v2 piece end into v1 padding; hash only the v2 portion.
+		if (!j->error.ec && ret == a.buffer_size && j->storage->v2())
+		{
+			int const piece_size2 = j->storage->files().piece_size2(a.piece);
+			if (a.offset < piece_size2)
+			{
+				int const blk = a.offset / default_block_size;
+				int const v2_len = std::min(int(a.buffer_size), piece_size2 - a.offset);
+				j->storage->store_precomputed_v2(a.piece, blk, hasher256(b.first(v2_len)).final());
+			}
+		}
+
 		m_store_buffer.erase({j->storage->storage_index(), a.piece, a.offset});
 
 		{
@@ -873,6 +889,12 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		TORRENT_ASSERT(!v2 || int(a.block_hashes.size()) >= blocks_in_piece2);
 		TORRENT_ASSERT(v1 || v2);
 
+		// consume SHA-256 hashes computed inline during do_job(write); for any
+		// block where we don't have one (an all-zero entry), fall through to the
+		// existing path
+		aux::vector<sha256_hash> const pc =
+			v2 ? j->storage->take_precomputed_v2(a.piece) : aux::vector<sha256_hash>{};
+
 		hasher h;
 		int ret = 0;
 		int offset = 0;
@@ -887,7 +909,24 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			std::ptrdiff_t const len = v1 ? std::min(default_block_size, piece_size - offset) : 0;
 			std::ptrdiff_t const len2 = v2_block ? std::min(default_block_size, piece_size2 - offset) : 0;
 
+			bool const have_precomputed_v2 =
+				v2_block && i < int(pc.size()) && !pc[i].is_all_zeros();
+
 			hasher256 h2;
+
+			if (have_precomputed_v2 && !v1)
+			{
+				// pure v2 fast path: no I/O, no SHA-256 work
+				a.block_hashes[i] = pc[i];
+				ret = int(len2);
+				offset += default_block_size;
+				continue;
+			}
+
+			// for hybrid with a precomputed v2 hash, we still need bytes for
+			// the v1 SHA-1 piece hash, but we can skip h2.update() and the
+			// hash2() fallback
+			bool const need_v2_io = v2_block && !have_precomputed_v2;
 
 			if (!m_store_buffer.get({ j->storage->storage_index(), a.piece, offset }
 				, [&](char const* buf)
@@ -897,7 +936,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 						h.update({ buf, len });
 						ret = int(len);
 					}
-					if (v2_block)
+					if (need_v2_io)
 					{
 						h2.update({ buf, len2 });
 						ret = int(len2);
@@ -908,13 +947,14 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 				{
 					// if we will call hash2() in a bit, don't trigger a flush
 					// just yet, let hash2() do it
-					auto const flags = v2_block ? (j->flags & ~disk_interface::flush_piece) : j->flags;
+					auto const flags =
+						need_v2_io ? (j->flags & ~disk_interface::flush_piece) : j->flags;
 					j->error.ec.clear();
 					ret = j->storage->hash(m_settings, h, len, a.piece, offset
 						, file_mode, flags, j->error);
 					if (ret < 0) break;
 				}
-				if (v2_block)
+				if (need_v2_io)
 				{
 					j->error.ec.clear();
 					ret = j->storage->hash2(m_settings, h2, len2, a.piece, offset
@@ -930,8 +970,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 				}
 			}
 
-			if (v2_block)
-				a.block_hashes[i] = h2.final();
+			if (v2_block) a.block_hashes[i] = have_precomputed_v2 ? pc[i] : h2.final();
 
 			if (ret <= 0) break;
 
@@ -966,6 +1005,19 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 
 		TORRENT_ASSERT(piece_size > a.offset);
 		std::ptrdiff_t const len = std::min(default_block_size, piece_size - a.offset);
+
+		// fast path: SHA-256 was computed inline during the write job
+		{
+			int const blk = a.offset / default_block_size;
+			if (auto pre = j->storage->take_precomputed_v2_block(a.piece, blk))
+			{
+				a.piece_hash2 = *pre;
+				std::int64_t const read_time = total_microseconds(clock_type::now() - start_time);
+				m_stats_counters.inc_stats_counter(counters::disk_hash_time, read_time);
+				m_stats_counters.inc_stats_counter(counters::disk_job_time, read_time);
+				return {};
+			}
+		}
 
 		if (!m_store_buffer.get({ j->storage->storage_index(), a.piece, a.offset }
 			, [&](char const* buf)
@@ -1136,10 +1188,12 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 	// this job won't return until all outstanding jobs on this
 	// piece are completed or cancelled and the buffers for it
 	// have been evicted
-	status_t mmap_disk_io::do_job(aux::job::clear_piece&, aux::mmap_disk_job*)
+	status_t mmap_disk_io::do_job(aux::job::clear_piece& a, aux::mmap_disk_job* j)
 	{
-		// there's nothing to do here, by the time this is called the jobs for
-		// this storage has been completed since this is a fence job
+		// by the time this is called the jobs for this storage have been
+		// completed since this is a fence job; drop any precomputed block
+		// hashes for the cleared piece so a re-download starts fresh
+		j->storage->drop_precomputed_v2(a.piece);
 		return {};
 	}
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -207,10 +207,6 @@ private:
 	// disk cache
 	aux::disk_buffer_pool m_buffer_pool;
 
-	// total number of blocks in use by both the read
-	// and the write cache. This is not supposed to
-	// exceed m_cache_size
-
 	counters& m_stats_counters;
 
 	// this is the main thread io_context. Callbacks are

--- a/src/mmap_storage.cpp
+++ b/src/mmap_storage.cpp
@@ -85,24 +85,26 @@ error_code translate_error(std::error_code const& err, bool const write)
 } // namespace
 
 
-	mmap_storage::mmap_storage(storage_params const& params
-		, aux::file_view_pool& pool)
-		: m_files(params.files)
-		, m_renamed_files(params.renamed_files)
-		, m_file_priority(params.priorities)
-		, m_save_path(complete(params.path))
-		, m_part_file_dir(params.part_file_dir)
-		, m_part_file_name("." + aux::to_hex(params.info_hash) + ".parts")
-		, m_pool(pool)
-		, m_allocate_files(params.mode == storage_mode_allocate)
-	{
-		TORRENT_ASSERT(files().num_files() > 0);
+mmap_storage::mmap_storage(storage_params const& params, aux::file_view_pool& pool)
+	: m_files(params.files)
+	, m_renamed_files(params.renamed_files)
+	, m_file_priority(params.priorities)
+	, m_save_path(complete(params.path))
+	, m_part_file_dir(params.part_file_dir)
+	, m_part_file_name("." + aux::to_hex(params.info_hash) + ".parts")
+	, m_pool(pool)
+	, m_allocate_files(params.mode == storage_mode_allocate)
+	, m_v1(params.v1)
+	, m_v2(params.v2)
+{
+	TORRENT_ASSERT(files().num_files() > 0);
+	TORRENT_ASSERT(m_v1 || m_v2);
 
 #if TORRENT_HAVE_MAP_VIEW_OF_FILE
 		m_file_open_unmap_lock.reset(new std::mutex[files().num_files()]
 			, [](std::mutex* o) { delete[] o; });
 #endif
-	}
+}
 
 	mmap_storage::~mmap_storage()
 	{
@@ -117,6 +119,30 @@ error_code translate_error(std::error_code const& err, bool const write)
 	filenames mmap_storage::names() const
 	{
 		return {m_files, m_renamed_files};
+	}
+
+	// these forward to the precomputed_block_hashes data structure, adding the
+	// storage's knowledge of the per-piece v2 block count.
+	void mmap_storage::store_precomputed_v2(
+		piece_index_t const piece, int const block, sha256_hash const& h)
+	{
+		m_precomputed_v2.store(piece, block, files().blocks_in_piece2(piece), h);
+	}
+
+	aux::vector<sha256_hash> mmap_storage::take_precomputed_v2(piece_index_t const piece)
+	{
+		return m_precomputed_v2.take(piece);
+	}
+
+	std::optional<sha256_hash> mmap_storage::take_precomputed_v2_block(
+		piece_index_t const piece, int const block)
+	{
+		return m_precomputed_v2.take_block(piece, block);
+	}
+
+	void mmap_storage::drop_precomputed_v2(piece_index_t const piece)
+	{
+		m_precomputed_v2.drop(piece);
 	}
 
 	void mmap_storage::need_partfile()

--- a/src/pread_disk_io.cpp
+++ b/src/pread_disk_io.cpp
@@ -223,10 +223,6 @@ private:
 	// disk cache
 	aux::disk_buffer_pool m_buffer_pool;
 
-	// total number of blocks in use by both the read
-	// and the write cache. This is not supposed to
-	// exceed m_cache_size
-
 	counters& m_stats_counters;
 
 	// this is the main thread io_context. Callbacks are

--- a/src/precomputed_block_hashes.cpp
+++ b/src/precomputed_block_hashes.cpp
@@ -1,0 +1,65 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#include "libtorrent/aux_/precomputed_block_hashes.hpp"
+#include "libtorrent/assert.hpp"
+
+#include <algorithm>
+
+namespace libtorrent::aux {
+
+	void precomputed_block_hashes::store(
+		piece_index_t const piece, int const block, int const num_blocks, sha256_hash const& h)
+	{
+		std::lock_guard<std::mutex> l(m_mutex);
+		auto& entry = m_hashes[piece];
+		// newly created elements are value-initialized to all-zero, i.e. "not
+		// computed".
+		if (entry.empty()) entry.resize(num_blocks);
+		TORRENT_ASSERT(block >= 0 && block < num_blocks);
+		// a real block hash is never all zeros (that's the "not computed" sentinel)
+		TORRENT_ASSERT(!h.is_all_zeros());
+		entry[block] = h;
+	}
+
+	aux::vector<sha256_hash> precomputed_block_hashes::take(piece_index_t const piece)
+	{
+		std::lock_guard<std::mutex> l(m_mutex);
+		auto const it = m_hashes.find(piece);
+		if (it == m_hashes.end()) return {};
+		aux::vector<sha256_hash> ret = std::move(it->second);
+		m_hashes.erase(it);
+		return ret;
+	}
+
+	std::optional<sha256_hash> precomputed_block_hashes::take_block(
+		piece_index_t const piece, int const block)
+	{
+		TORRENT_ASSERT(block >= 0);
+		std::lock_guard<std::mutex> l(m_mutex);
+		auto const it = m_hashes.find(piece);
+		if (it == m_hashes.end()) return std::nullopt;
+		auto& entry = it->second;
+		if (block >= int(entry.size()) || entry[block].is_all_zeros()) return std::nullopt;
+		sha256_hash const h = entry[block];
+		// mark the block consumed; drop the piece once nothing computed remains
+		entry[block].clear();
+		bool const any = std::any_of(
+			entry.begin(), entry.end(), [](sha256_hash const& x) { return !x.is_all_zeros(); });
+		if (!any) m_hashes.erase(it);
+		return h;
+	}
+
+	void precomputed_block_hashes::drop(piece_index_t const piece)
+	{
+		std::lock_guard<std::mutex> l(m_mutex);
+		m_hashes.erase(piece);
+	}
+
+}

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -140,6 +140,7 @@ run test_bloom_filter.cpp ;
 run test_identify_client.cpp ;
 run test_merkle.cpp ;
 run test_merkle_tree.cpp ;
+run test_precomputed_block_hashes.cpp ;
 run test_resolve_links.cpp ;
 run test_heterogeneous_queue.cpp ;
 run test_ip_voter.cpp ;
@@ -301,6 +302,7 @@ alias deterministic-tests :
 	test_peer_list
 	test_peer_priority
 	test_piece_picker
+	test_precomputed_block_hashes
 	test_primitives
 	test_read_resume
 	test_receive_buffer

--- a/test/test_disk_io.cpp
+++ b/test/test_disk_io.cpp
@@ -25,6 +25,7 @@ see LICENSE file.
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/time.hpp"
 #include "libtorrent/sha1_hash.hpp"
+#include "libtorrent/hasher.hpp"
 
 using disk_test_mode_t = lt::flags::bitfield_flag<std::uint32_t, struct disk_test_mode_tag>;
 
@@ -130,22 +131,64 @@ void disk_io_test_suite_impl(lt::disk_io_constructor_type disk_io
 				// completes).
 				int const blocks_in_piece = (len + block_size - 1) / block_size;
 				auto v2_hashes = need_v2
-					? std::make_shared<std::vector<lt::sha256_hash>>(blocks_in_piece)
+					? std::make_shared<std::vector<lt::sha256_hash>>(std::size_t(blocks_in_piece))
 					: std::make_shared<std::vector<lt::sha256_hash>>();
 				lt::disk_job_flags_t const hash_flags = need_v1
 					? lt::disk_interface::v1_hash
 					: lt::disk_job_flags_t{};
-				disk_thread->async_hash(storage, p
-					, lt::span<lt::sha256_hash>(*v2_hashes)
-					, hash_flags | lt::disk_interface::flush_piece
-					, [&hashes_done, p, v2_hashes](lt::piece_index_t, lt::sha1_hash const&
-						, lt::storage_error const& e) {
-						if (e.ec) {
+				// expected hashes computed from the same generate_piece data.
+				// v2 pieces don't span file boundaries, so v2 hashes only cover
+				// the v2 portion (up to piece_size2) of the block buffer.
+				std::vector<lt::sha256_hash> expected_v2;
+				lt::sha1_hash expected_v1;
+				if (need_v2)
+				{
+					expected_v2.resize(std::size_t(blocks_in_piece));
+					int const v2_blocks = fs.blocks_in_piece2(p);
+					int const v2_size = fs.piece_size2(p);
+					for (int b = 0; b < v2_blocks; ++b)
+					{
+						int const off = b * block_size;
+						int const bsize = std::min(block_size, v2_size - off);
+						lt::hasher256 hh;
+						hh.update({buffer.data() + off, bsize});
+						expected_v2[std::size_t(b)] = hh.final();
+					}
+				}
+				if (need_v1)
+				{
+					lt::hasher hh;
+					hh.update({buffer.data(), len});
+					expected_v1 = hh.final();
+				}
+
+				disk_thread->async_hash(storage,
+					p,
+					lt::span<lt::sha256_hash>(*v2_hashes),
+					hash_flags | lt::disk_interface::flush_piece,
+					[&hashes_done,
+						p,
+						v2_hashes,
+						need_v1,
+						need_v2,
+						expected_v2 = std::move(expected_v2),
+						expected_v1](lt::piece_index_t,
+						lt::sha1_hash const& v1_hash,
+						lt::storage_error const& e) {
+						if (e.ec)
+						{
 							std::cout << "ERROR: failed to hash piece (p: " << p
 								<< "): (" << e.ec.value()
 								<< ") " << e.ec.message() << std::endl;
 							std::abort();
 						}
+						if (need_v2)
+						{
+							TEST_EQUAL(v2_hashes->size(), expected_v2.size());
+							for (std::size_t i = 0; i < expected_v2.size(); ++i)
+								TEST_CHECK((*v2_hashes)[i] == expected_v2[i]);
+						}
+						if (need_v1) TEST_CHECK(v1_hash == expected_v1);
 						++hashes_done;
 					});
 				++expect_hashes;
@@ -203,6 +246,155 @@ void disk_io_test_suite(lt::disk_io_constructor_type disk_io
 	}
 }
 
+// Verify that async_hash2 returns the correct SHA-256 for a block that has
+// been written but is still sitting in the disk cache (for pread_disk_io) /
+// store buffer (for mmap_disk_io). With hashing_threads=0 the hasher kick is
+// disabled, so no precomputed v2 block hash is stashed on the storage. With
+// aio_threads=0 there is no thread to flush the cache to disk. In this state
+// any hash2 implementation that falls through to a disk read would read zeros
+// (the block has not been written to disk yet) and produce a wrong hash.
+void hash2_before_flush_impl(
+	lt::disk_io_constructor_type disk_io, disk_test_mode_t const flags, int const piece_size)
+{
+	lt::io_context ios;
+	lt::counters cnt;
+	lt::settings_pack sett = lt::default_settings();
+	sett.set_int(lt::settings_pack::hashing_threads, 0);
+	sett.set_int(lt::settings_pack::aio_threads, 0);
+	std::unique_ptr<lt::disk_interface> disk_thread = disk_io(ios, sett, cnt);
+
+	std::cout << "hash2_before_flush: " << ((flags & test_mode::v1) ? "v1 " : "")
+			  << ((flags & test_mode::v2) ? "v2 " : "") << " piece_size: " << piece_size
+			  << std::endl;
+
+	lt::file_storage fs;
+	fs.set_piece_length(piece_size);
+	int const file_size = piece_size * 3 + 17;
+	fs.add_file("hash2_before_flush_torrent/file-0", file_size, {});
+	fs.set_num_pieces(int((file_size + piece_size - 1) / piece_size));
+
+	lt::aux::vector<lt::download_priority_t, lt::file_index_t> priorities;
+	std::string const name = "hash2_before_flush_store";
+	lt::renamed_files rf;
+	lt::storage_params params{
+		fs,
+		rf,
+		name,
+		{},
+		lt::storage_mode_t::storage_mode_sparse,
+		priorities,
+		lt::sha1_hash{},
+		bool(flags & test_mode::v1),
+		bool(flags & test_mode::v2),
+	};
+
+	lt::storage_holder storage = disk_thread->new_torrent(params, std::shared_ptr<void>());
+
+	int const block_size = std::min(lt::default_block_size, piece_size);
+	bool const need_v1 = bool(flags & test_mode::v1);
+
+	// only counts hash2 callbacks: write callbacks won't fire here because
+	// nothing flushes the cache to disk.
+	int hashes_done = 0;
+	int hashes_expected = 0;
+	bool any_mismatch = false;
+
+	for (lt::piece_index_t p : fs.piece_range())
+	{
+		int const piece_size_v2 = fs.piece_size2(p);
+		int const len = need_v1 ? fs.piece_size(p) : piece_size_v2;
+		auto buffer = std::make_shared<std::vector<char>>(generate_piece(p, len));
+		for (int off = 0; off < len; off += block_size)
+		{
+			int const write_size = std::min(block_size, len - off);
+			disk_thread->async_write(
+				storage,
+				lt::peer_request{p, off, write_size},
+				buffer->data() + off,
+				std::shared_ptr<lt::disk_observer>(),
+				[buffer](lt::storage_error const&) {
+					// hold the buffer alive while a write is outstanding;
+					// no other action needed
+				},
+				lt::disk_job_flags_t{});
+
+			// only verify blocks inside the v2 piece (v2 pieces don't cross
+			// file boundaries, so v1 padding past piece_size2 is not covered).
+			if (off >= piece_size_v2) continue;
+
+			int const v2_size = std::min(block_size, piece_size_v2 - off);
+			lt::hasher256 hh;
+			hh.update({buffer->data() + off, v2_size});
+			lt::sha256_hash const expected = hh.final();
+
+			disk_thread->async_hash2(storage,
+				p,
+				off,
+				lt::disk_job_flags_t{},
+				[&hashes_done, &any_mismatch, expected, p, off](
+					lt::piece_index_t, lt::sha256_hash const& hash, lt::storage_error const& e) {
+					if (e.ec)
+					{
+						std::cout << "ERROR: failed to hash2 (p: " << p << " off: " << off << "): ("
+								  << e.ec.value() << ") " << e.ec.message() << std::endl;
+						std::abort();
+					}
+					if (hash != expected)
+					{
+						std::cout << "MISMATCH at piece " << p << " offset " << off << ": expected "
+								  << expected << " got " << hash << std::endl;
+						any_mismatch = true;
+					}
+					++hashes_done;
+				});
+			++hashes_expected;
+
+			disk_thread->submit_jobs();
+		}
+	}
+
+	// also drain any cached blocks so the disk_io destructor's m_cache.size()
+	// == 0 assert is happy. clear_piece aborts the queued write jobs (their
+	// callbacks fire with cancel) and drops the cached buffers. The hash2
+	// results were computed inline above, so issuing the clears now does not
+	// affect the values the hash2 callbacks will deliver.
+	int cleared = 0;
+	int const num_pieces = static_cast<int>(fs.num_pieces());
+	for (lt::piece_index_t p : fs.piece_range())
+	{
+		disk_thread->async_clear_piece(storage, p, [&cleared](lt::piece_index_t) { ++cleared; });
+	}
+	disk_thread->submit_jobs();
+
+	auto const start_time = lt::aux::time_now();
+	auto const timeout = lt::seconds(20);
+	while (hashes_done < hashes_expected || cleared < num_pieces)
+	{
+		ios.run_for(std::chrono::seconds(1));
+		if (lt::aux::time_now() - start_time > timeout)
+		{
+			TEST_ERROR("timeout");
+			break;
+		}
+	}
+
+	TEST_EQUAL(hashes_done, hashes_expected);
+	TEST_EQUAL(cleared, num_pieces);
+	TEST_CHECK(!any_mismatch);
+
+	disk_thread->abort(true);
+}
+
+void hash2_before_flush_suite(lt::disk_io_constructor_type disk_io)
+{
+	for (disk_test_mode_t flags : {test_mode::v2, test_mode::v1 | test_mode::v2})
+	{
+		for (int piece_size : {0x4000, 0x8000})
+		{
+			hash2_before_flush_impl(disk_io, flags, piece_size);
+		}
+	}
+}
 }
 
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
@@ -221,4 +413,22 @@ TORRENT_TEST(test_posix_disk_io)
 TORRENT_TEST(test_pread_disk_io)
 {
 	disk_io_test_suite(&lt::pread_disk_io_constructor, 3);
+}
+
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
+TORRENT_TEST(test_mmap_disk_io_hash2_before_flush)
+{
+	hash2_before_flush_suite(&lt::mmap_disk_io_constructor);
+}
+
+#endif
+
+TORRENT_TEST(test_posix_disk_io_hash2_before_flush)
+{
+	hash2_before_flush_suite(&lt::posix_disk_io_constructor);
+}
+
+TORRENT_TEST(test_pread_disk_io_hash2_before_flush)
+{
+	hash2_before_flush_suite(&lt::pread_disk_io_constructor);
 }

--- a/test/test_precomputed_block_hashes.cpp
+++ b/test/test_precomputed_block_hashes.cpp
@@ -1,0 +1,134 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#include "test.hpp"
+#include "test_utils.hpp" // for the _piece literal
+#include "libtorrent/aux_/precomputed_block_hashes.hpp"
+#include "libtorrent/hasher.hpp"
+
+#include <string>
+
+using lt::aux::precomputed_block_hashes;
+
+namespace {
+
+	// a distinct, non-zero SHA-256 for a given block id
+	lt::sha256_hash test_hash(int const v)
+	{
+		std::string const s = "block-" + std::to_string(v);
+		lt::hasher256 h;
+		h.update({s.data(), int(s.size())});
+		return h.final();
+	}
+
+} // anonymous namespace
+
+// store some blocks of a piece, then take the whole piece. Stored blocks come
+// back at their indices; un-stored blocks read as all-zero.
+TORRENT_TEST(precomputed_block_hashes_store_take)
+{
+	precomputed_block_hashes cache;
+	cache.store(3_piece, 0, 4, test_hash(0));
+	cache.store(3_piece, 2, 4, test_hash(2));
+
+	lt::aux::vector<lt::sha256_hash> const v = cache.take(3_piece);
+	TEST_EQUAL(int(v.size()), 4);
+	TEST_CHECK(v[0] == test_hash(0));
+	TEST_CHECK(v[1].is_all_zeros()); // never stored -> "missing"
+	TEST_CHECK(v[2] == test_hash(2));
+	TEST_CHECK(v[3].is_all_zeros());
+
+	// taking removes the piece
+	TEST_CHECK(cache.take(3_piece).empty());
+}
+
+// taking a piece that was never stored yields an empty result / nullopt
+TORRENT_TEST(precomputed_block_hashes_missing_piece)
+{
+	precomputed_block_hashes cache;
+	TEST_CHECK(cache.take(0_piece).empty());
+	TEST_CHECK(!cache.take_block(0_piece, 0).has_value());
+}
+
+// take_block returns a single stored hash and consumes it; un-stored blocks
+// are reported missing.
+TORRENT_TEST(precomputed_block_hashes_take_block)
+{
+	precomputed_block_hashes cache;
+	cache.store(1_piece, 1, 3, test_hash(1));
+
+	TEST_CHECK(!cache.take_block(1_piece, 0).has_value()); // not stored
+	TEST_CHECK(!cache.take_block(1_piece, 2).has_value());
+
+	auto const h = cache.take_block(1_piece, 1);
+	TEST_CHECK(h.has_value());
+	TEST_CHECK(*h == test_hash(1));
+
+	// consumed: missing now, and the piece (no hashes left) is gone
+	TEST_CHECK(!cache.take_block(1_piece, 1).has_value());
+	TEST_CHECK(cache.take(1_piece).empty());
+}
+
+// a block consumed via take_block is no longer present in a later take()
+TORRENT_TEST(precomputed_block_hashes_take_block_then_take)
+{
+	precomputed_block_hashes cache;
+	cache.store(2_piece, 0, 3, test_hash(0));
+	cache.store(2_piece, 1, 3, test_hash(1));
+	cache.store(2_piece, 2, 3, test_hash(2));
+
+	auto const h1 = cache.take_block(2_piece, 1);
+	TEST_CHECK(h1.has_value() && *h1 == test_hash(1));
+
+	lt::aux::vector<lt::sha256_hash> const v = cache.take(2_piece);
+	TEST_EQUAL(int(v.size()), 3);
+	TEST_CHECK(v[0] == test_hash(0));
+	TEST_CHECK(v[1].is_all_zeros()); // already consumed
+	TEST_CHECK(v[2] == test_hash(2));
+}
+
+// consuming every block via take_block drops the piece
+TORRENT_TEST(precomputed_block_hashes_take_block_drains_piece)
+{
+	precomputed_block_hashes cache;
+	cache.store(4_piece, 0, 2, test_hash(0));
+	cache.store(4_piece, 1, 2, test_hash(1));
+	TEST_CHECK(cache.take_block(4_piece, 0).has_value());
+	TEST_CHECK(cache.take_block(4_piece, 1).has_value());
+	TEST_CHECK(cache.take(4_piece).empty());
+}
+
+// drop() discards a piece's hashes
+TORRENT_TEST(precomputed_block_hashes_drop)
+{
+	precomputed_block_hashes cache;
+	cache.store(5_piece, 0, 2, test_hash(0));
+	cache.drop(5_piece);
+	TEST_CHECK(cache.take(5_piece).empty());
+	TEST_CHECK(!cache.take_block(5_piece, 0).has_value());
+}
+
+// storing the same block twice overwrites the hash
+TORRENT_TEST(precomputed_block_hashes_overwrite)
+{
+	precomputed_block_hashes cache;
+	cache.store(0_piece, 0, 1, test_hash(0));
+	cache.store(0_piece, 0, 1, test_hash(9));
+	lt::aux::vector<lt::sha256_hash> const v = cache.take(0_piece);
+	TEST_EQUAL(int(v.size()), 1);
+	TEST_CHECK(v[0] == test_hash(9));
+}
+
+// take_block out of range is reported missing, not a crash
+TORRENT_TEST(precomputed_block_hashes_take_block_out_of_range)
+{
+	precomputed_block_hashes cache;
+	cache.store(7_piece, 0, 2, test_hash(0));
+	TEST_CHECK(!cache.take_block(7_piece, 5).has_value());
+}


### PR DESCRIPTION
improve and optimize hashing of v2 blocks. They can be computed concurrently and independently, not tied to the v1 hash cursor.

Computing the v2 block hashes immediately, while the cache is still hot, is faster than waiting until the whole piece is done. It makes it more likely some blocks may have been evicted.

Since v2 blocks can be computed independently and concurrently, they never trigger read-back from disk.