### PR TITLE
Stop tracker timeout web server

### DIFF
--- a/test/test_tracker.cpp
+++ b/test/test_tracker.cpp
@@ -716,6 +716,8 @@ void test_stop_tracker_timeout(int const timeout)
 
 	int const count = count_stopped_events(s, (timeout == 0) ? 0 : 2);
 	TEST_EQUAL(count, (timeout == 0) ? 0 : 2);
+
+	stop_web_server();
 }
 } // anonymous namespace
 


### PR DESCRIPTION
What
Stops the local web server at the end of test_stop_tracker_timeout().

Why
The test starts a web server to observe stopped announces and should tear it down before returning so it does not leak into later local test runs.

Validation
git diff --check origin/RC_2_0
Filtered test/test_tracker.cpp.stop_tracker_timeout passed locally from test/ with the built test_tracker binary.
