### PR TITLE
compact merkle tree

### DIFF
--- a/fuzzers/Jamfile
+++ b/fuzzers/Jamfile
@@ -60,6 +60,7 @@ fuzzer parse_magnet_uri ;
 fuzzer bdecode_node ;
 fuzzer parse_int ;
 fuzzer piece_layers ;
+fuzzer merkle_tree ;
 fuzzer sanitize_path ;
 fuzzer escape_path ;
 fuzzer file_storage_add_file ;

--- a/fuzzers/src/merkle_tree.cpp
+++ b/fuzzers/src/merkle_tree.cpp
@@ -1,0 +1,446 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+// Fuzzer for aux::merkle_tree (src/merkle_tree.cpp). Builds a deterministic
+// reference flat tree from the fuzz input, constructs a merkle_tree with the
+// matching root, then drives a sequence of fuzz-controlled operations
+// (set_block, load_tree, load_sparse_tree, add_hashes with valid and corrupted
+// proofs, load_piece_layer) against it. After every operation it verifies
+// that every node the tree claims to know matches the reference, that padding
+// positions report the implied pad, and that round-tripping through
+// build_sparse_vector / load_sparse_tree preserves the state.
+//
+// For add_hashes() in particular, the fuzzer snapshots the tree's canonical
+// representation (build_vector) before each call and, if the call returns
+// nullopt, verifies that the post-call representation is bit-for-bit
+// identical -- i.e. that a failed proof leaves the tree fully restored to
+// its prior state. Any invariant violation or assertion failure terminates
+// the run.
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "libtorrent/aux_/merkle.hpp"
+#include "libtorrent/aux_/merkle_tree.hpp"
+#include "libtorrent/bitfield.hpp"
+#include "libtorrent/hasher.hpp"
+#include "libtorrent/sha1_hash.hpp"
+
+namespace {
+
+	namespace lt = libtorrent;
+
+	// Build a deterministic standard-layout reference tree. The leaf
+	// values just need to be reproducible and varied; std::mt19937_64
+	// seeded from the fuzz input gives us that with no cryptographic
+	// cost. Interior nodes still get computed with merkle_fill_tree's
+	// real sha256 -- those must match the merkle-tree algorithm.
+	std::vector<lt::sha256_hash> build_reference(int const num_blocks, std::uint32_t const seed)
+	{
+		int const num_leafs = lt::merkle_num_leafs(num_blocks);
+		int const num_nodes = lt::merkle_num_nodes(num_leafs);
+		std::vector<lt::sha256_hash> tree;
+		tree.resize(std::size_t(num_nodes));
+		int const first_leaf = lt::merkle_first_leaf(num_leafs);
+
+		std::mt19937_64 rng(seed);
+		for (int i = 0; i < num_blocks; ++i)
+		{
+			lt::sha256_hash& h = tree[std::size_t(first_leaf + i)];
+			char* dst = h.data();
+			for (int k = 0; k < 32; k += 8)
+			{
+				std::uint64_t v = rng();
+				std::memcpy(dst + k, &v, 8);
+			}
+		}
+
+		lt::merkle_fill_tree(tree, num_leafs);
+		return tree;
+	}
+
+	// Validate consistency between the tree and the reference. Aborts on any
+	// violation. Interior nodes that has_node reports must match the reference
+	// (the class invariant is: interior nodes are either set+valid or cleared).
+	// Leaf-layer slots can carry an unverified speculative hash from
+	// set_block; for those, only validated blocks must match.
+	//
+	// For small trees (<= 256 nodes) every position is checked. For larger
+	// trees we check the per-layer boundary positions (last live + first
+	// padding) deterministically and then sample a fixed number of random
+	// (L, O) positions from `rng`. This keeps validate() O(1) regardless
+	// of tree size, while preserving full coverage where it's affordable.
+	void validate(lt::aux::merkle_tree const& t,
+		int const num_blocks,
+		std::vector<lt::sha256_hash> const& reference,
+		std::mt19937_64& rng)
+	{
+		int const N = t.num_layers();
+		if (N != lt::merkle_num_layers(lt::merkle_num_leafs(num_blocks))) std::abort();
+		for (int L = 0; L <= N; ++L)
+		{
+			// layer_size_live should be ceil(num_blocks / 2^(N - L)) -- the
+			// number of live (non-padding) nodes in layer L when the leaf
+			// layer carries num_blocks live entries.
+			int const shift = N - L;
+			int const expected_live = (num_blocks + (1 << shift) - 1) >> shift;
+			if (t.layer_size_live(L) != expected_live) std::abort();
+		}
+
+		auto check = [&](int const L, int const O) {
+			int const flat_start = lt::merkle_layer_start(L);
+			lt::sha256_hash const ref = reference[std::size_t(flat_start + O)];
+			lt::sha256_hash const got = t.node_at(L, O);
+
+			// is_padding / live_count consistency
+			if (t.is_padding(L, O) != (O >= t.layer_size_live(L))) std::abort();
+
+			if (L == N)
+			{
+				// leaf layer: a non-zero slot may be unverified (set_block
+				// stores speculatively); only require a reference match
+				// when blocks_verified says the slot was validated.
+				if (O >= num_blocks) return; // padding
+				if (t.blocks_verified(O, 1) && got != ref) std::abort();
+			}
+			else if (t.has_node(L, O))
+			{
+				// interior nodes that we have are validated by class
+				// invariant: they must match the reference.
+				if (got != ref) std::abort();
+			}
+			else
+			{
+				// a not-known interior slot must be zero (or the implied
+				// pad if it's actually a padding offset).
+				if (!got.is_all_zeros() && !t.is_padding(L, O)) std::abort();
+			}
+		};
+
+		int const num_leafs = lt::merkle_num_leafs(num_blocks);
+		int const total_nodes = lt::merkle_num_nodes(num_leafs);
+
+		// Always check the live/padding boundary at every layer -- these
+		// are the most failure-prone positions and there are only O(N) of
+		// them.
+		for (int L = 0; L <= N; ++L)
+		{
+			int const live = t.layer_size_live(L);
+			int const layer_size = 1 << L;
+			if (live > 0) check(L, live - 1);
+			if (live < layer_size) check(L, live);
+		}
+
+		constexpr int full_check_threshold = 256;
+		if (total_nodes <= full_check_threshold)
+		{
+			for (int L = 0; L <= N; ++L)
+			{
+				int const layer_size = 1 << L;
+				for (int O = 0; O < layer_size; ++O)
+					check(L, O);
+			}
+		}
+		else
+		{
+			constexpr int sample_count = 50;
+			for (int s = 0; s < sample_count; ++s)
+			{
+				int const L = int(rng() % static_cast<std::uint64_t>(N + 1));
+				int const O = int(rng() % static_cast<std::uint64_t>(1 << L));
+				check(L, O);
+			}
+		}
+	}
+
+	// Round-trip via build_sparse_vector / load_sparse_tree and verify
+	// idempotency: a single round-trip may drop "orphan" data (hashes whose
+	// validation chain doesn't reach the root, which load_sparse_tree's
+	// merkle_fill_partial_tree clears intentionally), but a second round-trip
+	// from that result must give the same tree.
+	void round_trip(lt::aux::merkle_tree const& t,
+		int const num_blocks,
+		int const blocks_per_piece,
+		std::vector<lt::sha256_hash> const& reference,
+		std::mt19937_64& rng)
+	{
+		lt::bitfield const empty_verified(num_blocks);
+
+		auto const [sparse, mask] = t.build_sparse_vector();
+		lt::aux::merkle_tree t2(num_blocks, blocks_per_piece, reference[0].data());
+		t2.load_sparse_tree(sparse, mask, empty_verified);
+		validate(t2, num_blocks, reference, rng);
+
+		auto const [sparse2, mask2] = t2.build_sparse_vector();
+		lt::aux::merkle_tree t3(num_blocks, blocks_per_piece, reference[0].data());
+		t3.load_sparse_tree(sparse2, mask2, empty_verified);
+		validate(t3, num_blocks, reference, rng);
+
+		if (t2.build_vector() != t3.build_vector()) std::abort();
+	}
+
+	// Drive add_hashes with a fuzz-controlled (layer, subtree size, slot,
+	// corruption) tuple. The hashes and uncle proofs are taken from the
+	// reference, then optionally corrupted in one of three ways. The key
+	// invariant tested here: if add_hashes returns nullopt (failed proof),
+	// the tree's canonical representation must be unchanged from before
+	// the call -- merkle_validate_and_insert_proofs is responsible for
+	// rolling back any partial inserts on failure.
+	void do_add_hashes(lt::aux::merkle_tree& t,
+		int const num_blocks,
+		std::vector<lt::sha256_hash> const& reference,
+		std::uint8_t const layer_byte,
+		std::uint8_t const subtree_log_byte,
+		std::uint16_t const slot_raw,
+		std::uint8_t const corrupt_byte)
+	{
+		int const num_leafs = lt::merkle_num_leafs(num_blocks);
+		int const N = lt::merkle_num_layers(num_leafs);
+		// A single-block tree has only a root; no add_hashes call applies.
+		if (N == 0) return;
+
+		// Destination layer for the leaves of the subtree we're inserting.
+		// Restricted to [1, N] so the subtree has at least one proof level
+		// (an insertion at layer 0 is the root, which is already known).
+		int const dest_L = (layer_byte % N) + 1;
+
+		// Subtree-size exponent in [0, dest_L]: leaf_count = 1 << k. At
+		// k = 0 we insert a single hash; at k = dest_L the subtree spans
+		// the whole layer (its root is the tree root, no uncle hashes
+		// needed).
+		int const subtree_log = subtree_log_byte % (dest_L + 1);
+		int const leaf_count = 1 << subtree_log;
+
+		// Pick a subtree-aligned slot in the destination layer.
+		int const layer_size = 1 << dest_L;
+		int const num_subtrees = layer_size / leaf_count;
+		int const subtree_idx = int(slot_raw) % num_subtrees;
+		int const dest_O = subtree_idx * leaf_count;
+
+		int const dest_start_idx = lt::merkle_layer_start(dest_L) + dest_O;
+
+		std::vector<lt::sha256_hash> hashes;
+		hashes.reserve(std::size_t(leaf_count));
+		for (int i = 0; i < leaf_count; ++i)
+			hashes.push_back(reference[std::size_t(dest_start_idx + i)]);
+
+		// Build the uncle-proof chain from the subtree's root up to the
+		// tree root: at each level we include the sibling needed to recompute
+		// the parent. The subtree root sits at (dest_L - subtree_log,
+		// subtree_idx); its flat index is what we walk up.
+		int const subtree_root_L = dest_L - subtree_log;
+		int const subtree_root_flat = lt::merkle_layer_start(subtree_root_L) + subtree_idx;
+
+		std::vector<lt::sha256_hash> uncles;
+		for (int target = subtree_root_flat; target > 0; target = lt::merkle_get_parent(target))
+			uncles.push_back(reference[std::size_t(lt::merkle_get_sibling(target))]);
+
+		// Corruption mode in the low 2 bits of corrupt_byte:
+		//   bit 0 set = flip a byte in `hashes`
+		//   bit 1 set = flip a byte in `uncles`
+		// Both clear gives a clean (valid) call. The remaining 6 bits pick
+		// which entry to corrupt.
+		std::uint8_t const corrupt_mode = corrupt_byte & 0x3;
+		int const which = (corrupt_byte >> 2);
+
+		if ((corrupt_mode & 1) && !hashes.empty()) hashes[which % int(hashes.size())][0] ^= 0xff;
+		if ((corrupt_mode & 2) && !uncles.empty()) uncles[which % int(uncles.size())][0] ^= 0xff;
+
+		// Snapshot the canonical representation. build_vector depends only
+		// on what the tree knows, not on its internal storage mode, so a
+		// matched pre/post pair is the precise statement of "fully restored".
+		auto const before = t.build_vector();
+
+		auto const result =
+			t.add_hashes(dest_start_idx, lt::piece_index_t::diff_type{0}, hashes, uncles);
+
+		if (!result)
+		{
+			// Failed proof must leave the tree bit-identical to its prior
+			// canonical state.
+			if (t.build_vector() != before) std::abort();
+		}
+	}
+
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size)
+{
+	if (size < 4) return 0;
+
+	// Header: pick num_blocks in [1, 4096] and blocks_per_piece in
+	// {1, 2, 4, 8, ..., 4096} (still a power of two, as the class API
+	// asserts, but spanning a much wider range than the tiny piece sizes
+	// the previous header gave us). num_blocks doesn't need to be a
+	// multiple of blocks_per_piece -- the partial-last-piece case is
+	// part of the coverage we want. The seed is only 8 bits because the
+	// fuzzer doesn't care about the actual leaf hash values; 256 distinct
+	// reference trees per (num_blocks, blocks_per_piece) is plenty.
+	int const num_blocks = ((int(data[0]) << 8) | int(data[1])) % 4096 + 1;
+	int const blocks_per_piece_log = int(data[2]) % 13; // 0..12 -> 1..4096
+	int const blocks_per_piece = 1 << blocks_per_piece_log;
+	std::uint32_t const seed = std::uint32_t(data[3]);
+
+	auto const reference = build_reference(num_blocks, seed);
+
+	lt::aux::merkle_tree t(num_blocks, blocks_per_piece, reference[0].data());
+
+	int const num_leafs = lt::merkle_num_leafs(num_blocks);
+	int const first_leaf = lt::merkle_first_leaf(num_leafs);
+	lt::bitfield const empty_verified(num_blocks);
+
+	// Validate-sampling rng -- seeded deterministically from the fuzz
+	// header so a given input always picks the same sample positions
+	// (libFuzzer-reproducible).
+	std::mt19937_64 validate_rng(std::uint64_t(seed) ^ (std::uint64_t(num_blocks) << 32));
+
+	validate(t, num_blocks, reference, validate_rng);
+
+	// op stream; cap at 64 operations per fuzz case to keep individual
+	// runs short.
+	std::size_t pos = 4;
+	int op_count = 0;
+	while (pos < size && op_count < 64)
+	{
+		std::uint8_t const op = data[pos++];
+		++op_count;
+
+		switch (op % 7)
+		{
+			case 0: {
+				// set_block with correct hash
+				if (pos + 1 >= size) break;
+				int const raw = int(data[pos]) | (int(data[pos + 1]) << 8);
+				pos += 2;
+				int const block_idx = raw % num_blocks;
+				t.set_block(block_idx, reference[std::size_t(first_leaf + block_idx)]);
+				break;
+			}
+			case 1: {
+				// set_block with a derived-but-different hash (likely
+				// triggers block_hash_failed or hash_failed paths)
+				if (pos + 1 >= size) break;
+				int const raw = int(data[pos]) | (int(data[pos + 1]) << 8);
+				pos += 2;
+				int const block_idx = raw % num_blocks;
+				lt::sha256_hash bogus = reference[std::size_t(first_leaf + block_idx)];
+				bogus[0] ^= 0xff;
+				t.set_block(block_idx, bogus);
+				break;
+			}
+			case 2: {
+				// load_tree from the correct reference
+				lt::bitfield verified(num_blocks);
+				t.load_tree(reference, verified);
+				break;
+			}
+			case 3: {
+				// load_tree from a single-byte-flipped reference
+				if (pos + 2 >= size) break;
+				auto corrupted = reference;
+				int const corrupt_idx =
+					((int(data[pos]) << 8) | int(data[pos + 1])) % int(corrupted.size());
+				pos += 2;
+				corrupted[std::size_t(corrupt_idx)][0] ^= 0xff;
+				lt::bitfield verified(num_blocks);
+				t.load_tree(corrupted, verified);
+				break;
+			}
+			case 4: {
+				// load_sparse_tree from the reference, with a fuzz-controlled
+				// mask byte selecting which nodes to include.
+				if (pos + 1 >= size) break;
+				int const total = lt::merkle_num_nodes(num_leafs);
+				lt::bitfield mask(total, false);
+				std::vector<lt::sha256_hash> sparse;
+				std::uint8_t const mask_seed = data[pos++];
+				for (int i = 0; i < total; ++i)
+				{
+					// pseudo-random based on the mask byte and the index
+					if (((mask_seed * 31 + i) & 7) != 0) continue;
+					mask.set_bit(i);
+					sparse.push_back(reference[std::size_t(i)]);
+				}
+				t.load_sparse_tree(sparse, mask, empty_verified);
+				break;
+			}
+			case 5: {
+				// add_hashes: insert a subtree of hashes with an uncle-proof
+				// chain. Consumes 5 sub-bytes selecting layer, subtree size,
+				// slot, and a corruption mode that may flip a byte in the
+				// hashes, the proof, or both. The helper additionally checks
+				// that a failed proof leaves the tree fully restored.
+				if (pos + 4 >= size) break;
+				std::uint8_t const layer_byte = data[pos++];
+				std::uint8_t const subtree_log_byte = data[pos++];
+				std::uint16_t const slot_raw =
+					std::uint16_t(int(data[pos]) | (int(data[pos + 1]) << 8));
+				pos += 2;
+				std::uint8_t const corrupt_byte = data[pos++];
+				do_add_hashes(
+					t, num_blocks, reference, layer_byte, subtree_log_byte, slot_raw, corrupt_byte);
+				break;
+			}
+			case 6: {
+				// load_piece_layer with the correct piece-layer hashes,
+				// optionally with a single byte flipped (which must cause
+				// the call to return false). Per its production callsite
+				// in torrent.cpp, load_piece_layer is invoked on a freshly
+				// constructed merkle_tree -- it doesn't currently reset
+				// m_block_verified on mode transitions, so calling it on a
+				// live tree that's been modified would leave the verified
+				// bitfield in a state that violates the piece_layer/block_layer
+				// invariant. We therefore drive it through a fresh, parallel
+				// tree rather than the live one.
+				if (pos + 2 >= size) break;
+				int const num_pieces = (num_blocks + blocks_per_piece - 1) / blocks_per_piece;
+				int const piece_layer_size = num_pieces * int(lt::sha256_hash::size());
+
+				// Materialize the piece-layer bytes from the reference. If
+				// blocks_per_piece == 1 the block and piece layers coincide,
+				// so we read from the leaf layer instead.
+				int const piece_layer_first = (blocks_per_piece == 1)
+					? first_leaf
+					: lt::merkle_first_leaf(lt::merkle_num_leafs(num_pieces));
+
+				std::vector<char> piece_layer(std::size_t(piece_layer_size), '\0');
+				for (int i = 0; i < num_pieces; ++i)
+					std::memcpy(piece_layer.data() + i * int(lt::sha256_hash::size()),
+						reference[std::size_t(piece_layer_first + i)].data(),
+						lt::sha256_hash::size());
+
+				std::uint8_t const corrupt = data[pos++];
+				int const corrupt_pos_raw = int(data[pos++]);
+				bool const want_fail = (corrupt & 1) != 0;
+				if (want_fail)
+				{
+					int const cp = corrupt_pos_raw % piece_layer_size;
+					piece_layer[std::size_t(cp)] ^= 0xff;
+				}
+
+				lt::aux::merkle_tree fresh(num_blocks, blocks_per_piece, reference[0].data());
+				bool const ok = fresh.load_piece_layer(piece_layer);
+				if (ok == want_fail) std::abort();
+				validate(fresh, num_blocks, reference, validate_rng);
+				break;
+			}
+		}
+
+		// Round-trip after every op: it's an invariant the tree must
+		// satisfy in every reachable state, not an action to take some
+		// of the time.
+		validate(t, num_blocks, reference, validate_rng);
+		round_trip(t, num_blocks, blocks_per_piece, reference, validate_rng);
+	}
+
+	return 0;
+}

