### PR TITLE
persist BEP-21 upload_only on peer_list entry

### DIFF
--- a/include/libtorrent/aux_/peer_list.hpp
+++ b/include/libtorrent/aux_/peer_list.hpp
@@ -129,6 +129,7 @@ namespace libtorrent::aux {
 			, std::vector<tcp::endpoint>& banned);
 
 		void set_seed(torrent_peer* p, bool s);
+		void set_upload_only(torrent_peer* p, bool s);
 
 		// this clears all cached peer priorities. It's called when
 		// our external IP changes

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -736,6 +736,7 @@ namespace libtorrent::aux {
 		bool ban_peer(torrent_peer* tp);
 		void update_peer_port(int port, torrent_peer* p, peer_source_flags_t src);
 		void set_seed(torrent_peer* p, bool s);
+		void set_upload_only(torrent_peer* p, bool s);
 		void clear_failcount(torrent_peer* p);
 		std::pair<aux::peer_list::iterator, aux::peer_list::iterator> find_peers(address const& a);
 

--- a/include/libtorrent/aux_/torrent_peer.hpp
+++ b/include/libtorrent/aux_/torrent_peer.hpp
@@ -123,6 +123,12 @@ namespace libtorrent::aux {
 		// because we have connected to it and it told us it was a seed
 		std::uint32_t seed:1;
 
+		// this peer confirmed via BEP-21 (LTEP upload_only=1) that it will
+		// not download any more. A seed is upload_only by implication,
+		// but a partial seed can be upload_only without being a seed, so
+		// this is tracked separately from seed:1.
+		std::uint32_t upload_only:1;
+
 		// we've been told that this peer is upload-only, but we don't know for
 		// sure because we haven't connected to it yet. If we are finished, we
 		// will de-prioritize peers that may be seeds

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -6853,6 +6853,16 @@ namespace {
 	{
 		TORRENT_ASSERT(is_single_thread());
 		m_upload_only = u;
+
+		// keep the persistent peer_list entry in sync with the live m_upload_only bit,
+		// BEFORE the connection may be torn down by disconnect_if_redundant().
+		// Both transitions propagate so the persistent bit cannot go stale if
+		// peer toggles the flag back to 0.
+		if (m_peer_info != nullptr)
+		{
+			if (auto t = m_torrent.lock()) t->set_upload_only(m_peer_info, u);
+		}
+
 		disconnect_if_redundant();
 	}
 

--- a/src/peer_list.cpp
+++ b/src/peer_list.cpp
@@ -479,12 +479,8 @@ namespace libtorrent::aux {
 	{
 		TORRENT_ASSERT(is_single_thread());
 		TORRENT_ASSERT(p.in_use);
-		if (p.connection
-			|| p.banned
-			|| p.web_seed
-			|| !p.connectable
-			|| (p.seed && m_finished)
-			|| int(p.failcount) >= m_max_failcount)
+		if (p.connection || p.banned || p.web_seed || !p.connectable
+			|| ((p.seed || p.upload_only) && m_finished) || int(p.failcount) >= m_max_failcount)
 			return false;
 
 #if TORRENT_USE_RTC
@@ -983,6 +979,23 @@ namespace libtorrent::aux {
 			TORRENT_ASSERT(m_num_seeds > 0);
 			--m_num_seeds;
 		}
+	}
+
+	void peer_list::set_upload_only(torrent_peer* p, bool s)
+	{
+		TORRENT_ASSERT(is_single_thread());
+		if (p == nullptr) return;
+		TORRENT_ASSERT(p->in_use);
+		if (bool(p->upload_only) == s) return;
+		bool const was_conn_cand = is_connect_candidate(*p);
+		p->upload_only = s;
+		bool const is_conn_cand = is_connect_candidate(*p);
+		if (was_conn_cand && !is_conn_cand)
+			update_connect_candidates(-1);
+		else if (!was_conn_cand && is_conn_cand)
+			update_connect_candidates(1);
+		// unlike set_seed, do NOT touch m_num_seeds: a BEP-21 upload_only
+		// peer is not necessarily a full seed (partial seeds qualify too).
 	}
 
 	// this is an internal function

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -11657,6 +11657,11 @@ namespace {
 		update_auto_sequential();
 	}
 
+	void torrent::set_upload_only(torrent_peer* p, bool const s)
+	{
+		m_peer_list->set_upload_only(p, s);
+	}
+
 	void torrent::clear_failcount(torrent_peer* p)
 	{
 		need_peer_list();

--- a/src/torrent_peer.cpp
+++ b/src/torrent_peer.cpp
@@ -126,14 +126,14 @@ namespace libtorrent::aux {
 		return ret;
 	}
 
-	torrent_peer::torrent_peer(std::uint16_t port_, bool conn
-		, peer_source_flags_t const src)
+	torrent_peer::torrent_peer(std::uint16_t port_, bool conn, peer_source_flags_t const src)
 		: connection(nullptr)
 		, port(port_)
 		, failcount(0)
 		, connectable(conn)
 		, optimistically_unchoked(false)
 		, seed(false)
+		, upload_only(false)
 		, maybe_upload_only(false)
 		, fast_reconnects(0)
 		, trust_points(0)

--- a/test/test_peer_list.cpp
+++ b/test/test_peer_list.cpp
@@ -678,6 +678,56 @@ TORRENT_TEST(set_seed)
 	TEST_EQUAL(p.num_peers(), 100);
 }
 
+// test set_upload_only
+TORRENT_TEST(set_upload_only)
+{
+	torrent_state st = init_state();
+
+	mock_torrent t(&st);
+	peer_list p(allocator);
+	t.m_p = &p;
+
+	std::vector<torrent_peer*> upload_only_peers;
+	for (int i = 0; i < 100; ++i)
+	{
+		torrent_peer* peer =
+			p.add_peer(tcp::endpoint(address_v4(std::uint32_t((10 << 24) + ((i + 10) << 16))),
+						   std::uint16_t(i + 10)),
+				{},
+				{},
+				&st);
+		TEST_EQUAL(st.erased.size(), 0);
+		st.erased.clear();
+		// make every other peer upload_only
+		if (i % 2)
+		{
+			p.set_upload_only(peer, true);
+			upload_only_peers.push_back(peer);
+		}
+	}
+	TEST_EQUAL(p.num_peers(), 100);
+	TEST_EQUAL(p.num_connect_candidates(), 100);
+
+	// now, the torrent completes and we're no longer interested in
+	// connecting to upload_only peers. Make sure half the peers are no
+	// longer considered connect candidates
+	st.is_finished = true;
+
+	// this will make the peer_list recalculate the connect candidates
+	p.connect_one_peer(1, &st);
+
+	TEST_EQUAL(p.num_connect_candidates(), 50);
+	TEST_EQUAL(p.num_peers(), 100);
+
+	// per BEP-21, the upload_only flag may toggle back to 0. Verify the
+	// persistent bit follows and the peers become connect candidates again.
+	for (torrent_peer* peer : upload_only_peers)
+		p.set_upload_only(peer, false);
+
+	TEST_EQUAL(p.num_connect_candidates(), 100);
+	TEST_EQUAL(p.num_peers(), 100);
+}
+
 // test has_peer
 TORRENT_TEST(has_peer)
 {


### PR DESCRIPTION
Fixes https://github.com/arvidn/libtorrent/issues/7700.

There is a long standing problem in LT where it immediately drops connections from peers which advertise "upload_only" in the LTEP handshake, and thus even when LT is a seed it keeps recontacting the same peers which are also seeds. Transmission and other clients get this right and hold on to the upload_only indication and stop connecting peer-seeds when unnecessary.

This PR dramatically reduces connection chatter from LT clients. Currently, as described in https://github.com/arvidn/libtorrent/issues/7700, LT will attempt to aggressively reconnect to peer-seeds up to once per minute. When trackers do not seed-filter the peer list sent back on announce, this is an enormous number of outbound connections.

The core problem is that `upload_only` is sent during LTEP exchange, *before* the `have_all` message is sent during torrent messages that would indicate a seed. So that connection is dropped by LT before it ever sees the `have_all` message.

See also https://github.com/qbittorrent/qBittorrent/issues/22432