### PR TITLE
Validate resume files touched by completed pieces

### DIFF
--- a/src/storage_utils.cpp
+++ b/src/storage_utils.cpp
@@ -52,6 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include <set>
+#include <tuple>
 
 namespace libtorrent { namespace aux {
 
@@ -541,18 +542,10 @@ std::int64_t get_filesize(stat_cache& stat, file_index_t const file_index
 		if (added_files) return false;
 #endif
 
-		// parse have bitmask. Verify that the files we expect to have
-		// actually do exist
-		piece_index_t const end_piece = std::min(rd.have_pieces.end_index(), fs.end_piece());
-		for (piece_index_t i(0); i < end_piece; ++i)
+		// parse have bitmask. Verify that files touched by completed pieces
+		// actually exist. A completed piece may span multiple files.
+		for (file_index_t const file_index : fs.file_range())
 		{
-			if (rd.have_pieces.get_bit(i) == false) continue;
-
-			std::vector<file_slice> f = fs.map_block(i, 0, 1);
-			TORRENT_ASSERT(!f.empty());
-
-			file_index_t const file_index = f[0].file_index;
-
 			// files with priority zero may not have been saved to disk at their
 			// expected location, but is likely to be in a partfile. Just exempt it
 			// from checking
@@ -561,16 +554,28 @@ std::int64_t get_filesize(stat_cache& stat, file_index_t const file_index
 				continue;
 
 			if (fs.pad_file_at(file_index)) continue;
+			if (fs.file_size(file_index) == 0) continue;
+
+			piece_index_t start_piece;
+			piece_index_t file_end_piece;
+			std::tie(start_piece, file_end_piece)
+				= aux::file_piece_range_inclusive(fs, file_index);
+
+			piece_index_t const end_piece = std::min(file_end_piece
+				, rd.have_pieces.end_index());
+
+			bool has_completed_resume_piece = false;
+			for (piece_index_t piece = start_piece; piece < end_piece; ++piece)
+			{
+				if (!rd.have_pieces.get_bit(piece)) continue;
+				has_completed_resume_piece = true;
+				break;
+			}
+
+			if (!has_completed_resume_piece) continue;
 
 			if (get_filesize(stat, file_index, fs, save_path, ec) < 0)
 				return false;
-
-			// OK, this file existed, good. Now, skip all remaining pieces in
-			// this file. We're just sanity-checking whether the files exist
-			// or not.
-			peer_request const pr = fs.map_file(file_index
-				, fs.file_size(file_index) + 1, 0);
-			i = std::max(next(i), pr.piece);
 		}
 		return true;
 	}

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -54,6 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/storage_utils.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
+#include "libtorrent/stat_cache.hpp"
 #include "libtorrent/random.hpp"
 #include "libtorrent/mmap_disk_io.hpp"
 #include "libtorrent/posix_disk_io.hpp"
@@ -61,6 +62,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 #include <functional> // for bind
+#include <fstream>
 #include <iostream>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
@@ -1067,6 +1069,45 @@ TORRENT_TEST(fastresume_deprecated)
 	test_fastresume(true);
 }
 #endif
+
+TORRENT_TEST(fastresume_spanning_piece_missing_file)
+{
+	int const resume_piece_size = 0x4000;
+	std::string const save_path = complete("temp_storage_spanning_resume");
+	delete_dirs(save_path);
+
+	file_storage fs;
+	fs.add_file(combine_path("test", "first"), resume_piece_size / 2);
+	fs.add_file(combine_path("test", "missing"), resume_piece_size / 2);
+	fs.add_file(combine_path("test", "unchecked"), resume_piece_size);
+	fs.set_piece_length(resume_piece_size);
+	fs.set_num_pieces(aux::calc_num_pieces(fs));
+
+	error_code ec;
+	create_directories(combine_path(save_path, "test"), ec);
+	TEST_CHECK(!ec);
+
+	std::ofstream file(fs.file_path(0_file, save_path).c_str());
+	file.write("x", 1);
+	file.close();
+
+	add_torrent_params rd;
+	rd.have_pieces.resize(fs.num_pieces(), false);
+	rd.have_pieces.set_bit(0_piece);
+
+	aux::vector<std::string, file_index_t> links;
+	aux::vector<download_priority_t, file_index_t> priorities;
+	stat_cache stat;
+	storage_error se;
+	bool const valid = aux::verify_resume_data(rd, links, fs, priorities
+		, stat, save_path, se);
+
+	TEST_CHECK(!valid);
+	TEST_EQUAL(se.ec, error_code(errors::mismatching_file_size));
+	TEST_EQUAL(static_cast<int>(se.file()), 1);
+
+	delete_dirs(save_path);
+}
 
 namespace {
 


### PR DESCRIPTION
What
Updates resume validation to check every wanted, non-pad file that overlaps a completed resume piece, instead of only checking the first file mapped from each completed piece.

Adds regression coverage for a completed piece spanning two files where the second file is missing.

Why
Fastresume data can mark a piece complete even when that piece spans multiple files. The previous validation only checked the first mapped file for each completed piece, so a missing later file in the same piece could be accepted and the torrent could resume from stale or incomplete data instead of falling back to a check.

How
The non-seed resume validation now walks the torrent files and stats only wanted, non-pad files that overlap at least one set bit in have_pieces. It uses aux::file_piece_range_inclusive() for the file overlap bounds and scans the resume bitfield in that range.

The regression builds two half-piece files, marks the spanning piece complete, creates only the first file, and asserts resume validation rejects the resume data with a missing-file error for the second file.

Validation
git diff --check origin/RC_2_0
b2 -a crypto=openssl warnings=off test//test_storage