--- a/include/libtorrent/aux_/debug.hpp
+++ b/include/libtorrent/aux_/debug.hpp
@@ -216,8 +216,9 @@ namespace libtorrent::aux {
 #if TORRENT_USE_ASSERTS
 	struct TORRENT_EXTRA_EXPORT single_threaded
 	{
-		single_threaded(): m_id() {}
-		~single_threaded() { m_id = std::thread::id(); }
+		single_threaded()
+			: m_id()
+		{}
 		bool is_single_thread() const
 		{
 			if (m_id == std::thread::id())

--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -17,10 +17,15 @@ see LICENSE file.
 #include "libtorrent/aux_/vector.hpp"
 #include <vector>
 #include <utility> // pair
+#include <tuple>
 
 namespace libtorrent {
 
 	struct bitfield;
+
+	namespace aux {
+		struct merkle_tree;
+	}
 
 	// given layer and offset from the start of the layer, return the nodex
 	// index
@@ -55,16 +60,22 @@ namespace libtorrent {
 	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs, int level_start);
 	TORRENT_EXTRA_EXPORT void merkle_fill_tree(span<sha256_hash> tree, int num_leafs);
 
+	// Fill the interior nodes of a subtree of `tree`, given its leaves are
+	// already set. `L` and `O` are the (level, offset) of the leftmost leaf
+	// of the subtree; `level_size` is the number of contiguous leaves.
+	// Hashes upward to the subtree's root.
+	TORRENT_EXTRA_EXPORT void merkle_fill_tree(
+		aux::merkle_tree& tree, int L, int O, int level_size);
+
 	// fills in nodes that can be computed from a tree with arbitrary nodes set
 	// all "orphan" hashes, i.e ones that do not contribute towards computing
 	// the root, will be cleared.
-	TORRENT_EXTRA_EXPORT void merkle_fill_partial_tree(span<sha256_hash> tree);
+	TORRENT_EXTRA_EXPORT void merkle_fill_partial_tree(aux::merkle_tree& tree);
 
-	// given a merkle tree (`tree`), clears all hashes in the range of nodes:
-	// [ level_start, level_start+ num_leafs), as well as all of their parents,
-	// within the sub-tree. It does not clear the root of the sub-tree.
-	// see unit test for examples.
-	TORRENT_EXTRA_EXPORT void merkle_clear_tree(span<sha256_hash> tree, int num_leafs, int level_start);
+	// Clear a subtree: zero out the `level_size` leaves at (L, O) and all
+	// of their ancestors up to (but not including) the subtree's root.
+	TORRENT_EXTRA_EXPORT void merkle_clear_tree(
+		aux::merkle_tree& tree, int L, int O, int level_size);
 
 	// given the leaf hashes, computes the merkle root hash. The pad is the hash
 	// to use for the right-side padding, in case the number of leaves is not a
@@ -85,11 +96,11 @@ namespace libtorrent {
 	// piece layer
 	TORRENT_EXTRA_EXPORT sha256_hash const& merkle_pad(int blocks, int pieces);
 
-	// validates and inserts the uncle hashes (and the specified node) into the
-	// target tree. "node" is the hash at target_node_idx and uncle_hashes are
-	// the uncle hashes all the way up to the root of target_tree, to prove "node"
-	// is valid. The hashes are only inserted into target_tree if they validate.
-	// returns true if all hashes validated correctly, and false otherwise.
+	// Validate `node` against the chain of `uncle_hashes` and insert the
+	// proven hashes (the node, the uncles, and the computed parents along
+	// the chain) into `target_tree` starting at (target_L, target_O).
+	// Returns true on success; on failure, any hashes inserted along the
+	// way are rolled back.
 	//
 	// For example, consider the following tree (target_tree):
 	//
@@ -104,36 +115,37 @@ namespace libtorrent {
 	// will terminate the validation early, either successful (if there's a
 	// match) or unsuccessful (if there's a mismatch).
 	TORRENT_EXTRA_EXPORT
-	bool merkle_validate_and_insert_proofs(span<sha256_hash> target_tree
-		, int target_node_idx, sha256_hash const& node, span<sha256_hash const> uncle_hashes);
+	bool merkle_validate_and_insert_proofs(aux::merkle_tree& target_tree,
+		int target_L,
+		int target_O,
+		sha256_hash const& node,
+		span<sha256_hash const> uncle_hashes);
 
 	TORRENT_EXTRA_EXPORT
 	bool merkle_validate_node(sha256_hash const& left, sha256_hash const& right
 		, sha256_hash const& parent);
 
-	// validates hashes from src and copies the valid ones to dst given root as
-	// the expected root of the tree (i.e. index 0)
-	// src and dst must be the same size. dst is expected to be initialized
-	// cleared (or only have valid hashes set), this function will not clear
-	// hashes in dst that are invalid in src.
+	// Validate the standard-layout flat tree `src` against `expected_root`
+	// and copy validated subtrees into `dst`'s compact storage.
+	// `verified_leafs` is set (one bit per leaf) for every leaf whose hash
+	// was validated by a parent that itself was already known in dst.
 	TORRENT_EXTRA_EXPORT
-	void merkle_validate_copy(span<sha256_hash const> src, span<sha256_hash> dst
-		, sha256_hash const& root, bitfield& verified_leafs);
+	void merkle_validate_copy(span<sha256_hash const> src,
+		aux::merkle_tree& dst,
+		sha256_hash const& expected_root,
+		bitfield& verified_leafs);
 
 	TORRENT_EXTRA_EXPORT
 	bool merkle_validate_single_layer(span<sha256_hash const> tree);
 
-	// given a leaf index (0-based index in the leaf layer) and a tree, return
-	// the leafs_start, leafs_size and root_index representing a subtree that
-	// can be validated. The block_index and leaf_size is the range of the leaf
-	// layer that can be verified, and the root_index is the node that needs to
-	// be known in (tree) to do so. The num_valid_leafs specifies how many of
-	// the leafs that are actually *supposed* to be non-zero. Any leafs beyond
-	// these are padding and expected to be zero.
-	// The caller must validate the hash at root_index.
+	// Given a block index (offset in the leaf layer) and a tree, return the
+	// largest verifiable subtree containing that block: the leaf-layer range
+	// [leafs_start, leafs_start + leafs_size) and the (root_L, root_O) of
+	// the node that needs to be known in `tree` to validate the subtree.
+	// `num_valid_leafs` is the count of live (non-padding) leaves.
 	TORRENT_EXTRA_EXPORT
-	std::tuple<int, int, int> merkle_find_known_subtree(span<sha256_hash const> const tree
-		, int block_index, int num_valid_leafs);
+	std::tuple<int, int, int, int> merkle_find_known_subtree(
+		aux::merkle_tree const& tree, int block_index, int num_valid_leafs);
 }
 
 #endif

--- a/include/libtorrent/aux_/merkle_tree.hpp
+++ b/include/libtorrent/aux_/merkle_tree.hpp
@@ -17,8 +17,10 @@ see LICENSE file.
 #include <optional>
 
 #include "libtorrent/sha1_hash.hpp" // for sha256_hash
+#include "libtorrent/aux_/debug.hpp" // for single_threaded
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/aux_/export.hpp"
+#include "libtorrent/hasher.hpp"
 #include "libtorrent/span.hpp"
 #include "libtorrent/bitfield.hpp"
 #if TORRENT_USE_INVARIANT_CHECKS
@@ -49,15 +51,16 @@ struct add_hashes_result_t
 // metadata, we have files on disk but no hashes. We won't know whether the data
 // on disk is valid or not, until we've downloaded the hashes to validate them.
 
-// Idea for future space optimization:
-// while downloading, we need to store interior nodes of this tree. However, we
-// don't need to store the padding. a SHA-256 is 32 bytes. Instead of storing
-// the full (padded) tree of SHA-256 hashes, store the full tree of 32 bit
-// signed integers, being indices into the actual storage for the tree. We could
-// even grow the storage lazily. Instead of storing the padding hashes, use
-// negative indices to refer to fixed SHA-256(0), and SHA-256(SHA-256(0)) and so
-// on
-struct TORRENT_EXTRA_EXPORT merkle_tree
+// In full_tree mode, m_tree uses a compact, per-layer layout: only the
+// *live* (non-padding) nodes of each layer are stored, packed in order:
+// layer 0 (the root), then layer 1, ..., then the leaf layer.
+// m_layer_offsets[L] is the start of layer L in m_tree;
+// m_layer_offsets.back() is the total compact size. Padding nodes are not
+// stored: get() returns the implied pad hash from the merkle_pad cache, and
+// set() rejects writes of non-pad values to padding slots (the security
+// gate that turns a malicious uncle hash at a padding sibling into a
+// proof-validation failure).
+struct TORRENT_EXTRA_EXPORT merkle_tree : private single_threaded
 {
 	// TODO: remove this constructor. Don't support "uninitialized" trees. This
 	// also requires not constructing these for pad-files and small files as
@@ -67,6 +70,18 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 
 	sha256_hash root() const;
 
+	// Hash a pair of child hashes using the per-tree scratch SHA-256
+	// context. Reuses the underlying context rather than allocating a new
+	// one each call -- the EVP_MD_CTX allocations add up in tight pair-
+	// hashing loops. Asserted single-threaded; the merkle_tree is owned by
+	// (and only ever touched from) the network thread.
+	sha256_hash hash_pair(sha256_hash const& left, sha256_hash const& right) const
+	{
+		TORRENT_ASSERT(is_single_thread());
+		m_scratch_hasher.reset();
+		return m_scratch_hasher.update(left).update(right).final();
+	}
+
 	void load_tree(span<sha256_hash const> t, bitfield const& verified);
 	void load_sparse_tree(span<sha256_hash const> t, bitfield const& mask
 		, bitfield const& verified);
@@ -75,11 +90,39 @@ struct TORRENT_EXTRA_EXPORT merkle_tree
 	std::size_t size() const;
 	int end_index() const { return int(size()); }
 
-	bool has_node(int idx) const;
+	// Coordinate addressing for nodes in the tree. `level` 0 is the root,
+	// `level == num_layers()` is the leaf (block) layer. `offset` is the
+	// position within the layer, [0, layer_size_live(level)) for live
+	// positions and [layer_size_live(level), 1 << level) for padding.
+	int num_layers() const;
+	int layer_size_live(int level) const;
+	bool is_padding(int level, int offset) const;
 
-	bool compare_node(int idx, sha256_hash const& h) const;
+	// Physical index into `m_tree` for the node at (level, offset). In
+	// `full_tree` mode the underlying storage is the standard layout for
+	// now; phase 5 swaps it for a compact, per-layer layout indexed by
+	// `m_layer_offsets`.
+	int phys(int level, int offset) const;
 
-	sha256_hash operator[](int idx) const;
+	// Read or write the node at (level, offset). `set` returns false if
+	// the write is rejected (only relevant after the compact layout is
+	// in place: writing a non-pad hash into a padding slot fails).
+	sha256_hash get(int level, int offset) const;
+	bool set(int level, int offset, sha256_hash const& h);
+
+	bool has_node(int level, int offset) const;
+	bool compare_node(int level, int offset, sha256_hash const& h) const;
+
+	// Lazy-compute lookup for a (level, offset) node. Works in any mode,
+	// computing interior nodes from a stored layer if needed.
+	sha256_hash node_at(int level, int offset) const;
+
+	// Transition into full_tree mode by allocating storage for all nodes
+	// (compact in phase 5; standard layout currently). Idempotent on
+	// full_tree; rejects block_layer (we'd lose verified block hashes).
+	// Exposed so the merkle.cpp helpers and tests can address (L, O)
+	// directly via get/set after construction.
+	void allocate_compact();
 
 	std::vector<sha256_hash> build_vector() const;
 	std::pair<std::vector<sha256_hash>, bitfield> build_sparse_vector() const;
@@ -128,7 +171,7 @@ private:
 	// set to an empty tree
 	void clear();
 
-	sha256_hash get_impl(int idx, std::vector<sha256_hash>& scratch_space) const;
+	sha256_hash get_impl(int level, int offset, std::vector<sha256_hash>& scratch_space) const;
 
 	int blocks_per_piece() const { return 1 << m_blocks_per_piece_log; }
 	// the number tree levels per piece. This is 0 if the block layer is also
@@ -142,7 +185,6 @@ private:
 
 	void optimize_storage();
 	void optimize_storage_piece_layer();
-	void allocate_full();
 
 	// a pointer to the root hash for this file.
 	char const* m_root = nullptr;
@@ -152,11 +194,22 @@ private:
 	// TODO: make this a std::unique_ptr<sha256_hash[]>
 	aux::vector<sha256_hash> m_tree;
 
+	// physical start of each layer in `m_tree` when in `full_tree` mode.
+	// size = num_layers + 2; the last entry holds the total physical size.
+	// depends only on `m_num_blocks`; filled once in the constructor.
+	aux::vector<std::int32_t> m_layer_offsets;
+
 	// when the full tree is allocated, this has one bit for each block hash. a
 	// 1 means we have verified the block hash to be correct, otherwise the block
 	// hash may represent what's on disk, but we haven't been able to verify it
 	// yet
 	bitfield m_block_verified;
+
+	// scratch SHA-256 context reused by hash_pair() for the per-tree
+	// pair-hashing in build_vector, the merkle.cpp tree-walking helpers,
+	// etc. mutable so const methods (build_vector, ...) can reset/update
+	// it without giving up their const signature.
+	mutable hasher256 m_scratch_hasher;
 
 	// number of blocks in the file this tree represents. The number of leafs in
 	// the tree is rounded up to an even power of 2.

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -92,9 +92,8 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 			m_piece_hash_requested[f].resize((m_files.file_num_pieces(f) + 511) / 512);
 
-			int const piece_layer_idx = merkle_num_layers(
-				merkle_num_leafs(m_files.file_num_blocks(f))) - m_piece_layer;
-			int const piece_layer_start = merkle_layer_start(piece_layer_idx);
+			int const piece_layer_idx =
+				merkle_num_layers(merkle_num_leafs(m_files.file_num_blocks(f))) - m_piece_layer;
 
 			// check for hashes we already have and flag entries in m_piece_hash_requested
 			// so that we don't request them again
@@ -109,7 +108,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 					}
 					if ((m_files.piece_length() == default_block_size && !v.get_bit(j))
 						|| (m_files.piece_length() > default_block_size
-							&& !tree.has_node(piece_layer_start + j)))
+							&& !tree.has_node(piece_layer_idx, j)))
 						break;
 				}
 			}
@@ -379,7 +378,9 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 		file_index_t const f = m_files.file_index_at_piece(index);
 		if (m_files.file_size(f) <= m_files.piece_length()) return true;
 		piece_index_t const file_first_piece(int(m_files.file_offset(f) / m_files.piece_length()));
-		return m_merkle_trees[f].has_node(m_files.file_first_piece_node(f) + int(index - file_first_piece));
+		int const node = m_files.file_first_piece_node(f) + int(index - file_first_piece);
+		int const L = merkle_get_layer(node);
+		return m_merkle_trees[f].has_node(L, node - merkle_layer_start(L));
 	}
 
 	bool hash_picker::have_all(file_index_t const file) const
@@ -418,7 +419,8 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 		for (;;)
 		{
 			idx.node = merkle_get_parent(idx.node);
-			if (tree.has_node(idx.node)) break;
+			int const L = merkle_get_layer(idx.node);
+			if (tree.has_node(L, idx.node - merkle_layer_start(L))) break;
 			layers++;
 			if (layers == file_internal_layers) return layers;
 		}

--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -12,6 +12,7 @@ see LICENSE file.
 #include "libtorrent/aux_/merkle.hpp"
 #include "libtorrent/aux_/array.hpp"
 #include "libtorrent/aux_/ffs.hpp" // for log2p1
+#include "libtorrent/aux_/merkle_tree.hpp"
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/aux_/vector.hpp"
 #include "libtorrent/bitfield.hpp"
