### PR TITLE
Fix deprecated pair piece priorities

### DIFF
--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -567,6 +567,14 @@ namespace libtorrent {
 	{
 		std::vector<std::pair<piece_index_t, download_priority_t>> p;
 		p.reserve(pieces.size());
+		for (auto const& piece : pieces)
+		{
+			if (piece.second < int(dont_download) || piece.second > int(top_priority))
+				continue;
+
+			p.emplace_back(piece.first
+				, download_priority_t(static_cast<std::uint8_t>(piece.second)));
+		}
 		async_call(&torrent::prioritize_piece_list, std::move(p));
 	}
 

--- a/test/test_resume.cpp
+++ b/test/test_resume.cpp
@@ -306,6 +306,38 @@ TORRENT_TEST(piece_priorities_deprecated)
 {
 	test_piece_priorities(true);
 }
+
+TORRENT_TEST(prioritize_pieces_deprecated_pair_overload)
+{
+	lt::session ses(settings());
+	std::shared_ptr<torrent_info> ti = generate_torrent();
+	add_torrent_params p;
+	p.ti = ti;
+	p.save_path = ".";
+	torrent_handle h = ses.add_torrent(p);
+
+	h.prioritize_pieces(std::vector<std::pair<piece_index_t, int>>{
+		{2_piece, 2}
+		, {3_piece, 2}
+		, {4_piece, 2}
+	});
+
+	h.prioritize_pieces(std::vector<std::pair<piece_index_t, int>>{
+		{0_piece, int(dont_download)}
+		, {1_piece, int(top_priority)}
+		, {2_piece, 256}
+		, {3_piece, -1}
+		, {4_piece, int(top_priority) + 1}
+		, {ti->last_piece(), 6}
+	});
+
+	TEST_EQUAL(h.piece_priority(0_piece), dont_download);
+	TEST_EQUAL(h.piece_priority(1_piece), top_priority);
+	TEST_EQUAL(h.piece_priority(2_piece), 2_pri);
+	TEST_EQUAL(h.piece_priority(3_piece), 2_pri);
+	TEST_EQUAL(h.piece_priority(4_piece), 2_pri);
+	TEST_EQUAL(h.piece_priority(ti->last_piece()), 6_pri);
+}
 #endif
 
 TORRENT_TEST(piece_priorities)


### PR DESCRIPTION
Fixes the deprecated pair-based prioritize_pieces overload so valid priorities are forwarded to the typed implementation instead of being dropped.

The int priority is checked before conversion to download_priority_t, so out-of-range deprecated inputs cannot wrap into valid priorities.

Validated with test//test_resume and git diff --check.