### PR TITLE
Fix Merkle proof cleanup

### DIFF
--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -327,6 +327,7 @@ namespace libtorrent {
 
 		int cursor = target_node_idx;
 		target_tree[cursor] = node;
+		bool cursor_inserted = false;
 		for (auto const& proof : uncle_hashes)
 		{
 			int const proof_idx = merkle_get_sibling(cursor);
@@ -337,8 +338,12 @@ namespace libtorrent {
 			cursor = merkle_get_parent(cursor);
 			if (target_tree[cursor] == hash) return true;
 			if (!target_tree[cursor].is_all_zeros())
+			{
+				cursor_inserted = false;
 				break;
+			}
 			target_tree[cursor] = hash;
+			cursor_inserted = true;
 		}
 
 		// we get here if we never reached a known hash in the tree, i.e. the
@@ -352,6 +357,7 @@ namespace libtorrent {
 			target_tree[proof_idx].clear();
 			clear_cursor = merkle_get_parent(clear_cursor);
 		}
+		if (cursor_inserted) target_tree[cursor].clear();
 		return false;
 	}
 

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -1130,6 +1130,28 @@ TORRENT_TEST(validate_and_insert_proofs_mixed_failure)
 	          eh,
 	      o,        o,
 	  o,    o,   o,    o,
+	 o, o, o, o,o, o, o, o}));
+}
+
+TORRENT_TEST(validate_and_insert_proofs_under_length_failure)
+{
+// full tree:
+//       ah
+//    ad      eh
+//  ab  cd  ef  gh
+// a b c d  e f g h
+
+	v tree(15);
+	tree[0] = ah;
+	tree[6] = gh;
+
+	v const proofs{f};
+
+	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, e, proofs));
+	TEST_CHECK((tree == v{
+	          ah,
+	      o,        o,
+	  o,    o,   o,   gh,
 	o, o, o, o,o, o, o, o}));
 }
 


### PR DESCRIPTION
Clear hashes inserted by failed short Merkle proofs without touching existing tree state.