@@ -113,12 +114,13 @@ namespace libtorrent {
 		TORRENT_ASSERT(num_leafs >= 1);
 
 		int level_size = num_leafs;
+		hasher256 h;
 		while (level_size > 1)
 		{
 			int parent = merkle_get_parent(level_start);
 			for (int i = level_start; i < level_start + level_size; i += 2, ++parent)
 			{
-				hasher256 h;
+				h.reset();
 				h.update(tree[i]);
 				h.update(tree[i + 1]);
 				tree[parent] = h.final();
@@ -129,77 +131,87 @@ namespace libtorrent {
 		TORRENT_ASSERT(level_size == 1);
 	}
 
-	void merkle_fill_partial_tree(span<sha256_hash> tree)
+	void merkle_fill_tree(aux::merkle_tree& tree, int L, int O, int level_size)
 	{
-		int const num_nodes = aux::numeric_cast<int>(tree.size());
-		// the tree size must be one less than a power of two
-		TORRENT_ASSERT(((num_nodes+1) & num_nodes) == 0);
+		TORRENT_ASSERT(L >= 0);
+		TORRENT_ASSERT(L <= tree.num_layers());
+		TORRENT_ASSERT(O >= 0);
+		TORRENT_ASSERT(level_size >= 1);
+
+		while (level_size > 1)
+		{
+			for (int i = 0; i < level_size; i += 2)
+			{
+				tree.set(
+					L - 1, (O + i) / 2, tree.hash_pair(tree.get(L, O + i), tree.get(L, O + i + 1)));
+			}
+			--L;
+			O >>= 1;
+			level_size /= 2;
+		}
+		TORRENT_ASSERT(level_size == 1);
+	}
+
+	void merkle_fill_partial_tree(aux::merkle_tree& tree)
+	{
+		int const N = tree.num_layers();
 
 		// we do two passes over the tree, first to compute all the missing
 		// "interior" hashes. Then to clear all the ones that don't have a
 		// parent (i.e. "orphan" hashes). We clear them since we can't validate
 		// them against the root, which mean they may be incorrect.
-		int const num_leafs = (num_nodes + 1) / 2;
-		int level_size = num_leafs;
-		int level_start = merkle_first_leaf(num_leafs);
-		while (level_size > 1)
+		for (int L = N; L > 0; --L)
 		{
-			level_start = merkle_get_parent(level_start);
-			level_size /= 2;
-
-			for (int i = level_start; i < level_start + level_size; ++i)
+			int const layer_size = 1 << L;
+			for (int O = 0; O < layer_size; O += 2)
 			{
-				int const child = merkle_get_first_child(i);
-				bool const zeros_left = tree[child].is_all_zeros();
-				bool const zeros_right = tree[child + 1].is_all_zeros();
-				if (zeros_left || zeros_right) continue;
-				hasher256 h;
-				h.update(tree[child]);
-				h.update(tree[child + 1]);
-				tree[i] = h.final();
+				sha256_hash const left = tree.get(L, O);
+				sha256_hash const right = tree.get(L, O + 1);
+				if (left.is_all_zeros() || right.is_all_zeros()) continue;
+				tree.set(L - 1, O / 2, tree.hash_pair(left, right));
 			}
 		}
-		TORRENT_ASSERT(level_size == 1);
 
-		int parent = 0;
-		for (int i = 1; i < int(tree.size()); i += 2, parent += 1)
+		for (int L = 1; L <= N; ++L)
 		{
-			if (tree[parent].is_all_zeros())
+			int const layer_size = 1 << L;
+			for (int O = 0; O < layer_size; O += 2)
 			{
-				// if the parent is all zeros, the validation chain up to the
-				// root is broken, and this cannot be validated
-				tree[i].clear();
-				tree[i + 1].clear();
-			}
-			else if (tree[i + 1].is_all_zeros())
-			{
-				// if the sibling is all zeros, this hash cannot be validated
-				tree[i].clear();
-			}
-			else if (tree[i].is_all_zeros())
-			{
-				// if this hash is all zeros, the sibling hash cannot be validated
-				tree[i + 1].clear();
+				if (tree.get(L - 1, O / 2).is_all_zeros())
+				{
+					// if the parent is all zeros, the validation chain up to
+					// the root is broken, and these cannot be validated
+					tree.set(L, O, sha256_hash{});
+					tree.set(L, O + 1, sha256_hash{});
+				}
+				else if (tree.get(L, O + 1).is_all_zeros())
+				{
+					// if the sibling is all zeros, this hash cannot be validated
+					tree.set(L, O, sha256_hash{});
+				}
+				else if (tree.get(L, O).is_all_zeros())
+				{
+					// if this hash is all zeros, the sibling hash cannot be validated
+					tree.set(L, O + 1, sha256_hash{});
+				}
 			}
 		}
 	}
 
-	void merkle_clear_tree(span<sha256_hash> tree, int const num_leafs, int level_start)
+	void merkle_clear_tree(aux::merkle_tree& tree, int L, int O, int level_size)
 	{
-		TORRENT_ASSERT(num_leafs >= 1);
-		TORRENT_ASSERT(level_start >= 0);
-		TORRENT_ASSERT(level_start < tree.size());
-		TORRENT_ASSERT(level_start + num_leafs <= tree.size());
-		// the range of nodes must be within a single level
-		TORRENT_ASSERT(merkle_get_layer(level_start) == merkle_get_layer(level_start + num_leafs - 1));
+		TORRENT_ASSERT(L >= 0);
+		TORRENT_ASSERT(L <= tree.num_layers());
+		TORRENT_ASSERT(O >= 0);
+		TORRENT_ASSERT(level_size >= 1);
 
-		int level_size = num_leafs;
 		for (;;)
 		{
-			for (int i = level_start; i < level_start + level_size; ++i)
-				tree[i].clear();
+			for (int i = 0; i < level_size; ++i)
+				tree.set(L, O + i, sha256_hash{});
 			if (level_size == 1) break;
-			level_start = merkle_get_parent(level_start);
+			--L;
+			O >>= 1;
 			level_size /= 2;
 		}
 		TORRENT_ASSERT(level_size == 1);
@@ -227,29 +239,32 @@ namespace libtorrent {
 
 		if (num_leafs == 1) return leaves[0];
 
+		// reuse a single hasher rather than constructing and destructing
+		// one per pair-hash; the underlying SHA-256 context allocation
+		// (e.g. EVP_MD_CTX*) is non-trivial. reset() puts the hasher back
+		// into a just-default-constructed state after each final().
+		hasher256 h;
 		while (num_leafs > 1)
 		{
 			int i = 0;
 			for (; i < int(leaves.size()) / 2; ++i)
 			{
-				scratch_space[std::size_t(i)] = hasher256()
-					.update(leaves[i * 2])
-					.update(leaves[i * 2 + 1])
-					.final();
+				h.reset();
+				scratch_space[std::size_t(i)] =
+					h.update(leaves[i * 2]).update(leaves[i * 2 + 1]).final();
 			}
 			if (leaves.size() & 1)
 			{
 				// if we have an odd number of leaves, compute the boundary hash
 				// here, that spans both a payload-hash and a pad hash
-				scratch_space[std::size_t(i)] = hasher256()
-					.update(leaves[i * 2])
-					.update(pad)
-					.final();
+				h.reset();
+				scratch_space[std::size_t(i)] = h.update(leaves[i * 2]).update(pad).final();
 				++i;
 			}
 			// we don't have to copy any pad hashes into memory, they are implied
 			// just keep track of the current layer's pad hash
-			pad = hasher256().update(pad).update(pad).final();
+			h.reset();
+			pad = h.update(pad).update(pad).final();
 
 			// step one level up
 			leaves = span<sha256_hash const>(scratch_space.data(), i);
@@ -301,87 +316,61 @@ namespace libtorrent {
 		return table[d];
 	}
 
-	bool merkle_validate_and_insert_proofs(span<sha256_hash> target_tree
-		, int const target_node_idx, sha256_hash const& node, span<sha256_hash const> uncle_hashes)
+	bool merkle_validate_and_insert_proofs(aux::merkle_tree& target_tree,
+		int const target_L,
+		int const target_O,
+		sha256_hash const& node,
+		span<sha256_hash const> uncle_hashes)
 	{
-		if (target_tree[target_node_idx] == node)
-			return true;
+		if (target_tree.get(target_L, target_O) == node) return true;
 
-		if (!target_tree[target_node_idx].is_all_zeros())
-			return false;
+		if (!target_tree.get(target_L, target_O).is_all_zeros()) return false;
 
-		if (uncle_hashes.empty())
-			return false;
+		if (uncle_hashes.empty()) return false;
 
-		int cursor = target_node_idx;
-		target_tree[cursor] = node;
-
-		// One bit per iteration: did we write into that iteration's
-		// sibling slot, or was the slot already populated with the
-		// matching proof value? The cleanup skips clearing slots we
-		// didn't write so a pre-existing leaf hash (e.g. one
-		// merkle_tree::set_block stored speculatively) survives a
-		// failed proof. The walk length is bounded by the tree depth,
-		// which is well under 32 for any tree this library can build.
-		std::uint32_t wrote_sibling = 0;
-		int iter = 0;
-
+		int cursor_L = target_L;
+		int cursor_O = target_O;
+		if (!target_tree.set(cursor_L, cursor_O, node)) return false;
 		for (auto const& proof : uncle_hashes)
 		{
-			TORRENT_ASSERT(iter < 32);
-			int const proof_idx = merkle_get_sibling(cursor);
-			int const parent = merkle_get_parent(cursor);
-
-			if (target_tree[proof_idx].is_all_zeros())
-			{
-				target_tree[proof_idx] = proof;
-				wrote_sibling |= std::uint32_t(1) << iter;
-			}
-			else if (target_tree[proof_idx] != proof)
-			{
-				// pre-existing sibling contradicts the proof, fail
-				break;
-			}
-			// else: sibling already holds the proof value; leave it
-			// in place and walk on
-
-			int const left = std::min(proof_idx, cursor);
-			auto const hash = hasher256().update(target_tree[left]).update(target_tree[left + 1]).final();
-			// success: the computed pair-hash matches a known parent,
-			// anchoring the chain from `node` up to a trusted node in
-			// the tree
-			if (target_tree[parent] == hash) return true;
-			if (!target_tree[parent].is_all_zeros())
-			{
-				// mismatched known parent. undo this iteration's
-				// sibling write so the cleanup below has a uniform
-				// shape
-				if (wrote_sibling & (std::uint32_t(1) << iter))
-				{
-					target_tree[proof_idx].clear();
-					wrote_sibling &= ~(std::uint32_t(1) << iter);
-				}
-				break;
-			}
-			cursor = parent;
-			target_tree[cursor] = hash;
-			++iter;
+			int const sibling_O = cursor_O ^ 1;
+			// the sibling is either uninitialized (zero) or, in compact
+			// storage, a padding slot whose implied value is the layer's
+			// pad hash. set() rejects a non-pad write into a padding slot,
+			// which is how a malicious proof aimed at a padding sibling is
+			// caught.
+			TORRENT_ASSERT(target_tree.get(cursor_L, sibling_O).is_all_zeros()
+				|| target_tree.is_padding(cursor_L, sibling_O));
+			if (!target_tree.set(cursor_L, sibling_O, proof)) break;
+			int const left_O = cursor_O & ~1;
+			sha256_hash const hash = target_tree.hash_pair(
+				target_tree.get(cursor_L, left_O), target_tree.get(cursor_L, left_O + 1));
+			--cursor_L;
+			cursor_O >>= 1;
+			if (target_tree.get(cursor_L, cursor_O) == hash) return true;
+			if (!target_tree.get(cursor_L, cursor_O).is_all_zeros()) break;
+			if (!target_tree.set(cursor_L, cursor_O, hash)) break;
 		}
 
 		// we get here if we never reached a known hash in the tree, i.e. the
 		// uncle_hashes failed to prove the specified node hash.
-		// we now need to clear up the hashes we inserted while walking up.
-		int clear_cursor = target_node_idx;
-		int undo_iter = 0;
-		while (clear_cursor > cursor)
+		// we now need to clear up all the hashes we've inserted into the tree.
+		// Always clear the target (we wrote it before the loop). Then walk
+		// upward clearing each (sibling, parent) pair we wrote, stopping
+		// before `cursor` (whose slot we did not write -- either it has a
+		// pre-existing non-matching value, or set() rejected it as a
+		// padding mismatch).
+		int clear_L = target_L;
+		int clear_O = target_O;
+		target_tree.set(clear_L, clear_O, sha256_hash{});
+		while (clear_L > cursor_L)
 		{
-			int const proof_idx = merkle_get_sibling(clear_cursor);
-			target_tree[clear_cursor].clear();
-			if (wrote_sibling & (std::uint32_t(1) << undo_iter)) target_tree[proof_idx].clear();
-			clear_cursor = merkle_get_parent(clear_cursor);
-			++undo_iter;
+			target_tree.set(clear_L, clear_O ^ 1, sha256_hash{});
+			--clear_L;
+			clear_O >>= 1;
+			if (clear_L > cursor_L) target_tree.set(clear_L, clear_O, sha256_hash{});
 		}
-		target_tree[cursor].clear();
+		target_tree.set(cursor_L, cursor_O, sha256_hash{});
 		return false;
 	}
 
@@ -394,34 +383,44 @@ namespace libtorrent {
 		return (h.final() == parent);
 	}
 
-	void merkle_validate_copy(span<sha256_hash const> const src
-		, span<sha256_hash> const dst, sha256_hash const& root
-		, bitfield& verified_leafs)
+	void merkle_validate_copy(span<sha256_hash const> const src,
+		aux::merkle_tree& dst,
+		sha256_hash const& expected_root,
+		bitfield& verified_leafs)
 	{
-		TORRENT_ASSERT(src.size() == dst.size());
-		int const num_leafs = int((dst.size() + 1) / 2);
 		if (src.empty()) return;
-		if (src[0] != root) return;
-		dst[0] = src[0];
-		int const leaf_layer_start = int(src.size() - num_leafs);
-		for (int i = 0; i < leaf_layer_start; ++i)
+		if (src[0] != expected_root) return;
+		int const N = dst.num_layers();
+		int const num_leafs = 1 << N;
+		TORRENT_ASSERT(int(src.size()) == 2 * num_leafs - 1);
+
+		dst.set(0, 0, src[0]);
+		for (int L = 0; L < N; ++L)
 		{
-			if (dst[i].is_all_zeros()) continue;
-			int const left_child = merkle_get_first_child(i);
-			int const right_child = left_child + 1;
-			if (merkle_validate_node(src[left_child], src[right_child], dst[i]))
+			int const layer_size = 1 << L;
+			int const layer_flat = (1 << L) - 1;
+			for (int O = 0; O < layer_size; ++O)
 			{
-				dst[left_child] = src[left_child];
-				dst[right_child] = src[right_child];
-				int const block_idx = left_child - leaf_layer_start;
-				if (left_child >= leaf_layer_start
-					&& block_idx < verified_leafs.size())
+				if (dst.get(L, O).is_all_zeros()) continue;
+				int const left_flat = 2 * (layer_flat + O) + 1;
+				int const right_flat = left_flat + 1;
+				// inlined merkle_validate_node so we reuse dst's scratch hasher
+				if (dst.hash_pair(src[left_flat], src[right_flat]) != dst.get(L, O)) continue;
+
+				dst.set(L + 1, 2 * O, src[left_flat]);
+				dst.set(L + 1, 2 * O + 1, src[right_flat]);
+
+				if (L + 1 == N)
 				{
-					verified_leafs.set_bit(block_idx);
-					// the right child may be the first block of padding hash,
-					// in which case it's not part of the verified bitfield
-					if (block_idx + 1 < verified_leafs.size())
-						verified_leafs.set_bit(block_idx + 1);
+					int const block_idx = 2 * O;
+					if (block_idx < verified_leafs.size())
+					{
+						verified_leafs.set_bit(block_idx);
+						// the right child may be the first block of padding hash,
+						// in which case it's not part of the verified bitfield
+						if (block_idx + 1 < verified_leafs.size())
+							verified_leafs.set_bit(block_idx + 1);
+					}
 				}
 			}
 		}
@@ -437,48 +436,54 @@ namespace libtorrent {
 		int idx = merkle_first_leaf(num_leafs);
 		TORRENT_ASSERT(idx >= 1);
 
+		// inlined merkle_validate_node so the SHA-256 context is reused
+		// across all pair checks in this layer.
+		hasher256 h;
 		while (idx < end)
 		{
-			if (!merkle_validate_node(tree[idx], tree[idx + 1], tree[merkle_get_parent(idx)]))
+			h.reset();
+			if (h.update(tree[idx]).update(tree[idx + 1]).final() != tree[merkle_get_parent(idx)])
 				return false;
 			idx += 2;
 		}
 		return true;
 	}
 
-	std::tuple<int, int, int> merkle_find_known_subtree(span<sha256_hash const> const tree
-		, int const block_index, int const num_valid_leafs)
+	std::tuple<int, int, int, int> merkle_find_known_subtree(
+		aux::merkle_tree const& tree, int const block_index, int const num_valid_leafs)
 	{
 		// find the largest block of leafs from a single subtree we know the hashes of
+		int const N = tree.num_layers();
 		int leafs_start = block_index;
 		int leafs_size = 1;
-		int const first_leaf = int(tree.size() / 2);
-		int root_index = merkle_get_sibling(first_leaf + block_index);
+		int root_L = N;
+		int root_O = block_index ^ 1;
 		for (int i = block_index;; i >>= 1)
 		{
-			int const first_check_index = leafs_start + ((i & 1) ? -leafs_size : leafs_size);
-			for (int j = 0; j < std::min(leafs_size, num_valid_leafs - first_check_index); ++j)
+			int const first_check = leafs_start + ((i & 1) ? -leafs_size : leafs_size);
+			for (int j = 0; j < std::min(leafs_size, num_valid_leafs - first_check); ++j)
 			{
-				if (tree[first_leaf + first_check_index + j].is_all_zeros())
-					return std::make_tuple(leafs_start, leafs_size, root_index);
+				if (tree.get(N, first_check + j).is_all_zeros())
+					return std::make_tuple(leafs_start, leafs_size, root_L, root_O);
 			}
 			if (i & 1) leafs_start -= leafs_size;
 			leafs_size *= 2;
-			root_index = merkle_get_parent(root_index);
+			--root_L;
+			root_O >>= 1;
 			// if an inner node is known then its parent must be known too
 			// so if the root is known the next sibling subtree should already
 			// be computed if all of its leafs have valid hashes
-			if (!tree[root_index].is_all_zeros()) break;
-			TORRENT_ASSERT(root_index != 0);
+			if (!tree.get(root_L, root_O).is_all_zeros()) break;
+			TORRENT_ASSERT(root_L > 0);
 			TORRENT_ASSERT(leafs_start >= 0);
-			TORRENT_ASSERT(leafs_size <= merkle_num_leafs(num_valid_leafs));
+			TORRENT_ASSERT(leafs_size <= 1 << N);
 		}
 
 		TORRENT_ASSERT(leafs_start >= 0);
-		TORRENT_ASSERT(leafs_start < merkle_num_leafs(num_valid_leafs));
+		TORRENT_ASSERT(leafs_start < 1 << N);
 		TORRENT_ASSERT(leafs_start + leafs_size > block_index);
 
-		return std::make_tuple(leafs_start, leafs_size, root_index);
+		return std::make_tuple(leafs_start, leafs_size, root_L, root_O);
 	}
 }
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -31,6 +31,23 @@ namespace aux {
 		TORRENT_ASSERT(((blocks_per_piece - 1) & blocks_per_piece) == 0);
 		TORRENT_ASSERT(m_root != nullptr);
 		TORRENT_ASSERT(this->blocks_per_piece() == blocks_per_piece);
+
+		// fill the per-layer offsets table for the compact layout. layer L
+		// stores only its live (non-padding) nodes in m_tree, packed:
+		// m_layer_offsets[L] is the start of layer L; the last entry holds
+		// the total compact size. Depends only on m_num_blocks.
+		if (m_num_blocks > 0)
+		{
+			int const n_layers = merkle_num_layers(merkle_num_leafs(m_num_blocks));
+			m_layer_offsets.resize(n_layers + 2);
+			m_layer_offsets[0] = 0;
+			for (int L = 0; L <= n_layers; ++L)
+			{
+				int const shift = n_layers - L;
+				int const live = (m_num_blocks + (1 << shift) - 1) >> shift;
+				m_layer_offsets[L + 1] = m_layer_offsets[L] + live;
+			}
+		}
 	}
 
 	sha256_hash merkle_tree::root() const { return sha256_hash(m_root); }
@@ -41,12 +58,10 @@ namespace aux {
 
 		// The verified bitfield may be invalid. If so, correct it to
 		// maintain the invariant of this class
-		int block_index = block_layer_start();
+		int const leaf_L = num_layers();
 		for (int i = 0; i < std::min(int(verified.size()), m_num_blocks); ++i)
 		{
-			if (verified.get_bit(i) && has_node(block_index))
-				m_block_verified.set_bit(i);
-			++block_index;
+			if (verified.get_bit(i) && has_node(leaf_L, i)) m_block_verified.set_bit(i);
 		}
 	}
 
@@ -57,17 +72,23 @@ namespace aux {
 		if (root() != t[0]) return;
 		if (size() != static_cast<std::size_t>(t.size())) return;
 
+		// Input validates; install it regardless of our current mode by
+		// resetting to empty_tree first. This lets callers invoke
+		// load_tree() repeatedly without having to know whether a prior
+		// load or set_block has already collapsed us into block_layer
+		// (which would otherwise assert inside allocate_compact).
+		clear();
+
 		if (t.size() == 1)
 		{
 			// don't fully allocate a tree of 1 node. It's just the root and we
 			// have a special case representation for this
-			optimize_storage();
 			return;
 		}
 
-		allocate_full();
+		allocate_compact();
 
-		merkle_validate_copy(t, m_tree, root(), m_block_verified);
+		merkle_validate_copy(t, *this, root(), m_block_verified);
 
 		load_verified_bits(verified);
 
@@ -109,6 +130,13 @@ namespace {
 
 		TORRENT_ASSERT(first_block < int(size()));
 		TORRENT_ASSERT(end_block <= int(size()));
+
+		// Reset to empty_tree so the load is well-defined regardless of our
+		// current mode. The fast paths below would overwrite m_tree anyway,
+		// but the general-case path runs allocate_compact, which asserts
+		// against m_mode == block_layer; clearing here lets a caller
+		// re-load over any prior state.
+		clear();
 
 		// if the mask covers all blocks, go straight to block_layer
 		// mode, and validate
@@ -169,20 +197,20 @@ namespace {
 		if (t.empty() || std::none_of(mask.begin(), mask.begin() + mask_size, identity()))
 			return clear();
 
-		allocate_full();
+		allocate_compact();
 		int cursor = 0;
 		for (int i = 0, end = mask_size; i < end; ++i)
 		{
 			if (!mask[i]) continue;
 			if (cursor >= t.size()) break;
-			m_tree[int(i)] = t[cursor++];
+			int const L = merkle_get_layer(int(i));
+			set(L, int(i) - merkle_layer_start(L), t[cursor++]);
 		}
-		merkle_fill_partial_tree(m_tree);
+		merkle_fill_partial_tree(*this);
 
 		// this suggests that none of the hashes in the tree can be
 		// validated against the root. We effectively have an empty tree.
-		if (m_tree[0] != root())
-			return clear();
+		if (get(0, 0) != root()) return clear();
 
 		load_verified_bits(verified);
 
@@ -197,10 +225,13 @@ namespace {
 		{
 			case mode_t::uninitialized_tree: break;
 			case mode_t::empty_tree: break;
-			case mode_t::full_tree:
-				ret.assign(m_tree.begin() + piece_layer_start()
-					, m_tree.begin() + piece_layer_start() + num_pieces());
+			case mode_t::full_tree: {
+				int const piece_L = num_layers() - piece_levels();
+				int const piece_start = m_layer_offsets[piece_L];
+				ret.assign(
+					m_tree.begin() + piece_start, m_tree.begin() + piece_start + num_pieces());
 				break;
+			}
 			case mode_t::piece_layer:
 			{
 				ret = m_tree;
@@ -302,7 +333,7 @@ namespace {
 			return ret;
 		}
 
-		allocate_full();
+		allocate_compact();
 
 		// TODO: this can be optimized by using m_tree as storage to fill this
 		// tree into, and then clear it if the hashes fail
@@ -329,24 +360,28 @@ namespace {
 
 		int const base_num_layers = merkle_num_layers(leaf_count);
 
-		// this is the index of the node where we'll insert the root of the
+		// (level, offset) of the node where we'll insert the root of the
 		// subtree (tree). It's also the hash the uncle_hashes are here to prove
 		// is valid.
-		int const insert_root_idx = dest_start_idx >> base_num_layers;
+		int const insert_root_flat = dest_start_idx >> base_num_layers;
+		int const insert_root_L = merkle_get_layer(insert_root_flat);
+		int const insert_root_O = insert_root_flat - merkle_layer_start(insert_root_L);
 
 		// start with validating the proofs, and inserting them as we go.
-		if (!merkle_validate_and_insert_proofs(m_tree, insert_root_idx, tree[0], uncle_hashes))
+		if (!merkle_validate_and_insert_proofs(
+				*this, insert_root_L, insert_root_O, tree[0], uncle_hashes))
 			return {};
 
 		// first fill in the subtree of known hashes from the base layer
-		auto const num_leafs = merkle_num_leafs(m_num_blocks);
-		auto const first_leaf = merkle_first_leaf(num_leafs);
 
 		// this is the start of the leaf layer of "tree". We'll use this
 		// variable to step upwards towards the root
 		int source_cursor = int(tree.size()) - leaf_count;
-		// the running index in the loop
-		int dest_cursor = dest_start_idx;
+
+		// (level, offset) of the insertion cursor in m_tree. The walk
+		// steps up one layer per outer iteration.
+		int dest_L = merkle_get_layer(dest_start_idx);
+		int dest_O_base = dest_start_idx - merkle_layer_start(dest_L);
 
 		// the number of tree levels in a piece hash. 0 means the block layer is
 		// the same as the piece layer
@@ -358,18 +393,18 @@ namespace {
 		{
 			for (int i = 0; i < layer_size; ++i)
 			{
-				int const dst_idx = dest_cursor + i;
+				int const dst_O = dest_O_base + i;
 				int const src_idx = source_cursor + i;
-				if (has_node(dst_idx))
+				if (has_node(dest_L, dst_O))
 				{
-					if (m_tree[dst_idx] != tree[src_idx])
+					if (get(dest_L, dst_O) != tree[src_idx])
 					{
 						// this must be a block hash because inner nodes are not filled in until
 						// they can be verified. This assert ensures we're at the
 						// leaf layer of the file tree
-						TORRENT_ASSERT(dst_idx >= first_leaf);
+						TORRENT_ASSERT(dest_L == num_layers());
 
-						int const pos = dst_idx - first_leaf;
+						int const pos = dst_O;
 						auto const piece = piece_index_t{pos >> m_blocks_per_piece_log} + file_piece_offset;
 						int const block = pos & ((1 << m_blocks_per_piece_log) - 1);
 
@@ -382,27 +417,28 @@ namespace {
 						// now that this hash has been reported as failing, we
 						// can clear it. This will prevent it from being
 						// reported as failing again.
-						m_tree[dst_idx].clear();
+						set(dest_L, dst_O, sha256_hash{});
 					}
-					else if (dst_idx >= first_leaf)
+					else if (dest_L == num_layers())
 					{
 						// this covers the case where pieces are a single block.
 						// The common case is covered below
-						auto const piece = piece_index_t{(dst_idx - first_leaf) >> m_blocks_per_piece_log} + file_piece_offset;
+						auto const piece =
+							piece_index_t{dst_O >> m_blocks_per_piece_log} + file_piece_offset;
 
 						if (ret.passed.empty() || ret.passed.back() != piece)
 							ret.passed.push_back(piece);
 					}
 				}
 
-				if (dst_idx >= first_leaf && dst_idx - first_leaf < m_num_blocks)
-					m_block_verified.set_bit(dst_idx - first_leaf);
+				if (dest_L == num_layers() && dst_O < m_num_blocks) m_block_verified.set_bit(dst_O);
 
-				m_tree[dst_idx] = tree[src_idx];
+				set(dest_L, dst_O, tree[src_idx]);
 			}
 			if (layer_size == 1) break;
-			dest_cursor = merkle_get_parent(dest_cursor);
 			source_cursor = merkle_get_parent(source_cursor);
+			dest_O_base /= 2;
+			--dest_L;
 		}
 
 		// if the piece layer and the block layer is the same, we have already
@@ -415,53 +451,61 @@ namespace {
 			&& dest_start_idx < first_piece_idx + num_pieces())
 		{
 			int const blocks_in_piece = 1 << base;
+			int const leaf_L = num_layers();
+			int const piece_L = leaf_L - base;
 
 			// it may now be possible to verify the hashes of previously received blocks
 			// try to verify as many child nodes of the received hashes as possible
 			for (int i = 0; i < int(hashes.size()); ++i)
 			{
 				int const piece = dest_start_idx + i;
-				if (piece - first_piece_idx >= num_pieces())
-					break;
+				int const piece_O = piece - first_piece_idx;
+				if (piece_O >= num_pieces()) break;
 				// the first block in this piece
 				int const block_idx = merkle_get_first_child(piece, base);
+				int const block_O = block_idx - block_layer_start();
 
-				int const block_end_idx = std::min(block_idx + blocks_in_piece, first_leaf + m_num_blocks);
-				if (std::any_of(m_tree.begin() + block_idx
-					, m_tree.begin() + block_end_idx
-					, [](sha256_hash const& h) { return h.is_all_zeros(); }))
-					continue;
+				int const block_O_end = std::min(block_O + blocks_in_piece, m_num_blocks);
+				bool any_zero = false;
+				for (int k = block_O; k < block_O_end; ++k)
+				{
+					if (get(leaf_L, k).is_all_zeros())
+					{
+						any_zero = true;
+						break;
+					}
+				}
+				if (any_zero) continue;
 
 				// TODO: instead of overwriting the root and comparing it
 				// against hashes[], write a functions that *validates* a tree
 				// by just filling it up to the level below the root and then
 				// validates it.
-				merkle_fill_tree(m_tree, blocks_in_piece, block_idx);
-				if (m_tree[piece] != hashes[i])
+				merkle_fill_tree(*this, leaf_L, block_O, blocks_in_piece);
+				if (get(piece_L, piece_O) != hashes[i])
 				{
-					merkle_clear_tree(m_tree, blocks_in_piece, block_idx);
+					merkle_clear_tree(*this, leaf_L, block_O, blocks_in_piece);
 					// write back the correct hash
-					m_tree[piece] = hashes[i];
+					set(piece_L, piece_O, hashes[i]);
 					TORRENT_ASSERT(blocks_in_piece == blocks_per_piece());
 
 					// an empty blocks vector indicates that we don't have the
 					// block hashes, and we can't know which block failed
 					// this will cause the block hashes to be requested
-					ret.failed.emplace_back(piece_index_t{piece - first_piece_idx} + file_piece_offset
-						, std::vector<int>());
+					ret.failed.emplace_back(
+						piece_index_t{piece_O} + file_piece_offset, std::vector<int>());
 				}
 				else
 				{
-					ret.passed.push_back(piece_index_t{piece - first_piece_idx} + file_piece_offset);
+					ret.passed.push_back(piece_index_t{piece_O} + file_piece_offset);
 					// record that these block hashes are correct!
-					int const leafs_start = block_idx - block_layer_start();
-					int const leafs_end = std::min(m_num_blocks, leafs_start + blocks_in_piece);
+					int const leafs_end = std::min(m_num_blocks, block_O + blocks_in_piece);
 					// TODO: this could be done more efficiently if bitfield had a function
 					// to set a range of bits
-					for (int k = leafs_start; k < leafs_end; ++k)
+					for (int k = block_O; k < leafs_end; ++k)
 						m_block_verified.set_bit(k);
 				}
-				TORRENT_ASSERT((piece - first_piece_idx) >= 0);
+				TORRENT_ASSERT(piece_O >= 0);
 			}
 		}
 
@@ -478,45 +522,42 @@ namespace {
 #endif
 		TORRENT_ASSERT(block_index < m_num_blocks);
 
-		auto const num_leafs = merkle_num_leafs(m_num_blocks);
-		auto const first_leaf = merkle_first_leaf(num_leafs);
-		auto const block_tree_index = first_leaf + block_index;
-
+		int const leaf_L = num_layers();
 		if (blocks_verified(block_index, 1))
 		{
 			// if this blocks's hash is already known, check the passed-in hash against it
-			if (compare_node(block_tree_index, h))
+			if (compare_node(leaf_L, block_index, h))
 				return std::make_tuple(set_block_result::ok, block_index, 1);
 			else
 				return std::make_tuple(set_block_result::block_hash_failed, block_index, 1);
 		}
 
-		allocate_full();
+		allocate_compact();
 
-		m_tree[block_tree_index] = h;
+		set(leaf_L, block_index, h);
 
 		// to avoid wasting a lot of time hashing nodes only to discover they
 		// cannot be verified, check first to see if the root of the largest
 		// computable subtree is known
 
-		auto const [leafs_start, leafs_size, root_index] =
-			merkle_find_known_subtree(m_tree, block_index, m_num_blocks);
+		auto const [leafs_start, leafs_size, root_L, root_O] =
+			merkle_find_known_subtree(*this, block_index, m_num_blocks);
 
 		// if the root node is unknown the hashes cannot be verified yet
-		if (m_tree[root_index].is_all_zeros())
+		if (get(root_L, root_O).is_all_zeros())
 			return std::make_tuple(set_block_result::unknown, leafs_start, leafs_size);
 
 		// save the root hash because merkle_fill_tree will overwrite it
-		sha256_hash const root = m_tree[root_index];
-		merkle_fill_tree(m_tree, leafs_size, first_leaf + leafs_start);
+		sha256_hash const root = get(root_L, root_O);
+		merkle_fill_tree(*this, leaf_L, leafs_start, leafs_size);
 
-		if (root != m_tree[root_index])
+		if (root != get(root_L, root_O))
 		{
 			// hash failure, clear all the internal nodes
 			// the whole piece failed the hash check. Clear all block hashes
 			// in this piece and report a hash failure
-			merkle_clear_tree(m_tree, leafs_size, first_leaf + leafs_start);
-			m_tree[root_index] = root;
+			merkle_clear_tree(*this, leaf_L, leafs_start, leafs_size);
+			set(root_L, root_O, root);
 			return std::make_tuple(set_block_result::hash_failed, leafs_start, leafs_size);
 		}
 
@@ -528,7 +569,7 @@ namespace {
 
 		// attempting to optimize storage is quite costly, only do it if we have
 		// a reason to believe it might have an effect
-		if (block_index == m_num_blocks - 1 || !m_tree[block_tree_index + 1].is_all_zeros())
+		if (block_index == m_num_blocks - 1 || !get(leaf_L, block_index + 1).is_all_zeros())
 			optimize_storage();
 
 		return std::make_tuple(set_block_result::ok, leafs_start, leafs_size);
@@ -565,72 +606,44 @@ namespace {
 		return merkle_num_leafs(m_num_blocks);
 	}
 
-	bool merkle_tree::has_node(int const idx) const
+	bool merkle_tree::has_node(int const L, int const O) const
 	{
-		TORRENT_ASSERT(idx >= 0);
-		TORRENT_ASSERT(idx < int(size()));
+		TORRENT_ASSERT(L >= 0);
+		TORRENT_ASSERT(L <= num_layers());
+		TORRENT_ASSERT(O >= 0);
+		TORRENT_ASSERT(O < (1 << L));
 		switch (m_mode)
 		{
 			case mode_t::uninitialized_tree:
 				TORRENT_ASSERT_FAIL();
 				return false;
-			case mode_t::empty_tree: return idx == 0;
-			case mode_t::full_tree: return !m_tree[idx].is_all_zeros();
-			case mode_t::piece_layer: return idx < merkle_get_first_child(piece_layer_start());
-			case mode_t::block_layer: return idx < block_layer_start() + m_num_blocks;
-		}
-		TORRENT_ASSERT_FAIL();
-		return false;
-	}
-
-	bool merkle_tree::compare_node(int const idx, sha256_hash const& h) const
-	{
-		switch (m_mode)
-		{
-			case mode_t::uninitialized_tree:
-				TORRENT_ASSERT_FAIL();
-				return h.is_all_zeros();
 			case mode_t::empty_tree:
-				return idx == 0 ? root() == h : h.is_all_zeros();
+				return L == 0 && O == 0;
 			case mode_t::full_tree:
-				return m_tree[idx] == h;
+				return !get(L, O).is_all_zeros();
 			case mode_t::piece_layer:
-			{
-				int const first = piece_layer_start();
-				int const piece_count = num_pieces();
-				int const pieces_end = first + piece_count;
-				int const piece_layer_size = merkle_num_leafs(piece_count);
-				int const end = first + piece_layer_size;
-				if (idx >= end)
-					return h.is_all_zeros();
-				if (idx >= pieces_end)
-					return h == merkle_pad(1 << m_blocks_per_piece_log, 1);
-				if (idx >= first)
-					return m_tree[idx - first] == h;
-				return (*this)[idx] == h;
-			}
+				return L <= num_layers() - piece_levels();
 			case mode_t::block_layer:
-			{
-				int const first = block_layer_start();
-				int const end = first + m_num_blocks;
-				if (idx >= end)
-					return h.is_all_zeros();
-				if (idx >= first)
-					return m_tree[idx - first] == h;
-				return (*this)[idx] == h;
-			}
+				return L < num_layers() || O < m_num_blocks;
 		}
 		TORRENT_ASSERT_FAIL();
 		return false;
 	}
 
-	sha256_hash merkle_tree::operator[](int const idx) const
+	bool merkle_tree::compare_node(int const L, int const O, sha256_hash const& h) const
 	{
 		std::vector<sha256_hash> scratch;
-		return get_impl(idx, scratch);
+		return get_impl(L, O, scratch) == h;
 	}
 
-	sha256_hash merkle_tree::get_impl(int idx, std::vector<sha256_hash>& scratch_space) const
+	sha256_hash merkle_tree::node_at(int const L, int const O) const
+	{
+		std::vector<sha256_hash> scratch;
+		return get_impl(L, O, scratch);
+	}
+
+	sha256_hash merkle_tree::get_impl(
+		int const L, int const O, std::vector<sha256_hash>& scratch_space) const
 	{
 		switch (m_mode)
 		{
@@ -638,29 +651,24 @@ namespace {
 				TORRENT_ASSERT_FAIL();
 				return sha256_hash{};
 			case mode_t::empty_tree:
-				return idx == 0 ? root() : sha256_hash{};
+				return (L == 0 && O == 0) ? root() : sha256_hash{};
 			case mode_t::full_tree:
-				return m_tree[idx];
+				return get(L, O);
 			case mode_t::piece_layer:
 			case mode_t::block_layer:
 			{
-				int const start = (m_mode == mode_t::piece_layer)
-					? piece_layer_start()
-					: block_layer_start();
+				int const stored_L =
+					(m_mode == mode_t::piece_layer) ? num_layers() - piece_levels() : num_layers();
 
-				if (m_mode == mode_t::piece_layer && idx >= merkle_get_first_child(start))
-					return {};
+				if (L > stored_L) return {};
 
-				int layer_size = 1;
-				while (idx < start)
+				int const depth = stored_L - L;
+				int const layer_size = 1 << depth;
+				int const start_O = O << depth;
+
+				if (start_O >= m_tree.end_index())
 				{
-					idx = merkle_get_first_child(idx);
-					layer_size *= 2;
-				}
-
-				idx -= start;
-				if (idx >= m_tree.end_index())
-				{
+					// the requested subtree is entirely in padding
 					return merkle_pad(
 						(m_mode == mode_t::piece_layer)
 						? layer_size << m_blocks_per_piece_log
@@ -670,8 +678,8 @@ namespace {
 				sha256_hash const pad_hash = (m_mode == mode_t::piece_layer)
 					? merkle_pad(1 << m_blocks_per_piece_log, 1)
 					: sha256_hash{};
-				auto const layer = span<sha256_hash const>(m_tree)
-					.subspan(idx, std::min(m_tree.end_index() - idx, layer_size));
+				auto const layer = span<sha256_hash const>(m_tree).subspan(
+					start_O, std::min(m_tree.end_index() - start_O, layer_size));
 
 				return merkle_root_scratch(layer, layer_size, pad_hash, scratch_space);
 			}
@@ -685,35 +693,56 @@ namespace {
 		INVARIANT_CHECK;
 		if (m_mode == mode_t::uninitialized_tree) return {};
 
-		std::vector<sha256_hash> ret(size());
+		// produces the compact representation of the tree (the layout we
+		// store in m_tree when in full_tree mode). For non-full modes,
+		// place the known layer's hashes and walk upward, filling interior
+		// nodes from the live entries plus the implied pad for missing
+		// siblings.
+		std::vector<sha256_hash> ret(std::size_t(m_layer_offsets.back()));
+		int const N = num_layers();
 
 		switch (m_mode)
 		{
-			case mode_t::uninitialized_tree: break;
-			case mode_t::empty_tree: break;
+			case mode_t::uninitialized_tree:
+			case mode_t::empty_tree:
+				break;
 			case mode_t::full_tree:
 				ret.assign(m_tree.begin(), m_tree.end());
 				break;
 			case mode_t::piece_layer:
-			{
-				int const piece_layer_size = merkle_num_leafs(num_pieces());
-				sha256_hash const pad_hash = merkle_pad(1 << m_blocks_per_piece_log, 1);
-				int const start = merkle_first_leaf(piece_layer_size);
-				TORRENT_ASSERT(m_tree.end_index() <= piece_layer_size);
-				std::copy(m_tree.begin(), m_tree.end(), ret.begin() + start);
-				std::fill(ret.begin() + start + m_tree.end_index(), ret.begin() + start + piece_layer_size, pad_hash);
-				merkle_fill_tree(span<sha256_hash>(ret).subspan(0, merkle_num_nodes(piece_layer_size))
-					, piece_layer_size);
-				break;
-			}
 			case mode_t::block_layer:
 			{
-				int const num_leafs = merkle_num_leafs(m_num_blocks);
-				sha256_hash const pad_hash{};
-				int const start = merkle_first_leaf(num_leafs);
-				std::copy(m_tree.begin(), m_tree.end(), ret.begin() + start);
-				std::fill(ret.begin() + start + m_tree.end_index(), ret.begin() + start + num_leafs, sha256_hash{});
-				merkle_fill_tree(ret, num_leafs);
+				// for small trees where the piece layer would be at or
+				// above the root (a single-piece torrent with a large
+				// piece size), treat the root as the piece layer
+				int const start_L =
+					m_mode == mode_t::piece_layer ? std::max(0, N - piece_levels()) : N;
+				int const layer_start = m_layer_offsets[start_L];
+				std::copy(m_tree.begin(), m_tree.end(), ret.begin() + layer_start);
+
+				sha256_hash pad = m_mode == mode_t::piece_layer
+					? merkle_pad(1 << m_blocks_per_piece_log, 1)
+					: sha256_hash{};
+				int level_L = start_L;
+				int live = layer_size_live(level_L);
+				while (level_L > 0)
+				{
+					int const parent_L = level_L - 1;
+					int const parent_live = layer_size_live(parent_L);
+					int const child_start = m_layer_offsets[level_L];
+					int const parent_start = m_layer_offsets[parent_L];
+					for (int O = 0; O < parent_live; ++O)
+					{
+						sha256_hash const left =
+							2 * O < live ? ret[std::size_t(child_start + 2 * O)] : pad;
+						sha256_hash const right =
+							2 * O + 1 < live ? ret[std::size_t(child_start + 2 * O + 1)] : pad;
+						ret[std::size_t(parent_start + O)] = hash_pair(left, right);
+					}
+					--level_L;
+					live = parent_live;
+					pad = hash_pair(pad, pad);
+				}
 				break;
 			}
 		}
@@ -732,10 +761,12 @@ namespace {
 			case mode_t::uninitialized_tree: break;
 			case mode_t::empty_tree: break;
 			case mode_t::full_tree:
-				for (int i = 0, end = m_tree.end_index(); i < end; ++i)
+				for (int i = 0, end = int(size()); i < end; ++i)
 				{
-					if (m_tree[i].is_all_zeros()) continue;
-					ret.push_back(m_tree[i]);
+					int const L = merkle_get_layer(i);
+					sha256_hash const h = get(L, i - merkle_layer_start(L));
+					if (h.is_all_zeros()) continue;
+					ret.push_back(h);
 					mask.set_bit(i);
 				}
 				break;
@@ -823,7 +854,7 @@ namespace {
 		return false;
 	}
 
-	void merkle_tree::allocate_full()
+	void merkle_tree::allocate_compact()
 	{
 		if (m_mode == mode_t::full_tree) return;
 
@@ -835,6 +866,52 @@ namespace {
 		m_tree = aux::vector<sha256_hash>(build_vector());
 		m_mode = mode_t::full_tree;
 		m_block_verified.resize(m_num_blocks, false);
+	}
+
+	int merkle_tree::num_layers() const { return int(m_layer_offsets.size()) - 2; }
+
+	int merkle_tree::layer_size_live(int const level) const
+	{
+		TORRENT_ASSERT(level >= 0);
+		TORRENT_ASSERT(level <= num_layers());
+		// at the leaf level the live count is m_num_blocks; each step up
+		// halves (rounded up) since pairs of leaves combine into a parent.
+		int const shift = num_layers() - level;
+		return (m_num_blocks + (1 << shift) - 1) >> shift;
+	}
+
+	bool merkle_tree::is_padding(int const level, int const offset) const
+	{
+		TORRENT_ASSERT(offset >= 0);
+		return offset >= layer_size_live(level);
+	}
+
+	int merkle_tree::phys(int const level, int const offset) const
+	{
+		return m_layer_offsets[level] + offset;
+	}
+
+	sha256_hash merkle_tree::get(int const level, int const offset) const
+	{
+		TORRENT_ASSERT(m_mode == mode_t::full_tree);
+		if (is_padding(level, offset)) return merkle_pad(1 << (num_layers() - level), 1);
+		return m_tree[phys(level, offset)];
+	}
+
+	bool merkle_tree::set(int const level, int const offset, sha256_hash const& h)
+	{
+		TORRENT_ASSERT(m_mode == mode_t::full_tree);
+		if (is_padding(level, offset))
+		{
+			// padding has an implied value; accept harmless writes (zero or
+			// the implied pad) and reject anything else. This is the security
+			// gate that turns a malicious uncle hash at a padding sibling
+			// into a proof-validation failure.
+			if (h.is_all_zeros()) return true;
+			return h == merkle_pad(1 << (num_layers() - level), 1);
+		}
+		m_tree[phys(level, offset)] = h;
+		return true;
 	}
 
 	void merkle_tree::optimize_storage()
@@ -853,10 +930,12 @@ namespace {
 			return;
 		}
 
-		int const start = block_layer_start();
 		if (m_block_verified.all_set())
 		{
-			aux::vector<sha256_hash> new_tree(m_tree.begin() + start, m_tree.begin() + start + m_num_blocks);
+			// extract the live leaf-layer slice from the compact storage
+			int const leaf_start = m_layer_offsets[num_layers()];
+			aux::vector<sha256_hash> new_tree(
+				m_tree.begin() + leaf_start, m_tree.begin() + leaf_start + m_num_blocks);
 
 			m_tree = std::move(new_tree);
 			m_mode = mode_t::block_layer;
@@ -872,20 +951,46 @@ namespace {
 
 		// if we have *any* blocks, we can't transition into piece layer mode,
 		// since we would lose those hashes
-		int const piece_layer_size = merkle_num_leafs(num_pieces());
-		if (m_blocks_per_piece_log > 0
-			&& merkle_validate_single_layer(span<sha256_hash const>(m_tree).subspan(0, merkle_num_nodes(piece_layer_size)))
-			&& std::all_of(m_tree.begin() + block_layer_start(), m_tree.end(), [](sha256_hash const& h) { return h.is_all_zeros(); })
-			)
-		{
-			int const start = piece_layer_start();
-			aux::vector<sha256_hash> new_tree(m_tree.begin() + start, m_tree.begin() + start + num_pieces());
+		if (m_blocks_per_piece_log == 0) return;
 
-			m_tree = std::move(new_tree);
-			m_mode = mode_t::piece_layer;
-			m_block_verified.clear();
-			return;
+		int const N = num_layers();
+		// For trees small enough that the piece layer would be at or above
+		// the root (single-piece torrents with a large piece size), treat
+		// the root as the piece layer.
+		int const piece_L = std::max(0, N - piece_levels());
+
+		// validate the piece layer: each pair at piece_L must hash to its
+		// parent at piece_L - 1. Walking live + padding entries; padding
+		// is hashed from merkle_pad and the parent is the implied pad too,
+		// so those pairs always pass. For a single-piece tree (piece_L == 0)
+		// the piece layer is the root with no parent to validate against.
+		if (piece_L > 0)
+		{
+			int const piece_layer_total = 1 << piece_L;
+			for (int O = 0; O < piece_layer_total; O += 2)
+			{
+				// inlined merkle_validate_node so we reuse the per-tree
+				// scratch hasher rather than constructing one per pair.
+				if (hash_pair(get(piece_L, O), get(piece_L, O + 1)) != get(piece_L - 1, O / 2))
+					return;
+			}
 		}
+
+		// reject if there's any block-layer data we'd be dropping
+		int const leaf_start = m_layer_offsets[N];
+		int const leaf_end = m_layer_offsets[N + 1];
+		if (!std::all_of(m_tree.begin() + leaf_start,
+				m_tree.begin() + leaf_end,
+				[](sha256_hash const& h) { return h.is_all_zeros(); }))
+			return;
+
+		int const piece_start = m_layer_offsets[piece_L];
+		aux::vector<sha256_hash> new_tree(
+			m_tree.begin() + piece_start, m_tree.begin() + piece_start + num_pieces());
+
+		m_tree = std::move(new_tree);
+		m_mode = mode_t::piece_layer;
+		m_block_verified.clear();
 	}
 
 	std::vector<sha256_hash> merkle_tree::get_hashes(int const base
@@ -893,9 +998,6 @@ namespace {
 	{
 		// given the full size of the tree, half of it, rounded up, are leaf nodes
 		int const base_layer_idx = merkle_num_layers(num_leafs()) - base;
-		int const base_start_idx = merkle_to_flat_index(base_layer_idx, index);
-
-		int const layer_start_idx = base_start_idx;
 
 		std::vector<sha256_hash> ret;
 		ret.reserve(std::size_t(count));
@@ -913,14 +1015,13 @@ namespace {
 		}
 		else
 		{
-			for (int i = layer_start_idx; i < layer_start_idx + count; ++i)
+			for (int j = 0; j < count; ++j)
 			{
+				int const O = index + j;
 				// the pad hashes are expected to be zero, they should not fail
 				// the request
-				if ((base != 0 || i < m_num_blocks + layer_start_idx - index)
-					&& !has_node(i))
-					return {};
-				ret.push_back(get_impl(i, scratch_space));
+				if ((base != 0 || O < m_num_blocks) && !has_node(base_layer_idx, O)) return {};
+				ret.push_back(get_impl(base_layer_idx, O, scratch_space));
 			}
 		}
 
@@ -928,22 +1029,23 @@ namespace {
 		// subtract one because the base layer doesn't count
 		int const base_tree_layers = merkle_num_layers(merkle_num_leafs(count)) - 1;
 
-		int proof_idx = layer_start_idx;
+		int proof_L = base_layer_idx;
+		int proof_O = index;
 		for (int i = 0; i < proof_layers; ++i)
 		{
-			proof_idx = merkle_get_parent(proof_idx);
+			--proof_L;
+			proof_O >>= 1;
 
 			// if this assert fire, the requester set proof_layers too high
 			// and it wasn't correctly validated
-			TORRENT_ASSERT(proof_idx > 0);
+			TORRENT_ASSERT(proof_L >= 0);
 
 			if (i >= base_tree_layers)
 			{
-				int const sibling = merkle_get_sibling(proof_idx);
-				if (!has_node(proof_idx) || !has_node(sibling))
-					return {};
+				int const sibling_O = proof_O ^ 1;
+				if (!has_node(proof_L, proof_O) || !has_node(proof_L, sibling_O)) return {};
 
-				ret.push_back(get_impl(sibling, scratch_space));
+				ret.push_back(get_impl(proof_L, sibling_O, scratch_space));
 			}
 		}
 
@@ -971,24 +1073,31 @@ namespace {
 				break;
 			case mode_t::full_tree:
 			{
-				TORRENT_ASSERT(m_tree[0] == root());
+				TORRENT_ASSERT(get(0, 0) == root());
 				TORRENT_ASSERT(m_block_verified.size() == m_num_blocks);
 
-				auto const num_leafs = merkle_num_leafs(m_num_blocks);
+				int const leaf_L = num_layers();
 
-				if (m_tree.size() == 1) break;
+				if (leaf_L == 0) break;
 
 				// In all layers, except the block layer, all non-zero hashes
 				// must have a non-zero sibling and they must validate with
-				// their parent.
-				for (int i = 1; i < int(m_tree.size()) - num_leafs; i += 2)
+				// their parent. Walks live (L, O) pairs only; padding pairs
+				// are consistent by construction.
+				for (int L = 1; L < leaf_L; ++L)
 				{
-					if (m_tree[i].is_all_zeros())
+					int const live = layer_size_live(L);
+					for (int O = 0; O < live; O += 2)
 					{
-						TORRENT_ASSERT(m_tree[i + 1].is_all_zeros());
-						continue;
+						if (get(L, O).is_all_zeros())
+						{
+							TORRENT_ASSERT(O + 1 >= live || get(L, O + 1).is_all_zeros());
+							continue;
+						}
+						// inlined merkle_validate_node -- reuse the per-tree
+						// scratch hasher across all pair checks.
+						TORRENT_ASSERT(hash_pair(get(L, O), get(L, O + 1)) == get(L - 1, O / 2));
 					}
-					TORRENT_ASSERT(merkle_validate_node(m_tree[i], m_tree[i+1], m_tree[merkle_get_parent(i)]));
 				}
 
 				// the block layer may contain invalid hashes, but if the
@@ -997,33 +1106,27 @@ namespace {
 				// validate all blocks (that can be validated)
 				// since these are checked in pairs, we skip 2, to always
 				// consider the left side of the pair
-				auto const first_block = merkle_first_leaf(num_leafs);
-				for (int i = first_block, b = 0; i < first_block + m_num_blocks; i += 2, b += 2)
+				for (int b = 0; b < m_num_blocks; b += 2)
 				{
-					if (i + 1 == first_block + m_num_blocks)
+					if (b + 1 == m_num_blocks)
 					{
 						// the edge case where there's an odd number of blocks
 						// and this is the last one
 						if (!m_block_verified.get_bit(b)) continue;
-						TORRENT_ASSERT(has_node(i));
-						int const parent = merkle_get_parent(i);
-						TORRENT_ASSERT(merkle_validate_node(m_tree[i], sha256_hash(), m_tree[parent]));
+						TORRENT_ASSERT(has_node(leaf_L, b));
+						TORRENT_ASSERT(
+							hash_pair(get(leaf_L, b), sha256_hash()) == get(leaf_L - 1, b / 2));
 					}
 					else
 					{
 						TORRENT_ASSERT(m_block_verified.get_bit(b) == m_block_verified.get_bit(b + 1));
 						if (!m_block_verified.get_bit(b)) continue;
-						TORRENT_ASSERT(has_node(i));
-
-						if (i + 1 < block_layer_start() + m_num_blocks)
-							TORRENT_ASSERT(has_node(i + 1));
-						int const parent = merkle_get_parent(i);
-						TORRENT_ASSERT(merkle_validate_node(m_tree[i], m_tree[i + 1], m_tree[parent]));
+						TORRENT_ASSERT(has_node(leaf_L, b));
+						TORRENT_ASSERT(has_node(leaf_L, b + 1));
+						TORRENT_ASSERT(hash_pair(get(leaf_L, b), get(leaf_L, b + 1))
+							== get(leaf_L - 1, b / 2));
 					}
 				}
-				// ensure padding is all zeros
-				for (int i = first_block + m_num_blocks; i < int(m_tree.size()); ++i)
-					TORRENT_ASSERT(m_tree[i].is_all_zeros());
 				break;
 			}
 			case mode_t::piece_layer:

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -470,10 +470,15 @@ TORRENT_TEST(set_block_hash_fail)
 	auto const result = picker.set_block_hash(3_piece, default_block_size, sha256_hash("01234567890123456789012345678901"));
 	TEST_CHECK(result.status == aux::set_block_hash_result::result::piece_hash_failed);
 
-	TEST_CHECK(trees.front()[merkle_get_parent(first_leaf + 12)].is_all_zeros());
-	TEST_CHECK(trees.front()[merkle_get_parent(first_leaf + 13)].is_all_zeros());
-	TEST_CHECK(trees.front()[merkle_get_parent(first_leaf + 14)].is_all_zeros());
-	TEST_CHECK(trees.front()[merkle_get_parent(first_leaf + 15)].is_all_zeros());
+	auto const parent_flat = [&](int const leaf_offset) {
+		int const n = merkle_get_parent(first_leaf + leaf_offset);
+		int const L = merkle_get_layer(n);
+		return trees.front().node_at(L, n - merkle_layer_start(L));
+	};
+	TEST_CHECK(parent_flat(12).is_all_zeros());
+	TEST_CHECK(parent_flat(13).is_all_zeros());
+	TEST_CHECK(parent_flat(14).is_all_zeros());
+	TEST_CHECK(parent_flat(15).is_all_zeros());
 }
 
 TORRENT_TEST(set_block_hash_pass)

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -11,7 +11,9 @@ see LICENSE file.
 
 #include "test.hpp"
 #include "libtorrent/aux_/merkle.hpp"
+#include "libtorrent/aux_/merkle_tree.hpp"
 #include "libtorrent/bitfield.hpp"
+#include "libtorrent/hasher.hpp"
 #include <iostream>
 
 using namespace lt;
@@ -29,6 +31,44 @@ namespace {
 			else
 				TEST_CHECK(false);
 		}
+	}
+
+	// Construct an aux::merkle_tree pre-loaded with the hashes from a
+	// hand-laid-out flat std::vector (standard layout: root at index 0,
+	// layer L at [(1<<L) - 1, (1<<(L+1)) - 1)). The tree's root is taken
+	// from src[0]; the tree is transitioned into full_tree mode so the
+	// tests can address nodes via (L, O) directly.
+	aux::merkle_tree make_tree(std::vector<sha256_hash> const& src, int const blocks_per_piece = 1)
+	{
+		int const num_nodes = int(src.size());
+		TORRENT_ASSERT(((num_nodes + 1) & num_nodes) == 0);
+		int const num_leafs = (num_nodes + 1) / 2;
+		aux::merkle_tree t(num_leafs, blocks_per_piece, src[0].data());
+		t.allocate_compact();
+		int const N = t.num_layers();
+		for (int L = 0; L <= N; ++L)
+		{
+			int const start = (1 << L) - 1;
+			int const layer_size = 1 << L;
+			for (int O = 0; O < layer_size; ++O)
+				t.set(L, O, src[start + O]);
+		}
+		return t;
+	}
+
+	// Read back the tree's contents into a standard-layout flat vector.
+	std::vector<sha256_hash> flatten(aux::merkle_tree const& t)
+	{
+		int const N = t.num_layers();
+		std::vector<sha256_hash> out(std::size_t(merkle_num_nodes(1 << N)));
+		for (int L = 0; L <= N; ++L)
+		{
+			int const start = (1 << L) - 1;
+			int const layer_size = 1 << L;
+			for (int O = 0; O < layer_size; ++O)
+				out[start + O] = t.get(L, O);
+		}
+		return out;
 	}
 }
 
@@ -395,201 +435,110 @@ TORRENT_TEST(merkle_fill_partial_tree)
 {
 	// fill whole tree
 	{
-		v tree{o,
-		   o,      o,
-		  o, o,   o, o,
-		a,b,c,d,e,f,g,h};
+		auto t = make_tree(v{o, o, o, o, o, o, o, a, b, c, d, e, f, g, h});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 ab, cd, ef, gh,
-		a,b,c,d,e,f,g,h}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, ab, cd, ef, gh, a, b, c, d, e, f, g, h}));
 	}
 
 	// fill left side of the tree
 	{
-		v tree{o,
-		   o,      eh,
-		 ab,cd,   o, o,
-		a,b,c,d,o,o,o,o};
+		auto t = make_tree(v{o, o, eh, ab, cd, o, o, a, b, c, d, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,    eh,
-		 ab, cd, o, o,
-		a,b,c,d,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, ab, cd, o, o, a, b, c, d, o, o, o, o}));
 	}
 
 	// fill right side of the tree
 	{
-		v tree{o,
-		   ad,     o,
-		 o,  o,   o, o,
-		o,o,o,o,e,f,g,h};
+		auto t = make_tree(v{o, ad, o, o, o, o, o, o, o, o, o, e, f, g, h});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 o,  o,  ef,gh,
-		o,o,o,o,e,f,g,h}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, e, f, g, h}));
 	}
 
 	// fill shallow left of the tree
 	{
-		v tree{
-		       o,
-		   o,      eh,
-		 ab, cd,   o, o,
-		o,o,o,o,o,o,o,o};
+		auto t = make_tree(v{o, o, eh, ab, cd, o, o, o, o, o, o, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,    eh,
-		 ab, cd,   o, o,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, ab, cd, o, o, o, o, o, o, o, o, o, o}));
 	}
 
 	// fill shallow right of the tree
 	{
-		v tree{
-		       o,
-		   ad,     o,
-		 o,  o,   ef,gh,
-		o,o,o,o,o,o,o,o};
+		auto t = make_tree(v{o, ad, o, o, o, ef, gh, o, o, o, o, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 o,  o,   ef, gh,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, o, o, o, o}));
 	}
 
 	// fill uneven tree
 	{
-		v tree{
-		       o,
-		   ad,     o,
-		 o,  o,  ef, gh,
-		o,o,o,o,o,o,o,o};
+		auto t = make_tree(v{o, ad, o, o, o, ef, gh, o, o, o, o, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 o,  o,  ef, gh,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, o, o, o, o}));
 	}
 
 	// clear orphans
 	{
-		v tree{
-		       o,
-		   ad,    ah,
-		 o,  o,  ef, gh,
-		a,o,c,o,o,o,o,o};
+		auto t = make_tree(v{o, ad, ah, o, o, ef, gh, a, o, c, o, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 o,  o,   ef,gh,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, o, o, o, o}));
 	}
 
 	// clear orphan sub-tree
 	{
-		v tree{o,
-		   o,     o,
-		 o, o,   o, o,
-		a,b,c,d,o,o,o,o};
+		auto t = make_tree(v{o, o, o, o, o, o, o, a, b, c, d, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		    v{o,
-		   o,     o,
-		 o, o,   o, o,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{o, o, o, o, o, o, o, o, o, o, o, o, o, o, o}));
 	}
 
 	// fill sub-tree
 	{
-		v tree{o,
-		   o,     eh,
-		 o, o,   o, o,
-		a,b,c,d,o,o,o,o};
+		auto t = make_tree(v{o, o, eh, o, o, o, o, a, b, c, d, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		    v{ah,
-		   ad,   eh,
-		 ab,cd,   o, o,
-		a,b,c,d,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, ab, cd, o, o, a, b, c, d, o, o, o, o}));
 	}
 
 	// clear no-siblings left
 	{
-		v tree{
-		       o,
-		   ad,    ah,
-		 o,  o,  ef, gh,
-		o,o,o,o,o,o,o,h};
+		auto t = make_tree(v{o, ad, ah, o, o, ef, gh, o, o, o, o, o, o, o, h});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 o,  o,  ef, gh,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, o, o, o, o}));
 	}
 
 	// clear no-siblings right
 	{
-		v tree{
-		       o,
-		   ad,    ah,
-		 o,  o,  ef, gh,
-		o,o,o,o,o,o,g,o};
+		auto t = make_tree(v{o, ad, ah, o, o, ef, gh, o, o, o, o, o, o, g, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 o,  o,  ef, gh,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, o, o, o, o}));
 	}
 
 	// fill gaps
 	{
-		v tree{
-		       o,
-		   ad,    ah,
-		 o,  o,  ef,gh,
-		a,b,c,d,o,o,o,o};
+		auto t = make_tree(v{o, ad, ah, o, o, ef, gh, a, b, c, d, o, o, o, o});
 
-		merkle_fill_partial_tree(tree);
+		merkle_fill_partial_tree(t);
 
-		TEST_CHECK((tree ==
-		     v{ah,
-		   ad,     eh,
-		 ab,cd,   ef,gh,
-		a,b,c,d,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{ah, ad, eh, ab, cd, ef, gh, a, b, c, d, o, o, o, o}));
 	}
 }
 
@@ -625,121 +574,56 @@ TORRENT_TEST(merkle_root_scratch)
 	TEST_CHECK(merkle_root_scratch(v{a,b,c}, 8, o, buf) == H(H(ab, H(c, o)), H(H(o,o), H(o,o))));
 }
 
-namespace {
-void print_tree(span<sha256_hash const> tree)
-{
-	int const num_leafs = static_cast<int>((tree.size() + 1) / 2);
-	int spacing = num_leafs;
-	int const num_levels = merkle_num_layers(num_leafs) + 1;
-	int layer_width = 1;
-	int node = 0;
-	for (int i = 0; i < num_levels; ++i)
-	{
-		for (int k = 0; k < layer_width; ++k)
-		{
-			for (int j = 0; j < spacing; ++j) std::cout << ' ';
-			std::cout << (tree[node] == sha256_hash() ? '0' : '1');
-			for (int j = 0; j < spacing - 1; ++j) std::cout << ' ';
-			++node;
-		}
-		std::cout << '\n';
-		layer_width *= 2;
-		spacing /= 2;
-	}
-	std::cout << '\n';
-}
-}
-
 TORRENT_TEST(merkle_clear_tree)
 {
 	// test clearing the whole tree
 	{
-		v tree{l,
-		   l,      l,
-		  l, l,   l, l,
-		l,l,l,l,l,l,l,l};
+		auto t = make_tree(v{l, l, l, l, l, l, l, l, l, l, l, l, l, l, l});
 
-		print_tree(tree);
-		merkle_clear_tree(tree, 8, 7);
-		print_tree(tree);
+		// level_start=7 -> (L=3, O=0), num_leafs=8
+		merkle_clear_tree(t, 3, 0, 8);
 
-		TEST_CHECK((tree ==
-		     v{o,
-		   o,      o,
-		  o, o,   o, o,
-		o,o,o,o,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{o, o, o, o, o, o, o, o, o, o, o, o, o, o, o}));
 	}
 
 	// test clearing the left side of the tree
 	{
-		v tree{l,
-		   l,      l,
-		  l, l,   l, l,
-		l,l,l,l,l,l,l,l};
+		auto t = make_tree(v{l, l, l, l, l, l, l, l, l, l, l, l, l, l, l});
 
-		print_tree(tree);
-		merkle_clear_tree(tree, 4, 7);
-		print_tree(tree);
+		// level_start=7 -> (L=3, O=0), num_leafs=4
+		merkle_clear_tree(t, 3, 0, 4);
 
-		TEST_CHECK((tree ==
-		     v{l,
-		   o,      l,
-		  o, o,   l, l,
-		o,o,o,o,l,l,l,l}));
+		TEST_CHECK((flatten(t) == v{l, o, l, o, o, l, l, o, o, o, o, l, l, l, l}));
 	}
 
 	// test clearing the right side of the tree
 	{
-		v tree{l,
-		   l,      l,
-		  l, l,   l, l,
-		l,l,l,l,l,l,l,l};
+		auto t = make_tree(v{l, l, l, l, l, l, l, l, l, l, l, l, l, l, l});
 
-		print_tree(tree);
-		merkle_clear_tree(tree, 4, 11);
-		print_tree(tree);
+		// level_start=11 -> (L=3, O=4), num_leafs=4
+		merkle_clear_tree(t, 3, 4, 4);
 
-		TEST_CHECK((tree ==
-		     v{l,
-		   l,      o,
-		  l, l,   o, o,
-		l,l,l,l,o,o,o,o}));
+		TEST_CHECK((flatten(t) == v{l, l, o, l, l, o, o, l, l, l, l, o, o, o, o}));
 	}
 
 	// test clearing shallow left
 	{
-		v tree{l,
-		   l,      l,
-		  l, l,   l, l,
-		l,l,l,l,l,l,l,l};
+		auto t = make_tree(v{l, l, l, l, l, l, l, l, l, l, l, l, l, l, l});
 
-		print_tree(tree);
-		merkle_clear_tree(tree, 2, 3);
-		print_tree(tree);
+		// level_start=3 -> (L=2, O=0), num_leafs=2
+		merkle_clear_tree(t, 2, 0, 2);
 
-		TEST_CHECK((tree ==
-		     v{l,
-		   o,      l,
-		  o, o,   l, l,
-		l,l,l,l,l,l,l,l}));
+		TEST_CHECK((flatten(t) == v{l, o, l, o, o, l, l, l, l, l, l, l, l, l, l}));
 	}
 
 	// test clearing shallow right
 	{
-		v tree{l,
-		   l,      l,
-		  l, l,   l, l,
-		l,l,l,l,l,l,l,l};
+		auto t = make_tree(v{l, l, l, l, l, l, l, l, l, l, l, l, l, l, l});
 
-		print_tree(tree);
-		merkle_clear_tree(tree, 2, 5);
-		print_tree(tree);
+		// level_start=5 -> (L=2, O=2), num_leafs=2
+		merkle_clear_tree(t, 2, 2, 2);
 
-		TEST_CHECK((tree ==
-		     v{l,
-		   l,      o,
-		  l, l,   o, o,
-		l,l,l,l,l,l,l,l}));
+		TEST_CHECK((flatten(t) == v{l, l, o, l, l, o, o, l, l, l, l, l, l, l, l}));
 	}
 }
 
@@ -797,6 +681,21 @@ TORRENT_TEST(merkle_validate_node)
 	TEST_CHECK(!merkle_validate_node(h, g, gh));
 }
 
+namespace {
+	// Construct an empty (root-only) merkle_tree for use as the dst in
+	// merkle_validate_copy tests. The root is set to zero so that flatten()
+	// returns all-zeros when no copy happens (mismatched expected_root case).
+	aux::merkle_tree make_empty_dst(int num_blocks, sha256_hash const& root_buf)
+	{
+		aux::merkle_tree dst(num_blocks, 1, root_buf.data());
+		dst.allocate_compact();
+		// allocate_compact set position (0,0) to dst's root; zero it so the
+		// merkle_validate_copy walk's set(0,0,src[0]) is the only write there.
+		dst.set(0, 0, sha256_hash{});
+		return dst;
+	}
+}
+
 TORRENT_TEST(merkle_validate_copy_full)
 {
 	v const src{
@@ -805,13 +704,14 @@ TORRENT_TEST(merkle_validate_copy_full)
 	 ab, cd, ef, gh,
 	a,b,c,d,e,f,g,h};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	bitfield verified(8);
 
-	merkle_validate_copy(src, empty_tree, ah, verified);
+	merkle_validate_copy(src, dst, ah, verified);
 
 	compare_bits(verified, "11111111");
-	TEST_CHECK(empty_tree == src);
+	TEST_CHECK(flatten(dst) == src);
 }
 
 TORRENT_TEST(merkle_validate_copy_full_odd_nodes)
@@ -822,15 +722,16 @@ TORRENT_TEST(merkle_validate_copy_full_odd_nodes)
 	 ab, cd, ef, gh,
 	a,b,c,d,e,f,g,h};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	// we pretend that h is a padding node. This algorithm doesn't care that
 	// it's not zero (yet)
 	bitfield verified(7);
 
-	merkle_validate_copy(src, empty_tree, ah, verified);
+	merkle_validate_copy(src, dst, ah, verified);
 
 	compare_bits(verified, "1111111");
-	TEST_CHECK(empty_tree == src);
+	TEST_CHECK(flatten(dst) == src);
 }
 
 
@@ -842,10 +743,11 @@ TORRENT_TEST(merkle_validate_copy_invalid_leaf)
 	 ab, cd, ef, gh,
 	a,b,c,d,e,ef,g,h};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	bitfield verified(8);
 
-	merkle_validate_copy(src, empty_tree, ah, verified);
+	merkle_validate_copy(src, dst, ah, verified);
 
 	// leaf 5 had an invalid hash, it's sibling (leaf 4) could also not be
 	// validated because of it
@@ -856,7 +758,7 @@ TORRENT_TEST(merkle_validate_copy_invalid_leaf)
 	   ad,     eh,
 	 ab, cd, ef, gh,
 	a,b,c,d,o,o,g,h};
-	TEST_CHECK(empty_tree == expected);
+	TEST_CHECK(flatten(dst) == expected);
 }
 
 TORRENT_TEST(merkle_validate_copy_many_invalid_leafs)
@@ -867,10 +769,11 @@ TORRENT_TEST(merkle_validate_copy_many_invalid_leafs)
 	 ab, cd, ef, gh,
 	a,b,ef,d,eh,ef,g,ah};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	bitfield verified(8);
 
-	merkle_validate_copy(src, empty_tree, ah, verified);
+	merkle_validate_copy(src, dst, ah, verified);
 
 	// leaf 2,4, 5 and 7 had an invalid hash, their siblings (leaf 3 and 6) could also not be
 	// validated because of it
@@ -881,7 +784,7 @@ TORRENT_TEST(merkle_validate_copy_many_invalid_leafs)
 	   ad,     eh,
 	 ab, cd, ef, gh,
 	a,b,o,o,o,o,o,o};
-	TEST_CHECK(empty_tree == expected);
+	TEST_CHECK(flatten(dst) == expected);
 }
 
 TORRENT_TEST(merkle_validate_copy_partial)
@@ -892,10 +795,11 @@ TORRENT_TEST(merkle_validate_copy_partial)
 	 ab, cd, ef, o,
 	a,b,c,o,o,o,o,o};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	bitfield verified(8);
 
-	merkle_validate_copy(src, empty_tree, ah, verified);
+	merkle_validate_copy(src, dst, ah, verified);
 
 	compare_bits(verified, "11000000");
 
@@ -905,7 +809,7 @@ TORRENT_TEST(merkle_validate_copy_partial)
 	 ab, cd,  o, o,
 	a,b,o,o,o,o,o,o};
 
-	TEST_CHECK(empty_tree == expected);
+	TEST_CHECK(flatten(dst) == expected);
 }
 
 TORRENT_TEST(merkle_validate_copy_invalid_root)
@@ -916,15 +820,16 @@ TORRENT_TEST(merkle_validate_copy_invalid_root)
 	 ab, cd, ef, o,
 	a,b,c,o,o,o,o,o};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	bitfield verified(8);
 
-	merkle_validate_copy(src, empty_tree, a, verified);
+	merkle_validate_copy(src, dst, a, verified);
 
 	v const expected(15);
 
 	compare_bits(verified, "00000000");
-	TEST_CHECK(empty_tree == expected);
+	TEST_CHECK(flatten(dst) == expected);
 }
 
 TORRENT_TEST(merkle_validate_copy_root_only)
@@ -935,10 +840,11 @@ TORRENT_TEST(merkle_validate_copy_root_only)
 	  o,  o,  o, o,
 	o,o,o,o,o,o,o,o};
 
-	v empty_tree(15);
+	sha256_hash const zero{};
+	auto dst = make_empty_dst(8, zero);
 	bitfield verified(8);
 
-	merkle_validate_copy(src, empty_tree, ah, verified);
+	merkle_validate_copy(src, dst, ah, verified);
 
 	compare_bits(verified, "00000000");
 
@@ -948,7 +854,7 @@ TORRENT_TEST(merkle_validate_copy_root_only)
 	  o,  o,  o, o,
 	o,o,o,o,o,o,o,o};
 
