### PR TITLE
simplify peer transfer stats collection

### DIFF
--- a/include/libtorrent/aux_/peer_connection.hpp
+++ b/include/libtorrent/aux_/peer_connection.hpp
@@ -771,6 +771,8 @@ namespace libtorrent::aux {
 		io_context& get_context() { return m_ios; }
 
 	private:
+		// flushes m_pending_stats into t (which also propagates to session)
+		void flush_pending_stats(aux::torrent& t);
 
 		// callbacks for data being sent or received
 		void on_send_data(error_code const& error
@@ -1030,6 +1032,12 @@ namespace libtorrent::aux {
 		// TODO: factor this out into its own class with a virtual interface
 		// torrent and session should implement this interface
 		aux::stat m_statistics;
+
+		// stat deltas accumulated locally on the per-byte hot path;
+		// flushed once per second_tick() via a single accumulate_stats
+		// call. ip_overhead is pre-computed packet-by-packet so the
+		// aggregation preserves the per-packet count
+		aux::stat_delta m_pending_stats;
 
 		// the number of outstanding bytes expected
 		// to be received by extensions

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -1108,11 +1108,7 @@ namespace aux {
 			stat m_stat;
 
 			// implements session_interface
-			void sent_bytes(int bytes_payload, int bytes_protocol) override;
-			void received_bytes(int bytes_payload, int bytes_protocol) override;
-			void trancieve_ip_packet(int bytes, bool ipv6) override;
-			void sent_syn(bool ipv6) override;
-			void received_synack(bool ipv6) override;
+			void accumulate_stats(stat_delta const& d) override;
 
 #if TORRENT_ABI_VERSION == 1
 			int m_peak_up_rate = 0;

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -55,6 +55,7 @@ namespace aux {
 	struct torrent_peer;
 	struct torrent_peer_allocator_interface;
 	struct external_ip;
+	struct stat_delta;
 }
 
 	// hidden
@@ -216,11 +217,11 @@ namespace libtorrent::aux {
 
 		virtual bandwidth_manager* get_bandwidth_manager(int channel) = 0;
 
-		virtual void sent_bytes(int bytes_payload, int bytes_protocol) = 0;
-		virtual void received_bytes(int bytes_payload, int bytes_protocol) = 0;
-		virtual void trancieve_ip_packet(int bytes, bool ipv6) = 0;
-		virtual void sent_syn(bool ipv6) = 0;
-		virtual void received_synack(bool ipv6) = 0;
+		// per-tick stats delta flushed from peer_connection. covers
+		// payload/protocol bytes (both directions) and IP overhead
+		// (asymmetric for SYN/SYN-ACK, symmetric for data packets).
+		// pre-computed at peer call sites so aggregation is exact
+		virtual void accumulate_stats(stat_delta const&) = 0;
 
 		// this is the set of (subscribed) torrents that have changed
 		// their states since the last time the user requested updates.

--- a/include/libtorrent/aux_/stat.hpp
+++ b/include/libtorrent/aux_/stat.hpp
@@ -84,6 +84,20 @@ namespace libtorrent::aux {
 		std::int32_t m_5_sec_average;
 	};
 
+	// per-tick deltas accumulated on the peer-connection hot path and
+	// flushed through aux::session_interface::accumulate_stats() and
+	// aux::torrent::accumulate_stats(). IP overhead bytes are pre-computed
+	// at peer call sites so aggregation preserves the per-packet count.
+	struct stat_delta
+	{
+		int payload_recv = 0;
+		int protocol_recv = 0;
+		int payload_sent = 0;
+		int protocol_sent = 0;
+		int ip_overhead_recv = 0;
+		int ip_overhead_sent = 0;
+	};
+
 	class TORRENT_EXTRA_EXPORT stat
 	{
 	public:
@@ -91,6 +105,16 @@ namespace libtorrent::aux {
 		{
 			for (int i = 0; i < num_channels; ++i)
 				m_stat[i] += s.m_stat[i];
+		}
+
+		void accumulate(stat_delta const& d)
+		{
+			m_stat[download_payload].add(d.payload_recv);
+			m_stat[download_protocol].add(d.protocol_recv);
+			m_stat[upload_payload].add(d.payload_sent);
+			m_stat[upload_protocol].add(d.protocol_sent);
+			m_stat[download_ip_protocol].add(d.ip_overhead_recv);
+			m_stat[upload_ip_protocol].add(d.ip_overhead_sent);
 		}
 
 		void sent_syn(bool ipv6)

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -522,11 +522,9 @@ namespace libtorrent::aux {
 
 		void bytes_done(torrent_status& st, status_flags_t) const;
 
-		void sent_bytes(int bytes_payload, int bytes_protocol);
-		void received_bytes(int bytes_payload, int bytes_protocol);
-		void trancieve_ip_packet(int bytes, bool ipv6);
-		void sent_syn(bool ipv6);
-		void received_synack(bool ipv6);
+		// per-tick stats delta flushed by peer_connection. propagates
+		// the deltas to m_stat and to the session
+		void accumulate_stats(stat_delta const& d);
 
 		void set_ip_filter(std::shared_ptr<const ip_filter> ipf);
 		void privileged_port_updated();

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1122,9 +1122,8 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.received_bytes(bytes_payload, bytes_protocol);
 		if (m_ignore_stats) return;
-		auto t = m_torrent.lock();
-		if (!t) return;
-		t->received_bytes(bytes_payload, bytes_protocol);
+		m_pending_stats.payload_recv += bytes_payload;
+		m_pending_stats.protocol_recv += bytes_protocol;
 	}
 
 	void peer_connection::sent_bytes(int const bytes_payload, int const bytes_protocol)
@@ -1142,9 +1141,8 @@ namespace {
 #endif
 		if (bytes_payload > 0) m_last_sent_payload.set(m_connect, clock_type::now());
 		if (m_ignore_stats) return;
-		auto t = m_torrent.lock();
-		if (!t) return;
-		t->sent_bytes(bytes_payload, bytes_protocol);
+		m_pending_stats.payload_sent += bytes_payload;
+		m_pending_stats.protocol_sent += bytes_protocol;
 	}
 
 	void peer_connection::trancieve_ip_packet(int const bytes, bool const ipv6)
@@ -1152,9 +1150,21 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.trancieve_ip_packet(bytes, ipv6);
 		if (m_ignore_stats) return;
-		auto t = m_torrent.lock();
-		if (!t) return;
-		t->trancieve_ip_packet(bytes, ipv6);
+		// compute per-call overhead packet-by-packet, then accumulate.
+		// summing overhead (not bytes) preserves the per-call packet
+		// count across the per-tick flush. trancieve covers both
+		// directions (packet + ACK) so add to both channels
+		int const header = (ipv6 ? 40 : 20) + 20;
+		int const packet_size = 1500 - header;
+		int const overhead = std::max(1, (bytes + packet_size - 1) / packet_size) * header;
+		m_pending_stats.ip_overhead_recv += overhead;
+		m_pending_stats.ip_overhead_sent += overhead;
+	}
+
+	void peer_connection::flush_pending_stats(aux::torrent& t)
+	{
+		t.accumulate_stats(m_pending_stats);
+		m_pending_stats = {};
 	}
 
 	void peer_connection::sent_syn(bool const ipv6)
@@ -1162,9 +1172,8 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.sent_syn(ipv6);
 		if (m_ignore_stats) return;
-		auto t = m_torrent.lock();
-		if (!t) return;
-		t->sent_syn(ipv6);
+		// only the outgoing SYN -- no ACK back yet
+		m_pending_stats.ip_overhead_sent += ipv6 ? 60 : 40;
 	}
 
 	void peer_connection::received_synack(bool const ipv6)
@@ -1172,9 +1181,10 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 		m_statistics.received_synack(ipv6);
 		if (m_ignore_stats) return;
-		auto t = m_torrent.lock();
-		if (!t) return;
-		t->received_synack(ipv6);
+		// the received SYN-ACK and our ACK back -- one of each direction
+		int const overhead = ipv6 ? 60 : 40;
+		m_pending_stats.ip_overhead_recv += overhead;
+		m_pending_stats.ip_overhead_sent += overhead;
 	}
 
 	peer_endpoint_t peer_connection::remote_endpoint() const
@@ -4484,6 +4494,8 @@ namespace {
 
 		if (t)
 		{
+			flush_pending_stats(*t);
+
 			// make sure we keep all the stats!
 			if (!m_ignore_stats)
 			{
@@ -4851,6 +4863,8 @@ namespace {
 		INVARIANT_CHECK;
 
 		auto t = m_torrent.lock();
+
+		if (t) flush_pending_stats(*t);
 
 		std::uint8_t warning = 0;
 		// drain the IP overhead from the bandwidth limiters

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3381,67 +3381,32 @@ retry:
 	}
 #endif
 
-	void session_impl::sent_bytes(int bytes_payload, int bytes_protocol)
+	void session_impl::accumulate_stats(stat_delta const& d)
 	{
-		TORRENT_ASSERT(bytes_payload >= 0);
-		TORRENT_ASSERT(bytes_protocol >= 0);
-		m_stats_counters.inc_stats_counter(counters::sent_bytes
-			, bytes_payload + bytes_protocol);
-		m_stats_counters.inc_stats_counter(counters::sent_payload_bytes
-			, bytes_payload);
+		TORRENT_ASSERT(d.payload_recv >= 0 && d.protocol_recv >= 0);
+		TORRENT_ASSERT(d.payload_sent >= 0 && d.protocol_sent >= 0);
+		TORRENT_ASSERT(d.ip_overhead_recv >= 0 && d.ip_overhead_sent >= 0);
 
-		m_stat.sent_bytes(bytes_payload, bytes_protocol);
-	}
+		if (d.payload_recv || d.protocol_recv)
+		{
+			m_stats_counters.inc_stats_counter(
+				counters::recv_bytes, d.payload_recv + d.protocol_recv);
+			m_stats_counters.inc_stats_counter(counters::recv_payload_bytes, d.payload_recv);
+		}
+		if (d.payload_sent || d.protocol_sent)
+		{
+			m_stats_counters.inc_stats_counter(
+				counters::sent_bytes, d.payload_sent + d.protocol_sent);
+			m_stats_counters.inc_stats_counter(counters::sent_payload_bytes, d.payload_sent);
+		}
+		if (d.ip_overhead_recv)
+			m_stats_counters.inc_stats_counter(
+				counters::recv_ip_overhead_bytes, d.ip_overhead_recv);
+		if (d.ip_overhead_sent)
+			m_stats_counters.inc_stats_counter(
+				counters::sent_ip_overhead_bytes, d.ip_overhead_sent);
 
-	void session_impl::received_bytes(int bytes_payload, int bytes_protocol)
-	{
-		TORRENT_ASSERT(bytes_payload >= 0);
-		TORRENT_ASSERT(bytes_protocol >= 0);
-		m_stats_counters.inc_stats_counter(counters::recv_bytes
-			, bytes_payload + bytes_protocol);
-		m_stats_counters.inc_stats_counter(counters::recv_payload_bytes
-			, bytes_payload);
-
-		m_stat.received_bytes(bytes_payload, bytes_protocol);
-	}
-
-	void session_impl::trancieve_ip_packet(int bytes, bool ipv6)
-	{
-		TORRENT_ASSERT(bytes >= 0);
-		// one TCP/IP packet header for the packet
-		// sent or received, and one for the ACK
-		// The IPv4 header is 20 bytes
-		// and IPv6 header is 40 bytes
-		int const header = (ipv6 ? 40 : 20) + 20;
-		int const mtu = 1500;
-		int const packet_size = mtu - header;
-		int const overhead = std::max(1, (bytes + packet_size - 1) / packet_size) * header;
-		m_stats_counters.inc_stats_counter(counters::sent_ip_overhead_bytes
-			, overhead);
-		m_stats_counters.inc_stats_counter(counters::recv_ip_overhead_bytes
-			, overhead);
-
-		m_stat.trancieve_ip_packet(bytes, ipv6);
-	}
-
-	void session_impl::sent_syn(bool ipv6)
-	{
-		int const overhead = ipv6 ? 60 : 40;
-		m_stats_counters.inc_stats_counter(counters::sent_ip_overhead_bytes
-			, overhead);
-
-		m_stat.sent_syn(ipv6);
-	}
-
-	void session_impl::received_synack(bool ipv6)
-	{
-		int const overhead = ipv6 ? 60 : 40;
-		m_stats_counters.inc_stats_counter(counters::sent_ip_overhead_bytes
-			, overhead);
-		m_stats_counters.inc_stats_counter(counters::recv_ip_overhead_bytes
-			, overhead);
-
-		m_stat.received_synack(ipv6);
+		m_stat.accumulate(d);
 	}
 
 	void session_impl::on_tick(error_code const& e)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10876,34 +10876,10 @@ namespace {
 	}
 #endif // TORRENT_DISABLE_SHARE_MODE
 
-	void torrent::sent_bytes(int const bytes_payload, int const bytes_protocol)
+	void torrent::accumulate_stats(stat_delta const& d)
 	{
-		m_stat.sent_bytes(bytes_payload, bytes_protocol);
-		m_ses.sent_bytes(bytes_payload, bytes_protocol);
-	}
-
-	void torrent::received_bytes(int const bytes_payload, int const bytes_protocol)
-	{
-		m_stat.received_bytes(bytes_payload, bytes_protocol);
-		m_ses.received_bytes(bytes_payload, bytes_protocol);
-	}
-
-	void torrent::trancieve_ip_packet(int const bytes, bool const ipv6)
-	{
-		m_stat.trancieve_ip_packet(bytes, ipv6);
-		m_ses.trancieve_ip_packet(bytes, ipv6);
-	}
-
-	void torrent::sent_syn(bool const ipv6)
-	{
-		m_stat.sent_syn(ipv6);
-		m_ses.sent_syn(ipv6);
-	}
-
-	void torrent::received_synack(bool const ipv6)
-	{
-		m_stat.received_synack(ipv6);
-		m_ses.received_synack(ipv6);
+		m_stat.accumulate(d);
+		m_ses.accumulate_stats(d);
 	}
 
 #ifndef TORRENT_DISABLE_STREAMING

--- a/test/session_mock.hpp
+++ b/test/session_mock.hpp
@@ -120,11 +120,7 @@ struct session_mock : aux::session_interface
 
 	aux::bandwidth_manager* get_bandwidth_manager(int) override { return nullptr; }
 
-	void sent_bytes(int, int) override {}
-	void received_bytes(int, int) override {}
-	void trancieve_ip_packet(int, bool) override {}
-	void sent_syn(bool) override {}
-	void received_synack(bool) override {}
+	void accumulate_stats(aux::stat_delta const&) override {}
 
 	aux::vector<aux::torrent*>& torrent_list(aux::torrent_list_index_t) override { return _torrent_list; }
 


### PR DESCRIPTION
accumulate stats per-peer and fold into torrent- and session stats once per second.

The upsides are:

* smaller/simpler interface to torrent, session_impl and stats
* more separation between peer_connection, torrent and session_impl; preparing for multi-threading
* More efficient to accumulate into local, non-shared, counters and only fold periodically