### PR TITLE
fix a concurrency bug in kick_hasher

### DIFF
--- a/src/disk_cache.cpp
+++ b/src/disk_cache.cpp
@@ -471,6 +471,7 @@ bool disk_cache::kick_hasher(piece_container::nth_index<4>::type::iterator piece
 	TORRENT_ASSERT(l.owns_lock());
 
 	std::uint16_t cursor = piece_iter->hasher_cursor;
+	TORRENT_ASSERT(cursor <= piece_iter->blocks_in_piece());
 
 	// NOTE: block_storage is indexed starting at cursor. We don't waste space
 	// allocating a slot for every block, just the ones in front of the cursor
@@ -479,12 +480,21 @@ bool disk_cache::kick_hasher(piece_container::nth_index<4>::type::iterator piece
 	// hashing_flag is already set by caller. We need to clear it before returning.
 	TORRENT_ASSERT(piece_iter->flags & cached_piece_entry::hashing_flag);
 
+#if TORRENT_USE_ASSERTS
+	piece_location const original_piece = piece_iter->piece;
+#endif
+
 keep_going:
 
 	// Snapshot all block buffer pointers from cursor onwards while holding the
 	// mutex. New blocks may be added asynchronously after we release the lock,
 	// so we must not read their buf() pointers then.
 	int const n = piece_iter->blocks_in_piece() - int(cursor);
+	TORRENT_ASSERT(n >= 0);
+
+	// we may loop here, so this may not be the first time around the hashing loop.
+	// Make sure blocks_storage only covers the remaining blocks in the piece
+	blocks_storage = blocks_storage.subspan(0, n);
 	for (int i = 0; i < n; ++i)
 	{
 		int const blk_idx = int(cursor) + i;
@@ -517,9 +527,14 @@ keep_going:
 		auto& ctx = const_cast<aux::piece_hasher&>(*piece_iter->ph);
 		ctx.update(buf);
 		++cursor;
+		TORRENT_ASSERT(cursor <= piece_iter->blocks_in_piece());
 	}
 
 	l.lock();
+
+	// sanity check to ensure the piece entry wasn't removed under our feet
+	TORRENT_ASSERT(piece_iter->piece == original_piece);
+	TORRENT_ASSERT(piece_iter->flags & cached_piece_entry::hashing_flag);
 
 	// if some other thread added the next block, keep going
 	if (cursor != piece_iter->blocks_in_piece()

--- a/test/test_slow_hash.cpp
+++ b/test/test_slow_hash.cpp
@@ -482,6 +482,47 @@ void test_flush_storage_during_hashing(test_mode_t const mode)
 	TEST_EQUAL(f.alloc.live, 0);
 }
 
+// Exercises kick_hasher's keep_going path: a 3-block piece with the middle
+// block missing stalls the hasher at the hole. The test fills block 1 while
+// the hasher is asleep inside slow-hash's ctx.update(buf0), so the relock
+// sees blocks[1].data() and goes to keep_going to hash the rest of the piece.
+void test_kick_hasher_keep_going_fills_hole(test_mode_t const mode)
+{
+	// The bug lives on the v1 hasher cursor path. v2-only pieces have no
+	// hashing_flag (their work is in drain_v2_hash_queue), so they don't
+	// reach kick_hasher's keep_going loop at all.
+	if (!(mode & test_mode::v1)) return;
+
+	cache_fixture f(3, mode);
+	f.insert(0_piece, 0);
+	f.insert(0_piece, 2);
+
+	jobqueue_t completed, retry;
+	std::thread hasher_thread([&]() { f.cache.kick_pending_hashers(completed, retry); });
+
+	// Wait until kick_hasher has released the mutex inside its slow-hash
+	// update on block 0. 50ms is comfortably inside the ~1.6s slow window.
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Fill the hole while the hasher is still feeding block 0 into ph.
+	// When it relocks it will see blocks[1].data() and goto keep_going --
+	// the path that walks into the stale tail of blocks_storage.
+	f.insert(0_piece, 1);
+
+	hasher_thread.join();
+
+	// For hybrid pieces every insert also pushed a v2 queue entry that
+	// owns the buffer; drain those so cache.size() / alloc.live can drop
+	// to zero after the flush below.
+	if (mode & test_mode::v2) f.kick_hashers();
+
+	// Post-fix: cursor reached exactly blocks_in_piece without re-feeding
+	// any block, so all 3 write_jobs are still pending and flush picks
+	// them all up.
+	TEST_EQUAL(f.flush(), 3);
+	TEST_EQUAL(int(f.cache.size()), 0);
+	TEST_EQUAL(f.alloc.live, 0);
+}
 }
 
 TORRENT_TEST(test_pread_hash_job_retry)
@@ -527,6 +568,15 @@ TORRENT_TEST(flush_storage_during_hashing_hybrid)
 	TORRENT_TEST(drop_held_alive_hybrid)
 	{
 		test_drop_held_alive_buffers(test_mode::v1 | test_mode::v2);
+	}
+
+	TORRENT_TEST(kick_hasher_keep_going_fills_hole_v1)
+	{
+		test_kick_hasher_keep_going_fills_hole(test_mode::v1);
+	}
+	TORRENT_TEST(kick_hasher_keep_going_fills_hole_hybrid)
+	{
+		test_kick_hasher_keep_going_fills_hole(test_mode::v1 | test_mode::v2);
 	}
 
 #endif // TORRENT_SIMULATE_SLOW_HASH


### PR DESCRIPTION
when a new block arrives while the first batch is being hashed