### PR TITLE
improve choker

### DIFF
--- a/include/libtorrent/aux_/peer_connection.hpp
+++ b/include/libtorrent/aux_/peer_connection.hpp
@@ -875,6 +875,12 @@ namespace libtorrent::aux {
 		// attached.
 		std::shared_ptr<torrent_info const> m_ti;
 
+		// snapshot of the torrent's priority per channel, taken at
+		// attach. lets the choker's compare predicate read priority
+		// without touching the torrent. not refreshed; a runtime
+		// set_peer_class only takes effect on reconnect.
+		std::array<int, 2> m_torrent_priority_cache{};
+
 	public:
 		aux::chained_buffer m_send_buffer;
 	private:

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -25,6 +25,7 @@ see LICENSE file.
 #define TORRENT_TORRENT_HPP_INCLUDE
 
 #include <algorithm>
+#include <array>
 #include <vector>
 #include <set>
 #include <list>
@@ -500,6 +501,10 @@ namespace libtorrent::aux {
 		// per-tick stats delta flushed by peer_connection. propagates
 		// the deltas to m_stat and to the session
 		void accumulate_stats(stat_delta const& d);
+
+		// max priority across torrent's peer_class_set, per channel.
+		// peer snapshots this at attach (m_torrent_priority_cache).
+		std::array<int, 2> torrent_priority() const;
 
 		void set_ip_filter(std::shared_ptr<const ip_filter> ipf);
 		void privileged_port_updated();

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -136,10 +136,13 @@ namespace {
 			+ static_cast<std::uint8_t>(socket_type_idx(m_socket)));
 		auto t = m_torrent.lock();
 
-		// for outgoing connections the torrent is known at construction
-		// time, so we can cache the torrent_info pointer up-front. For
-		// incoming connections attach_to_torrent() sets it later.
-		if (t) m_ti = t->torrent_file_ptr();
+		// outgoing connections know the torrent here; incoming ones
+		// snapshot the same state in attach_to_torrent().
+		if (t)
+		{
+			m_ti = t->torrent_file_ptr();
+			m_torrent_priority_cache = t->torrent_priority();
+		}
 
 		// the protocol_v2 flag should not be set for non-v2 torrents
 		TORRENT_ASSERT(!m_ti || m_ti->info_hashes().has_v2() || !m_peer_info->protocol_v2);
@@ -256,10 +259,8 @@ namespace {
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(channel >= 0 && channel < 2);
 		// the bandwidth allocator's minimum priority is 1
-		int prio = std::max(1, m_rates.max_priority(*this, channel));
-		auto const t = associated_torrent().lock();
-		if (t) prio = std::max(prio, m_rates.max_priority(*t, channel));
-		return prio;
+		int const peer_prio = std::max(1, m_rates.max_priority(*this, channel));
+		return std::max(peer_prio, m_torrent_priority_cache[std::size_t(channel)]);
 	}
 
 	void peer_connection::reset_choke_counters()
@@ -1387,6 +1388,8 @@ namespace {
 		// of the torrent and peer_connection::disconnect() will fail if it
 		// think it is
 		m_torrent = t;
+
+		m_torrent_priority_cache = t->torrent_priority();
 
 		if (t && m_alerts.should_post<peer_connect_alert>())
 		{

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -73,6 +73,7 @@ see LICENSE file.
 #include "libtorrent/identify_client.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/extensions.hpp"
+#include "libtorrent/aux_/rate_limits.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
 #include "libtorrent/aux_/instantiate_connection.hpp"
 #include "libtorrent/assert.hpp"
@@ -10857,6 +10858,13 @@ namespace {
 	{
 		m_stat.accumulate(d);
 		m_ses.accumulate_stats(d);
+	}
+
+	std::array<int, 2> torrent::torrent_priority() const
+	{
+		auto& rates = m_ses.rates();
+		return {{rates.max_priority(*this, rate_limits::upload_channel),
+			rates.max_priority(*this, rate_limits::download_channel)}};
 	}
 
 #ifndef TORRENT_DISABLE_STREAMING


### PR DESCRIPTION
avoid reaching into the torrent for every comparison when sorting peers in the choker.

This also reduces the coupling between the peer and the torrent, moving towards simpler multi-threading