-	TEST_CHECK(empty_tree == expected);
+	TEST_CHECK(flatten(dst) == expected);
 }
 
 TORRENT_TEST(merkle_validate_single_leayer_fail_no_parents)
@@ -997,74 +903,67 @@ TORRENT_TEST(merkle_validate_single_layer)
 
 TORRENT_TEST(is_subtree_known_full)
 {
-	v const src{
-	        ah,
-	    ad,     eh,
-	  ab, cd, ef,gh,
-	a,b,c,d,e,f,g,h};
+	auto t = make_tree(v{ah, ad, eh, ab, cd, ef, gh, a, b, c, d, e, f, g, h});
 
-	TEST_CHECK(merkle_find_known_subtree(src, 1, 8) == std::make_tuple(0, 2, 3));
+	// root_index=3 -> (root_L=2, root_O=0)
+	TEST_CHECK(merkle_find_known_subtree(t, 1, 8) == std::make_tuple(0, 2, 2, 0));
 }
 
 TORRENT_TEST(is_subtree_known_two_levels)
 {
-	v const src{
-	        ah,
-	    ad,     eh,
-	  o, o, ef,gh,
-	a,b,c,d,e,f,g,h};
+	auto t = make_tree(v{ah, ad, eh, o, o, ef, gh, a, b, c, d, e, f, g, h});
 
-	TEST_CHECK(merkle_find_known_subtree(src, 1, 8) == std::make_tuple(0, 4, 1));
+	// root_index=1 -> (root_L=1, root_O=0)
+	TEST_CHECK(merkle_find_known_subtree(t, 1, 8) == std::make_tuple(0, 4, 1, 0));
 }
 
 TORRENT_TEST(is_subtree_known_unknown)
 {
-	v const src{
-	        ah,
-	    ad,     eh,
-	  o, o, ef,gh,
-	a,b,o,d,e,f,g,h};
+	auto t = make_tree(v{ah, ad, eh, o, o, ef, gh, a, b, o, d, e, f, g, h});
 
-	TEST_CHECK(merkle_find_known_subtree(src, 1, 8) == std::make_tuple(0, 2, 3));
+	// root_index=3 -> (root_L=2, root_O=0)
+	TEST_CHECK(merkle_find_known_subtree(t, 1, 8) == std::make_tuple(0, 2, 2, 0));
 }
 
 TORRENT_TEST(is_subtree_known_padding)
 {
 	// the last leaf is padding, it should be assumed to be correct despite
 	// being zero
-	v const src{
-	        ah,
-	    ad,     eh,
-	  o, o, ef,gh,
-	a,b,o,d,e,f,g,o};
+	auto t = make_tree(v{ah, ad, eh, o, o, ef, gh, a, b, o, d, e, f, g, o});
 
-	TEST_CHECK(merkle_find_known_subtree(src, 6, 7) == std::make_tuple(6, 2, 6));
+	// root_index=6 -> (root_L=2, root_O=3)
+	TEST_CHECK(merkle_find_known_subtree(t, 6, 7) == std::make_tuple(6, 2, 2, 3));
 }
 
 TORRENT_TEST(is_subtree_known_padding_two_levels)
 {
 	// the last leaf is padding, it should be assumed to be correct despite
 	// being zero
-	v const src{
-	        ah,
-	    ad,     eh,
-	  o, o,  o, o,
-	a,b,o,d,e,f,g,o};
+	auto t = make_tree(v{ah, ad, eh, o, o, o, o, a, b, o, d, e, f, g, o});
 
-	TEST_CHECK(merkle_find_known_subtree(src, 6, 7) == std::make_tuple(4, 4, 2));
+	// root_index=2 -> (root_L=1, root_O=1)
+	TEST_CHECK(merkle_find_known_subtree(t, 6, 7) == std::make_tuple(4, 4, 1, 1));
 }
 
 TORRENT_TEST(is_subtree_known_more_padding_two_levels)
 {
 	// the last two leafs are padding, they should be assumed to be correct despite
 	// being zero
-	v const src{
-	        ah,
-	    ad,     eh,
-	  o, o,  o, o,
-	a,b,o,d,e,f,o,o};
+	auto t = make_tree(v{ah, ad, eh, o, o, o, o, a, b, o, d, e, f, o, o});
 
-	TEST_CHECK(merkle_find_known_subtree(src, 5, 6) == std::make_tuple(4, 4, 2));
+	// root_index=2 -> (root_L=1, root_O=1)
+	TEST_CHECK(merkle_find_known_subtree(t, 5, 6) == std::make_tuple(4, 4, 1, 1));
+}
+
+namespace {
+	// Build a fresh tree with only `tree[0] = root_hash` set, in full_tree
+	// mode, for the proof-validation tests below.
+	aux::merkle_tree make_root_only(sha256_hash const& root_hash)
+	{
+		aux::merkle_tree t(8, 1, root_hash.data());
+		t.allocate_compact();
+		return t;
+	}
 }
 
 TORRENT_TEST(validate_and_insert_proofs_mixed)
