### PR TITLE
Fix DHT upload quota zero limit

### DIFF
--- a/src/kademlia/dht_tracker.cpp
+++ b/src/kademlia/dht_tracker.cpp
@@ -649,6 +649,11 @@ namespace {
 		m_last_tick = now;
 
 		std::int64_t const limit = m_settings.get_int(settings_pack::dht_upload_rate_limit);
+		if (limit <= 0)
+		{
+			m_send_quota = 0;
+			return false;
+		}
 
 		// allow 3 seconds worth of burst
 		std::int64_t const max_accrue = std::min(3 * limit, std::int64_t(std::numeric_limits<int>::max()));

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -4086,6 +4086,16 @@ void test_rate_limit(aux::session_settings const& sett, std::function<void(lt::d
 }
 }
 
+TORRENT_TEST(rate_limit_zero)
+{
+	aux::session_settings sett;
+	sett.set_int(settings_pack::dht_upload_rate_limit, 0);
+
+	test_rate_limit(sett, [](lt::dht::socket_manager& sm) {
+		TEST_CHECK(!sm.has_quota());
+	});
+}
+
 TORRENT_TEST(rate_limit_int_max)
 {
 	aux::session_settings sett;

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -4086,14 +4086,19 @@ void test_rate_limit(aux::session_settings const& sett, std::function<void(lt::d
 }
 }
 
-TORRENT_TEST(rate_limit_zero)
+TORRENT_TEST(rate_limit_non_positive)
 {
-	aux::session_settings sett;
-	sett.set_int(settings_pack::dht_upload_rate_limit, 0);
+	int const limits[] = {0, -1};
 
-	test_rate_limit(sett, [](lt::dht::socket_manager& sm) {
-		TEST_CHECK(!sm.has_quota());
-	});
+	for (int const limit : limits)
+	{
+		aux::session_settings sett;
+		sett.set_int(settings_pack::dht_upload_rate_limit, limit);
+
+		test_rate_limit(sett, [](lt::dht::socket_manager& sm) {
+			TEST_CHECK(!sm.has_quota());
+		});
+	}
 }
 
 TORRENT_TEST(rate_limit_int_max)


### PR DESCRIPTION
Avoid divide-by-zero when DHT upload rate limit is zero by treating it as no response quota.