### PR TITLE
simplify flush_storage() by not making it erase the piece

### DIFF
--- a/.claude/rules/disk-cache.md
+++ b/.claude/rules/disk-cache.md
@@ -35,6 +35,7 @@ Flags are stored in `cached_piece_flags flags` (a `bitfield_flag<uint8_t>` bitfi
 - `v1_hashes_flag` — set if this piece requires v1 SHA-1 hashing (`ph` is allocated).
 - `v2_hashes_flag` — set if this piece requires v2 SHA-256 block hashing (`block_hashes` is allocated).
 - `needs_hasher_kick_flag` — set when a block is inserted and the hasher thread should be woken; cleared when the hasher picks it up. Coalesces multiple insertions into one wakeup.
+- `notify_flushed_flag` — set by a `flush_storage()` caller that is waiting on a piece another thread is mid-flush on; `flush_piece_impl`'s `scope_end` checks it and signals `m_flushing_cv`. Only a wakeup signal supporting a single waiter, not a pin — the waiter re-looks-up the piece after each wakeup because it may have been flushed, hashed, or evicted while it slept.
 
 In both hashing and flushing cases, the lock is **released** for the duration of the actual I/O (hashing or `pwrite()`), then re-acquired to update cursors/flags and potentially free buffers.
 
@@ -56,3 +57,5 @@ The held-alive buffer is reclaimed when `kick_hasher` next advances the cursor p
 4. Expensive flush pass (`view4`) — flush any dirty blocks even if they haven't been hashed yet, requiring a read-back later to complete the piece hash. Used only when the cache exceeds the high-water mark.
 
 Passes 2-4 run only when `optimistic=false`. The optimistic flush at the top of each disk thread's loop runs only pass 1.
+
+**`flush_storage()`:** Called as a fence job during torrent teardown (`release_files`, `delete_files`, etc.) to flush every cached piece of one storage to disk. For each piece it flushes any still-dirty blocks (completing their write jobs via `flush_piece_impl`). It does **not** free or erase the piece — eviction is left to `flush_to_disk`. Keeping the piece preserves its partial hash state and lets another thread erase it concurrently without racing the flush. If a piece is mid-flush on another thread (`flushing_flag` set), it sets `notify_flushed_flag`, waits on `m_flushing_cv`, and re-looks-up the piece on each wakeup (it may be flushed, hashed, or evicted while waiting); if it is gone, it moves on. A concurrent `flush_storage()` already waiting on a piece (`notify_flushed_flag` already set) is left to that waiter, since the flag supports only one waiter.

--- a/include/libtorrent/aux_/disk_cache.hpp
+++ b/include/libtorrent/aux_/disk_cache.hpp
@@ -244,11 +244,6 @@ struct TORRENT_EXTRA_EXPORT cached_piece_entry
 	// flag is set, avoiding the cost of signalling.
 	static constexpr cached_piece_flags notify_flushed_flag = 7_bit;
 
-	// set by flush_storage() when it wants to erase a piece but a hasher
-	// thread holds hashing_flag. When kick_hasher() later clears
-	// hashing_flag it will see this flag and free+erase the piece itself.
-	static constexpr cached_piece_flags pending_free_flag = 8_bit;
-
 	// flags are protected by the main disk cache mutex and may only be
 	// accessed while holding it
 	cached_piece_flags flags{};
@@ -624,6 +619,11 @@ struct TORRENT_EXTRA_EXPORT disk_cache
 	void flush_storage(std::function<int(bitfield&, span<disk_job* const>)> f,
 		storage_index_t storage,
 		std::function<void(jobqueue_t, disk_job*)> clear_piece_fun);
+
+	// called when a storage index is removed, so leftover entries cannot
+	// collide with a future torrent that reuses the index. Any still-attached
+	// jobs (none expected) are moved into `aborted` for the caller to finish.
+	void remove_storage(storage_index_t storage, jobqueue_t& aborted);
 
 	std::size_t size() const;
 	std::tuple<std::int64_t, std::int64_t> stats() const;

--- a/src/disk_cache.cpp
+++ b/src/disk_cache.cpp
@@ -460,9 +460,6 @@ bool disk_cache::wait_for_v2_queue(piece_location const loc, disk_job* hash_job)
 // this should be called from a hasher thread, with m_mutex held.
 // hashing_flag must already be set on the piece by the caller.
 // Returns true if force_flush_flag was set on the piece.
-// NOTE: if pending_free_flag is set, this function will erase the piece from
-// the cache before returning, invalidating piece_iter. Callers must not
-// dereference it after this call returns.
 bool disk_cache::kick_hasher(piece_container::nth_index<4>::type::iterator piece_iter
 	, std::unique_lock<std::mutex>& l, jobqueue_t& completed_jobs
 	, jobqueue_t& retry_jobs)
@@ -585,12 +582,6 @@ keep_going:
 		});
 		if (rj) retry_jobs.push_back(rj);
 
