### PR TITLE
Fix web seed Host header ports

### DIFF
--- a/include/libtorrent/string_util.hpp
+++ b/include/libtorrent/string_util.hpp
@@ -154,6 +154,10 @@ namespace libtorrent {
 	// - otherwise append ":port" for regular hostnames/IPv4
 	TORRENT_EXTRA_EXPORT std::string format_host_for_connect(std::string host, unsigned short port);
 
+	// Format a hostname for an HTTP Host header. IPv6 literals are bracketed,
+	// and the port is omitted when it is not positive or matches the default.
+	TORRENT_EXTRA_EXPORT std::string format_host_header(std::string host, int port, int default_port);
+
 #if TORRENT_USE_I2P
 
 	TORRENT_EXTRA_EXPORT bool is_i2p_url(std::string const& url);

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -55,6 +55,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/io_context.hpp"
 #include "libtorrent/i2p_stream.hpp"
 #include "libtorrent/aux_/ip_helpers.hpp"
+#include "libtorrent/string_util.hpp"
 #include "libtorrent/ssl.hpp"
 
 #include <functional>
@@ -187,18 +188,15 @@ void http_connection::get(std::string const& url, time_duration timeout
 			request << "Proxy-Authorization: Basic " << base64encode(
 				ps->username + ":" + ps->password) << "\r\n";
 
-		request << "Host: " << hostname;
-		if (port != default_port) request << ":" << port << "\r\n";
-		else request << "\r\n";
+		request << "Host: " << format_host_header(hostname, port, default_port) << "\r\n";
 
 		hostname = ps->hostname;
 		port = ps->port;
 	}
 	else
 	{
-		request << "GET " << path << " HTTP/1.1\r\nHost: " << hostname;
-		if (port != default_port) request << ":" << port << "\r\n";
-		else request << "\r\n";
+		request << "GET " << path << " HTTP/1.1\r\nHost: "
+			<< format_host_header(hostname, port, default_port) << "\r\n";
 	}
 
 //	request << "Accept: */*\r\n";

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib> // for malloc
 #include <cstring> // for strlen
 #include <algorithm> // for search
+#include <utility> // for move
 
 namespace libtorrent {
 
@@ -396,32 +397,48 @@ namespace libtorrent {
 			s.erase(s.begin());
 	}
 
+	namespace {
+		std::string format_host_authority(std::string host, int const port)
+		{
+			bool const has_port = port > 0;
+
+			if (!host.empty() && host.front() == '[' && host.back() == ']')
+			{
+				if (has_port)
+				{
+					host += ":";
+					host += to_string(port).data();
+				}
+				return host;
+			}
+
+			if (host.find(':') != std::string::npos)
+			{
+				host = "[" + host;
+				host += ']';
+			}
+
+			if (has_port)
+			{
+				host += ":";
+				host += to_string(port).data();
+			}
+			return host;
+		}
+	}
+
 	std::string format_host_for_connect(std::string host, unsigned short const port)
 	{
 		// Handle edge case: if no port specified, return host as-is
 		if (port == 0) return host;
 
-		// Already bracketed IPv6 literal
-		if (!host.empty() && host.front() == '[' && host.back() == ']')
-		{
-			host += ":";
-			host += to_string(port).data();
-			return host;
-		}
+		return format_host_authority(std::move(host), port);
+	}
 
-		// Contains colons (unbracketed IPv6) - need to bracket
-		if (host.find(':') != string_view::npos)
-		{
-			host = "[" + host;
-			host += "]:";
-			host += to_string(port).data();
-			return host;
-		}
-
-		// Regular hostname or IPv4
-		host += ":";
-		host += to_string(port).data();
-		return host;
+	std::string format_host_header(std::string host, int const port, int const default_port)
+	{
+		return format_host_authority(std::move(host)
+			, (port <= 0 || port == default_port) ? 0 : port);
 	}
 
 #if TORRENT_USE_I2P

--- a/src/web_connection_base.cpp
+++ b/src/web_connection_base.cpp
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/aux_/invariant_check.hpp"
 #include "libtorrent/parse_url.hpp"
 #include "libtorrent/peer_info.hpp"
+#include "libtorrent/string_util.hpp"
 
 namespace libtorrent {
 
@@ -131,7 +132,7 @@ namespace libtorrent {
 		, aux::session_settings const& sett, bool const using_proxy) const
 	{
 		request += "Host: ";
-		request += m_host;
+		request += format_host_header(m_host, m_port, m_ssl ? 443 : 80);
 		if ((m_first_request || m_settings.get_bool(settings_pack::always_send_user_agent))
 			&& !m_settings.get_bool(settings_pack::anonymous_mode))
 		{

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -1162,17 +1162,22 @@ namespace {
 pid_type web_server_pid = 0;
 }
 
-int start_web_server(bool ssl, bool chunked_encoding, bool keepalive, int min_interval)
+int start_web_server(bool ssl, bool chunked_encoding, bool keepalive
+	, int min_interval, bool expect_host_header)
 {
 	int const port = find_available_port();
+	char expected_host[200] = {};
+	if (expect_host_header)
+		std::snprintf(expected_host, sizeof(expected_host), "127.0.0.1:%d", port);
 
 	std::vector<std::string> python_exes = get_python();
 
 	for (auto const& python_exe : python_exes)
 	{
-		char buf[200];
-		std::snprintf(buf, sizeof(buf), "%s .." SEPARATOR "web_server.py %d %d %d %d %d"
-			, python_exe.c_str(), port, chunked_encoding, ssl, keepalive, min_interval);
+		char buf[300];
+		std::snprintf(buf, sizeof(buf), "%s .." SEPARATOR "web_server.py %d %d %d %d %d %s"
+			, python_exe.c_str(), port, chunked_encoding, ssl, keepalive, min_interval
+			, expected_host);
 
 		std::printf("%s starting web_server on port %d...\n", time_now_string().c_str(), port);
 

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -113,7 +113,8 @@ setup_transfer(lt::session* ses1, lt::session* ses2
 	, lt::create_flags_t flags = {});
 
 EXPORT int start_web_server(bool ssl = false, bool chunked = false
-	, bool keepalive = true, int min_interval = 30);
+	, bool keepalive = true, int min_interval = 30
+	, bool expect_host_header = false);
 
 EXPORT void stop_web_server();
 EXPORT int start_proxy(int type);

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -657,3 +657,19 @@ TORRENT_TEST(format_host_for_connect)
 	TEST_EQUAL(format_host_for_connect("123", 80), "123:80");
 }
 
+TORRENT_TEST(format_host_header)
+{
+	TEST_EQUAL(format_host_header("example.com", 80, 80), "example.com");
+	TEST_EQUAL(format_host_header("example.com", 8080, 80), "example.com:8080");
+	TEST_EQUAL(format_host_header("example.com", 70000, 80), "example.com:70000");
+	TEST_EQUAL(format_host_header("example.com", 0, 80), "example.com");
+	TEST_EQUAL(format_host_header("example.com", -1, 80), "example.com");
+
+	TEST_EQUAL(format_host_header("127.0.0.1", 80, 80), "127.0.0.1");
+	TEST_EQUAL(format_host_header("127.0.0.1", 8080, 80), "127.0.0.1:8080");
+
+	TEST_EQUAL(format_host_header("2001:db8::1", 443, 443), "[2001:db8::1]");
+	TEST_EQUAL(format_host_header("2001:db8::1", 8443, 443), "[2001:db8::1]:8443");
+	TEST_EQUAL(format_host_header("[2001:db8::1]", 443, 443), "[2001:db8::1]");
+	TEST_EQUAL(format_host_header("[2001:db8::1]", 8443, 443), "[2001:db8::1]:8443");
+}

--- a/test/test_url_seed.cpp
+++ b/test/test_url_seed.cpp
@@ -61,6 +61,11 @@ TORRENT_TEST(url_seed)
 	run_http_suite(proxy, "http", 1, 0, 0, 0);
 }
 
+TORRENT_TEST(url_seed_host_header)
+{
+	run_http_suite(proxy, "http", true, false, false, false, false, true, true);
+}
+
 TORRENT_TEST(url_seed_keepalive_rename)
 {
 	run_http_suite(proxy, "http", 1, 0, 0, 1, 1);

--- a/test/web_seed_suite.cpp
+++ b/test/web_seed_suite.cpp
@@ -260,7 +260,7 @@ void test_transfer(lt::session& ses, std::shared_ptr<torrent_info> torrent_file
 // test_url_seed determines whether to use url-seed or http-seed
 int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 	, bool chunked_encoding, bool test_ban, bool keepalive, bool test_rename
-	, bool proxy_peers)
+	, bool proxy_peers, bool expect_host_header)
 {
 	using namespace lt;
 
@@ -268,7 +268,8 @@ int EXPORT run_http_suite(int proxy, char const* protocol, bool test_url_seed
 	save_path += proxy_name[proxy];
 
 	error_code ec;
-	int const port = start_web_server(protocol == "https"_sv, chunked_encoding, keepalive);
+	int const port = start_web_server(protocol == "https"_sv, chunked_encoding, keepalive
+		, 30, expect_host_header);
 
 	std::vector<torrent_args> test_cases;
 

--- a/test/web_seed_suite.hpp
+++ b/test/web_seed_suite.hpp
@@ -34,7 +34,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 int EXPORT run_http_suite(int proxy, char const* protocol
 	, bool test_url_seed, bool chunked_encoding = false, bool test_ban = false
-	, bool keepalive = true, bool test_rename = false, bool proxy_peers = true);
+	, bool keepalive = true, bool test_rename = false, bool proxy_peers = true
+	, bool expect_host_header = false);
 
 void EXPORT test_transfer(lt::session& ses
 	, std::shared_ptr<lt::torrent_info> torrent_file

--- a/test/web_server.py
+++ b/test/web_server.py
@@ -12,6 +12,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 
 chunked_encoding = False
 keepalive = True
+expected_host = ''
 
 try:
     fin = open('test_file', 'rb')
@@ -56,6 +57,17 @@ class http_handler(BaseHTTPRequestHandler):
 
         global chunked_encoding
         global keepalive
+        global expected_host
+
+        if expected_host and self.headers.get('Host') != expected_host:
+            print('UNEXPECTED-HOST expected={} actual={}'.format(
+                expected_host, self.headers.get('Host')))
+            sys.stdout.flush()
+            self.send_response(400)
+            self.send_header("Content-Length", "0")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            return
 
         self.normalize_request_path()
         file_path = os.path.normpath(self.path)
@@ -292,6 +304,7 @@ if __name__ == '__main__':
     use_ssl = sys.argv[3] != '0'
     keepalive = sys.argv[4] != '0'
     min_interval = sys.argv[5]
+    expected_host = sys.argv[6] if len(sys.argv) > 6 else ''
     print('python version: %s' % sys.version_info.__str__())
 
     http_handler.protocol_version = 'HTTP/1.1'


### PR DESCRIPTION
Fixes web-seed Host header construction by routing Host authority formatting through a shared string_util helper.

The formatter brackets IPv6 literals, omits default or non-positive ports, and includes non-default ports. web_connection_base and http_connection now use the same formatter so normal hostname behavior stays consistent while random-port web seeds send Host with the port.

Validation:
cmake --build cmake-build-local-tests -j2
ctest --test-dir cmake-build-local-tests --output-on-failure