### PR TITLE
torrent's interface

### DIFF
--- a/include/libtorrent/aux_/peer_connection.hpp
+++ b/include/libtorrent/aux_/peer_connection.hpp
@@ -460,9 +460,8 @@ namespace libtorrent::aux {
 		// before the peer has attached to a torrent.
 		std::shared_ptr<torrent_info const> const& torrent_file() const { return m_ti; }
 
-		// the block size in bytes for this peer's torrent. matches
-		// torrent::block_size(): default_block_size pre-metadata,
-		// min(piece_length, default_block_size) once metadata is known.
+		// default_block_size pre-metadata, min(piece_length, default_block_size)
+		// once metadata is known.
 		int block_size() const;
 
 		// get the info hash associated with this peer

--- a/include/libtorrent/aux_/request_blocks.hpp
+++ b/include/libtorrent/aux_/request_blocks.hpp
@@ -12,6 +12,7 @@ see LICENSE file.
 #define TORRENT_REQUEST_BLOCKS_HPP_INCLUDED
 
 #include "libtorrent/peer_info.hpp"
+#include "libtorrent/fwd.hpp"
 
 namespace libtorrent::aux {
 
@@ -22,7 +23,7 @@ namespace libtorrent::aux {
 	// of an early exit condition. In this case, the stats counter
 	// shouldn't be incremented, since it won't use any significant
 	// amount of CPU
-	bool request_a_block(torrent& t, peer_connection& c);
+	bool request_a_block(torrent& t, torrent_info const& ti, peer_connection& c);
 
 	// returns the rank of a peer's source. We have an affinity
 	// to connecting to peers with higher rank. This is to avoid

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -386,6 +386,7 @@ TORRENT_VERSION_NAMESPACE_4
 		// smaller.
 		int piece_length() const { return m_files.piece_length(); }
 		int num_pieces() const { return m_files.num_pieces(); }
+		int block_size() const { return std::min(m_files.piece_length(), default_block_size); }
 
 		// returns the number of blocks there are in the typical piece. There
 		// may be fewer in the last piece)

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -1095,8 +1095,8 @@ namespace {
 
 	int peer_connection::block_size() const
 	{
-		// matches torrent::block_size(): default_block_size pre-metadata,
-		// min(piece_length, default_block_size) once metadata is known.
+		// default_block_size pre-metadata, min(piece_length, default_block_size)
+		// once metadata is known.
 		if (!m_ti || !m_ti->is_valid()) return default_block_size;
 		return std::min(m_ti->piece_length(), default_block_size);
 	}
@@ -1672,7 +1672,7 @@ namespace {
 
 		if (m_request_queue.empty() && m_download_queue.size() < 2)
 		{
-			if (aux::request_a_block(*t, *this))
+			if (aux::request_a_block(*t, *m_ti, *this))
 				m_counters.inc_stats_counter(counters::reject_piece_picks);
 		}
 
@@ -1775,7 +1775,7 @@ namespace {
 
 		if (is_interesting())
 		{
-			if (request_a_block(*t, *this))
+			if (request_a_block(*t, *m_ti, *this))
 				m_counters.inc_stats_counter(counters::unchoke_piece_picks);
 			send_block_requests();
 		}
@@ -2759,37 +2759,6 @@ namespace {
 		}
 	}
 
-#if TORRENT_USE_INVARIANT_CHECKS
-	struct check_postcondition
-	{
-		explicit check_postcondition(std::shared_ptr<aux::torrent> const& t_
-			, bool init_check = true): t(t_) { if (init_check) check(); }
-
-		~check_postcondition() { check(); }
-
-		void check()
-		{
-			if (!t->is_seed())
-			{
-				const int blocks_per_piece = static_cast<int>(
-					(t->torrent_file().piece_length() + t->block_size() - 1) / t->block_size());
-
-				std::vector<piece_picker::downloading_piece> const& dl_queue
-					= t->picker().get_download_queue();
-
-				for (std::vector<piece_picker::downloading_piece>::const_iterator i =
-					dl_queue.begin(); i != dl_queue.end(); ++i)
-				{
-					TORRENT_ASSERT(i->finished <= blocks_per_piece);
-				}
-			}
-		}
-
-		std::shared_ptr<aux::torrent> t;
-	};
-#endif
-
-
 	// -----------------------------
 	// ----------- PIECE -----------
 	// -----------------------------
@@ -2839,13 +2808,6 @@ namespace {
 		}
 #endif
 		if (is_disconnecting()) return;
-
-#if TORRENT_USE_INVARIANT_CHECKS
-		check_postcondition post_checker_(t);
-#if defined TORRENT_EXPENSIVE_INVARIANT_CHECKS
-		t->check_invariant();
-#endif
-#endif
 
 #ifndef TORRENT_DISABLE_LOGGING
 		if (should_log(peer_log_alert::incoming_message))
@@ -2968,7 +2930,7 @@ namespace {
 			if (!m_download_queue.empty())
 				m_requested.set(m_connect, now);
 
-			if (request_a_block(*t, *this))
+			if (request_a_block(*t, *m_ti, *this))
 				m_counters.inc_stats_counter(counters::incoming_redundant_piece_picks);
 			send_block_requests();
 			return;
@@ -3134,9 +3096,6 @@ namespace {
 		// to disk or are in the disk write cache
 		if (picker.is_piece_finished(p.piece) && !was_finished)
 		{
-#if TORRENT_USE_INVARIANT_CHECKS
-			check_postcondition post_checker2_(t, false);
-#endif
 			t->verify_piece(p.piece);
 		}
 
@@ -3144,7 +3103,7 @@ namespace {
 
 		if (is_disconnecting()) return;
 
-		if (request_a_block(*t, *this))
+		if (request_a_block(*t, *m_ti, *this))
 			m_counters.inc_stats_counter(counters::incoming_piece_picks);
 		send_block_requests();
 	}
@@ -4899,7 +4858,7 @@ namespace {
 			// we should try to pick another block to see
 			// if we can pick a busy one
 			m_last_request.set(m_connect, now);
-			if (request_a_block(*t, *this))
+			if (request_a_block(*t, *m_ti, *this))
 				m_counters.inc_stats_counter(counters::end_game_piece_picks);
 			if (m_disconnecting) return;
 			send_block_requests();
@@ -5223,7 +5182,7 @@ namespace {
 			// picking the same block again, stalling the
 			// same piece indefinitely.
 			m_desired_queue_size = 2;
-			if (request_a_block(*t, *this))
+			if (request_a_block(*t, *m_ti, *this))
 				m_counters.inc_stats_counter(counters::snubbed_piece_picks);
 
 			// the block we just picked (potentially)

--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -13,6 +13,7 @@ see LICENSE file.
 #include "libtorrent/bitfield.hpp"
 #include "libtorrent/aux_/peer_connection.hpp"
 #include "libtorrent/aux_/torrent.hpp"
+#include "libtorrent/torrent_info.hpp"
 #include "libtorrent/aux_/socket_type.hpp"
 #include "libtorrent/peer_info.hpp" // for peer_info flags
 #include "libtorrent/aux_/request_blocks.hpp"
@@ -40,7 +41,7 @@ namespace libtorrent::aux {
 	// infinite loop, fighting to request the same blocks.
 	// returns false if the function is aborted by an early-exit
 	// condition.
-	bool request_a_block(torrent& t, peer_connection& c)
+	bool request_a_block(torrent& t, torrent_info const& ti, peer_connection& c)
 	{
 		if (t.is_seed()) return false;
 		if (c.no_download()) return false;
@@ -48,7 +49,7 @@ namespace libtorrent::aux {
 		if (c.is_disconnecting()) return false;
 
 		// don't request pieces before we have the metadata
-		if (!t.valid_metadata()) return false;
+		if (!ti.is_valid()) return false;
 
 		// don't request pieces before the peer is properly
 		// initialized after we have the metadata
@@ -109,11 +110,10 @@ namespace libtorrent::aux {
 				// in the window.
 				std::int64_t const download_window =
 					std::int64_t(c.statistics().download_payload_rate()) * whole_pieces_threshold;
-				int const contiguous_pieces =
-					int(std::min(download_window, std::int64_t(8 * 1024 * 1024))
-						/ t.torrent_file().piece_length());
+				int const contiguous_pieces = int(
+					std::min(download_window, std::int64_t(8 * 1024 * 1024)) / ti.piece_length());
 
-				int const blocks_per_piece = t.torrent_file().piece_length() / t.block_size();
+				int const blocks_per_piece = ti.piece_length() / ti.block_size();
 
 				prefer_contiguous_blocks = contiguous_pieces * blocks_per_piece;
 			}

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1237,7 +1237,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 			p->update_interest();
 			if (!m_abort)
 			{
-				if (request_a_block(*this, *p))
+				if (request_a_block(*this, torrent_file(), *p))
 					inc_stats_counter(counters::hash_fail_piece_picks);
 				p->send_block_requests();
 			}
@@ -5007,7 +5007,7 @@ namespace {
 			&& c.allowed_fast().empty())
 			return;
 
-		if (request_a_block(*this, c))
+		if (request_a_block(*this, torrent_file(), c))
 			inc_stats_counter(counters::interesting_piece_picks);
 		c.send_block_requests();
 	}
@@ -8921,7 +8921,7 @@ namespace {
 #endif
 			if (pc->is_interesting() && !pc->has_peer_choked())
 			{
-				if (request_a_block(*this, *pc))
+				if (request_a_block(*this, torrent_file(), *pc))
 				{
 					inc_stats_counter(counters::unchoke_piece_picks);
 					pc->send_block_requests();


### PR DESCRIPTION
work down peer_connection's coupling with torrent a little bit. Don't invoke torrent's invariant check from outside