@@ -1075,17 +974,13 @@ TORRENT_TEST(validate_and_insert_proofs_mixed)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs{f, gh, ad};
+v const proofs{f, gh, ad};
 
-	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 11, e, proofs));
-	TEST_CHECK((tree == v{
-	          ah,
-	     ad,       eh,
-	  o,    o,  ef,   gh,
-	o, o, o, o,e, f, o, o}));
+// target node_idx 11 -> (L=3, O=4)
+TEST_CHECK(merkle_validate_and_insert_proofs(t, 3, 4, e, proofs));
+TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, e, f, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_mixed_failure)
@@ -1096,45 +991,15 @@ TORRENT_TEST(validate_and_insert_proofs_mixed_failure)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = eh; // this is not the correct root
+auto t = make_root_only(eh); // this is not the correct root
 
-	v const proofs{f, gh, ad};
+v const proofs{f, gh, ad};
 
-	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, e, proofs));
+// target node_idx 11 -> (L=3, O=4)
+TEST_CHECK(!merkle_validate_and_insert_proofs(t, 3, 4, e, proofs));
 
-	// make sure all nodes that were filled in were cleared correctly
-	// clang-format off
-	TEST_CHECK((tree == v{
-	          eh,
-	      o,        o,
-	  o,    o,   o,    o,
-	o, o, o, o,o, o, o, o}));
-	// clang-format on
-}
-
-TORRENT_TEST(validate_and_insert_proofs_under_length_failure)
-{
-	// full tree:
-	//       ah
-	//    ad      eh
-	//  ab  cd  ef  gh
-	// a b c d  e f g h
-
-	v tree(15);
-	tree[0] = ah;
-	tree[6] = gh;
-
-	v const proofs{f};
-
-	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, e, proofs));
-	// clang-format off
-	TEST_CHECK((tree == v{
-	          ah,
-	      o,        o,
-	  o,    o,   o,   gh,
-	o, o, o, o,o, o, o, o}));
-	// clang-format on
+// make sure all nodes that were filled in were cleared correctly
+TEST_CHECK((flatten(t) == v{eh, o, o, o, o, o, o, o, o, o, o, o, o, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_left)
@@ -1145,17 +1010,13 @@ TORRENT_TEST(validate_and_insert_proofs_left)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs{b, cd, eh};
+v const proofs{b, cd, eh};
 
-	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 7, a, proofs));
-	TEST_CHECK((tree == v{
-	          ah,
-	     ad,       eh,
-	  ab,   cd,  o,    o,
-	a, b, o, o,o, o, o, o}));
+// target node_idx 7 -> (L=3, O=0)
+TEST_CHECK(merkle_validate_and_insert_proofs(t, 3, 0, a, proofs));
+TEST_CHECK((flatten(t) == v{ah, ad, eh, ab, cd, o, o, a, b, o, o, o, o, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_right)
@@ -1166,17 +1027,13 @@ TORRENT_TEST(validate_and_insert_proofs_right)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs{g, ef, ad};
+v const proofs{g, ef, ad};
 
-	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 14, h, proofs));
-	TEST_CHECK((tree == v{
-	          ah,
-	     ad,       eh,
-	  o,    o,   ef,   gh,
-	o, o, o, o,o, o, g, h}));
+// target node_idx 14 -> (L=3, O=7)
+TEST_CHECK(merkle_validate_and_insert_proofs(t, 3, 7, h, proofs));
+TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, o, o, g, h}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_early_success)
@@ -1187,19 +1044,15 @@ TORRENT_TEST(validate_and_insert_proofs_early_success)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
-	tree[1] = ad;
-	tree[2] = eh;
+auto t = make_root_only(ah);
+t.set(1, 0, ad); // tree[1] = ad
+t.set(1, 1, eh); // tree[2] = eh
 
