### PR TITLE
Fix whole-piece prefetch overflow

### DIFF
--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/alert_manager.hpp"
 #include "libtorrent/aux_/has_block.hpp"
 
+#include <cstdint>
 #include <vector>
 
 namespace libtorrent {
@@ -114,27 +115,30 @@ namespace libtorrent {
 		int prefer_contiguous_blocks = c.prefer_contiguous_blocks();
 
 		if (prefer_contiguous_blocks == 0
-			&& !time_critical_mode
-			&& t.settings().get_int(settings_pack::whole_pieces_threshold) > 0)
+			&& !time_critical_mode)
 		{
-			// if our download rate lets us download a whole piece in
-			// "whole_pieces_threshold" seconds, we prefer to pick an entire piece.
-			// If we can download multiple whole pieces, we prefer to download that
-			// many contiguous pieces.
+			int const whole_pieces_threshold = t.settings().get_int(settings_pack::whole_pieces_threshold);
+			if (whole_pieces_threshold > 0)
+			{
+				// if our download rate lets us download a whole piece in
+				// "whole_pieces_threshold" seconds, we prefer to pick an entire piece.
+				// If we can download multiple whole pieces, we prefer to download that
+				// many contiguous pieces.
 
-			// download_rate times the whole piece threshold (seconds) gives the
-			// number of bytes downloaded in one window of that threshold, divided
-			// by the piece size give us the number of (whole) pieces downloaded
-			// in the window.
-			int const contiguous_pieces =
-				std::min(c.statistics().download_payload_rate()
-				* t.settings().get_int(settings_pack::whole_pieces_threshold)
-				, 8 * 1024 * 1024)
-				/ t.torrent_file().piece_length();
+				// download_rate times the whole piece threshold (seconds) gives the
+				// number of bytes downloaded in one window of that threshold, divided
+				// by the piece size give us the number of (whole) pieces downloaded
+				// in the window.
+				std::int64_t const download_window =
+					std::int64_t(c.statistics().download_payload_rate())
+					* whole_pieces_threshold;
+				int const contiguous_pieces = int(std::min(download_window
+					, std::int64_t(8 * 1024 * 1024)) / t.torrent_file().piece_length());
 
-			int const blocks_per_piece = t.torrent_file().piece_length() / t.block_size();
+				int const blocks_per_piece = t.torrent_file().piece_length() / t.block_size();
 
-			prefer_contiguous_blocks = contiguous_pieces * blocks_per_piece;
+				prefer_contiguous_blocks = contiguous_pieces * blocks_per_piece;
+			}
 		}
 
 		// if we prefer whole pieces, the piece picker will pick at least


### PR DESCRIPTION
Fixes signed overflow when sizing whole-piece prefetch requests.

The download rate window is now computed in 64-bit before applying the existing 8 MiB clamp.

Validated with test//test_piece_picker and pre-commit for the touched file.