### PR TITLE
fix issue with graceful pause during shutdown

### DIFF
--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -4975,6 +4975,10 @@ namespace {
 
 		m_abort = true;
 		m_paused = false;
+		// clear graceful pause too. on_remove_peers() below would otherwise
+		// hit the "last peer in graceful pause" branch and assert is_paused(),
+		// which no longer holds now that m_paused has been cleared.
+		m_graceful_pause_mode = false;
 		m_auto_managed = false;
 		m_state_subscription = false;
 		for (torrent_list_index_t i{}; i != m_links.end_index(); ++i)


### PR DESCRIPTION
fixes a possible assert during shutdown:

```
  file: 'libtorrent/src/torrent.cpp'
  line: 6508
  function: on_remove_peers
  expression: is_paused()

  ::group::call stack
  stack:
  1: libtorrent::assert_fail(char const*, int, char const*, char const*, char const*, int)
  2: libtorrent::aux::torrent::on_remove_peers()
  3: libtorrent::aux::torrent::abort()
```