-	v const proofs{f, gh, ad};
+v const proofs{f, gh, ad};
 
-	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 11, e, proofs));
-	TEST_CHECK((tree == v{
-	          ah,
-	     ad,       eh,
-	  o,    o,  ef,   gh,
-	o, o, o, o,e, f, o, o}));
+// target node_idx 11 -> (L=3, O=4)
+TEST_CHECK(merkle_validate_and_insert_proofs(t, 3, 4, e, proofs));
+TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, e, f, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_early_failure)
@@ -1210,21 +1063,17 @@ TORRENT_TEST(validate_and_insert_proofs_early_failure)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
-	tree[1] = ad;
-	tree[2] = ah; // <- this is not the right hash. It should cause validation to fail
+auto t = make_root_only(ah);
+t.set(1, 0, ad); // tree[1] = ad
+t.set(1, 1, ah); // tree[2] = ah <- this is not the right hash; validation should fail
 
-	v const proofs{f, gh, ad};
+v const proofs{f, gh, ad};
 
-	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, e, proofs));
+// target node_idx 11 -> (L=3, O=4)
+TEST_CHECK(!merkle_validate_and_insert_proofs(t, 3, 4, e, proofs));
 
-	// make sure tree was correctly restored
-	TEST_CHECK((tree == v{
-	          ah,
-	     ad,       ah,
-	  o,    o,   o,    o,
-	o, o, o, o,o, o, o, o}));
+// make sure tree was correctly restored
+TEST_CHECK((flatten(t) == v{ah, ad, ah, o, o, o, o, o, o, o, o, o, o, o, o}));
 }
 
 
