### PR TITLE
Extra torrent handle piece and file functions

### DIFF
--- a/include/libtorrent/aux_/piece_picker.hpp
+++ b/include/libtorrent/aux_/piece_picker.hpp
@@ -7,6 +7,7 @@ Copyright (c) 2017, Pavel Pimenov
 Copyright (c) 2019, Steven Siloti
 Copyright (c) 2021, Denis Kuzmenok
 Copyright (c) 2021, Mark Scott
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -264,6 +265,10 @@ namespace libtorrent::aux {
 		// returns true if we have the piece or if the piece
 		// has passed the hash check
 		bool have_piece(piece_index_t) const;
+
+		// returns true if we have the piece range or if the piece range
+		// has passed the hash check
+		bool have_piece_range(const index_range<piece_index_t>&) const;
 
 		// returns true if the piece has been completely downloaded and
 		// successfully flushed to disk (i.e. "finished").

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -35,6 +35,7 @@ see LICENSE file.
 #include <mutex>
 #include <optional>
 
+#include <boost/core/span.hpp>
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/logic/tribool.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
@@ -469,6 +470,7 @@ namespace libtorrent::aux {
 			error_code error;
 		};
 		void read_piece(piece_index_t);
+		void read_piece_range(const index_range<piece_index_t>&);
 		void set_sequential_range(piece_index_t first_piece, piece_index_t last_piece);
 		void set_sequential_range(piece_index_t first_piece);
 		void on_disk_read_complete(disk_buffer_holder, storage_error const&
@@ -624,7 +626,10 @@ namespace libtorrent::aux {
 #ifndef TORRENT_DISABLE_STREAMING
 		void cancel_non_critical();
 		void set_piece_deadline(piece_index_t piece, int t, deadline_flags_t flags);
+		void set_piece_range_deadline(const index_range<piece_index_t>& range, int deadline, deadline_flags_t flags);
+		void set_piece_range_deadline(const index_range<piece_index_t>& range, boost::span<int>&& deadlines, deadline_flags_t flags);
 		void reset_piece_deadline(piece_index_t piece);
+		void reset_piece_range_deadline(const index_range<piece_index_t>& range);
 		void clear_time_critical();
 #endif // TORRENT_DISABLE_STREAMING
 

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -15,6 +15,7 @@ Copyright (c) 2020, Viktor Elofsson
 Copyright (c) 2021, AdvenT
 Copyright (c) 2025, Vladimir Golovnev (glassez)
 Copyright (c) 2021, Mark Scott
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -867,6 +868,15 @@ namespace libtorrent::aux {
 			if (index < piece_index_t{0} || index >= m_torrent_file->end_piece()) return false;
 			if (!has_picker()) return m_have_all;
 			return m_picker->have_piece(index);
+		}
+
+		// returns true if we have downloaded the given piece range
+		bool user_have_piece_range(const index_range<piece_index_t>& range) const
+		{
+			if (!valid_metadata()) return false;
+			if (*range.begin() < piece_index_t{0} || *range.begin() >= m_torrent_file->end_piece() || *range.end() < piece_index_t{0} || *range.end() >= m_torrent_file->end_piece()) return false;
+			if (!has_picker()) return m_have_all;
+			return m_picker->have_piece_range(range);
 		}
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES

--- a/include/libtorrent/index_range.hpp
+++ b/include/libtorrent/index_range.hpp
@@ -1,6 +1,7 @@
 /*
 
 Copyright (c) 2018-2021, Arvid Norberg
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -10,27 +11,81 @@ see LICENSE file.
 #ifndef TORRENT_INDEX_RANGE_HPP
 #define TORRENT_INDEX_RANGE_HPP
 
+#include <cstddef>
+#include <iterator>
+
 namespace libtorrent {
 
 template <typename Index>
 struct index_iter
 {
-	explicit index_iter(Index i) : m_idx(i) {}
-	index_iter operator++()
+	using value_type = Index;
+	using difference_type = std::ptrdiff_t;
+	using pointer = Index const*;
+	using reference = Index;
+	using iterator_category = std::random_access_iterator_tag;
+	constexpr index_iter() : m_idx(Index(0)) {}
+	explicit constexpr index_iter(Index i) : m_idx(i) {}
+	constexpr index_iter& operator++()
 	{
 		++m_idx;
 		return *this;
 	}
-	index_iter operator--()
+	constexpr index_iter& operator--()
 	{
 		--m_idx;
 		return *this;
 	}
-	Index operator*() const { return m_idx; }
-	friend inline bool operator==(index_iter lhs, index_iter rhs)
+	constexpr index_iter operator++(int)
+	{
+		index_iter it(*this);
+		++m_idx;
+		return it;
+	}
+	constexpr index_iter operator--(int)
+	{
+		index_iter it(*this);
+		--m_idx;
+		return it;
+	}
+	constexpr reference operator*() const { return m_idx; }
+	constexpr reference operator[](difference_type n) const
+	{ return m_idx + static_cast<Index>(n); }
+	friend constexpr inline bool operator==(index_iter lhs, index_iter rhs)
 	{ return lhs.m_idx == rhs.m_idx; }
-	friend inline bool operator!=(index_iter lhs, index_iter rhs)
+	friend constexpr inline bool operator!=(index_iter lhs, index_iter rhs)
 	{ return lhs.m_idx != rhs.m_idx; }
+	friend constexpr inline bool operator<(const index_iter& lhs, const index_iter& rhs)
+	{ return lhs.m_idx < rhs.m_idx; }
+	friend constexpr inline bool operator>(const index_iter& lhs, const index_iter& rhs)
+	{ return lhs.m_idx > rhs.m_idx; }
+	friend constexpr inline bool operator<=(const index_iter& lhs, const index_iter& rhs)
+	{ return lhs.m_idx <= rhs.m_idx; }
+	friend constexpr inline bool operator>=(const index_iter& lhs, const index_iter& rhs)
+	{ return lhs.m_idx >= rhs.m_idx; }
+	friend constexpr inline index_iter operator+(index_iter it, difference_type n)
+	{ return index_iter(it.m_idx + static_cast<Index>(n)); }
+	friend constexpr inline index_iter operator+(difference_type n, index_iter it)
+	{ return index_iter(it.m_idx + static_cast<Index>(n)); }
+	friend constexpr inline index_iter operator-(index_iter it, difference_type n)
+	{ return index_iter(it.m_idx - static_cast<Index>(n)); }
+	friend constexpr inline difference_type operator-(const index_iter& lhs, const index_iter& rhs)
+	{ return static_cast<difference_type>(lhs.m_idx - rhs.m_idx); }
+	constexpr inline index_iter& operator+=(difference_type n)
+	{
+		m_idx += static_cast<Index>(n);
+		return *this;
+	}
+	constexpr inline index_iter& operator-=(difference_type n)
+	{
+		m_idx -= static_cast<Index>(n);
+		return *this;
+	}
+	constexpr inline index_iter& operator-=(const index_iter& other)
+	{
+		m_idx -= other.m_idx;
+		return *this;
+	}
 private:
 	Index m_idx;
 };

--- a/include/libtorrent/index_range.hpp
+++ b/include/libtorrent/index_range.hpp
@@ -90,11 +90,20 @@ private:
 	Index m_idx;
 };
 
+// Ranges can be represented with both a starting and an ending index. Functions
+// from libtorrent that are called with a range parameter will always take the
+// starting index as is and the ending index will either be used exclusively or
+// inclusively, depending on each method.
 template <typename Index>
 struct index_range
 {
+	// hidden
 	Index _begin;
 	Index _end;
+	// With these two methods a range can be iterated upon.
+	//
+	// ``begin()`` returns an iterator at the start of the range.
+	// ``end()`` return an iterator at the end of the range.
 	index_iter<Index> begin() const { return index_iter<Index>{_begin}; }
 	index_iter<Index> end() const { return index_iter<Index>{_end}; }
 	friend bool operator==(index_range const& lhs, index_range const& rhs)
@@ -102,6 +111,15 @@ struct index_range
 		return lhs._begin == rhs._begin && lhs._end == rhs._end;
 	}
 	friend bool operator!=(index_range const& lhs, index_range const& rhs) { return !(lhs == rhs); }
+	// Check if an index value is part of a range.
+	//
+	// ``belongs()`` will check from start to end exclusive.
+	// ``bounds()`` will check from start to end inclusive.
+	bool belongs(Index value) const { return _begin <= value && _end > value; }
+	bool bounds(Index value) const { return _begin <= value && _end >= value; }
+	// Check if this range contains another.
+	bool contains(const index_range<Index>& other) const
+	{ return _begin <= other._begin && _begin <= other._end && _end >= other._begin && _end >= other._end; }
 };
 
 }

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -1210,6 +1210,7 @@ namespace aux {
 		download_priority_t file_priority(file_index_t index) const;
 		void prioritize_files(std::vector<download_priority_t> const& files) const;
 		std::vector<download_priority_t> get_file_priorities() const;
+		void get_file_priorities(std::vector<download_priority_t>& priorities) const;
 
 		// ``post_file_priorities()`` will trigger a file_priorities_alert to be
 		// posted, containing the download priority of each file in the torrent.

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -11,6 +11,7 @@ Copyright (c) 2019, Andrei Kurushin
 Copyright (c) 2019, ghbplayer
 Copyright (c) 2025, Vladimir Golovnev (glassez)
 Copyright (c) 2021, Mark Scott
+Copyright (c) 2024-2026 Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -321,9 +322,13 @@ namespace aux {
 		// then the functions do nothing.
 		void set_sequential_range(piece_index_t first_piece, piece_index_t last_piece) const;
 		void set_sequential_range(piece_index_t first_piece) const;
-		// Returns true if this piece has been completely downloaded and written
-		// to disk, and false otherwise.
+		// Returns true if pieces have been completely downloaded and written to
+		// disk, and false otherwise.
+		//
+		// ``have_piece()`` checks for a single piece.
+		// ``have_piece_range()`` does so for a range of pieces.
 		bool have_piece(piece_index_t piece) const;
+		bool have_piece_range(const index_range<piece_index_t>& range) const;
 
 #if TORRENT_ABI_VERSION == 1
 		// internal
@@ -1152,6 +1157,7 @@ namespace aux {
 		void prioritize_pieces(std::vector<download_priority_t> const& pieces) const;
 		void prioritize_pieces(std::vector<std::pair<piece_index_t, download_priority_t>> const& pieces) const;
 		std::vector<download_priority_t> get_piece_priorities() const;
+		void get_piece_priorities(std::vector<download_priority_t>& priorities) const;
 
 #if TORRENT_ABI_VERSION == 1
 		TORRENT_DEPRECATED

--- a/include/libtorrent/torrent_handle.hpp
+++ b/include/libtorrent/torrent_handle.hpp
@@ -299,8 +299,8 @@ namespace aux {
 		void add_piece(piece_index_t piece, std::vector<char> data, add_piece_flags_t flags = {}) const;
 
 		// This function starts an asynchronous read operation of the specified
-		// piece from this torrent. You must have completed the download of the
-		// specified piece before calling this function.
+		// pieces from this torrent. You must have completed the download of the
+		// specified pieces before calling this function.
 		//
 		// When the read operation is completed, it is passed back through an
 		// alert, read_piece_alert. Since this alert is a response to an explicit
@@ -312,7 +312,11 @@ namespace aux {
 		// .. note:: the size of the buffer passed back in the alert is not
 		//    necessarily piece_length() long. The last piece or pieces at the end
 		//    of files (in v2 and hybrid torrents) are not full size.
+		//
+		// ``read_piece()`` requests a single piece.
+		// ``read_piece_range()`` requests a range of pieces.
 		void read_piece(piece_index_t piece) const;
+		void read_piece_range(const index_range<piece_index_t>& range) const;
 
 		// These functions set the first piece and the last piece of the range
 		// for the piece picker. They start downloading from the specified piece
@@ -441,14 +445,25 @@ namespace aux {
 		// ``deadline`` is the number of milliseconds until this piece should be
 		// completed.
 		//
-		// ``reset_piece_deadline`` removes the deadline from the piece. If it
+		// ``set_piece_range_deadline()`` sets deadlines for a range of pieces.
+		//
+		// ``deadlines`` vector of deadlines of each individual piece. If its
+		// length does not coincide with the range then it's truncated from its
+		// first index to an equal size or its last value is used as filler.
+		//
+		// ``reset_piece_deadline()`` removes the deadline from the piece. If it
 		// hasn't already been downloaded, it will no longer be considered a
 		// priority.
+		//
+		// ``reset_piece_range_deadline()`` does so for a range of pieces.
 		//
 		// ``clear_piece_deadlines()`` removes deadlines on all pieces in
 		// the torrent. As if reset_piece_deadline() was called on all pieces.
 		void set_piece_deadline(piece_index_t index, int deadline, deadline_flags_t flags = {}) const;
+		void set_piece_range_deadline(const index_range<piece_index_t>& range, int deadline, deadline_flags_t flags = {}) const;
+		void set_piece_range_deadline(const index_range<piece_index_t>& range, std::vector<int>&& deadlines, deadline_flags_t flags = {}) const;
 		void reset_piece_deadline(piece_index_t index) const;
+		void reset_piece_range_deadline(const index_range<piece_index_t>& range) const;
 		void clear_piece_deadlines() const;
 
 #if TORRENT_ABI_VERSION == 1

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -8,6 +8,7 @@ Copyright (c) 2016, 2019, Steven Siloti
 Copyright (c) 2018, Pavel Pimenov
 Copyright (c) 2021, Denis Kuzmenok
 Copyright (c) 2021, Mark Scott
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -2901,6 +2902,11 @@ get_out:
 		auto const i = find_dl_piece(state, index);
 		TORRENT_ASSERT(i != m_downloads[state].end());
 		return bool(i->passed_hash_check);
+	}
+
+	bool piece_picker::have_piece_range(const index_range<piece_index_t>& range) const
+	{
+		return std::all_of(range.begin(), range.end(), [this](piece_index_t index) { return have_piece(index); });
 	}
 
 	std::vector<piece_picker::downloading_piece>::iterator piece_picker::find_dl_piece(

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -27,6 +27,7 @@ Copyright (c) 2021, Mark Scott
 Copyright (c) 2021, thrnz
 Copyright (c) 2024, Elyas EL IDRISSI
 Copyright (c) 2025, Vladimir Golovnev (glassez)
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -859,6 +860,81 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 				{ self->on_disk_read_complete(std::move(block), se, r, rp); }
 				, flags);
 		}
+		m_ses.deferred_submit_jobs();
+	}
+
+	void torrent::read_piece_range(const index_range<piece_index_t> &range)
+	{
+		error_code ec;
+		if (m_abort || m_deleted)
+		{
+			ec.assign(boost::system::errc::operation_canceled, generic_category());
+		}
+		else if (!valid_metadata())
+		{
+			ec.assign(errors::no_metadata, libtorrent_category());
+		}
+
+		if (ec)
+		{
+			for (const auto p : range)
+				m_ses.alerts().emplace_alert<read_piece_alert>(get_handle(), p, ec);
+			return;
+		}
+
+		for (const auto p : range) {
+			if (!user_have_piece(p))
+			{
+				ec.assign(errors::invalid_piece_index, libtorrent_category());
+				m_ses.alerts().emplace_alert<read_piece_alert>(get_handle(), p, ec);
+				continue;
+			}
+
+			const int piece_size = m_torrent_file->piece_size_for_req(p);
+			const int blocks_in_piece = (piece_size + block_size() - 1) / block_size();
+
+			TORRENT_ASSERT(blocks_in_piece > 0);
+			TORRENT_ASSERT(piece_size > 0);
+
+			if (blocks_in_piece == 0)
+			{
+				// this shouldn't actually happen
+				boost::shared_array<char> buf;
+				m_ses.alerts().emplace_alert<read_piece_alert>(
+					get_handle(), p, buf, 0);
+				continue;
+			}
+
+			std::shared_ptr<read_piece_struct> rp = std::make_shared<read_piece_struct>();
+			rp->piece_data.reset(new (std::nothrow) char[std::size_t(piece_size)]);
+			if (!rp->piece_data)
+			{
+				m_ses.alerts().emplace_alert<read_piece_alert>(
+					get_handle(), p, error_code(boost::system::errc::not_enough_memory, generic_category()));
+				continue;
+			}
+			rp->blocks_left = blocks_in_piece;
+			rp->fail = false;
+
+			disk_job_flags_t flags{};
+			auto const read_mode = settings().get_int(settings_pack::disk_io_read_mode);
+			if (read_mode == settings_pack::disable_os_cache)
+				flags |= disk_interface::volatile_read;
+
+			peer_request r;
+			r.piece = p;
+			r.start = 0;
+			auto self = shared_from_this();
+			for (int i = 0; i < blocks_in_piece; ++i, r.start += block_size())
+			{
+				r.length = std::min(piece_size - r.start, block_size());
+				m_ses.disk_thread().async_read(m_storage, r
+					, [self, r, rp](disk_buffer_holder block, storage_error const& se) mutable
+					{ self->on_disk_read_complete(std::move(block), se, r, rp); }
+					, flags);
+			}
+		}
+
 		m_ses.deferred_submit_jobs();
 	}
 
@@ -5529,9 +5605,159 @@ namespace {
 		}
 	}
 
+	void torrent::set_piece_range_deadline(const index_range<piece_index_t>& range, int deadline
+		, deadline_flags_t const flags)
+	{
+		std::array<int, 1> t({deadline});
+		set_piece_range_deadline(range, boost::span<int>(t), flags);
+	}
+
+	void torrent::set_piece_range_deadline(const index_range<piece_index_t>& range, boost::span<int>&& deadlines
+		, deadline_flags_t const flags)
+	{
+		INVARIANT_CHECK;
+
+		TORRENT_ASSERT_PRECOND(valid_metadata());
+		TORRENT_ASSERT_PRECOND(valid_metadata() && m_torrent_file->piece_range().contains(range));
+		TORRENT_ASSERT_PRECOND(deadlines.size());
+
+		if (m_abort || !valid_metadata()
+			|| !m_torrent_file->piece_range().contains(range)
+			|| !deadlines.size())
+		{
+			// failed
+			if (flags & torrent_handle::alert_when_available)
+			{
+				for (auto const p : range)
+					m_ses.alerts().emplace_alert<read_piece_alert>(
+						get_handle(), p, error_code(boost::system::errc::operation_canceled, generic_category()));
+			}
+			return;
+		}
+
+		// if we already have the range, no need to set the deadline.
+		// however, if the user asked to get the pieces, give 'em up.
+		if (is_seed() || (has_picker() && m_picker->have_piece_range(range)))
+		{
+			if (flags & torrent_handle::alert_when_available)
+				read_piece_range(range);
+			return;
+		}
+
+		auto it = deadlines.cbegin();
+		int d = deadlines.back();
+		for (auto const piece : range) {
+			int t = it == deadlines.cend() ? d : *it;
+			++it;
+			time_point const deadline = aux::time_now() + milliseconds(t);
+			bool skip = false;
+
+			// don't deadline the piece that is already on disk.
+			if (is_seed() || (has_picker() && m_picker->have_piece(piece)))
+			{
+				if (flags & torrent_handle::alert_when_available)
+					read_piece(piece);
+				continue;
+			}
+
+			// if this is the first time critical piece we add. in order to make it
+			// react quickly, cancel all the currently outstanding requests
+			if (m_time_critical_pieces.empty())
+			{
+				// defer this by posting it to the end of the message queue.
+				// this gives the client a chance to specify multiple time-critical
+				// pieces before libtorrent cancels requests
+				auto self = shared_from_this();
+				post(m_ses.get_context(), [self] { self->wrap(&torrent::cancel_non_critical); });
+			}
+
+			for (auto i = m_time_critical_pieces.begin()
+				, end(m_time_critical_pieces.end()); i != end; ++i)
+			{
+				if (i->piece != piece) continue;
+				i->deadline = deadline;
+				i->flags = flags;
+
+				// resort i since deadline might have changed
+				while (std::next(i) != m_time_critical_pieces.end() && i->deadline > std::next(i)->deadline)
+				{
+					std::iter_swap(i, std::next(i));
+					++i;
+				}
+				while (i != m_time_critical_pieces.begin() && i->deadline < std::prev(i)->deadline)
+				{
+					std::iter_swap(i, std::prev(i));
+					--i;
+				}
+				// just in case this piece had priority 0
+				download_priority_t const prev_prio = m_picker->piece_priority(piece);
+				bool const was_finished = is_finished();
+				bool const filter_updated = m_picker->set_piece_priority(piece, top_priority);
+				if (prev_prio == dont_download)
+				{
+					update_gauge();
+					if (filter_updated) update_peer_interest(was_finished);
+				}
+				skip = true;
+				break;
+			}
+
+			if (skip) continue;
+
+			need_picker();
+
+			time_critical_piece p;
+			p.first_requested = min_time();
+			p.last_requested = min_time();
+			p.flags = flags;
+			p.deadline = deadline;
+			p.peers = 0;
+			p.piece = piece;
+			auto const critical_piece_it = std::upper_bound(m_time_critical_pieces.begin()
+				, m_time_critical_pieces.end(), p);
+			m_time_critical_pieces.insert(critical_piece_it, p);
+
+			// just in case this piece had priority 0
+			download_priority_t const prev_prio = m_picker->piece_priority(piece);
+			bool const was_finished = is_finished();
+			bool const filter_updated = m_picker->set_piece_priority(piece, top_priority);
+			if (prev_prio == dont_download)
+			{
+				update_gauge();
+				if (filter_updated) update_peer_interest(was_finished);
+			}
+
+			piece_picker::downloading_piece pi;
+			m_picker->piece_info(piece, pi);
+			if (pi.requested == 0) return;
+			// this means we have outstanding requests (or queued
+			// up requests that haven't been sent yet). Promote them
+			// to deadline pieces immediately
+			std::vector<torrent_peer*> const downloaders
+				= m_picker->get_downloaders(piece);
+
+			int block = 0;
+			for (auto i = downloaders.begin()
+				, end(downloaders.end()); i != end; ++i, ++block)
+			{
+				torrent_peer* const tp = *i;
+				if (tp == nullptr || tp->connection == nullptr) continue;
+				auto* peer = static_cast<peer_connection*>(tp->connection);
+				peer->make_time_critical(piece_block(piece, block));
+			}
+		}
+	}
+
 	void torrent::reset_piece_deadline(piece_index_t piece)
 	{
 		remove_time_critical_piece(piece);
+	}
+
+	void torrent::reset_piece_range_deadline(const index_range<piece_index_t>& range)
+	{
+		for (auto const piece : range) {
+			remove_time_critical_piece(piece);
+		}
 	}
 
 	void torrent::remove_time_critical_piece(piece_index_t const piece, bool const finished)

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -11,6 +11,7 @@ Copyright (c) 2019, ghbplayer
 Copyright (c) 2025, Vladimir Golovnev (glassez)
 Copyright (c) 2021, Mark Scott
 Copyright (c) 2025, Vladimir Golovnev (glassez)
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -497,10 +498,17 @@ namespace libtorrent {
 
 	std::vector<download_priority_t> torrent_handle::get_piece_priorities() const
 	{
-		aux::vector<download_priority_t, piece_index_t> ret;
-		auto* const retp = &ret;
+		std::vector<download_priority_t> ret;
+		get_piece_priorities(ret);
+		return ret;
+	}
+
+	void torrent_handle::get_piece_priorities(std::vector<download_priority_t>& priorities) const
+	{
+		aux::vector<download_priority_t, piece_index_t> ret(std::move(priorities));
+		auto retp = &ret;
 		sync_call(&aux::torrent::piece_priorities, retp);
-		return TORRENT_RVO(ret);
+		priorities = std::move(ret);
 	}
 
 #if TORRENT_ABI_VERSION == 1
@@ -724,6 +732,11 @@ namespace libtorrent {
 		TORRENT_ASSERT_PRECOND(first_piece >= piece_index_t(0));
 		if (first_piece >= piece_index_t(0))
 			async_call(static_cast<void (aux::torrent::*)(piece_index_t)>(&aux::torrent::set_sequential_range), first_piece);
+	}
+
+	bool torrent_handle::have_piece_range(const index_range<piece_index_t>& range) const
+	{
+		return sync_call_ret<bool>(false, &aux::torrent::user_have_piece_range, range);
 	}
 
 	bool torrent_handle::is_valid() const

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -573,10 +573,17 @@ namespace libtorrent {
 
 	std::vector<download_priority_t> torrent_handle::get_file_priorities() const
 	{
-		aux::vector<download_priority_t, file_index_t> ret;
-		auto* const retp = &ret;
+		std::vector<download_priority_t> ret;
+		get_file_priorities(ret);
+		return ret;
+	}
+
+	void torrent_handle::get_file_priorities(std::vector<download_priority_t>& priorities) const
+	{
+		aux::vector<download_priority_t, file_index_t> ret(std::move(priorities));
+		auto retp = &ret;
 		sync_call(&aux::torrent::file_priorities, retp);
-		return TORRENT_RVO(ret);
+		priorities = std::move(ret);
 	}
 
 #if TORRENT_ABI_VERSION == 1

--- a/src/torrent_handle.cpp
+++ b/src/torrent_handle.cpp
@@ -722,6 +722,11 @@ namespace libtorrent {
 		async_call(&aux::torrent::read_piece, piece);
 	}
 
+	void torrent_handle::read_piece_range(const index_range<piece_index_t>& range) const
+	{
+		async_call(&aux::torrent::read_piece_range, range);
+	}
+
 	bool torrent_handle::have_piece(piece_index_t piece) const
 	{
 		return sync_call_ret<bool>(false, &aux::torrent::user_have_piece, piece);
@@ -957,10 +962,43 @@ namespace libtorrent {
 #endif
 	}
 
+	void torrent_handle::set_piece_range_deadline(const index_range<piece_index_t>& range
+		, int deadline, deadline_flags_t const flags) const
+	{
+#ifndef TORRENT_DISABLE_STREAMING
+		async_call(static_cast<void (aux::torrent::*)(const index_range<piece_index_t>&, int, deadline_flags_t const)>(&aux::torrent::set_piece_range_deadline), range, deadline, flags);
+#else
+		TORRENT_UNUSED(deadline);
+		if (flags & alert_when_available)
+			async_call(&aux::torrent::read_piece_range, range);
+#endif
+	}
+
+	void torrent_handle::set_piece_range_deadline(const index_range<piece_index_t>& range
+		, std::vector<int>&& deadlines, deadline_flags_t const flags) const
+	{
+#ifndef TORRENT_DISABLE_STREAMING
+		async_call(static_cast<void (aux::torrent::*)(const index_range<piece_index_t>&, boost::span<int>&&, deadline_flags_t const)>(&aux::torrent::set_piece_range_deadline), range, boost::span<int>(deadlines), flags);
+#else
+		TORRENT_UNUSED(deadlines);
+		if (flags & alert_when_available)
+			async_call(&aux::torrent::read_piece_range, range);
+#endif
+	}
+
 	void torrent_handle::reset_piece_deadline(piece_index_t index) const
 	{
 #ifndef TORRENT_DISABLE_STREAMING
 		async_call(&aux::torrent::reset_piece_deadline, index);
+#else
+		TORRENT_UNUSED(index);
+#endif
+	}
+
+	void torrent_handle::reset_piece_range_deadline(const index_range<piece_index_t>& range) const
+	{
+#ifndef TORRENT_DISABLE_STREAMING
+		async_call(&aux::torrent::reset_piece_range_deadline, range);
 #else
 		TORRENT_UNUSED(index);
 #endif

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -4,6 +4,7 @@ Copyright (c) 2018, Steven Siloti
 Copyright (c) 2013-2021, Arvid Norberg
 Copyright (c) 2016-2018, Alden Torres
 Copyright (c) 2018, d-komarov
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -189,6 +190,8 @@ void test_transfer(settings_pack const& sett,
 		, std::ostream_iterator<download_priority_t>(std::cout, ", "));
 	std::cout << std::endl;
 	TEST_CHECK(std::equal(priorities.begin(), priorities.end(), priorities2.begin()));
+	tor2.get_piece_priorities(priorities2);
+	TEST_CHECK(std::equal(priorities.begin(), priorities.end(), priorities2.begin()));
 
 	std::cout << "force recheck" << std::endl;
 	tor2.force_recheck();
@@ -197,6 +200,8 @@ void test_transfer(settings_pack const& sett,
 	std::copy(priorities2.begin(), priorities2.end()
 		, std::ostream_iterator<download_priority_t>(std::cout, ", "));
 	std::cout << std::endl;
+	TEST_CHECK(std::equal(priorities.begin(), priorities.end(), priorities2.begin()));
+	tor2.get_piece_priorities(priorities2);
 	TEST_CHECK(std::equal(priorities.begin(), priorities.end(), priorities2.begin()));
 
 	peer_disconnects = 0;
@@ -229,6 +234,8 @@ void test_transfer(settings_pack const& sett,
 	priorities2 = tor2.get_piece_priorities();
 	std::copy(priorities2.begin(), priorities2.end(), std::ostream_iterator<download_priority_t>(std::cout, ", "));
 	std::cout << std::endl;
+	TEST_CHECK(std::equal(priorities.begin(), priorities.end(), priorities2.begin()));
+	tor2.get_piece_priorities(priorities2);
 	TEST_CHECK(std::equal(priorities.begin(), priorities.end(), priorities2.begin()));
 
 	tor2.pause();

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -499,7 +499,8 @@ TORRENT_TEST(file_priority_multiple_calls)
 		std::size_t(addp.ti->num_files()), lt::low_priority);
 	for (int i = 0; i < 10; ++i)
 	{
-		auto const p = h.get_file_priorities();
+		auto p = h.get_file_priorities();
+		if (p == expected) h.get_file_priorities(p);
 		if (p == expected) return;
 		std::this_thread::sleep_for(milliseconds(500));
 	}

--- a/test/test_read_piece.cpp
+++ b/test/test_read_piece.cpp
@@ -3,6 +3,7 @@
 Copyright (c) 2013, 2015-2021, Arvid Norberg
 Copyright (c) 2017, Steven Siloti
 Copyright (c) 2018, Alden Torres
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -116,19 +117,118 @@ void test_read_piece(int flags)
 		, ec.value(), ec.message().c_str());
 }
 
+void test_read_piece_range(int flags)
+{
+	using namespace lt;
+
+	std::printf("==== TEST READ PIECE RANGE =====\n");
+
+	// in case the previous run was terminated
+	error_code ec;
+	remove_all("tmp2_read_piece", ec);
+	if (ec) std::printf("ERROR: removing tmp2_read_piece: (%d) %s\n"
+		, ec.value(), ec.message().c_str());
+
+	create_directory("tmp2_read_piece", ec);
+	if (ec) std::printf("ERROR: creating directory tmp2_read_piece: (%d) %s\n"
+		, ec.value(), ec.message().c_str());
+
+	create_directory(combine_path("tmp2_read_piece", "test_torrent"), ec);
+	if (ec) std::printf("ERROR: creating directory test_torrent: (%d) %s\n"
+		, ec.value(), ec.message().c_str());
+
+	file_storage fs;
+	int piece_size = 0x4000;
+
+	static std::array<const int, 2> const file_sizes{{ 100000, 10000 }};
+
+	create_random_files(combine_path("tmp2_read_piece", "test_torrent"), file_sizes);
+
+	add_files(fs, combine_path("tmp2_read_piece", "test_torrent"));
+	lt::create_torrent t(fs, piece_size);
+
+	// calculate the hash for all pieces
+	set_piece_hashes(t, "tmp2_read_piece", ec);
+	if (ec) std::printf("ERROR: set_piece_hashes: (%d) %s\n"
+		, ec.value(), ec.message().c_str());
+
+	std::vector<char> buf;
+	bencode(std::back_inserter(buf), t.generate());
+	auto ti = std::make_shared<torrent_info>(buf, ec, from_span);
+
+	std::printf("generated torrent: %s tmp2_read_piece/test_torrent\n"
+		, aux::to_hex(ti->info_hashes().v1).c_str());
+
+	settings_pack sett = settings();
+	sett.set_str(settings_pack::listen_interfaces, test_listen_interface());
+	lt::session ses(sett);
+
+	add_torrent_params p;
+	p.flags &= ~torrent_flags::paused;
+	p.flags &= ~torrent_flags::auto_managed;
+	p.save_path = "tmp2_read_piece";
+	p.ti = ti;
+	if (flags & flags_t::seed_mode)
+		p.flags |= torrent_flags::seed_mode;
+	torrent_handle tor2 = ses.add_torrent(p, ec);
+	if (ec) std::printf("ERROR: add_torrent: (%d) %s\n"
+		, ec.value(), ec.message().c_str());
+	TEST_CHECK(!ec);
+	TEST_CHECK(tor2.is_valid());
+
+	alert const* a = wait_for_alert(ses, torrent_finished_alert::alert_type, "ses");
+	TEST_CHECK(a);
+
+	TEST_CHECK(tor2.status().is_seeding);
+
+	index_range<piece_index_t> range({0_piece, 2_piece});
+
+	if (flags & time_critical)
+	{
+		tor2.set_piece_range_deadline(range, 0, torrent_handle::alert_when_available);
+	}
+	else
+	{
+		tor2.read_piece_range(range);
+	}
+
+	for (auto const piece : range) {
+		a = wait_for_alert(ses, read_piece_alert::alert_type, "ses", pop_alerts::cache_alerts);
+
+		TEST_CHECK(a);
+		if (a)
+		{
+			read_piece_alert const* rp = alert_cast<read_piece_alert>(a);
+			TEST_CHECK(rp);
+			if (rp)
+			{
+				TEST_CHECK(range.belongs(rp->piece));
+				TEST_CHECK(range.bounds(rp->piece));
+			}
+		}
+	}
+
+	remove_all("tmp2_read_piece", ec);
+	if (ec) std::printf("ERROR: removing tmp2_read_piece: (%d) %s\n"
+		, ec.value(), ec.message().c_str());
+}
+
 } // anonymous namespace
 
 TORRENT_TEST(read_piece)
 {
 	test_read_piece(0);
+	test_read_piece_range(0);
 }
 
 TORRENT_TEST(seed_mode)
 {
 	test_read_piece(seed_mode);
+	test_read_piece_range(seed_mode);
 }
 
 TORRENT_TEST(time_critical)
 {
 	test_read_piece(time_critical);
+	test_read_piece_range(time_critical);
 }

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -6,6 +6,7 @@ Copyright (c) 2017, Falcosc
 Copyright (c) 2017, Steven Siloti
 Copyright (c) 2018, d-komarov
 Copyright (c) 2020, AllSeeingEyeTolledEweSew
+Copyright (c) 2024-2026, Martin Rodriguez Reboredo
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -691,6 +692,8 @@ TORRENT_TEST(test_have_piece_out_of_range)
 	TEST_EQUAL(h.have_piece(piece_index_t{-1}), false);
 	TEST_EQUAL(h.have_piece(0_piece), true);
 	TEST_EQUAL(h.have_piece(100_piece), false);
+	TEST_EQUAL(h.have_piece_range(lt::index_range<lt::piece_index_t>{0_piece, 7_piece}), true);
+	TEST_EQUAL(h.have_piece_range(lt::index_range<lt::piece_index_t>{0_piece, 100_piece}), false);
 }
 
 TORRENT_TEST(test_read_piece_no_metadata)


### PR DESCRIPTION
This PR contains extra functionality regarding piece and file ranges. My [gst-libtorrent](https://gitlab.freedesktop.org/YakoYakoYokuYoku/gst-libtorrent) module requests many pieces at time for buffering during multimedia streaming, but having to do so requires loop boilerplate which could be simplified. I could write my own methods, but part of them cannot be done in my project so I have no to implement them in this library. This could be handy for other projects as well.
