### PR TITLE
remove thin accessor wrappers on torrent, we can just call flags() now

### DIFF
--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -411,7 +411,6 @@ namespace libtorrent::aux {
 #ifndef TORRENT_DISABLE_SHARE_MODE
 		void send_share_mode();
 		void set_share_mode(bool s);
-		bool share_mode() const { return bool(m_flags & torrent_flags::share_mode); }
 #endif
 
 		// TODO: make graceful pause also finish all sending blocks
@@ -425,11 +424,10 @@ namespace libtorrent::aux {
 		void set_flags(torrent_flags_t flags, torrent_flags_t mask);
 
 		void set_upload_mode(bool b);
-		bool upload_mode() const
+		bool is_upload_only() const
 		{
-			return bool(m_flags & torrent_internal_flags::effective_upload_mode);
+			return is_finished() || bool(m_flags & torrent_internal_flags::effective_upload_mode);
 		}
-		bool is_upload_only() const { return is_finished() || upload_mode(); }
 
 		int seed_rank(aux::session_settings const& s) const;
 
@@ -472,10 +470,6 @@ namespace libtorrent::aux {
 		aux::session_interface& session() { return m_ses; }
 
 		void set_sequential_download(bool sd);
-		bool is_sequential_download() const
-		{
-			return bool(m_flags & torrent_internal_flags::effective_sequential);
-		}
 
 		void queue_up();
 		void queue_down();
@@ -570,7 +564,6 @@ namespace libtorrent::aux {
 
 		add_torrent_params get_resume_data(resume_data_flags_t flags) const;
 
-		bool is_auto_managed() const { return bool(m_flags & torrent_flags::auto_managed); }
 		void auto_managed(bool a);
 
 		bool should_check_files() const;
@@ -823,12 +816,6 @@ namespace libtorrent::aux {
 #endif
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		bool super_seeding() const
-		{
-			// we're not super seeding if we're not a seed
-			return bool(m_flags & torrent_flags::super_seeding);
-		}
-
 		void set_super_seeding(bool on);
 		piece_index_t get_piece_to_super_seed(typed_bitfield<piece_index_t> const&);
 #endif
@@ -879,7 +866,7 @@ namespace libtorrent::aux {
 		int num_have() const
 		{
 			// pretend we have every piece when in seed mode
-			if (m_flags & torrent_flags::seed_mode && m_torrent_file)
+			if ((m_flags & torrent_flags::seed_mode) && m_torrent_file)
 				return m_torrent_file->num_pieces();
 			if (has_picker()) return m_picker->have().num_pieces;
 			if (m_flags & torrent_internal_flags::have_all)
@@ -908,8 +895,6 @@ namespace libtorrent::aux {
 				? (std::min)(m_torrent_file->piece_length(), default_block_size)
 				: default_block_size;
 		}
-
-		bool disable_v1_hashes() const { return bool(m_flags & torrent_flags::disable_v1_hashes); }
 
 		// like torrent_info::piece_size_for_req(), but when disable_v1_hashes
 		// was set at the time the torrent was added, the engine treats the torrent
@@ -1206,8 +1191,6 @@ namespace libtorrent::aux {
 		bool set_metadata(span<char const> metadata);
 
 		queue_position_t sequence_number() const { return m_sequence_number; }
-
-		bool seed_mode() const { return bool(m_flags & torrent_flags::seed_mode); }
 
 		enum class seed_mode_t { check_files, skip_checking };
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -294,13 +294,16 @@ namespace {
 		// will send their bitfield when the handshake
 		// is done
 		auto t = associated_torrent().lock();
+#if !defined TORRENT_DISABLE_SHARE_MODE || !defined TORRENT_DISABLE_SUPERSEEDING
+		auto const tflags = t->flags();
+#endif
 #ifndef TORRENT_DISABLE_SHARE_MODE
-		if (!t->share_mode())
+		if (!(tflags & torrent_flags::share_mode))
 #endif
 		{
 			bool const upload_only_enabled = t->is_upload_only()
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-				&& !t->super_seeding()
+				&& !(tflags & torrent_flags::super_seeding)
 #endif
 				;
 			send_upload_only(upload_only_enabled);
@@ -2073,7 +2076,7 @@ namespace {
 		if (t->is_finished() && upload_only()
 			&& m_settings.get_bool(settings_pack::close_redundant_connections)
 #ifndef TORRENT_DISABLE_SHARE_MODE
-			&& !t->share_mode()
+			&& !(t->flags() & torrent_flags::share_mode)
 #endif
 			&& can_disconnect(errors::upload_upload_connection))
 			disconnect(errors::upload_upload_connection, operation_t::bittorrent);
@@ -2179,7 +2182,7 @@ namespace {
 
 #if TORRENT_USE_ASSERTS && !defined TORRENT_DISABLE_SHARE_MODE
 		auto t = associated_torrent().lock();
-		TORRENT_ASSERT(!t->share_mode());
+		TORRENT_ASSERT(!(t->flags() & torrent_flags::share_mode));
 #endif
 
 		if (m_upload_only_id == 0) return;
@@ -2209,7 +2212,7 @@ namespace {
 		char msg[7] = {0, 0, 0, 3, msg_extended};
 		char* ptr = msg + 5;
 		aux::write_uint8(m_share_mode_id, ptr);
-		aux::write_uint8(t->share_mode(), ptr);
+		aux::write_uint8(bool(t->flags() & torrent_flags::share_mode), ptr);
 		send_buffer(msg);
 
 		stats_counters().inc_stats_counter(counters::num_outgoing_extended);
@@ -2272,7 +2275,7 @@ namespace {
 		TORRENT_ASSERT(m_ti->is_valid());
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		if (t->super_seeding())
+		if (t->flags() & torrent_flags::super_seeding)
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, peer_log_alert::bitfield, "not sending bitfield, super seeding");
@@ -2443,13 +2446,16 @@ namespace {
 		// If we don't have metadata, we also need to suppress saying we're
 		// upload-only. If we do, we may be disconnected before we receive the
 		// metadata.
+#if !defined TORRENT_DISABLE_SHARE_MODE || !defined TORRENT_DISABLE_SUPERSEEDING
+		auto const tflags = t->flags();
+#endif
 		if (t->is_upload_only()
 #ifndef TORRENT_DISABLE_SHARE_MODE
-			&& !t->share_mode()
+			&& !(tflags & torrent_flags::share_mode)
 #endif
 			&& m_ti->is_valid()
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-			&& !t->super_seeding()
+			&& !(tflags & torrent_flags::super_seeding)
 #endif
 		)
 		{
@@ -2458,7 +2464,7 @@ namespace {
 
 #ifndef TORRENT_DISABLE_SHARE_MODE
 		if (m_settings.get_bool(settings_pack::support_share_mode)
-			&& t->share_mode())
+			&& (tflags & torrent_flags::share_mode))
 			handshake["share_mode"] = 1;
 #endif
 

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -46,6 +46,7 @@ see LICENSE file.
 #include "libtorrent/aux_/bandwidth_manager.hpp"
 #include "libtorrent/aux_/rate_limits.hpp"
 #include "libtorrent/aux_/request_blocks.hpp" // for request_a_block
+#include "libtorrent/aux_/torrent_internal_flags.hpp"
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/alert_manager.hpp" // for alert_manager
 #include "libtorrent/ip_filter.hpp"
@@ -592,7 +593,7 @@ namespace {
 		}
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		if (t->super_seeding())
+		if (t->flags() & torrent_flags::super_seeding)
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, peer_log_alert::allowed, "skipping allowed set because of super seeding");
@@ -880,7 +881,7 @@ namespace {
 		TORRENT_ASSERT(t);
 		if (!t) return {};
 
-		if (t->is_sequential_download())
+		if (t->flags() & torrent_internal_flags::effective_sequential)
 		{
 			ret |= piece_picker::sequential;
 		}
@@ -1339,8 +1340,7 @@ namespace {
 		TORRENT_ASSERT(m_ti->info_hashes().has_v2()
 			|| !(peer_info_struct() && peer_info_struct()->protocol_v2));
 
-		if (t->is_paused()
-			&& t->is_auto_managed()
+		if (t->is_paused() && (t->flags() & torrent_flags::auto_managed)
 			&& m_settings.get_bool(settings_pack::incoming_starts_queued_torrents)
 			&& !t->is_aborted())
 		{
@@ -2008,11 +2008,11 @@ namespace {
 		}
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		if (t->super_seeding()
+		if ((t->flags() & torrent_flags::super_seeding)
 #if TORRENT_ABI_VERSION == 1
 			&& !m_settings.get_bool(settings_pack::strict_super_seeding)
 #endif
-			)
+		)
 		{
 			// if we're super-seeding and the peer just told
 			// us that it completed the piece we're super-seeding
@@ -2097,7 +2097,7 @@ namespace {
 		// if we're super seeding, this might mean that somebody
 		// forwarded this piece. In which case we need to give
 		// a new piece to that peer
-		if (t->super_seeding()
+		if ((t->flags() & torrent_flags::super_seeding)
 			&& m_settings.get_bool(settings_pack::strict_super_seeding)
 			&& (!super_seeded_piece(index) || t->num_peers() == 1))
 		{
@@ -2332,7 +2332,7 @@ namespace {
 
 #ifndef TORRENT_DISABLE_SHARE_MODE
 		// don't close connections in share mode, we don't know if we need them
-		if (t->share_mode()) return false;
+		if (t->flags() & torrent_flags::share_mode) return false;
 #endif
 
 		if (upload_only() && t->is_upload_only()
@@ -2398,8 +2398,7 @@ namespace {
 #endif
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		if (t->super_seeding()
-			&& !super_seeded_piece(r.piece))
+		if ((t->flags() & torrent_flags::super_seeding) && !super_seeded_piece(r.piece))
 		{
 			m_counters.inc_stats_counter(counters::invalid_piece_requests);
 			if (m_num_invalid_requests < std::numeric_limits<decltype(m_num_invalid_requests)>::max())
@@ -2522,7 +2521,7 @@ namespace {
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 				&& !t->is_predictive_piece(r.piece)
 #endif
-				&& !t->seed_mode())
+				&& !(t->flags() & torrent_flags::seed_mode))
 			|| r.start < 0 || r.start >= ti.piece_size(r.piece) || r.length <= 0
 			|| r.length + r.start > ti.piece_size(r.piece) || r.length > block_size())
 		{
@@ -3529,7 +3528,7 @@ namespace {
 		if (m_disconnecting) return false;
 		auto t = m_torrent.lock();
 		TORRENT_ASSERT(t);
-		if (t->upload_mode()) return false;
+		if (t->flags() & torrent_internal_flags::effective_upload_mode) return false;
 
 		// ignore snubbed peers, since they're not likely to return pieces in a
 		// timely manner anyway
@@ -3583,7 +3582,7 @@ namespace {
 		TORRENT_ASSERT(std::find(m_request_queue.begin(), m_request_queue.end()
 			, block) == m_request_queue.end());
 
-		if (t->upload_mode())
+		if (t->flags() & torrent_internal_flags::effective_upload_mode)
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			peer_log(peer_log_alert::info, peer_log_alert::piece_picker
@@ -4011,7 +4010,8 @@ namespace {
 			return;
 
 		if (int(m_download_queue.size()) >= m_desired_queue_size
-			|| t->upload_mode()) return;
+			|| (t->flags() & torrent_internal_flags::effective_upload_mode))
+			return;
 
 		bool const empty_download_queue = m_download_queue.empty();
 
@@ -4865,7 +4865,7 @@ namespace {
 		}
 
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		if (t->super_seeding() && m_ti->is_valid() && !m_peer_interested
+		if ((t->flags() & torrent_flags::super_seeding) && m_ti->is_valid() && !m_peer_interested
 			&& m_became_uninterested.get(m_connect) + seconds(10) < now)
 		{
 			// maybe we need to try another piece, to see if the peer
@@ -5212,6 +5212,10 @@ namespace {
 		auto t = m_torrent.lock();
 		if (!t || t->is_aborted() || m_requests.empty()) return;
 
+		// snapshot the torrent flags once for the loop below
+		auto const tflags = t->flags();
+		bool const seed_mode = bool(tflags & torrent_flags::seed_mode);
+
 		// only add new piece-chunks if the send buffer is small enough
 		// otherwise there will be no end to how large it will be!
 
@@ -5269,8 +5273,6 @@ namespace {
 			TORRENT_ASSERT(r.length > 0);
 			TORRENT_ASSERT(r.start >= 0);
 
-			bool const seed_mode = t->seed_mode();
-
 			if (seed_mode
 				&& !t->verified_piece(r.piece)
 				&& !m_settings.get_bool(settings_pack::disable_hash_checks))
@@ -5291,7 +5293,7 @@ namespace {
 				// this means we're in seed mode and we haven't yet
 				// verified this piece (r.piece)
 				disk_job_flags_t flags;
-				if (m_ti->info_hashes().has_v1() && !t->disable_v1_hashes())
+				if (m_ti->info_hashes().has_v1() && !(tflags & torrent_flags::disable_v1_hashes))
 					flags |= disk_interface::v1_hash;
 				aux::vector<sha256_hash> hashes;
 				if (m_ti->info_hashes().has_v2())
@@ -5362,8 +5364,7 @@ namespace {
 		m_ses.deferred_submit_jobs();
 
 #ifndef TORRENT_DISABLE_SHARE_MODE
-		if (t->share_mode() && sent_a_piece)
-			t->recalc_share_mode();
+		if ((tflags & torrent_flags::share_mode) && sent_a_piece) t->recalc_share_mode();
 #endif
 	}
 
@@ -5390,6 +5391,8 @@ namespace {
 			return;
 		}
 
+		auto const tflags = t->flags();
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-braces"
@@ -5402,7 +5405,7 @@ namespace {
 
 		// we're using the piece hashes here, we need the torrent to be loaded
 		if (!m_settings.get_bool(settings_pack::disable_hash_checks) && m_ti->info_hashes().has_v1()
-			&& !t->disable_v1_hashes())
+			&& !(tflags & torrent_flags::disable_v1_hashes))
 		{
 			hash_failed[protocol_version::V1] = piece_hash != m_ti->hash_for_piece(piece);
 		}
@@ -5455,7 +5458,8 @@ namespace {
 		}
 		else
 		{
-			if (t->seed_mode())
+			bool const seed_mode = bool(tflags & torrent_flags::seed_mode);
+			if (seed_mode)
 			{
 				TORRENT_ASSERT(t->verifying_piece(piece));
 				t->verified(piece);
@@ -5465,7 +5469,7 @@ namespace {
 			peer_log(peer_log_alert::info, peer_log_alert::seed_mode_file_hash
 				, "piece: %d passed", static_cast<int>(piece));
 #endif
-			if (t->seed_mode() && t->all_verified())
+			if (seed_mode && t->all_verified())
 				t->leave_seed_mode(aux::torrent::seed_mode_t::skip_checking);
 		}
 
@@ -6610,9 +6614,9 @@ namespace {
 		// in share mode we don't close redundant connections
 		if (m_settings.get_bool(settings_pack::close_redundant_connections)
 #ifndef TORRENT_DISABLE_SHARE_MODE
-			&& !t->share_mode()
+			&& !(t->flags() & torrent_flags::share_mode)
 #endif
-			)
+		)
 		{
 			bool const ok_to_disconnect =
 				can_disconnect(errors::upload_upload_connection)

--- a/src/request_blocks.cpp
+++ b/src/request_blocks.cpp
@@ -19,6 +19,7 @@ see LICENSE file.
 #include "libtorrent/aux_/request_blocks.hpp"
 #include "libtorrent/aux_/alert_manager.hpp"
 #include "libtorrent/aux_/has_block.hpp"
+#include "libtorrent/aux_/torrent_internal_flags.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -45,7 +46,7 @@ namespace libtorrent::aux {
 	{
 		if (t.is_seed()) return false;
 		if (c.no_download()) return false;
-		if (t.upload_mode()) return false;
+		if (t.flags() & torrent_internal_flags::effective_upload_mode) return false;
 		if (c.is_disconnecting()) return false;
 
 		// don't request pieces before we have the metadata

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -3614,7 +3614,7 @@ retry:
 						m_next_scrape_torrent = 0;
 
 					torrent& t = *want_scrape[m_next_scrape_torrent];
-					TORRENT_ASSERT(t.is_paused() && t.is_auto_managed());
+					TORRENT_ASSERT(t.is_paused() && (t.flags() & torrent_flags::auto_managed));
 
 					// false means it's not triggered by the user, but automatically
 					// by libtorrent
@@ -3927,7 +3927,7 @@ retry:
 		for (auto& t : list)
 		{
 			TORRENT_ASSERT(t->state() == torrent_status::checking_files);
-			TORRENT_ASSERT(t->is_auto_managed());
+			TORRENT_ASSERT(t->flags() & torrent_flags::auto_managed);
 			if (limit <= 0)
 			{
 				t->pause();

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -458,7 +458,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 	int torrent::current_stats_state() const
 	{
-		if (m_flags & torrent_internal_flags::torrent_aborted
+		if ((m_flags & torrent_internal_flags::torrent_aborted)
 			|| !(m_flags & torrent_internal_flags::added))
 			return counters::num_checking_torrents + no_gauge_state;
 
@@ -777,8 +777,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 	void torrent::read_piece(piece_index_t const piece)
 	{
 		error_code ec;
-		if (m_flags & torrent_internal_flags::torrent_aborted
-			|| m_flags & torrent_internal_flags::deleted)
+		if ((m_flags & torrent_internal_flags::torrent_aborted)
+			|| (m_flags & torrent_internal_flags::deleted))
 		{
 			ec.assign(boost::system::errc::operation_canceled, generic_category());
 		}
@@ -863,10 +863,10 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 #ifndef TORRENT_DISABLE_EXTENSIONS
 
 #ifndef TORRENT_DISABLE_SHARE_MODE
-		if (share_mode()) return;
+		if (m_flags & torrent_flags::share_mode) return;
 #endif
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		if (super_seeding()) return;
+		if (m_flags & torrent_flags::super_seeding) return;
 #endif
 
 		// if we send upload-only, the other end is very likely to disconnect
@@ -881,7 +881,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		// make another piece available
 		bool const upload_only_enabled = is_upload_only()
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-			&& !super_seeding()
+			&& !(m_flags & torrent_flags::super_seeding)
 #endif
 			;
 
@@ -1278,7 +1278,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (m_picker) return;
 
 		TORRENT_ASSERT(valid_metadata());
-		TORRENT_ASSERT((m_flags & torrent_internal_flags::connections_initialized));
+		TORRENT_ASSERT(m_flags & torrent_internal_flags::connections_initialized);
 
 		INVARIANT_CHECK;
 
@@ -1327,7 +1327,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (m_hash_picker) return;
 
 		TORRENT_ASSERT(valid_metadata());
-		TORRENT_ASSERT((m_flags & torrent_internal_flags::connections_initialized));
+		TORRENT_ASSERT(m_flags & torrent_internal_flags::connections_initialized);
 
 		//INVARIANT_CHECK;
 
@@ -1398,7 +1398,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (m_flags & torrent_internal_flags::deleted) return;
 
 		// avoid crash trying to access the picker when there is none
-		if (m_flags & torrent_internal_flags::have_all && !has_picker()) return;
+		if ((m_flags & torrent_internal_flags::have_all) && !has_picker()) return;
 
 		// we don't support clobbering the piece picker while checking the
 		// files. We may end up having the same piece multiple times
@@ -1926,7 +1926,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		construct_storage();
 
 #ifndef TORRENT_DISABLE_SHARE_MODE
-		if (m_flags & torrent_flags::share_mode && valid_metadata())
+		if ((m_flags & torrent_flags::share_mode) && valid_metadata())
 		{
 			// in share mode, all pieces have their priorities initialized to 0
 			m_file_priority.clear();
@@ -2138,7 +2138,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		, storage_error const& error) try
 	{
 #if TORRENT_USE_ASSERTS
-		TORRENT_ASSERT((m_flags & torrent_internal_flags::outstanding_check_files));
+		TORRENT_ASSERT(m_flags & torrent_internal_flags::outstanding_check_files);
 		m_flags &= ~torrent_internal_flags::outstanding_check_files;
 #endif
 
@@ -2760,7 +2760,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 			, get_int_setting(settings_pack::active_seeds)
 			, get_int_setting(settings_pack::active_limit)});
 		int const num_torrents = m_ses.num_torrents();
-		if (m_flags & torrent_flags::auto_managed && num_torrents > limit)
+		if ((m_flags & torrent_flags::auto_managed) && num_torrents > limit)
 		{
 			// if we're auto managed and we've reached one of the limits. Assume
 			// we need to be paused until the auto managed logic runs again
@@ -3254,10 +3254,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 #ifndef TORRENT_DISABLE_LOGGING
 			++idx;
 #endif
-			refresh_endpoint_list(m_ses,
-				is_ssl_torrent(),
-				bool((m_flags & torrent_internal_flags::complete_sent)),
-				ae);
+			refresh_endpoint_list(
+				m_ses, is_ssl_torrent(), bool(m_flags & torrent_internal_flags::complete_sent), ae);
 
 			// if trackerid is not specified for tracker use default one, probably set explicitly
 			req.trackerid = ae.trackerid.empty() ? m_trackerid : ae.trackerid;
@@ -3397,7 +3395,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 					// if we're not logging session logs, don't bother creating an
 					// observer object just for logging
-					if (m_flags & torrent_internal_flags::torrent_aborted && m_ses.should_log())
+					if ((m_flags & torrent_internal_flags::torrent_aborted) && m_ses.should_log())
 					{
 						auto tl = std::make_shared<aux::tracker_logger>(m_ses);
 						m_ses.queue_tracker_request(req, tl);
@@ -3490,7 +3488,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (ae.i2p) req.kind |= tracker_request::i2p;
 #endif
 		refresh_endpoint_list(
-			m_ses, is_ssl_torrent(), bool((m_flags & torrent_internal_flags::complete_sent)), ae);
+			m_ses, is_ssl_torrent(), bool(m_flags & torrent_internal_flags::complete_sent), ae);
 		req.url = ae.url;
 		req.private_torrent = m_torrent_file && m_torrent_file->priv();
 #if TORRENT_ABI_VERSION == 1
@@ -3963,11 +3961,11 @@ namespace {
 				// make sure we check for new endpoints from the listen sockets
 				refresh_endpoint_list(m_ses,
 					is_ssl_torrent(),
-					bool((m_flags & torrent_internal_flags::complete_sent)),
+					bool(m_flags & torrent_internal_flags::complete_sent),
 					e);
 				found_one |= trigger_announce(m_ses,
 					is_ssl_torrent(),
-					bool((m_flags & torrent_internal_flags::complete_sent)),
+					bool(m_flags & torrent_internal_flags::complete_sent),
 					flags,
 					t,
 					e);
@@ -3981,7 +3979,7 @@ namespace {
 			if (e == nullptr) return;
 			found_one |= trigger_announce(m_ses,
 				is_ssl_torrent(),
-				bool((m_flags & torrent_internal_flags::complete_sent)),
+				bool(m_flags & torrent_internal_flags::complete_sent),
 				flags,
 				t,
 				*e);
@@ -4024,7 +4022,7 @@ namespace {
 
 		bool const found = trigger_announce(m_ses,
 			is_ssl_torrent(),
-			bool((m_flags & torrent_internal_flags::complete_sent)),
+			bool(m_flags & torrent_internal_flags::complete_sent),
 			flags,
 			t,
 			*e);
@@ -4208,7 +4206,7 @@ namespace {
 		TORRENT_ASSERT(!valid_metadata() || m_torrent_file->num_pieces() > 0);
 		if (!valid_metadata()) return;
 
-		if (m_flags & torrent_flags::seed_mode || is_seed())
+		if ((m_flags & torrent_flags::seed_mode) || is_seed())
 		{
 			// once we're a seed and remove the piece picker, we stop tracking
 			// piece- and file priority. We consider everything as being
@@ -4890,7 +4888,7 @@ namespace {
 		}
 		else
 		{
-			TORRENT_ASSERT((m_flags & torrent_internal_flags::torrent_aborted));
+			TORRENT_ASSERT(m_flags & torrent_internal_flags::torrent_aborted);
 			// it doesn't really matter what we do
 			// here, since we're about to destruct the
 			// torrent anyway.
@@ -5404,7 +5402,7 @@ namespace {
 		TORRENT_ASSERT_PRECOND(valid_metadata());
 		TORRENT_ASSERT_PRECOND(valid_metadata() && piece < m_torrent_file->end_piece());
 
-		if (m_flags & torrent_internal_flags::torrent_aborted || !valid_metadata()
+		if ((m_flags & torrent_internal_flags::torrent_aborted) || !valid_metadata()
 			|| piece < piece_index_t(0) || piece >= m_torrent_file->end_piece())
 		{
 			// failed
@@ -6114,7 +6112,7 @@ namespace {
 		if (settings().get_bool(settings_pack::prefer_udp_trackers))
 			m_trackers.prioritize_udp_trackers();
 
-		if (m_flags & torrent_internal_flags::announcing && !m_trackers.empty())
+		if ((m_flags & torrent_internal_flags::announcing) && !m_trackers.empty())
 			announce_with_tracker();
 
 		set_need_save_resume(torrent_handle::if_metadata_changed);
@@ -6124,7 +6122,7 @@ namespace {
 	{
 		bool const added = m_trackers.add_tracker(aux::announce_entry(url));
 		if (added) set_need_save_resume(torrent_handle::if_metadata_changed);
-		if (m_flags & torrent_internal_flags::announcing && added) announce_with_tracker();
+		if ((m_flags & torrent_internal_flags::announcing) && added) announce_with_tracker();
 		return added;
 	}
 
@@ -6481,7 +6479,7 @@ namespace {
 		TORRENT_ASSERT_VAL(m_peers_to_disconnect.size() == num, m_peers_to_disconnect.size() - num);
 		m_peers_to_disconnect.clear();
 
-		if (m_flags & torrent_internal_flags::graceful_pause && m_connections.empty())
+		if ((m_flags & torrent_internal_flags::graceful_pause) && m_connections.empty())
 		{
 			// we're in graceful pause mode and this was the last peer we
 			// disconnected. This will clear the graceful_pause_mode and post the
@@ -8200,7 +8198,7 @@ namespace {
 
 		m_flags |= torrent_internal_flags::has_incoming;
 
-		if (m_flags & torrent_flags::apply_ip_filter && m_ip_filter
+		if ((m_flags & torrent_flags::apply_ip_filter) && m_ip_filter
 			&& m_ip_filter->access(p->remote().address()) & ip_filter::blocked)
 		{
 			if (m_ses.alerts().should_post<peer_blocked_alert>())
@@ -8434,7 +8432,7 @@ namespace {
 		bool is_downloading = false;
 		bool is_seeding = false;
 
-		if (m_flags & torrent_flags::auto_managed && !has_error())
+		if ((m_flags & torrent_flags::auto_managed) && !has_error())
 		{
 			if (m_state == torrent_status::checking_files)
 			{
@@ -9140,7 +9138,7 @@ namespace {
 		bool is_downloading = false;
 		bool is_seeding = false;
 
-		if (m_flags & torrent_flags::auto_managed && !has_error())
+		if ((m_flags & torrent_flags::auto_managed) && !has_error())
 		{
 			if (m_state == torrent_status::checking_files)
 			{
@@ -9373,7 +9371,7 @@ namespace {
 			}
 		}
 */
-		if (m_flags & torrent_internal_flags::files_checked && valid_metadata())
+		if ((m_flags & torrent_internal_flags::files_checked) && valid_metadata())
 		{
 			TORRENT_ASSERT(block_size() > 0);
 		}
@@ -9399,7 +9397,7 @@ namespace {
 	{
 		// finished torrents may not change their queue positions, as it's set to
 		// -1
-		if (m_flags & torrent_internal_flags::torrent_aborted || is_finished()) return;
+		if ((m_flags & torrent_internal_flags::torrent_aborted) || is_finished()) return;
 
 		set_queue_position(queue_position() == queue_position_t{0}
 			? queue_position() : prev(queue_position()));
@@ -9416,7 +9414,7 @@ namespace {
 
 		// finished torrents may not change their queue positions, as it's set to
 		// -1
-		if ((m_flags & torrent_internal_flags::torrent_aborted || is_finished()) && p != no_pos)
+		if (((m_flags & torrent_internal_flags::torrent_aborted) || is_finished()) && p != no_pos)
 			return;
 
 		TORRENT_ASSERT((p == no_pos) == is_finished()
@@ -9823,7 +9821,7 @@ namespace {
 		// storage may be nullptr during shutdown
 		if (!m_storage)
 		{
-			TORRENT_ASSERT((m_flags & torrent_internal_flags::torrent_aborted));
+			TORRENT_ASSERT(m_flags & torrent_internal_flags::torrent_aborted);
 			return;
 		}
 		m_ses.disk_thread().async_release_files(m_storage
@@ -10086,7 +10084,7 @@ namespace {
 			// there is one special case here. If we are
 			// currently in graceful pause mode, and we just turned into regular
 			// paused mode, we need to actually pause the torrent properly
-			if (m_flags & torrent_flags::paused
+			if ((m_flags & torrent_flags::paused)
 				&& bool(m_flags & torrent_internal_flags::graceful_pause)
 				&& !(flags & torrent_handle::graceful_pause))
 			{
@@ -10511,7 +10509,7 @@ namespace {
 		// if we're in upload only mode and we're auto-managed
 		// leave upload mode every 10 minutes hoping that the error
 		// condition has been fixed
-		if (m_flags & torrent_flags::upload_mode && m_flags & torrent_flags::auto_managed
+		if ((m_flags & torrent_flags::upload_mode) && (m_flags & torrent_flags::auto_managed)
 			&& upload_mode_time()
 				>= seconds(settings().get_int(settings_pack::optimistic_disk_retry)))
 		{
@@ -10581,7 +10579,8 @@ namespace {
 		}
 #endif // TORRENT_DEBUG_STREAMING
 
-		if (!m_time_critical_pieces.empty() && !upload_mode())
+		if (!m_time_critical_pieces.empty() && !(m_flags & torrent_flags::upload_mode)
+			&& !(m_flags & torrent_internal_flags::graceful_pause))
 		{
 			request_time_critical_pieces();
 		}
@@ -10628,7 +10627,7 @@ namespace {
 
 		if (settings().get_bool(settings_pack::dont_count_slow_torrents))
 		{
-			if (is_inactive != bool((m_flags & torrent_internal_flags::inactive))
+			if (is_inactive != bool(m_flags & torrent_internal_flags::inactive)
 				&& !(m_flags & torrent_internal_flags::pending_active_change))
 			{
 				int const delay = settings().get_int(settings_pack::auto_manage_startup);
@@ -10637,7 +10636,7 @@ namespace {
 					self->wrap(&torrent::on_inactivity_tick, ec); });
 				m_flags |= torrent_internal_flags::pending_active_change;
 			}
-			else if (is_inactive == bool((m_flags & torrent_internal_flags::inactive))
+			else if (is_inactive == bool(m_flags & torrent_internal_flags::inactive)
 				&& (m_flags & torrent_internal_flags::pending_active_change))
 			{
 				m_inactivity_timer.cancel();
@@ -10666,7 +10665,7 @@ namespace {
 		if (ec) return;
 
 		bool const is_inactive = is_inactive_internal();
-		if (is_inactive == bool((m_flags & torrent_internal_flags::inactive))) return;
+		if (is_inactive == bool(m_flags & torrent_internal_flags::inactive)) return;
 
 		set_flag(torrent_internal_flags::inactive, is_inactive);
 
@@ -10721,7 +10720,7 @@ namespace {
 #ifndef TORRENT_DISABLE_SHARE_MODE
 	void torrent::recalc_share_mode()
 	{
-		TORRENT_ASSERT(share_mode());
+		TORRENT_ASSERT(m_flags & torrent_flags::share_mode);
 		if (is_seed()) return;
 
 		int const pieces_in_torrent = m_torrent_file->num_pieces();
@@ -11214,7 +11213,8 @@ namespace {
 	void torrent::request_time_critical_pieces()
 	{
 		TORRENT_ASSERT(is_single_thread());
-		TORRENT_ASSERT(!upload_mode());
+		TORRENT_ASSERT(!(m_flags & torrent_flags::upload_mode)
+			&& !(m_flags & torrent_internal_flags::graceful_pause));
 
 		// build a list of peers and sort it by download_queue_time
 		// we use this sorted list to determine which peer we should
@@ -11944,7 +11944,7 @@ namespace {
 
 		// to avoid race condition, if we're already in a downloading state,
 		// trigger the stop-when-ready logic immediately.
-		if (m_flags & torrent_flags::stop_when_ready && is_downloading_state(m_state))
+		if ((m_flags & torrent_flags::stop_when_ready) && is_downloading_state(m_state))
 		{
 #ifndef TORRENT_DISABLE_LOGGING
 			debug_log("stop_when_ready triggered");

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -25,6 +25,7 @@ see LICENSE file.
 
 #include "libtorrent/torrent_handle.hpp"
 #include "libtorrent/aux_/torrent.hpp"
+#include "libtorrent/aux_/torrent_internal_flags.hpp"
 #include "libtorrent/entry.hpp"
 #include "libtorrent/aux_/session_impl.hpp"
 #include "libtorrent/aux_/session_call.hpp"
@@ -639,10 +640,14 @@ namespace libtorrent {
 	{ return sync_call_ret<bool>(false, &aux::torrent::is_torrent_paused); }
 
 	bool torrent_handle::is_sequential_download() const
-	{ return sync_call_ret<bool>(false, &aux::torrent::is_sequential_download); }
+	{
+		return bool(internal_flags() & aux::torrent_internal_flags::effective_sequential);
+	}
 
 	bool torrent_handle::is_auto_managed() const
-	{ return sync_call_ret<bool>(false, &aux::torrent::is_auto_managed); }
+	{
+		return bool(internal_flags() & torrent_flags::auto_managed);
+	}
 
 	bool torrent_handle::has_metadata() const
 	{ return sync_call_ret<bool>(false, &aux::torrent::valid_metadata); }
@@ -650,7 +655,7 @@ namespace libtorrent {
 	bool torrent_handle::super_seeding() const
 	{
 #ifndef TORRENT_DISABLE_SUPERSEEDING
-		return sync_call_ret<bool>(false, &aux::torrent::super_seeding);
+		return bool(internal_flags() & torrent_flags::super_seeding);
 #else
 		return false;
 #endif


### PR DESCRIPTION
make the torrent interface smaller; preparing for multi-threading support