@@ -1236,19 +1085,15 @@ TORRENT_TEST(validate_and_insert_proofs_no_uncles)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs;
+v const proofs;
 
-	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 1, ad, proofs));
+// target node_idx 1 -> (L=1, O=0)
+TEST_CHECK(!merkle_validate_and_insert_proofs(t, 1, 0, ad, proofs));
 
-	// make sure tree was correctly restored
-	TEST_CHECK((tree == v{
-	          ah,
-	      o,        o,
-	  o,    o,   o,    o,
-	o, o, o, o,o, o, o, o}));
+// make sure tree was correctly restored
+TEST_CHECK((flatten(t) == v{ah, o, o, o, o, o, o, o, o, o, o, o, o, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_root)
@@ -1259,20 +1104,16 @@ TORRENT_TEST(validate_and_insert_proofs_root)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs;
+v const proofs;
 
-	// this is just attempting to prove the root, which is ok
-	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 0, ah, proofs));
+// this is just attempting to prove the root, which is ok.
+// target node_idx 0 -> (L=0, O=0)
+TEST_CHECK(merkle_validate_and_insert_proofs(t, 0, 0, ah, proofs));
 
-	// nothing happens to the tree in this case, we already had the root
-	TEST_CHECK((tree == v{
-	          ah,
-	      o,        o,
-	  o,    o,   o,    o,
-	o, o, o, o,o, o, o, o}));
+// nothing happens to the tree in this case, we already had the root
+TEST_CHECK((flatten(t) == v{ah, o, o, o, o, o, o, o, o, o, o, o, o, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_root_fail)
@@ -1283,20 +1124,16 @@ TORRENT_TEST(validate_and_insert_proofs_root_fail)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs;
+v const proofs;
 
-	// this is just attempting to prove the root, but with the wrong hash
-	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 0, a, proofs));
+// this is just attempting to prove the root, but with the wrong hash.
+// target node_idx 0 -> (L=0, O=0)
+TEST_CHECK(!merkle_validate_and_insert_proofs(t, 0, 0, a, proofs));
 
-	// nothing happens to the tree in this case
-	TEST_CHECK((tree == v{
-	          ah,
-	      o,        o,
-	  o,    o,   o,    o,
-	o, o, o, o,o, o, o, o}));
+// nothing happens to the tree in this case
+TEST_CHECK((flatten(t) == v{ah, o, o, o, o, o, o, o, o, o, o, o, o, o, o}));
 }
 
 TORRENT_TEST(validate_and_insert_proofs_too_many_uncles)
@@ -1307,17 +1144,13 @@ TORRENT_TEST(validate_and_insert_proofs_too_many_uncles)
 //  ab  cd  ef  gh
 // a b c d  e f g h
 
-	v tree(15);
-	tree[0] = ah;
+auto t = make_root_only(ah);
 
-	v const proofs{f, gh, ad, a, b, c , d};
+v const proofs{f, gh, ad, a, b, c, d};
 
-	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 11, e, proofs));
-	TEST_CHECK((tree == v{
-	          ah,
-	     ad,       eh,
-	  o,    o,  ef,   gh,
-	o, o, o, o,e, f, o, o}));
+// target node_idx 11 -> (L=3, O=4)
+TEST_CHECK(merkle_validate_and_insert_proofs(t, 3, 4, e, proofs));
+TEST_CHECK((flatten(t) == v{ah, ad, eh, o, o, ef, gh, o, o, o, o, e, f, o, o}));
 }
 
 // A pre-existing sibling slot that already holds the same value the proof

--- a/test/test_merkle_tree.cpp
+++ b/test/test_merkle_tree.cpp
@@ -67,6 +67,26 @@ std::vector<sha256_hash> corrupt(span<sha256_hash const> hashes)
 	return ret;
 }
 
