### PR TITLE
Fix SOCKS5 auth request bounds

### DIFF
--- a/include/libtorrent/socks5_stream.hpp
+++ b/include/libtorrent/socks5_stream.hpp
@@ -123,6 +123,8 @@ public:
 	{
 		m_user = user;
 		m_password = password;
+		if (m_user.size() > 255) m_user.resize(255);
+		if (m_password.size() > 255) m_password.resize(255);
 	}
 
 	void set_dst_name(std::string const& host)

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -68,7 +68,7 @@ namespace libtorrent {
 using namespace std::placeholders;
 
 // used to build SOCKS messages in
-std::size_t const tmp_buffer_size = 270;
+std::size_t const tmp_buffer_size = 3 + 255 + 255;
 
 // used for SOCKS5 UDP wrapper header
 std::size_t const max_header_size = 255;
@@ -533,17 +533,19 @@ void udp_socket::set_proxy_settings(aux::proxy_settings const& ps
 	}
 
 	m_proxy_settings = ps;
+	if (m_proxy_settings.username.size() > 255) m_proxy_settings.username.resize(255);
+	if (m_proxy_settings.password.size() > 255) m_proxy_settings.password.resize(255);
 
 	if (m_abort) return;
 
-	if (ps.type == settings_pack::socks5
-		|| ps.type == settings_pack::socks5_pw)
+	if (m_proxy_settings.type == settings_pack::socks5
+		|| m_proxy_settings.type == settings_pack::socks5_pw)
 	{
 		// connect to socks5 server and open up the UDP tunnel
 
 		m_socks5_connection = std::make_shared<socks5>(m_ioc
 			, m_listen_socket, alerts, resolver, send_local_ep);
-		m_socks5_connection->start(ps);
+		m_socks5_connection->start(m_proxy_settings);
 	}
 }
 


### PR DESCRIPTION
Truncate SOCKS5 username/password values to the protocol's one-byte length limit before building auth requests.

TCP SOCKS5 now clamps credentials in set_username(). UDP proxy settings clamp credentials when they are applied, and the UDP scratch buffer is large enough for the max valid auth request.

Validation:
b2 -j8 cxxflags=-I/Users/smd/personal-work/libtorrent/include test//test_udp_socket
b2 -j8 undefined-sanitizer=norecover cxxflags=-I/Users/smd/personal-work/libtorrent/include test//test_udp_socket
SKIP=flake8-pyi-install,flake8-pyi-run pre-commit run --files include/libtorrent/socks5_stream.hpp src/udp_socket.cpp