### PR TITLE
fix: validate peer-supplied endpoints against local addresses (SSRF)

### DIFF
--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -47,6 +47,7 @@ see LICENSE file.
 #include "libtorrent/aux_/merkle.hpp"
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/alert_manager.hpp" // for alert_manager
+#include "libtorrent/aux_/ip_helpers.hpp"
 #include "libtorrent/aux_/string_util.hpp" // for search
 #include "libtorrent/aux_/generate_peer_id.hpp"
 
@@ -1589,11 +1590,41 @@ namespace {
 					break;
 				}
 
+				// don't bridge local and non-local peers
+				if (aux::is_local(ep.address()) != aux::is_local(remote().address()))
+				{
+#ifndef TORRENT_DISABLE_LOGGING
+					if (should_log(peer_log_alert::incoming_message))
+					{
+						peer_log(peer_log_alert::incoming_message,
+							peer_log_alert::holepunch,
+							"msg:rendezvous to: %s ERROR: bridging local and non-local peer",
+							print_address(ep.address()).c_str());
+					}
+#endif
+					break;
+				}
+
 				write_holepunch_msg(hp_message::connect, ep);
 				p->write_holepunch_msg(hp_message::connect, remote());
 			} break;
 			case hp_message::connect:
 			{
+				// ignore local addresses unless the peer is local
+				if (aux::is_local(ep.address()) && !aux::is_local(remote().address()))
+				{
+#ifndef TORRENT_DISABLE_LOGGING
+					if (should_log(peer_log_alert::incoming_message))
+					{
+						peer_log(peer_log_alert::incoming_message,
+							peer_log_alert::holepunch,
+							"msg:connect to: %s ERROR: rejected local address from non-local peer",
+							print_address(ep.address()).c_str());
+					}
+#endif
+					break;
+				}
+
 				// add or find the peer with this endpoint
 				torrent_peer* p = t->add_peer(ep, peer_info::pex);
 				if (p == nullptr || p->connection)

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -28,6 +28,7 @@ see LICENSE file.
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/aux_/ssl.hpp"
 #include "libtorrent/aux_/scope_end.hpp"
+#include "libtorrent/aux_/ip_helpers.hpp"
 #include "libtorrent/aux_/string_util.hpp" // for format_host_for_connect
 
 #if defined TORRENT_ASIO_DEBUGGING
@@ -622,6 +623,25 @@ void upnp::on_reply(aux::socket_package& s, error_code const& ec, std::size_t co
 			}
 #endif
 			return;
+		}
+
+		if (aux::is_ip_address(d.hostname))
+		{
+			error_code ip_ec;
+			address const addr = make_address(d.hostname.c_str(), ip_ec);
+			if (!ip_ec
+				&& (addr.is_unspecified() || aux::is_link_local(addr) || addr.is_multicast()))
+			{
+#ifndef TORRENT_DISABLE_LOGGING
+				if (should_log())
+				{
+					log("ignoring rootdevice from %s with local address: %s",
+						print_endpoint(from).c_str(),
+						d.hostname.c_str());
+				}
+#endif
+				return;
+			}
 		}
 
 #ifndef TORRENT_DISABLE_LOGGING


### PR DESCRIPTION
Two issues where the library opens connections to attacker-chosen addresses without validation.

1. UPnP SSDP Location header. on_reply() accepts the Location header from any SSDP response and fetches it via HTTP GET without checking if the hostname is a loopback, link-local, multicast or unspecified IP literal.

2. Holepunch connect. on_holepunch() calls add_peer() and connect_to_peer() for connect messages without checking if the target address is local. The PEX handler already has this check at ut_pex.cpp:349.