+// Thin flat-index adapters over merkle_tree's (level, offset) API, used
+// by tests that iterate the full standard-layout flat index space.
+sha256_hash node_at_flat(aux::merkle_tree const& t, int const idx)
+{
+	int const L = merkle_get_layer(idx);
+	return t.node_at(L, idx - merkle_layer_start(L));
+}
+
+bool has_node_at(aux::merkle_tree const& t, int const idx)
+{
+	int const L = merkle_get_layer(idx);
+	return t.has_node(L, idx - merkle_layer_start(L));
+}
+
+bool compare_at(aux::merkle_tree const& t, int const idx, sha256_hash const& h)
+{
+	int const L = merkle_get_layer(idx);
+	return t.compare_node(L, idx - merkle_layer_start(L), h);
+}
+
 bitfield all_set(int count)
 {
 	return bitfield(count, true);
@@ -99,13 +119,13 @@ TORRENT_TEST(load_tree)
 		t.load_tree(f, empty_verified);
 		for (int i = 0; i < num_nodes - num_pad_leafs; ++i)
 		{
-			TEST_CHECK(t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 		for (int i = num_nodes - num_pad_leafs; i < num_nodes; ++i)
 		{
-			TEST_CHECK(!t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(!has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 	}
 
@@ -114,18 +134,18 @@ TORRENT_TEST(load_tree)
 		sha256_hash const bad_root("01234567890123456789012345678901");
 		aux::merkle_tree t(num_blocks, 1, bad_root.data());
 		t.load_tree(f, empty_verified);
-		TEST_CHECK(t.has_node(0));
+		TEST_CHECK(has_node_at(t, 0));
 		for (int i = 1; i < num_nodes; ++i)
-			TEST_CHECK(!t.has_node(i));
+			TEST_CHECK(!has_node_at(t, i));
 	}
 
 	// mismatching size
 	{
 		aux::merkle_tree t(num_blocks, 1, f[0].data());
 		t.load_tree(span<sha256_hash const>(f).first(f.end_index() - 1), empty_verified);
-		TEST_CHECK(t.has_node(0));
+		TEST_CHECK(has_node_at(t, 0));
 		for (int i = 1; i < num_nodes; ++i)
-			TEST_CHECK(!t.has_node(i));
+			TEST_CHECK(!has_node_at(t, i));
 	}
 }
 
@@ -138,13 +158,13 @@ TORRENT_TEST(load_sparse_tree)
 		t.load_sparse_tree(f, mask, empty_verified);
 		for (int i = 0; i < num_nodes - num_pad_leafs; ++i)
 		{
-			TEST_CHECK(t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 		for (int i = num_nodes - num_pad_leafs; i < num_nodes; ++i)
 		{
-			TEST_CHECK(!t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(!has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 	}
 
@@ -156,9 +176,9 @@ TORRENT_TEST(load_sparse_tree)
 		mask.set_bit(1);
 		mask.set_bit(2);
 		t.load_sparse_tree(span<sha256_hash const>(f).subspan(1, 2), mask, empty_verified);
-		TEST_CHECK(t.has_node(0));
+		TEST_CHECK(has_node_at(t, 0));
 		for (int i = 1; i < num_nodes; ++i)
-			TEST_CHECK(!t.has_node(i));
+			TEST_CHECK(!has_node_at(t, i));
 	}
 
 	// block layer
@@ -172,13 +192,13 @@ TORRENT_TEST(load_sparse_tree)
 		t.load_sparse_tree(span<sha256_hash const>(f).subspan(first_block, num_blocks), mask, empty_verified);
 		for (int i = 0; i < num_nodes - num_pad_leafs; ++i)
 		{
-			TEST_CHECK(t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 		for (int i = num_nodes - num_pad_leafs; i < num_nodes; ++i)
 		{
-			TEST_CHECK(!t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(!has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 	}
 
@@ -194,12 +214,12 @@ TORRENT_TEST(load_sparse_tree)
 		int const end_piece_layer = first_piece + merkle_num_leafs(num_pieces);
 		for (int i = 0; i < end_piece_layer; ++i)
 		{
-			TEST_CHECK(t.has_node(i));
-			TEST_CHECK(t.compare_node(i, f[i]));
+			TEST_CHECK(has_node_at(t, i));
+			TEST_CHECK(compare_at(t, i, f[i]));
 		}
 		for (int i = end_piece_layer; i < num_nodes; ++i)
 		{
-			TEST_CHECK(!t.has_node(i));
+			TEST_CHECK(!has_node_at(t, i));
 		}
 	}
 }
@@ -217,16 +237,14 @@ void test_roundtrip(aux::merkle_tree const& t
 	TEST_CHECK(t.build_vector() == t2.build_vector());
 	for (int i = 0; i < int(t.size()); ++i)
 	{
-		TEST_EQUAL(t[i], t2[i]);
-		TEST_EQUAL(t.has_node(i), t2.has_node(i));
+		TEST_EQUAL(node_at_flat(t, i), node_at_flat(t2, i));
+		TEST_EQUAL(has_node_at(t, i), has_node_at(t2, i));
 
-		if (!t.has_node(i))
-			TEST_CHECK(t[i].is_all_zeros());
-		if (!t2.has_node(i))
-			TEST_CHECK(t2[i].is_all_zeros());
+		if (!has_node_at(t, i)) TEST_CHECK(node_at_flat(t, i).is_all_zeros());
+		if (!has_node_at(t2, i)) TEST_CHECK(node_at_flat(t2, i).is_all_zeros());
 
-		TEST_CHECK(t.compare_node(i, t2[i]));
-		TEST_CHECK(t2.compare_node(i, t[i]));
+		TEST_CHECK(compare_at(t, i, node_at_flat(t2, i)));
+		TEST_CHECK(compare_at(t2, i, node_at_flat(t, i)));
 	}
 }
 }
@@ -328,7 +346,7 @@ TORRENT_TEST(sparse_merkle_tree_block_layer)
 	t.load_tree(span<sha256_hash const>(f).first(int(t.size())), empty_verified);
 
 	for (int i = 0; i < int(t.size()); ++i)
-		TEST_CHECK(t[i] == f[i]);
+		TEST_CHECK(node_at_flat(t, i) == f[i]);
 }
 
 TORRENT_TEST(get_piece_layer)
@@ -348,7 +366,7 @@ TORRENT_TEST(get_piece_layer)
 	TEST_EQUAL(num_pieces, int(piece_layer.size()));
 	for (int i = 0; i < int(piece_layer.size()); ++i)
 	{
-		TEST_CHECK(t[piece_layer_start + i] == piece_layer[i]);
+		TEST_CHECK(node_at_flat(t, piece_layer_start + i) == piece_layer[i]);
 	}
 }
 
@@ -369,7 +387,7 @@ TORRENT_TEST(get_piece_layer_piece_layer_mode)
 	TEST_EQUAL(num_pieces, int(piece_layer.size()));
 	for (int i = 0; i < int(piece_layer.size()); ++i)
 	{
-		TEST_CHECK(t[piece_layer_start + i] == piece_layer[i]);
+		TEST_CHECK(node_at_flat(t, piece_layer_start + i) == piece_layer[i]);
 	}
 }
 
@@ -505,11 +523,11 @@ TORRENT_TEST(add_hashes_full_tree)
 
 		// check the piece layer
 		for (int i = 127; i < 255; ++i)
-			TEST_EQUAL(t[i], f[i]);
+			TEST_EQUAL(node_at_flat(t, i), f[i]);
 
 		// check the block layer
 		for (int i = 511; i < 1023; ++i)
-			TEST_EQUAL(t[i], f[i]);
+			TEST_EQUAL(node_at_flat(t, i), f[i]);
 
 		TEST_CHECK(t.verified_leafs() == all_set(num_blocks));
 	}
@@ -537,28 +555,34 @@ TORRENT_TEST(add_hashes_one_piece)
 		// the trail of proof hashes
 		for (int i = insert_idx; i > 0; i = merkle_get_parent(i))
 		{
-			TEST_EQUAL(t[i], f[i]);
-			TEST_EQUAL(t[merkle_get_sibling(i)], f[merkle_get_sibling(i)]);
+			TEST_EQUAL(node_at_flat(t, i), f[i]);
+			TEST_EQUAL(node_at_flat(t, merkle_get_sibling(i)), f[merkle_get_sibling(i)]);
 		}
 
-		// check the piece layer
+		// check the piece layer (only live positions; compact storage
+		// returns the implied pad hash at padding positions)
 		for (int i = 127; i < 255; ++i)
 		{
+			int const L = merkle_get_layer(i);
+			int const O = i - merkle_layer_start(L);
 			// one is the root of the hashes we added, the other is part of the
 			// proof anchroing it in the root
 			if (i == 127 + piece_index || merkle_get_sibling(i) == 127 + piece_index)
-				TEST_EQUAL(t[i], f[i]);
-			else
-				TEST_CHECK(t[i].is_all_zeros());
+				TEST_EQUAL(node_at_flat(t, i), f[i]);
+			else if (!t.is_padding(L, O))
+				TEST_CHECK(node_at_flat(t, i).is_all_zeros());
 		}
 
-		// check the block layer
+		// check the block layer (only live positions; padding returns
+		// the implied pad value, here zero at the leaf layer)
 		for (int i = 511; i < 1023; ++i)
 		{
+			int const L = merkle_get_layer(i);
+			int const O = i - merkle_layer_start(L);
 			if (i >= 511 + piece_index*blocks_per_piece && i < 511 + piece_index*blocks_per_piece + 4)
-				TEST_EQUAL(t[i], f[i]);
-			else
-				TEST_CHECK(t[i].is_all_zeros());
+				TEST_EQUAL(node_at_flat(t, i), f[i]);
+			else if (!t.is_padding(L, O))
+				TEST_CHECK(node_at_flat(t, i).is_all_zeros());
 		}
 
 		int const start_block = piece_index * blocks_per_piece;
@@ -854,7 +878,7 @@ TORRENT_TEST(add_hashes_block_layer_no_padding)
 	TEST_EQUAL(res.failed.size(), 0);
 
 	for (int i = 0; i < 1023; ++i)
-		TEST_EQUAL(t[i], f[i]);
+		TEST_EQUAL(node_at_flat(t, i), f[i]);
 
 	TEST_CHECK(t.verified_leafs() == all_set(num_blocks));
 }
@@ -874,10 +898,14 @@ TORRENT_TEST(add_hashes_piece_layer_no_padding)
 	TEST_EQUAL(res.failed.size(), 0);
 
 	for (int i = 0; i < 255; ++i)
-		TEST_EQUAL(t[i], f[i]);
+		TEST_EQUAL(node_at_flat(t, i), f[i]);
 
 	for (int i = 255; i < 1023; ++i)
-		TEST_CHECK(t[i].is_all_zeros());
+	{
+		int const L = merkle_get_layer(i);
+		int const O = i - merkle_layer_start(L);
+		if (!t.is_padding(L, O)) TEST_CHECK(node_at_flat(t, i).is_all_zeros());
+	}
 
 	TEST_CHECK(t.verified_leafs() == none_set(num_blocks));
 }
@@ -893,7 +921,7 @@ TORRENT_TEST(add_hashes_partial_proofs)
 		if (!result) return;
 
 		for (int i = 0; i < 7; ++i)
-			TEST_EQUAL(t[i], f[i]);
+			TEST_EQUAL(node_at_flat(t, i), f[i]);
 	}
 
 	// use a proof that ties the first piece node 3 (since we don't need it all
@@ -906,7 +934,7 @@ TORRENT_TEST(add_hashes_partial_proofs)
 	TEST_EQUAL(res.failed.size(), 0);
 
 	for (int i = 127; i < 127 + 4; ++i)
-		TEST_CHECK(t[i] == f[i]);
+		TEST_CHECK(node_at_flat(t, i) == f[i]);
 
 	TEST_CHECK(t.verified_leafs() == none_set(num_blocks));
 }
@@ -972,3 +1000,125 @@ TORRENT_TEST(load_piece_layer_clears_verified_bits)
 // TODO: add test for add_hashes() with an odd number of blocks
 // TODO: add test for set_block() (setting the last block) with an odd number of blocks
 
+TORRENT_TEST(compact_storage_smaller_than_flat)
+{
+	// For non-power-of-2 block counts, the compact layout stores fewer
+	// hashes than the standard 2*L - 1 nodes.
+	aux::merkle_tree t(num_blocks, 1, f[0].data());
+	int const compact_size = int(t.build_vector().size());
+	int const flat_size = merkle_num_nodes(num_leafs);
+	TEST_CHECK(compact_size < flat_size);
+	// For 259 blocks: sum of live counts = 1+2+3+5+9+17+33+65+130+259 = 524
+	TEST_EQUAL(compact_size, 524);
+	TEST_EQUAL(flat_size, 1023);
+}
+
+TORRENT_TEST(padding_position_reads_implied_pad)
+{
+	// In a non-power-of-2 tree, padding positions report the implied pad
+	// hash (merkle_pad with the appropriate subtree size) rather than
+	// zero. Verify this for an interior padding slot.
+	aux::merkle_tree t(num_blocks, 1, f[0].data());
+	t.allocate_compact();
+
+	// At L=2 in a 9-layer tree (num_blocks=259), live count is 3 so
+	// offset 3 is the first padding slot. The implied pad covers
+	// 2^(9 - 2) = 128 zero leaves.
+	int const pad_L = 2;
+	int const pad_O = 3;
+	sha256_hash const expected_pad = merkle_pad(128, 1);
+	TEST_EQUAL(t.node_at(pad_L, pad_O), expected_pad);
+	TEST_CHECK(t.is_padding(pad_L, pad_O));
+	// And a live slot at the same layer is unset (zero):
+	TEST_CHECK(!t.is_padding(pad_L, 2));
+	TEST_CHECK(t.node_at(pad_L, 2).is_all_zeros());
+}
+
+TORRENT_TEST(set_padding_rejects_non_pad_value)
+{
+	// Writing a non-pad hash to a padding slot is rejected; writing the
+	// implied pad (or zero, as a harmless clear) is accepted as a no-op.
+	aux::merkle_tree t(num_blocks, 1, f[0].data());
+	t.allocate_compact();
+
+	int const pad_L = 2;
+	int const pad_O = 3;
+
+	// rejected: a non-pad, non-zero value
+	sha256_hash const bogus("01234567890123456789012345678901");
+	TEST_CHECK(!t.set(pad_L, pad_O, bogus));
+
+	// accepted: zero (a no-op clear)
+	TEST_CHECK(t.set(pad_L, pad_O, sha256_hash{}));
+
+	// accepted: the implied pad value
+	TEST_CHECK(t.set(pad_L, pad_O, merkle_pad(128, 1)));
+
+	// after all of that, the slot still reads back as the implied pad
+	TEST_EQUAL(t.node_at(pad_L, pad_O), merkle_pad(128, 1));
+}
+
+TORRENT_TEST(validate_and_insert_proofs_padding_uncle_rejected)
+{
+	// A proof chain whose first uncle lands on a padding sibling must
+	// supply the implied pad. A non-pad uncle is rejected by set() and
+	// the proof-validation walk fails, leaving the tree unchanged.
+	aux::merkle_tree t(num_blocks, 1, f[0].data());
+	t.allocate_compact();
+
+	// Insert at (L=9, O=258), the rightmost live leaf. Its sibling at
+	// (L=9, O=259) is padding; the leaf-layer pad is zero. A non-zero
+	// uncle here must be rejected.
+	sha256_hash const leaf_hash = f[merkle_first_leaf(num_leafs) + 258];
+	std::vector<sha256_hash> bogus_proofs{sha256_hash("01234567890123456789012345678901")};
+
+	TEST_CHECK(!merkle_validate_and_insert_proofs(t, 9, 258, leaf_hash, bogus_proofs));
+
+	// Rollback: the target node and the rejected sibling must both be
+	// back to their pre-call state (uninitialized / implied-pad).
+	TEST_CHECK(t.node_at(9, 258).is_all_zeros());
+	TEST_CHECK(t.node_at(9, 259).is_all_zeros()); // leaf-layer pad is zero
+}
+
+TORRENT_TEST(load_sparse_tree_padding_mask_bit_implied_pad)
+{
+	// load_sparse_tree can carry a mask bit at a padding flat index; the
+	// value alongside that bit must match the implied pad. The slot then
+	// reads back as the implied pad. (set() silently accepts the matching
+	// pad write as a no-op; the actual storage doesn't change.)
+	aux::merkle_tree t(num_blocks, 1, f[0].data());
+
+	int const pad_L = 2;
+	int const pad_O = 3;
+	int const pad_flat = merkle_to_flat_index(pad_L, pad_O);
+	sha256_hash const expected_pad = merkle_pad(128, 1);
+
+	std::vector<sha256_hash> sparse{expected_pad};
+	bitfield mask(num_nodes, false);
+	mask.set_bit(pad_flat);
+
+	t.load_sparse_tree(sparse, mask, empty_verified);
+
+	// Padding read-back is unaffected by whether the sparse load touched
+	// it -- the slot is implied.
+	TEST_EQUAL(t.node_at(pad_L, pad_O), expected_pad);
+}
+
+TORRENT_TEST(build_vector_roundtrip_odd_blocks)
+{
+	// Round-trip a partial tree through the sparse-vector serialization:
+	// load some data, build_sparse_vector, construct a new tree, load,
+	// build_vector. The two compact representations must agree.
+	aux::merkle_tree t(num_blocks, 1, f[0].data());
+	t.load_tree(f, empty_verified);
+
+	auto const compact_before = t.build_vector();
+
+	auto const [sparse, mask] = t.build_sparse_vector();
+	aux::merkle_tree t2(num_blocks, 1, f[0].data());
+	t2.load_sparse_tree(sparse, mask, empty_verified);
+
+	auto const compact_after = t2.build_vector();
+	TEST_CHECK(compact_before == compact_after);
+	TEST_EQUAL(int(compact_before.size()), 524);
+}


### PR DESCRIPTION
update merkle_tree to not store pad blocks, not any of their parents. They are implied.