-		if (piece_iter->flags & cached_piece_entry::pending_free_flag)
-		{
-			free_piece(*piece_iter);
-			view.erase(piece_iter);
-		}
-
 		DLOG("kick_hasher: no attached hash job\n");
 		return false;
 	}
@@ -604,13 +595,6 @@ keep_going:
 			e.flags &= ~cached_piece_entry::hashing_flag;
 			e.flags |= cached_piece_entry::force_flush_flag;
 		});
-
-		if (piece_iter->flags & cached_piece_entry::pending_free_flag)
-		{
-			free_piece(*piece_iter);
-			view.erase(piece_iter);
-			return false;
-		}
 
 		return true;
 	}
@@ -659,13 +643,6 @@ keep_going:
 		DLOG("kick_hasher: posting attached job piece: %d\n",
 			static_cast<int>(piece_iter->piece.piece));
 		completed_jobs.push_back(j);
-	}
-
-	if (piece_iter->flags & cached_piece_entry::pending_free_flag)
-	{
-		free_piece(*piece_iter);
-		view.erase(piece_iter);
-		return false;
 	}
 
 	return force_flush;
@@ -759,8 +736,6 @@ Iter disk_cache::flush_piece_impl(View& view,
 			view.modify(piece_iter, [&notify](cached_piece_entry& e) {
 				TORRENT_ASSERT(bool(e.flags & cached_piece_entry::flushing_flag));
 				notify = bool(e.flags & cached_piece_entry::notify_flushed_flag);
-				// leave notify_flushed_flag set — it pins the piece against eviction
-				// until flush_storage clears it after waking up
 				e.flags &= ~cached_piece_entry::flushing_flag;
 			});
 			if (notify) m_flushing_cv.notify_all();
@@ -878,10 +853,6 @@ int disk_cache::drop_v2_queue_entries(piece_location const loc)
 void disk_cache::free_piece(cached_piece_entry const& cpe)
 {
 #if TORRENT_USE_ASSERTS
-	// a piece with notify_flushed_flag set is pinned: flush_storage() is
-	// waiting on it and erases it itself. No other path may free it.
-	TORRENT_ASSERT(!(cpe.flags & cached_piece_entry::notify_flushed_flag));
-
 	// piece_hash_returned_flag implies hasher_cursor == blocks_in_piece():
 	// try_hash_piece() requires the cursor to already be at the end before
 	// it sets the flag, and kick_hasher() and hash_piece() both move the
@@ -982,7 +953,6 @@ void disk_cache::flush_to_disk(std::function<int(bitfield&, span<disk_job* const
 		if (piece_iter->flushed_cursor == piece_iter->blocks_in_piece()
 			&& bool(piece_iter->flags & cached_piece_entry::piece_hash_returned_flag)
 			&& !(piece_iter->flags & cached_piece_entry::flushing_flag)
-			&& !(piece_iter->flags & cached_piece_entry::notify_flushed_flag)
 			&& !(piece_iter->flags & cached_piece_entry::hashing_flag))
 		{
 			// piece_hash_returned_flag is set at the same modify() that
@@ -1109,6 +1079,33 @@ void disk_cache::flush_to_disk(std::function<int(bitfield&, span<disk_job* const
 	}
 }
 
+void disk_cache::remove_storage(storage_index_t const storage, jobqueue_t& aborted)
+{
+	std::unique_lock<std::mutex> l(m_mutex);
+
+	INVARIANT_CHECK;
+
+	auto& view = m_pieces.template get<0>();
+	auto const [begin, end] = view.equal_range(storage, compare_storage());
+
+	for (auto i = begin; i != end;)
+	{
+		// advance before erasing invalidates the iterator
+		auto const next = std::next(i);
+
+		// removing a storage happens after its torrent has been fully torn down:
+		// the release_files/stop_torrent fence has flushed every dirty block and
+		// no new jobs can be queued, so nothing is mid-flush or mid-hash here.
+		TORRENT_ASSERT(!(i->flags & cached_piece_entry::flushing_flag));
+		TORRENT_ASSERT(!(i->flags & cached_piece_entry::hashing_flag));
+
+		view.modify(i, [&](cached_piece_entry& e) { clear_piece_impl(e, aborted); });
+		view.erase(i);
+
+		i = next;
+	}
+}
+
 void disk_cache::flush_storage(std::function<int(bitfield&, span<disk_job* const>)> f,
 	storage_index_t const storage,
 	std::function<void(jobqueue_t, disk_job*)> clear_piece_fun)
@@ -1127,7 +1124,7 @@ void disk_cache::flush_storage(std::function<int(bitfield&, span<disk_job* const
 
 	for (auto piece : pieces)
 	{
-		auto const piece_iter = view.find(piece_location{storage, piece});
+		auto piece_iter = view.find(piece_location{storage, piece});
 		if (piece_iter == view.end())
 			continue;
 
@@ -1143,65 +1140,26 @@ void disk_cache::flush_storage(std::function<int(bitfield&, span<disk_job* const
 		{
 			view.modify(piece_iter, [](cached_piece_entry& e)
 				{ e.flags |= cached_piece_entry::notify_flushed_flag; });
-			m_flushing_cv.wait(l, [&]
-				{ return !(piece_iter->flags & cached_piece_entry::flushing_flag); });
-			// clear the pin now that we hold the lock and piece_iter is safe
+			m_flushing_cv.wait(l, [&] {
+				piece_iter = view.find(piece_location{storage, piece});
+				return piece_iter == view.end()
+					|| !(piece_iter->flags & cached_piece_entry::flushing_flag);
+			});
+			if (piece_iter == view.end()) continue;
 			view.modify(piece_iter, [](cached_piece_entry& e)
 				{ e.flags &= ~cached_piece_entry::notify_flushed_flag; });
 		}
 
-		// flush storage is a fence-job, no other jobs should be running at the
-		// same time on this torrent
 		TORRENT_ASSERT(!(piece_iter->flags & cached_piece_entry::flushing_flag));
 
 		int const num_blocks = piece_iter->num_jobs;
 		if (num_blocks == 0) continue;
+
 		span<cached_block_entry> const blocks = piece_iter->get_blocks();
 
 		flush_piece_impl(view, piece_iter, f, l, blocks, clear_piece_fun);
 		TORRENT_ASSERT(l.owns_lock());
 		TORRENT_ASSERT(!(piece_iter->flags & cached_piece_entry::flushing_flag));
-		TORRENT_ASSERT(!(piece_iter->flags & cached_piece_entry::notify_flushed_flag));
-
-		// A hasher thread may have picked up this piece. Freeing
-		// or erasing this piece while hashing is active can invalidate buffers
-		// currently being fed into hasher::update(). Defer the erasure: set
-		// pending_free_flag so kick_hasher() will free the piece once it's done.
-		if (piece_iter->flags & cached_piece_entry::hashing_flag)
-		{
-			view.modify(piece_iter, [](cached_piece_entry& e) {
-				e.flags |= cached_piece_entry::pending_free_flag;
-			});
-			continue;
-		}
-
-		// It's safe to free the piece here because flush_storage() is only
-		// called during torrent teardown (release_files, delete_files, etc.),
-		// where the bittorrent layer will not make further hash requests for
-		// this storage. If hashing had completed without a pending hash_job
-		// (piece_hash_returned_flag is not set), the precomputed hash in ph
-		// is simply discarded. Any subsequent try_hash_piece() call would
-		// find the piece absent from cache and re-read from disk, which is
-		// correct since all blocks have been flushed above.
-
-		// hash_job may be hung via wait_for_v2_queue. Abort it so free_piece's
-		// invariant holds; the storage is going away regardless.
-		if (piece_iter->hash_job != nullptr)
-		{
-			jobqueue_t aborted;
-			view.modify(piece_iter, [&](cached_piece_entry& e) {
-				aborted.push_back(std::exchange(e.hash_job, nullptr));
-			});
-			clear_piece_fun(std::move(aborted), nullptr);
-		}
-
-		// In-flight drain batches keep their own copy of the buffer; freeing
-		// the piece here just removes the cbe. When the drain finishes and
-		// looks up the piece it'll find it gone, store the precomputed hash
-		// on the (still-alive via shared_ptr) storage, and drop the buffer
-		// naturally. The stored hash is harmless: nobody will read it back.
-		free_piece(*piece_iter);
-		view.erase(piece_iter);
 	}
 }
 
@@ -1274,12 +1232,6 @@ void disk_cache::check_invariant() const
 			TORRENT_ASSERT(queued <= int(piece_entry.v2_pending));
 		}
 		total_v2_pending += int(piece_entry.v2_pending);
-
-		// pending_free_flag is set by flush_storage() when it wants to erase a
-		// piece but hashing_flag is active. The hasher will erase it when done.
-		// It must never outlive the hashing window.
-		if (piece_entry.flags & cached_piece_entry::pending_free_flag)
-			TORRENT_ASSERT(piece_entry.flags & cached_piece_entry::hashing_flag);
 
 		int idx = 0;
 		for (auto& be : blocks)

--- a/src/pread_disk_io.cpp
+++ b/src/pread_disk_io.cpp
@@ -309,6 +309,13 @@ storage_holder pread_disk_io::new_torrent(storage_params const& params
 
 void pread_disk_io::remove_torrent(storage_index_t const idx)
 {
+	// purge the cache so stale entries can't collide with a future torrent
+	// that reuses this index. The torrent is fully torn down by now, so no
+	// jobs should still be attached -- abort any defensively.
+	jobqueue_t aborted;
+	m_cache.remove_storage(idx, aborted);
+	TORRENT_ASSERT(aborted.empty());
+	m_completed_jobs.abort_jobs(m_ios, std::move(aborted));
 	m_torrents.remove(idx);
 }
 

--- a/test/disk_cache_test_utils.hpp
+++ b/test/disk_cache_test_utils.hpp
@@ -225,6 +225,14 @@ struct cache_fixture
 			[](lt::jobqueue_t, lt::aux::disk_job*) {});
 	}
 
+	// Simulate remove_storage(): erase every cached piece of the storage.
+	// Returns any jobs the teardown aborted (none expected here).
+	lt::jobqueue_t remove_storage_for(lt::storage_index_t const storage = lt::storage_index_t{0})
+	{
+		lt::jobqueue_t aborted;
+		cache.remove_storage(storage, aborted);
+		return aborted;
+	}
 };
 
 #endif // TORRENT_DISK_CACHE_TEST_UTILS_HPP_INCLUDED

--- a/test/test_slow_hash.cpp
+++ b/test/test_slow_hash.cpp
@@ -433,18 +433,17 @@ void test_clear_piece_during_hashing(test_mode_t const mode)
 	TEST_EQUAL(f.alloc.live, 0);
 }
 
-// Regression test for the pending_free_flag mechanism.
+// Regression test for tearing down a storage while a hasher is running.
 //
 // flush_storage() is called to tear down a storage while a hasher thread
 // holds hashing_flag (mutex released mid-hash). flush_storage() must NOT
 // free or erase the piece entry while the hasher is accessing ph and
-// block_hashes; instead it sets pending_free_flag and defers the erasure.
-// When kick_hasher() subsequently clears hashing_flag it sees
-// pending_free_flag and erases the piece itself.
+// block_hashes; it only flushes the dirty blocks to disk and leaves the
+// piece in place.
 //
 // hashing_flag is set by kick_pending_hashers, which only kicks v1/hybrid
 // pieces. v2-only pieces have no hashing_flag (their work happens in
-// drain_v2_hash_queue), so they don't exercise the pending_free_flag race.
+// drain_v2_hash_queue), so they don't exercise this race.
 void test_flush_storage_during_hashing(test_mode_t const mode)
 {
 	if (!(mode & test_mode::v1)) return;
@@ -465,16 +464,19 @@ void test_flush_storage_during_hashing(test_mode_t const mode)
 	// Give the hasher time to set hashing_flag and release the mutex.
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-	// flush_storage() sees hashing_flag set: it flushes the blocks to disk,
-	// sets pending_free_flag, and returns WITHOUT erasing the piece entry.
+	// flush_storage() sees hashing_flag set: it flushes the blocks to disk
+	// and returns WITHOUT erasing the piece entry.
 	f.flush_storage_for();
 
 	// The hasher thread is still running; the piece entry must still exist.
 	TEST_CHECK(f.cache.size() > 0);
 
 	hasher_thread.join();
-	// kick_hasher() saw pending_free_flag when clearing hashing_flag and
-	// erased the piece itself.
+
+	// flush_storage() only flushes, it never erases. remove_storage() does the
+	// actual teardown: it frees any remaining buffers and erases every piece.
+	jobqueue_t const aborted = f.remove_storage_for();
+	TEST_CHECK(aborted.empty());
 
 	TEST_EQUAL(int(f.cache.size()), 0);
 	TEST_EQUAL(f.alloc.live, 0);


### PR DESCRIPTION
just flush dirty buffers. this makes pending_free_flag unnecessary which takes some logic with it as it goes