### PR TITLE
Bandwidth managers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -646,6 +646,7 @@ HEADERS = \
   aux_/puff.hpp                     \
   aux_/random.hpp                   \
   aux_/range.hpp                    \
+  aux_/rate_limits.hpp              \
   aux_/readwrite.hpp                \
   aux_/receive_buffer.hpp           \
   aux_/request_blocks.hpp           \

--- a/include/libtorrent/aux_/bandwidth_limit.hpp
+++ b/include/libtorrent/aux_/bandwidth_limit.hpp
@@ -27,8 +27,8 @@ struct TORRENT_EXTRA_EXPORT bandwidth_channel
 
 	bandwidth_channel();
 
-	// 0 means infinite
-	void throttle(int limit);
+	// 0 means infinite. returns true iff the stored value actually changed.
+	bool throttle(int limit);
 	int throttle() const
 	{
 		TORRENT_ASSERT_VAL(m_limit >= 0, m_limit);

--- a/include/libtorrent/aux_/peer_class_set.hpp
+++ b/include/libtorrent/aux_/peer_class_set.hpp
@@ -18,12 +18,18 @@ namespace libtorrent::aux {
 
 	// this represents an object that can have many peer classes applied
 	// to it. Most notably, peer connections and torrents derive from this.
+	// the membership list is tracked here; reference counting on the
+	// peer_class_pool is the caller's responsibility (rate_limits owns
+	// that part).
 	struct TORRENT_EXTRA_EXPORT peer_class_set
 	{
 		peer_class_set() : m_size(0) {}
-		void add_class(peer_class_pool& pool, peer_class_t c);
+		// returns true iff `c` was actually added (false if already a
+		// member, or if the fixed-size membership array is full).
+		bool add(peer_class_t c);
+		// returns true iff `c` was actually removed (false if not a member).
+		bool remove(peer_class_t c);
 		bool has_class(peer_class_t c) const;
-		void remove_class(peer_class_pool& pool, peer_class_t c);
 		int num_classes() const { return m_size; }
 		peer_class_t class_at(int i) const
 		{

--- a/include/libtorrent/aux_/peer_connection.hpp
+++ b/include/libtorrent/aux_/peer_connection.hpp
@@ -29,8 +29,8 @@ see LICENSE file.
 #include "libtorrent/aux_/bandwidth_socket.hpp"
 #include "libtorrent/error_code.hpp"
 #include "libtorrent/aux_/sliding_average.hpp"
-#include "libtorrent/peer_class.hpp"
 #include "libtorrent/aux_/peer_class_set.hpp"
+#include "libtorrent/aux_/rate_limits.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
 #include "libtorrent/disk_observer.hpp"
@@ -172,6 +172,7 @@ namespace libtorrent::aux {
 			, m_ses(ses)
 			, m_settings(sett)
 			, m_alerts(ses.alerts())
+			, m_rates(ses.rates())
 			, m_disconnecting(false)
 			, m_connecting(!m_torrent.expired())
 			, m_endgame_mode(false)
@@ -212,6 +213,12 @@ namespace libtorrent::aux {
 
 		// cached reference to session's alert_manager
 		aux::alert_manager& m_alerts;
+
+		// cached reference to the session's bandwidth subsystem. concrete
+		// owner of the bandwidth_managers and the peer_class -> channel
+		// translation; the eventual home of the bandwidth mutex once
+		// peer_connection runs on its own strand
+		aux::rate_limits& m_rates;
 
 	protected:
 
@@ -274,12 +281,12 @@ namespace libtorrent::aux {
 
 		virtual connection_type type() const = 0;
 
-		enum channels
-		{
-			upload_channel,
-			download_channel,
-			num_channels
-		};
+		// channel indices live on rate_limits; aliased here so existing
+		// peer_connection::upload_channel spellings keep working.
+		using channels = aux::rate_limits::channels;
+		static constexpr int upload_channel = aux::rate_limits::upload_channel;
+		static constexpr int download_channel = aux::rate_limits::download_channel;
+		static constexpr int num_channels = aux::rate_limits::num_channels;
 
 		explicit peer_connection(peer_connection_args& pack);
 

--- a/include/libtorrent/aux_/rate_limits.hpp
+++ b/include/libtorrent/aux_/rate_limits.hpp
@@ -1,0 +1,350 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#ifndef TORRENT_RATE_LIMITS_HPP_INCLUDED
+#define TORRENT_RATE_LIMITS_HPP_INCLUDED
+
+#include "libtorrent/config.hpp"
+#include "libtorrent/aux_/bandwidth_manager.hpp"
+#include "libtorrent/aux_/bandwidth_queue_entry.hpp"
+#include "libtorrent/aux_/bandwidth_socket.hpp"
+#include "libtorrent/aux_/peer_class_set.hpp"
+#include "libtorrent/aux_/alloca.hpp"
+#include "libtorrent/peer_class.hpp"
+#include "libtorrent/span.hpp"
+#if TORRENT_USE_INVARIANT_CHECKS
+#include "libtorrent/aux_/string_util.hpp" // for url_random
+#endif
+
+#include <algorithm> // for std::min
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility> // for std::move
+#if TORRENT_USE_ASSERTS
+#include <set>
+#endif
+
+namespace libtorrent::aux {
+
+	// concrete owner of the per-session bandwidth subsystem (channel
+	// collection, manager dispatch, IP overhead application). peer_connection
+	// holds a reference to this and calls its methods directly -- no virtual
+	// dispatch. exists so that, when peer_connection runs on its own strand,
+	// a single mutex held inside this class can encapsulate all bandwidth
+	// state behind the language's access control, rather than relying on
+	// callers to remember to lock.
+	struct TORRENT_EXTRA_EXPORT rate_limits
+	{
+		// channel indices used throughout the bandwidth subsystem: into
+		// peer_class::channel[2], peer_connection::m_channel_state[2] and
+		// m_quota[2]. peer_connection re-exports these names as
+		// peer_connection::upload_channel etc. for backward compatibility
+		// with the ~100 existing call sites.
+		enum channels
+		{
+			upload_channel,
+			download_channel,
+			num_channels
+		};
+
+		rate_limits(bandwidth_manager& download, bandwidth_manager& upload)
+			: m_download_rate(download)
+			, m_upload_rate(upload)
+		{}
+
+		rate_limits(rate_limits const&) = delete;
+		rate_limits& operator=(rate_limits const&) = delete;
+		rate_limits(rate_limits&&) = delete;
+		rate_limits& operator=(rate_limits&&) = delete;
+
+		int request_bandwidth(std::shared_ptr<bandwidth_socket> peer,
+			int const channel,
+			int const bytes,
+			int const priority,
+			peer_class_set const& peer_classes,
+			peer_class_set const* torrent_classes)
+		{
+			int const max_supported_channels = bw_request::max_bandwidth_channels;
+			int const max_channels = std::min(max_supported_channels,
+				peer_classes.num_classes() + (torrent_classes ? torrent_classes->num_classes() : 0)
+					+ 2);
+			TORRENT_ALLOCA(channels, bandwidth_channel*, max_channels);
+
+			int c = 0;
+			c += copy_pertinent_channels(peer_classes, channel, channels.subspan(c));
+			if (torrent_classes)
+				c += copy_pertinent_channels(*torrent_classes, channel, channels.subspan(c));
+
+#if TORRENT_USE_ASSERTS
+			std::set<bandwidth_channel*> unique_classes;
+			for (auto* chan : channels.first(c))
+			{
+				TORRENT_ASSERT(unique_classes.count(chan) == 0);
+				unique_classes.insert(chan);
+			}
+#endif
+
+			bandwidth_manager& manager =
+				(channel == download_channel) ? m_download_rate : m_upload_rate;
+			return manager.request_bandwidth(std::move(peer), bytes, priority, channels.first(c));
+		}
+
+		std::uint8_t apply_ip_overhead(peer_class_set& peer_classes,
+			peer_class_set* torrent_classes,
+			int const amount_down,
+			int const amount_up)
+		{
+			std::uint8_t ret = use_quota_overhead(peer_classes, amount_down, amount_up);
+			if (torrent_classes)
+				ret |= use_quota_overhead(*torrent_classes, amount_down, amount_up);
+			return ret;
+		}
+
+#if TORRENT_USE_ASSERTS
+		bool is_queued(bandwidth_socket const* peer, int const channel) const
+		{
+			bandwidth_manager const& manager =
+				(channel == download_channel) ? m_download_rate : m_upload_rate;
+			return manager.is_queued(peer);
+		}
+
+		// returns true if `cid` refers to a live class. used by precondition
+		// asserts on the public peer-class API.
+		bool exists(peer_class_t const cid) const { return m_classes.at(cid) != nullptr; }
+#endif
+
+		bool ignore_unchoke_slots_set(peer_class_set const& set) const
+		{
+			int const num = set.num_classes();
+			for (int i = 0; i < num; ++i)
+			{
+				peer_class const* pc = m_classes.at(set.class_at(i));
+				if (pc == nullptr) continue;
+				if (pc->ignore_unchoke_slots) return true;
+			}
+			return false;
+		}
+
+		// reads a class into a peer_class_info. returns the default-constructed
+		// (or, under invariant checks, garbage-filled) info if the class is
+		// missing, matching the long-standing get_peer_class() behavior.
+		peer_class_info info(peer_class_t const cid) const
+		{
+			peer_class_info ret{};
+			peer_class const* pc = m_classes.at(cid);
+			if (pc == nullptr)
+			{
+#if TORRENT_USE_INVARIANT_CHECKS
+				// make it obvious that the return value is undefined
+				ret.upload_limit = 0xf0f0f0f;
+				ret.download_limit = 0xf0f0f0f;
+				ret.label.resize(20);
+				url_random(span<char>(ret.label));
+				ret.ignore_unchoke_slots = false;
+				ret.connection_limit_factor = 0xf0f0f0f;
+				ret.upload_priority = 0xf0f0f0f;
+				ret.download_priority = 0xf0f0f0f;
+#endif
+				return ret;
+			}
+			pc->get_info(&ret);
+			return ret;
+		}
+
+		// returns the throttle on a class' channel, or 0 ("no limit") if the
+		// class doesn't exist. matches session_impl::rate_limit semantics.
+		int throttle(peer_class_t const cid, int const channel) const
+		{
+			peer_class const* pc = m_classes.at(cid);
+			if (pc == nullptr) return 0;
+			return pc->channel[channel].throttle();
+		}
+
+		// returns the max of priority[channel] across all classes in `set`,
+		// or 0 if `set` is empty. callers apply their own floor (the
+		// bandwidth allocator's minimum priority is 1).
+		int max_priority(peer_class_set const& set, int const channel) const
+		{
+			int prio = 0;
+			int const n = set.num_classes();
+			for (int i = 0; i < n; ++i)
+			{
+				peer_class const* pc = m_classes.at(set.class_at(i));
+				if (pc == nullptr) continue;
+				int const p = pc->priority[std::size_t(channel)];
+				if (prio < p) prio = p;
+			}
+			return prio;
+		}
+
+#ifndef TORRENT_DISABLE_LOGGING
+		// appends the label of each class in `set` to `out`, each followed
+		// by a space. used for debug logging only.
+		void format_class_labels(peer_class_set const& set, std::string& out) const
+		{
+			int const n = set.num_classes();
+			for (int i = 0; i < n; ++i)
+			{
+				peer_class const* pc = m_classes.at(set.class_at(i));
+				if (pc == nullptr) continue;
+				out += pc->label;
+				out += ' ';
+			}
+		}
+#endif
+
+		// returns the max connection_limit_factor across all classes in `set`,
+		// or 0 if no class contributed a factor (caller treats 0 as "use default").
+		int max_connection_limit_factor(peer_class_set const& set) const
+		{
+			int factor = 0;
+			int const n = set.num_classes();
+			for (int i = 0; i < n; ++i)
+			{
+				peer_class const* pc = m_classes.at(set.class_at(i));
+				if (pc == nullptr) continue;
+				if (factor < pc->connection_limit_factor) factor = pc->connection_limit_factor;
+			}
+			return factor;
+		}
+
+		// creates a new peer_class with `label` and returns its id.
+		peer_class_t new_class(std::string label)
+		{
+			return m_classes.new_peer_class(std::move(label));
+		}
+
+		// adds `cid` to `set` and bumps the pool refcount iff it wasn't
+		// already a member. silent no-op if `cid` is not a live class --
+		// matches the long-standing runtime safety net at the call sites.
+		void add_class_to(peer_class_set& set, peer_class_t const cid)
+		{
+			if (m_classes.at(cid) == nullptr) return;
+			if (set.add(cid)) m_classes.incref(cid);
+		}
+
+		// removes `cid` from `set` and drops the pool refcount iff it was
+		// a member.
+		void remove_class_from(peer_class_set& set, peer_class_t const cid)
+		{
+			if (set.remove(cid)) m_classes.decref(cid);
+		}
+
+		// drops a reference to the class. no-op if `cid` doesn't refer to a
+		// live class -- the caller is responsible for any precondition assert.
+		void delete_class(peer_class_t const cid)
+		{
+			if (m_classes.at(cid) == nullptr) return;
+			m_classes.decref(cid);
+		}
+
+		// writes all fields of `pci` into the class. silent no-op if `cid`
+		// is not live, matching the long-standing set_peer_class() behavior.
+		void set_info(peer_class_t const cid, peer_class_info const& pci)
+		{
+			peer_class* pc = m_classes.at(cid);
+			if (pc == nullptr) return;
+			pc->set_info(&pci);
+		}
+
+		// sets the throttle (bytes/sec) on a class' channel. `limit <= 0` is
+		// normalized to 0 ("no limit"). silent no-op if `cid` is not live.
+		// the caller is responsible for validating `channel`. returns true
+		// iff the stored value actually changed -- lets callers gate
+		// save-resume / state-update side effects on a real change.
+		bool set_throttle(peer_class_t const cid, int const channel, int limit)
+		{
+			peer_class* pc = m_classes.at(cid);
+			if (pc == nullptr) return false;
+			if (limit <= 0)
+				limit = 0;
+			else
+				limit = std::min(limit, std::numeric_limits<int>::max() - 1);
+			return pc->channel[channel].throttle(limit);
+		}
+
+		// narrow setters used at boot time to configure built-in classes
+		// (local, tcp, ...) without a full read-modify-write of peer_class_info.
+		void set_ignore_unchoke_slots(peer_class_t const cid, bool const v)
+		{
+			peer_class* pc = m_classes.at(cid);
+			if (pc == nullptr) return;
+			pc->ignore_unchoke_slots = v;
+		}
+
+		void set_connection_limit_factor(peer_class_t const cid, int const f)
+		{
+			peer_class* pc = m_classes.at(cid);
+			if (pc == nullptr) return;
+			pc->connection_limit_factor = f;
+		}
+
+#if TORRENT_ABI_VERSION == 1
+		// writes priority[channel] directly, without the [1,255] clamp that
+		// set_info() applies. only used by the deprecated ABI-1
+		// torrent::set_priority.
+		void set_priority(peer_class_t const cid, int const channel, int const prio)
+		{
+			peer_class* pc = m_classes.at(cid);
+			if (pc == nullptr) return;
+			pc->priority[std::size_t(channel)] = prio;
+		}
+#endif
+
+	private:
+		int copy_pertinent_channels(
+			peer_class_set const& set, int const channel, span<bandwidth_channel*> dst)
+		{
+			int const num_channels = set.num_classes();
+			int num_copied = 0;
+			for (int i = 0; i < num_channels; ++i)
+			{
+				if (num_copied >= dst.size()) break;
+				peer_class* pc = m_classes.at(set.class_at(i));
+				TORRENT_ASSERT(pc);
+				if (pc == nullptr) continue;
+				bandwidth_channel* chan = &pc->channel[channel];
+				if (chan->throttle() == 0) continue;
+				dst[num_copied] = chan;
+				++num_copied;
+			}
+			return num_copied;
+		}
+
+		std::uint8_t use_quota_overhead(
+			peer_class_set& set, int const amount_down, int const amount_up)
+		{
+			std::uint8_t ret = 0;
+			int const num = set.num_classes();
+			for (int i = 0; i < num; ++i)
+			{
+				peer_class* p = m_classes.at(set.class_at(i));
+				if (p == nullptr) continue;
+
+				bandwidth_channel* ch = &p->channel[download_channel];
+				ch->use_quota(amount_down);
+				if (ch->throttle() > 0 && ch->throttle() < amount_down)
+					ret |= std::uint8_t(1u) << download_channel;
+				ch = &p->channel[upload_channel];
+				ch->use_quota(amount_up);
+				if (ch->throttle() > 0 && ch->throttle() < amount_up)
+					ret |= std::uint8_t(1u) << upload_channel;
+			}
+			return ret;
+		}
+
+		bandwidth_manager& m_download_rate;
+		bandwidth_manager& m_upload_rate;
+		peer_class_pool m_classes;
+	};
+}
+
+#endif

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -47,6 +47,7 @@ see LICENSE file.
 #include "libtorrent/add_torrent_params.hpp"
 #include "libtorrent/aux_/stat.hpp"
 #include "libtorrent/aux_/bandwidth_manager.hpp"
+#include "libtorrent/aux_/rate_limits.hpp"
 #include "libtorrent/aux_/udp_socket.hpp"
 #include "libtorrent/assert.hpp"
 #include "libtorrent/aux_/alert_manager.hpp" // for alert_manager
@@ -558,13 +559,8 @@ namespace aux {
 
 			// implements session_interface
 			void set_peer_classes(peer_class_set* s, address const& a, socket_type_t st) override;
-			peer_class_pool const& peer_classes() const override { return m_classes; }
-			peer_class_pool& peer_classes() override { return m_classes; }
-			bool ignore_unchoke_slots_set(peer_class_set const& set) const override;
-			int copy_pertinent_channels(peer_class_set const& set
-				, int channel, bandwidth_channel** dst, int m) override;
-			std::uint8_t use_quota_overhead(peer_class_set& set, int amount_down, int amount_up) override;
-			bool use_quota_overhead(bandwidth_channel* ch, int amount);
+			// session_interface
+			rate_limits& rates() override { return m_rates; }
 
 			peer_class_t create_peer_class(char const* name);
 			void delete_peer_class(peer_class_t cid);
@@ -647,7 +643,6 @@ namespace aux {
 			TORRENT_DEPRECATED int max_uploads() const;
 #endif
 
-			aux::bandwidth_manager* get_bandwidth_manager(int channel) override;
 
 			int upload_rate_limit(peer_class_t c) const;
 			int download_rate_limit(peer_class_t c) const;
@@ -878,8 +873,6 @@ namespace aux {
 			aux::array<aux::vector<torrent*>, num_torrent_lists, torrent_list_index_t>
 				m_torrent_lists;
 
-			peer_class_pool m_classes;
-
 			void init();
 
 			void submit_disk_jobs();
@@ -951,6 +944,14 @@ namespace aux {
 			// rate.
 			bandwidth_manager m_download_rate;
 			bandwidth_manager m_upload_rate;
+
+			// concrete owner of the bandwidth subsystem -- bandwidth_managers,
+			// peer_class_pool, and the channel-lookup dispatch -- exposed to
+			// peer_connection via rates(). references the bandwidth_managers
+			// above (which session_impl still owns to keep the io_context
+			// dependency direction simple); declared after them so destruction
+			// order is reverse and the references remain valid for its lifetime.
+			rate_limits m_rates{m_download_rate, m_upload_rate};
 
 			// the peer class that all peers belong to by default
 			peer_class_t m_global_class{0};

--- a/include/libtorrent/aux_/session_interface.hpp
+++ b/include/libtorrent/aux_/session_interface.hpp
@@ -56,6 +56,7 @@ namespace aux {
 	struct torrent_peer_allocator_interface;
 	struct external_ip;
 	struct stat_delta;
+	struct rate_limits;
 }
 
 	// hidden
@@ -206,16 +207,14 @@ namespace libtorrent::aux {
 		virtual void queue_tracker_request(aux::tracker_request req
 			, std::weak_ptr<aux::request_callback> c) = 0;
 
-		// peer-classes
+		// classifies a peer connection or torrent against the peer-class
+		// filter / type filter; appends matching classes to `s`.
 		virtual void set_peer_classes(peer_class_set* s, address const& a, socket_type_t st) = 0;
-		virtual peer_class_pool const& peer_classes() const = 0;
-		virtual peer_class_pool& peer_classes() = 0;
-		virtual bool ignore_unchoke_slots_set(peer_class_set const& set) const = 0;
-		virtual int copy_pertinent_channels(peer_class_set const& set
-			, int channel, bandwidth_channel** dst, int m) = 0;
-		virtual std::uint8_t use_quota_overhead(peer_class_set& set, int amount_down, int amount_up) = 0;
 
-		virtual bandwidth_manager* get_bandwidth_manager(int channel) = 0;
+		// returns the session's bandwidth subsystem. owns the peer_class_pool
+		// and the bandwidth_managers; the eventual home of the bandwidth
+		// mutex once peer_connection runs on its own strand.
+		virtual rate_limits& rates() = 0;
 
 		// per-tick stats delta flushed from peer_connection. covers
 		// payload/protocol bytes (both directions) and IP overhead

--- a/src/bandwidth_limit.cpp
+++ b/src/bandwidth_limit.cpp
@@ -23,12 +23,14 @@ namespace libtorrent::aux {
 	{}
 
 	// 0 means infinite
-	void bandwidth_channel::throttle(int const limit)
+	bool bandwidth_channel::throttle(int const limit)
 	{
 		TORRENT_ASSERT_VAL(limit >= 0, limit);
 		// if the throttle is more than this, we might overflow
 		TORRENT_ASSERT_VAL(limit < inf, limit);
+		if (m_limit == limit) return false;
 		m_limit = limit;
+		return true;
 	}
 
 	int bandwidth_channel::quota_left() const

--- a/src/peer_class_set.cpp
+++ b/src/peer_class_set.cpp
@@ -14,18 +14,18 @@ see LICENSE file.
 
 namespace libtorrent::aux {
 
-	void peer_class_set::add_class(peer_class_pool& pool, peer_class_t c)
+	bool peer_class_set::add(peer_class_t c)
 	{
-		if (std::find(m_class.begin(), m_class.begin() + m_size, c)
-			!= m_class.begin() + m_size) return;
+		if (std::find(m_class.begin(), m_class.begin() + m_size, c) != m_class.begin() + m_size)
+			return false;
 		if (m_size >= int(m_class.size()))
 		{
 			TORRENT_ASSERT_FAIL();
-			return;
+			return false;
 		}
 		m_class[m_size] = c;
-		pool.incref(c);
 		++m_size;
+		return true;
 	}
 
 	bool peer_class_set::has_class(peer_class_t c) const
@@ -34,17 +34,17 @@ namespace libtorrent::aux {
 			!= m_class.begin() + m_size;
 	}
 
-	void peer_class_set::remove_class(peer_class_pool& pool, peer_class_t const c)
+	bool peer_class_set::remove(peer_class_t const c)
 	{
 		auto const i = std::find(m_class.begin(), m_class.begin() + m_size, c);
 		int const idx = int(i - m_class.begin());
-		if (idx == m_size) return; // not found
+		if (idx == m_size) return false; // not found
 		if (idx < m_size - 1)
 		{
 			// place the last element in the slot of the erased one
 			m_class[idx] = m_class[m_size - 1];
 		}
 		--m_size;
-		pool.decref(c);
+		return true;
 	}
 }

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -44,6 +44,7 @@ see LICENSE file.
 #include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/disk_interface.hpp"
 #include "libtorrent/aux_/bandwidth_manager.hpp"
+#include "libtorrent/aux_/rate_limits.hpp"
 #include "libtorrent/aux_/request_blocks.hpp" // for request_a_block
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/alert_manager.hpp" // for alert_manager
@@ -253,23 +254,10 @@ namespace {
 	{
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(channel >= 0 && channel < 2);
-		int prio = 1;
-		for (int i = 0; i < num_classes(); ++i)
-		{
-			int class_prio = m_ses.peer_classes().at(class_at(i))->priority[std::size_t(channel)];
-			if (prio < class_prio) prio = class_prio;
-		}
-
+		// the bandwidth allocator's minimum priority is 1
+		int prio = std::max(1, m_rates.max_priority(*this, channel));
 		auto const t = associated_torrent().lock();
-
-		if (t)
-		{
-			for (int i = 0; i < t->num_classes(); ++i)
-			{
-				int class_prio = m_ses.peer_classes().at(t->class_at(i))->priority[std::size_t(channel)];
-				if (prio < class_prio) prio = class_prio;
-			}
-		}
+		if (t) prio = std::max(prio, m_rates.max_priority(*t, channel));
 		return prio;
 	}
 
@@ -335,11 +323,7 @@ namespace {
 		if (should_log(peer_log_alert::info))
 		{
 			std::string classes;
-			for (int i = 0; i < num_classes(); ++i)
-			{
-				classes += m_ses.peer_classes().at(class_at(i))->label;
-				classes += ' ';
-			}
+			m_rates.format_class_labels(*this, classes);
 			peer_log(peer_log_alert::info, peer_log_alert::peer_class, "%s"
 				, classes.c_str());
 		}
@@ -4560,9 +4544,9 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 		if (num_classes() == 0) return true;
 
-		if (m_ses.ignore_unchoke_slots_set(*this)) return true;
+		if (m_rates.ignore_unchoke_slots_set(*this)) return true;
 		auto t = m_torrent.lock();
-		if (t && m_ses.ignore_unchoke_slots_set(*t)) return true;
+		if (t && m_rates.ignore_unchoke_slots_set(*t)) return true;
 		return false;
 	}
 
@@ -4870,12 +4854,10 @@ namespace {
 		// drain the IP overhead from the bandwidth limiters
 		if (m_settings.get_bool(settings_pack::rate_limit_ip_overhead) && t)
 		{
-			warning |= m_ses.use_quota_overhead(*this
-				, m_statistics.download_ip_overhead()
-				, m_statistics.upload_ip_overhead());
-			warning |= m_ses.use_quota_overhead(*t
-				, m_statistics.download_ip_overhead()
-				, m_statistics.upload_ip_overhead());
+			warning |= m_rates.apply_ip_overhead(*this,
+				t.get(),
+				m_statistics.download_ip_overhead(),
+				m_statistics.upload_ip_overhead());
 		}
 
 		if (warning && m_alerts.should_post<performance_alert>())
@@ -5740,41 +5722,9 @@ namespace {
 
 		int const priority = get_priority(channel);
 
-		// Reserve for the peer classes, torrent classes and existing slack,
-		// capped to the number of channels bw_request can store.
-		int const max_supported_channels = aux::bw_request::max_bandwidth_channels;
-		int const max_channels =
-			std::min(max_supported_channels, num_classes() + (t ? t->num_classes() : 0) + 2);
-		TORRENT_ALLOCA(channels, aux::bandwidth_channel*, max_channels);
-
-		// collect the pointers to all bandwidth channels
-		// that apply to this torrent
-		int c = 0;
-
-		c += m_ses.copy_pertinent_channels(*this, channel
-			, channels.subspan(c).data(), max_channels - c);
-		if (t)
-		{
-			c += m_ses.copy_pertinent_channels(*t, channel
-				, channels.subspan(c).data(), max_channels - c);
-		}
-
-#if TORRENT_USE_ASSERTS
-		// make sure we don't have duplicates
-		std::set<aux::bandwidth_channel*> unique_classes;
-		for (auto chan : channels.first(c))
-		{
-			TORRENT_ASSERT(unique_classes.count(chan) == 0);
-			unique_classes.insert(chan);
-		}
-#endif
-
 		TORRENT_ASSERT(!(m_channel_state[channel] & peer_info::bw_limit));
 
-		aux::bandwidth_manager* manager = m_ses.get_bandwidth_manager(channel);
-
-		int const ret = manager->request_bandwidth(self()
-			, bytes, priority, channels.first(c));
+		int const ret = m_rates.request_bandwidth(self(), channel, bytes, priority, *this, t.get());
 
 		if (ret == 0)
 		{
@@ -5784,9 +5734,14 @@ namespace {
 			if (should_log(dir))
 			{
 				peer_log(dir,
-					peer_log_alert::request_bandwidth, "bytes: %d quota: %d wanted_transfer: %d "
-					"prio: %d num_channels: %d", bytes, m_quota[channel]
-					, wanted_transfer(channel), priority, c);
+					peer_log_alert::request_bandwidth,
+					"bytes: %d quota: %d wanted_transfer: %d"
+					" prio: %d num_channels: %d",
+					bytes,
+					m_quota[channel],
+					wanted_transfer(channel),
+					priority,
+					num_classes() + (t ? t->num_classes() : 0));
 			}
 #endif
 			m_channel_state[channel] |= peer_info::bw_limit;
@@ -6568,7 +6523,7 @@ namespace {
 			{
 				// if we're waiting for bandwidth, we should be in the
 				// bandwidth manager's queue
-				TORRENT_ASSERT(m_ses.get_bandwidth_manager(i)->is_queued(this));
+				TORRENT_ASSERT(m_rates.is_queued(this, i));
 			}
 		}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -629,14 +629,14 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 #endif
 		m_next_lsd_torrent = 0;
 
-		m_global_class = m_classes.new_peer_class("global");
-		m_tcp_peer_class = m_classes.new_peer_class("tcp");
-		m_local_peer_class = m_classes.new_peer_class("local");
+		m_global_class = m_rates.new_class("global");
+		m_tcp_peer_class = m_rates.new_class("tcp");
+		m_local_peer_class = m_rates.new_class("local");
 		// local peers are always unchoked
-		m_classes.at(m_local_peer_class)->ignore_unchoke_slots = true;
+		m_rates.set_ignore_unchoke_slots(m_local_peer_class, true);
 		// local peers are allowed to exceed the normal connection
 		// limit by 50%
-		m_classes.at(m_local_peer_class)->connection_limit_factor = 150;
+		m_rates.set_connection_limit_factor(m_local_peer_class, 150);
 
 		TORRENT_ASSERT(m_global_class == session::global_peer_class_id);
 		TORRENT_ASSERT(m_tcp_peer_class == session::tcp_peer_class_id);
@@ -1188,42 +1188,22 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 	peer_class_t session_impl::create_peer_class(char const* name)
 	{
 		TORRENT_ASSERT(is_single_thread());
-		return m_classes.new_peer_class(name);
+		return m_rates.new_class(name);
 	}
 
 	void session_impl::delete_peer_class(peer_class_t const cid)
 	{
 		TORRENT_ASSERT(is_single_thread());
 		// if you hit this assert, you're deleting a non-existent peer class
-		TORRENT_ASSERT_PRECOND(m_classes.at(cid));
-		if (m_classes.at(cid) == nullptr) return;
-		m_classes.decref(cid);
+		TORRENT_ASSERT_PRECOND(m_rates.exists(cid));
+		m_rates.delete_class(cid);
 	}
 
 	peer_class_info session_impl::get_peer_class(peer_class_t const cid) const
 	{
-		peer_class_info ret{};
-		peer_class const* pc = m_classes.at(cid);
 		// if you hit this assert, you're passing in an invalid cid
-		TORRENT_ASSERT_PRECOND(pc);
-		if (pc == nullptr)
-		{
-#if TORRENT_USE_INVARIANT_CHECKS
-			// make it obvious that the return value is undefined
-			ret.upload_limit = 0xf0f0f0f;
-			ret.download_limit = 0xf0f0f0f;
-			ret.label.resize(20);
-			url_random(span<char>(ret.label));
-			ret.ignore_unchoke_slots = false;
-			ret.connection_limit_factor = 0xf0f0f0f;
-			ret.upload_priority = 0xf0f0f0f;
-			ret.download_priority = 0xf0f0f0f;
-#endif
-			return ret;
-		}
-
-		pc->get_info(&ret);
-		return ret;
+		TORRENT_ASSERT_PRECOND(m_rates.exists(cid));
+		return m_rates.info(cid);
 	}
 
 namespace {
@@ -1278,12 +1258,9 @@ namespace {
 
 	void session_impl::set_peer_class(peer_class_t const cid, peer_class_info const& pci)
 	{
-		peer_class* pc = m_classes.at(cid);
 		// if you hit this assert, you're passing in an invalid cid
-		TORRENT_ASSERT_PRECOND(pc);
-		if (pc == nullptr) return;
-
-		pc->set_info(&pci);
+		TORRENT_ASSERT_PRECOND(m_rates.exists(cid));
+		m_rates.set_info(cid, pci);
 	}
 
 	void session_impl::set_peer_class_filter(ip_filter const& f)
@@ -1334,31 +1311,13 @@ namespace {
 			if ((peer_class_mask & 1) == 0) continue;
 
 			// if you hit this assert, your peer class filter contains
-			// a bitmask referencing a non-existent peer class
-			TORRENT_ASSERT_PRECOND(m_classes.at(i));
-
-			if (m_classes.at(i) == nullptr) continue;
-			s->add_class(m_classes, i);
+			// a bitmask referencing a non-existent peer class.
+			// add_class_to silently no-ops in release.
+			TORRENT_ASSERT_PRECOND(m_rates.exists(i));
+			m_rates.add_class_to(*s, i);
 		}
 	}
 
-	bool session_impl::ignore_unchoke_slots_set(peer_class_set const& set) const
-	{
-		int num = set.num_classes();
-		for (int i = 0; i < num; ++i)
-		{
-			peer_class const* pc = m_classes.at(set.class_at(i));
-			if (pc == nullptr) continue;
-			if (pc->ignore_unchoke_slots) return true;
-		}
-		return false;
-	}
-
-	bandwidth_manager* session_impl::get_bandwidth_manager(int channel)
-	{
-		return (channel == peer_connection::download_channel)
-			? &m_download_rate : &m_upload_rate;
-	}
 
 	void session_impl::deferred_submit_jobs()
 	{
@@ -1374,57 +1333,6 @@ namespace {
 		TORRENT_ASSERT(m_deferred_submit_disk_jobs);
 		m_deferred_submit_disk_jobs = false;
 		m_disk_thread->submit_jobs();
-	}
-
-	// copies pointers to bandwidth channels from the peer classes
-	// into the array. Only bandwidth channels with a bandwidth limit
-	// is considered pertinent and copied
-	// returns the number of pointers copied
-	// channel is upload_channel or download_channel
-	int session_impl::copy_pertinent_channels(peer_class_set const& set
-		, int channel, bandwidth_channel** dst, int const max)
-	{
-		TORRENT_ASSERT(max >= 0);
-		int num_channels = set.num_classes();
-		int num_copied = 0;
-		for (int i = 0; i < num_channels; ++i)
-		{
-			if (num_copied >= max) break;
-			peer_class* pc = m_classes.at(set.class_at(i));
-			TORRENT_ASSERT(pc);
-			if (pc == nullptr) continue;
-			bandwidth_channel* chan = &pc->channel[channel];
-			// no need to include channels that don't have any bandwidth limits
-			if (chan->throttle() == 0) continue;
-			dst[num_copied] = chan;
-			++num_copied;
-		}
-		return num_copied;
-	}
-
-	bool session_impl::use_quota_overhead(bandwidth_channel* ch, int amount)
-	{
-		ch->use_quota(amount);
-		return (ch->throttle() > 0 && ch->throttle() < amount);
-	}
-
-	std::uint8_t session_impl::use_quota_overhead(peer_class_set& set, int const amount_down, int const amount_up)
-	{
-		std::uint8_t ret = 0;
-		int const num = set.num_classes();
-		for (int i = 0; i < num; ++i)
-		{
-			peer_class* p = m_classes.at(set.class_at(i));
-			if (p == nullptr) continue;
-
-			bandwidth_channel* ch = &p->channel[peer_connection::download_channel];
-			if (use_quota_overhead(ch, amount_down))
-				ret |= 1u << peer_connection::download_channel;
-			ch = &p->channel[peer_connection::upload_channel];
-			if (use_quota_overhead(ch, amount_up))
-				ret |= 1u << peer_connection::upload_channel;
-		}
-		return ret;
 	}
 
 	// session_impl is responsible for deleting 'pack'
@@ -3169,14 +3077,7 @@ retry:
 		// to get connection_limit_factor
 		peer_class_set pcs;
 		set_peer_classes(&pcs, endp.address(), socket_type_idx(s));
-		int connection_limit_factor = 0;
-		for (int i = 0; i < pcs.num_classes(); ++i)
-		{
-			peer_class_t pc = pcs.class_at(i);
-			if (m_classes.at(pc) == nullptr) continue;
-			int f = m_classes.at(pc)->connection_limit_factor;
-			if (connection_limit_factor < f) connection_limit_factor = f;
-		}
+		int connection_limit_factor = m_rates.max_connection_limit_factor(pcs);
 		if (connection_limit_factor == 0) connection_limit_factor = 100;
 
 		std::int64_t limit = m_settings.get_int(settings_pack::connections_limit);
@@ -3319,9 +3220,7 @@ retry:
 		TORRENT_ASSERT(channel >= 0 && channel <= 1);
 		if (channel < 0 || channel > 1) return 0;
 
-		peer_class const* pc = m_classes.at(c);
-		if (pc == nullptr) return 0;
-		return pc->channel[channel].throttle();
+		return m_rates.throttle(c, channel);
 	}
 
 	int session_impl::upload_rate_limit(peer_class_t c) const
@@ -3341,12 +3240,7 @@ retry:
 		TORRENT_ASSERT(channel >= 0 && channel <= 1);
 
 		if (channel < 0 || channel > 1) return;
-
-		peer_class* pc = m_classes.at(c);
-		if (pc == nullptr) return;
-		if (limit <= 0) limit = 0;
-		else limit = std::min(limit, std::numeric_limits<int>::max() - 1);
-		pc->channel[channel].throttle(limit);
+		m_rates.set_throttle(c, channel, limit);
 	}
 
 	void session_impl::set_upload_rate_limit(peer_class_t c, int limit)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5159,8 +5159,10 @@ namespace {
 
 		if (m_peer_class > peer_class_t{0})
 		{
-			remove_class(m_ses.peer_classes(), m_peer_class);
-			m_ses.peer_classes().decref(m_peer_class);
+			// drops the membership refcount + the explicit one held since
+			// setup_peer_class() called new_class()
+			m_ses.rates().remove_class_from(*this, m_peer_class);
+			m_ses.rates().delete_class(m_peer_class);
 			m_peer_class = peer_class_t{0};
 		}
 
@@ -8251,14 +8253,7 @@ namespace {
 			return false;
 		}
 
-		int connection_limit_factor = 0;
-		for (int i = 0; i < p->num_classes(); ++i)
-		{
-			peer_class_t pc = p->class_at(i);
-			if (m_ses.peer_classes().at(pc) == nullptr) continue;
-			int f = m_ses.peer_classes().at(pc)->connection_limit_factor;
-			if (connection_limit_factor < f) connection_limit_factor = f;
-		}
+		int connection_limit_factor = m_ses.rates().max_connection_limit_factor(*p);
 		if (connection_limit_factor == 0) connection_limit_factor = 100;
 
 		std::int64_t const limit = std::int64_t(m_max_connections) * 100 / connection_limit_factor;
@@ -9521,22 +9516,21 @@ namespace {
 			setup_peer_class();
 		}
 
-		struct peer_class* tpc = m_ses.peer_classes().at(m_peer_class);
-		TORRENT_ASSERT(tpc);
-		if (tpc->channel[channel].throttle() == limit) return;
+		auto& rates = m_ses.rates();
+		TORRENT_ASSERT(rates.exists(m_peer_class));
+		if (!rates.set_throttle(m_peer_class, channel, limit)) return;
 		if (state_update)
 		{
 			state_updated();
 			set_need_save_resume(torrent_handle::if_config_changed);
 		}
-		tpc->channel[channel].throttle(limit);
 	}
 
 	void torrent::setup_peer_class()
 	{
 		TORRENT_ASSERT(m_peer_class == peer_class_t{0});
-		m_peer_class = m_ses.peer_classes().new_peer_class(name());
-		add_class(m_ses.peer_classes(), m_peer_class);
+		m_peer_class = m_ses.rates().new_class(name());
+		m_ses.rates().add_class_to(*this, m_peer_class);
 	}
 
 	int torrent::limit_impl(int const channel) const
@@ -9544,7 +9538,7 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 
 		if (m_peer_class == peer_class_t{0}) return -1;
-		int limit = m_ses.peer_classes().at(m_peer_class)->channel[channel].throttle();
+		int limit = m_ses.rates().throttle(m_peer_class, channel);
 		if (limit == std::numeric_limits<int>::max()) limit = -1;
 		return limit;
 	}
@@ -12426,14 +12420,9 @@ namespace {
 
 	int torrent::priority() const
 	{
-		int priority = 0;
-		for (int i = 0; i < num_classes(); ++i)
-		{
-			span<int const> prio = m_ses.peer_classes().at(class_at(i))->priority;
-			priority = std::max(priority, prio[peer_connection::upload_channel]);
-			priority = std::max(priority, prio[peer_connection::download_channel]);
-		}
-		return priority;
+		auto const& rates = m_ses.rates();
+		return std::max(rates.max_priority(*this, peer_connection::upload_channel),
+			rates.max_priority(*this, peer_connection::download_channel));
 	}
 
 #if TORRENT_ABI_VERSION == 1
@@ -12445,10 +12434,10 @@ namespace {
 		if (m_peer_class == peer_class_t{})
 			setup_peer_class();
 
-		struct peer_class* tpc = m_ses.peer_classes().at(m_peer_class);
-		TORRENT_ASSERT(tpc);
-		tpc->priority[peer_connection::download_channel] = prio;
-		tpc->priority[peer_connection::upload_channel] = prio;
+		auto& rates = m_ses.rates();
+		TORRENT_ASSERT(rates.exists(m_peer_class));
+		rates.set_priority(m_peer_class, peer_connection::download_channel, prio);
+		rates.set_priority(m_peer_class, peer_connection::upload_channel, prio);
 
 		state_updated();
 	}

--- a/test/session_mock.hpp
+++ b/test/session_mock.hpp
@@ -11,6 +11,8 @@ see LICENSE file.
 
 #include "libtorrent/config.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
+#include "libtorrent/aux_/bandwidth_manager.hpp"
+#include "libtorrent/aux_/rate_limits.hpp"
 #include "libtorrent/aux_/alert_manager.hpp"
 #include "libtorrent/aux_/resolver.hpp"
 #include "libtorrent/aux_/session_settings.hpp"
@@ -112,13 +114,7 @@ struct session_mock : aux::session_interface
 	void queue_tracker_request(aux::tracker_request, std::weak_ptr<aux::request_callback>) override {}
 
 	void set_peer_classes(aux::peer_class_set*, address const&, socket_type_t) override {}
-	peer_class_pool const& peer_classes() const override { return _peer_class_pool; }
-	peer_class_pool& peer_classes() override { return _peer_class_pool; }
-	bool ignore_unchoke_slots_set(aux::peer_class_set const&) const override { return false; }
-	int copy_pertinent_channels(aux::peer_class_set const&, int, aux::bandwidth_channel**, int) override { return 0; }
-	std::uint8_t use_quota_overhead(aux::peer_class_set&, int, int) override { return 0; }
-
-	aux::bandwidth_manager* get_bandwidth_manager(int) override { return nullptr; }
+	aux::rate_limits& rates() override { return _rates; }
 
 	void accumulate_stats(aux::stat_delta const&) override {}
 
@@ -225,7 +221,9 @@ struct session_mock : aux::session_interface
 	aux::torrent_peer_allocator _torrent_peer_allocator;
 	port_filter _port_filter;
 	counters _counters;
-	peer_class_pool _peer_class_pool;
+	aux::bandwidth_manager _download_rate{1};
+	aux::bandwidth_manager _upload_rate{0};
+	aux::rate_limits _rates{_download_rate, _upload_rate};
 	time_point _start_time;
 
 	std::unique_ptr<disk_interface> _disk_io;

--- a/test/test_peer_classes.cpp
+++ b/test/test_peer_classes.cpp
@@ -107,7 +107,7 @@ TORRENT_TEST(peer_class_set_capacity)
 	for (std::size_t i = 0; i < classes.size(); ++i)
 	{
 		classes[i] = pool.new_peer_class("test");
-		set.add_class(pool, classes[i]);
+		if (set.add(classes[i])) pool.incref(classes[i]);
 	}
 
 	TEST_EQUAL(set.num_classes(), int(classes.size()));
@@ -115,7 +115,7 @@ TORRENT_TEST(peer_class_set_capacity)
 	for (std::size_t i = 0; i < classes.size(); ++i)
 	{
 		TEST_CHECK(set.has_class(classes[i]));
-		set.remove_class(pool, classes[i]);
+		if (set.remove(classes[i])) pool.decref(classes[i]);
 		pool.decref(classes[i]);
 	}
 


### PR DESCRIPTION
encapsulate handling of rate limits into a single class. This is a step to limit interactions between peer_connection, torrent and session_impl, to prepare for multi-threaded networking support.