### PR TITLE
enable webtorrent by default

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -72,7 +72,7 @@ jobs:
           <cxxflags>-fPIC
           <cxxflags>-march=armv7-a
           <cxxflags>-mfpu=neon ;" >>~/user-config.jam;
-          ${BOOST_ROOT}/b2 warnings-as-errors=on toolset=clang-linux-arm target-os=android link=static crypto=openssl openssl-include=${OPENSSL_ROOT}/include openssl-lib=${OPENSSL_ROOT}/lib
+          ${BOOST_ROOT}/b2 warnings-as-errors=on toolset=clang-linux-arm target-os=android link=static crypto=openssl openssl-include=${OPENSSL_ROOT}/include openssl-lib=${OPENSSL_ROOT}/lib webtorrent=off
 
    android_arm32_webtorrent_build:
       name: Build Android Arm 32bits with WebTorrent

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
 
     - name: dependencies (MacOS)
       if: runner.os == 'macOS'
@@ -48,6 +48,17 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
+
+    - name: install openssl (windows)
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/win_install_openssl
+      with:
+        architecture: x64
+        linking: static
+
+    - name: setup msbuild (windows)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
 
     - name: install boost (windows)
       if: runner.os == 'Windows'
@@ -73,7 +84,7 @@ jobs:
         set PATH=%BOOST_ROOT%;%PATH%
 
         cd bindings\c
-        b2 address-model=64
+        b2 address-model=64 release openssl-include="C:\Program Files\OpenSSL\include" openssl-lib="C:\Program Files\OpenSSL\lib"
 
     - name: build
       if: runner.os != 'Windows'

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        submodules: true
+        submodules: recursive
         fetch-depth: 1
         filter: tree:0
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -148,6 +148,11 @@ jobs:
         fetch-depth: 1
         filter: tree:0
 
+    - name: patch libdatachannel (windows 32/64-bit builds)
+      if: runner.os == 'Windows'
+      run: git apply ../patch-libdatachannel-32bit-builds.patch
+      working-directory: deps/libdatachannel
+
     - uses: actions/cache@v5
       id: cache-wheel
       with:
@@ -167,6 +172,10 @@ jobs:
     - name: install openssl (linux)
       if: runner.os == 'Linux'
       run: sudo apt-get install libssl-dev
+
+    - name: setup msbuild (windows)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
 
     - uses: pypa/cibuildwheel@v2.23.4
       if: ${{ steps.cache-wheel.outputs.cache-hit != 'true' || github.event_name == 'pull_request' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,10 +42,10 @@ jobs:
          matrix:
             std: [17, 20]
             config:
-              - asio-debugging=on picker-debugging=on
-              - extensions=off logging=off streaming=off super-seeding=off share-mode=off predictive-pieces=off dht=off alert-msg=off encryption=off mutable-torrents=off deprecated-functions=off
-              - crypto=gcrypt
-              - mmap-disk-io=off
+              - webtorrent=off asio-debugging=on picker-debugging=on
+              - webtorrent=off extensions=off logging=off streaming=off super-seeding=off share-mode=off predictive-pieces=off dht=off alert-msg=off encryption=off mutable-torrents=off deprecated-functions=off
+              - webtorrent=off crypto=gcrypt
+              - webtorrent=off mmap-disk-io=off
 
       steps:
       - name: checkout
@@ -95,6 +95,53 @@ jobs:
           cd bindings/python
           echo "using python ;" >>~/user-config.jam
           BOOST_ROOT="" b2 ${{ matrix.config }} cxxstd=${{ matrix.std }} warnings-as-errors=on
+
+
+   cmake:
+      name: cmake
+      runs-on: ubuntu-24.04
+      continue-on-error: true
+
+      steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+           submodules: recursive
+           fetch-depth: 1
+           filter: tree:0
+
+      - name: update package lists
+        continue-on-error: true
+        run: |
+          sudo apt update
+
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+          override_cache_key: ccache-linux-cmake-${{ github.base_ref }}
+          ccache_options: |
+            max_size=5G
+
+      - name: install boost
+        run: |
+          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev libboost-json-dev ninja-build
+          pip install websockets
+
+      - name: cmake configure
+        env:
+          # required by deps/libdatachannel's own deps (usrsctp, plog), which
+          # declare cmake_minimum_required versions older than modern cmake allows
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
+        run: |
+          cmake -B build-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dwebtorrent=on -Dasserts=on -DCMAKE_CXX_STANDARD=17
+
+      - name: cmake build
+        run: cmake --build build-cmake
+
+      - name: ctest
+        run: |
+          cd build-cmake
+          ctest --output-on-failure
 
 
    fuzzers:
@@ -147,7 +194,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
         with:
-           submodules: true
+           submodules: recursive
            fetch-depth: 1
            filter: tree:0
 
@@ -165,7 +212,7 @@ jobs:
 
       - name: install boost
         run: |
-          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev
+          sudo apt install libboost-tools-dev libboost-dev libboost-system-dev libboost-json-dev
           echo "using gcc ;" >>~/user-config.jam
 
       - name: compile header files individually
@@ -183,7 +230,10 @@ jobs:
             include:
                - config: webtorrent=on address-sanitizer=norecover undefined-sanitizer=norecover crypto=openssl invariant-checks=on
                - config: toolset=clang logging=off address-sanitizer=norecover undefined-sanitizer=norecover invariant-checks=on
-               - config: thread-sanitizer=norecover crypto=openssl release debug-symbols=on cxxflags=-Wno-tsan
+               # thread-sanitizer is left off webtorrent: libdatachannel's third-party
+               # deps (usrsctp, libjuice) are multi-threaded and not vetted against TSan,
+               # which would make this job noisy/flaky for reasons outside our control
+               - config: webtorrent=off thread-sanitizer=norecover crypto=openssl release debug-symbols=on cxxflags=-Wno-tsan
                - config: crypto=gnutls invariant-checks=full
                - config: deprecated-functions=off invariant-checks=full
 
@@ -213,7 +263,7 @@ jobs:
           sudo apt install libgnutls28-dev
 
       - name: install boost.json
-        if: ${{ contains(matrix.config, 'webtorrent=on') }}
+        if: ${{ !contains(matrix.config, 'webtorrent=off') }}
         run: |
           sudo apt install libboost-json-dev
 
@@ -305,7 +355,7 @@ jobs:
           cd test
           ${BOOST_ROOT}/b2 address-model=32 architecture=x86 -l500 \
             crypto=built-in warnings-as-errors=on debug-iterators=on asserts=on \
-            deterministic-tests
+            webtorrent=off deterministic-tests
 
 
    sim:
@@ -356,15 +406,15 @@ jobs:
       strategy:
          matrix:
             config:
-              - release asserts=on debug-iterators=on
-              - release asserts=on debug-iterators=on address-sanitizer=norecover undefined-sanitizer=norecover crypto=openssl
-              - release asserts=on debug-iterators=on thread-sanitizer=norecover crypto=openssl debug-symbols=on cxxflags=-Wno-tsan
+              - webtorrent=off release asserts=on debug-iterators=on
+              - webtorrent=off release asserts=on debug-iterators=on address-sanitizer=norecover undefined-sanitizer=norecover crypto=openssl
+              - webtorrent=off release asserts=on debug-iterators=on thread-sanitizer=norecover crypto=openssl debug-symbols=on cxxflags=-Wno-tsan
 
       steps:
       - name: checkout
         uses: actions/checkout@v6
         with:
-           submodules: recursive
+           submodules: true
            fetch-depth: 1
            filter: tree:0
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,6 @@ jobs:
    build:
       name: build
       runs-on: ubuntu-22.04
-      continue-on-error: true
 
       strategy:
          matrix:
@@ -100,7 +99,6 @@ jobs:
    cmake:
       name: cmake
       runs-on: ubuntu-24.04
-      continue-on-error: true
 
       steps:
       - name: checkout
@@ -147,7 +145,6 @@ jobs:
    fuzzers:
       name: Fuzzers
       runs-on: ubuntu-24.04
-      continue-on-error: true
 
       steps:
       - name: checkout
@@ -223,7 +220,6 @@ jobs:
    test:
       name: Tests
       runs-on: ubuntu-24.04
-      continue-on-error: true
 
       strategy:
          matrix:
@@ -309,7 +305,6 @@ jobs:
    test-32bit:
       name: Tests (32-bit)
       runs-on: ubuntu-24.04
-      continue-on-error: true
 
       steps:
       - name: checkout
@@ -401,7 +396,6 @@ jobs:
    disk-stress:
       name: disk I/O stress (smoke)
       runs-on: ubuntu-24.04
-      continue-on-error: true
 
       strategy:
          matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,6 @@ jobs:
    test:
       name: Tests
       runs-on: macos-14
-      continue-on-error: true
 
       strategy:
          matrix:
@@ -94,7 +93,6 @@ jobs:
    build:
       name: Build
       runs-on: macos-14
-      continue-on-error: true
 
       strategy:
          matrix:
@@ -127,7 +125,6 @@ jobs:
    cmake:
       name: cmake
       runs-on: macos-14
-      continue-on-error: true
 
       steps:
       - name: checkout
@@ -164,7 +161,6 @@ jobs:
    ios_build:
       name: Build iOS
       runs-on: macos-14
-      continue-on-error: true
 
       steps:
       - name: checkout

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
 
       strategy:
          matrix:
-            config: [ crypto=built-in, webtorrent=on deprecated-functions=off ]
+            config: [ webtorrent=off crypto=built-in, webtorrent=on deprecated-functions=off ]
 
       steps:
       - name: checkout
@@ -98,7 +98,7 @@ jobs:
 
       strategy:
          matrix:
-            config: [ crypto=built-in, release ]
+            config: [ webtorrent=off crypto=built-in, webtorrent=off release ]
 
       steps:
       - name: checkout
@@ -122,6 +122,43 @@ jobs:
       - name: build library
         run: |
           b2 ${{ matrix.config }} -l400 warnings-as-errors=on
+
+
+   cmake:
+      name: cmake
+      runs-on: macos-14
+      continue-on-error: true
+
+      steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+           submodules: recursive
+           fetch-depth: 1
+           filter: tree:0
+
+      - uses: Chocobo1/setup-ccache-action@v1
+        with:
+          override_cache_key: ccache-macos-cmake-${{ github.base_ref }}
+          ccache_options: |
+            max_size=1G
+
+      - name: install boost
+        run: |
+          brew install boost openssl@3 ninja
+          pip3 install websockets --break-system-packages
+
+      - name: cmake configure
+        run: |
+          cmake -B build-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -Dbuild_tests=ON -Dbuild_examples=ON -Dbuild_tools=ON -Dwebtorrent=on -Dasserts=on
+
+      - name: cmake build
+        run: cmake --build build-cmake
+
+      - name: ctest
+        run: |
+          cd build-cmake
+          ctest --output-on-failure
 
 
    ios_build:
@@ -163,4 +200,4 @@ jobs:
 
       - name: build library
         run: |
-          b2 -l400 cxxstd=14 target-os=iphone crypto=built-in darwin-ios darwin-ios_sim address-model=64 link=static
+          b2 -l400 cxxstd=14 target-os=iphone crypto=built-in darwin-ios darwin-ios_sim address-model=64 link=static webtorrent=off

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        submodules: true
+        submodules: recursive
         fetch-depth: 1
         filter: tree:0
 
@@ -80,7 +80,7 @@ jobs:
     - name: dependencies (linux)
       if: runner.os == 'Linux'
       run: |
-        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev python3 python3-setuptools libssl-dev
+        sudo apt install libboost-tools-dev libboost-python-dev libboost-dev libboost-system-dev libboost-json-dev python3 python3-setuptools libssl-dev
 
     - name: dependencies (windows)
       if: runner.os == 'Windows'
@@ -93,6 +93,10 @@ jobs:
       with:
         architecture: x64
         linking: static
+
+    - name: setup msbuild (windows)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
 
     - name: install boost (windows)
       if: runner.os == 'Windows'
@@ -116,6 +120,7 @@ jobs:
         set BOOST_ROOT=%CD%\boost
         set PATH=%BOOST_ROOT%;%PATH%
         set PYTHON_INTERPRETER=python
+        set B2_EXTRA_ARGS=openssl-include="C:\Program Files\OpenSSL\include" openssl-lib="C:\Program Files\OpenSSL\lib"
         tox -e py
 
     - name: build no-deprecated (Linux)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,9 +26,9 @@ jobs:
       strategy:
          matrix:
            include:
-             - config: address-model=32 crypto=built-in
-             - config: address-model=64
-             - config: release
+             - config: webtorrent=off address-model=32 crypto=built-in
+             - config: webtorrent=off address-model=64
+             - config: webtorrent=off release
 
       steps:
 
@@ -56,7 +56,7 @@ jobs:
           set PATH=%BOOST_ROOT%;%PATH%
           set PYTHON_INTERPRETER=python
           cd test
-          b2 -l400 msvc-version-macro=on warnings=all warnings-as-errors=on ${{ matrix.config }} deterministic-tests
+          b2 --hash -l400 msvc-version-macro=on warnings=all warnings-as-errors=on ${{ matrix.config }} deterministic-tests
 
 
       - name: tests (flaky)
@@ -69,7 +69,7 @@ jobs:
           :retry
           if %c%==0 exit /B 1
           set /a c = %c% -1
-          b2 -l400 msvc-version-macro=on warnings=all warnings-as-errors=on ${{ matrix.config }}
+          b2 --hash -l400 msvc-version-macro=on warnings=all warnings-as-errors=on ${{ matrix.config }}
           if %errorlevel%==0 exit /B 0
           if %c% gtr 0 goto retry
           exit /B 1
@@ -131,12 +131,12 @@ jobs:
       strategy:
          matrix:
            include:
-             - config: asio-debugging=on picker-debugging=on windows-version=vista
-             - config: asio-debugging=on picker-debugging=on windows-version=win10
+             - config: webtorrent=off asio-debugging=on picker-debugging=on windows-version=vista
+             - config: webtorrent=off asio-debugging=on picker-debugging=on windows-version=win10
              # the Windows Store API build is disabled because boost.container
              # contains a .c file that cannot be built with /ZW in msvc
              #- config: windows-api=store windows-version=win10
-             - config: deprecated-functions=off
+             - config: webtorrent=off deprecated-functions=off
 
       steps:
       - name: checkout
@@ -161,7 +161,7 @@ jobs:
         run: |
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
-          b2 ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
+          b2 --hash ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
 
       - name: build examples
         if: ${{ ! contains(matrix.config, 'windows-api=store') }}
@@ -169,7 +169,7 @@ jobs:
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
           cd examples
-          b2 ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
+          b2 --hash ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
 
       - name: build tools
         if: ${{ ! contains(matrix.config, 'windows-api=store') }}
@@ -177,7 +177,7 @@ jobs:
           set BOOST_ROOT=%CD%\boost
           set PATH=%BOOST_ROOT%;%PATH%
           cd tools
-          b2 ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
+          b2 --hash ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
 
    mingw:
       name: MingW
@@ -186,10 +186,10 @@ jobs:
       strategy:
          matrix:
            include:
-             - config: address-model=64
+             - config: webtorrent=off address-model=64
                msys2_pkg: mingw-w64-x86_64
                msystem: MINGW64
-             - config: address-model=32
+             - config: webtorrent=off address-model=32
                msys2_pkg: mingw-w64-i686
                msystem: MINGW32
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -747,7 +747,7 @@ target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME extens
 	DESCRIPTION "Enables protocol extensions" DISABLED TORRENT_DISABLE_EXTENSIONS)
 target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME i2p DEFAULT ON
 	DESCRIPTION "build with I2P support" DISABLED TORRENT_USE_I2P=0)
-target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME webtorrent DEFAULT OFF
+target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME webtorrent DEFAULT ON
 	DESCRIPTION "build with WebTorrent support" DISABLED TORRENT_USE_RTC=0)
 target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME logging DEFAULT ON
 	DESCRIPTION "build with logging" DISABLED TORRENT_DISABLE_LOGGING)

--- a/Jamfile
+++ b/Jamfile
@@ -591,7 +591,7 @@ feature i2p : on off : composite propagated ;
 feature.compose <i2p>on : <define>TORRENT_USE_I2P=1 ;
 feature.compose <i2p>off : <define>TORRENT_USE_I2P=0 ;
 
-feature webtorrent : off on : composite propagated ;
+feature webtorrent : on off : composite propagated ;
 feature.compose <webtorrent>on : <define>TORRENT_USE_RTC=1 ;
 feature.compose <webtorrent>off : <define>TORRENT_USE_RTC=0 ;
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -196,7 +196,11 @@ class LibtorrentBuildExt(build_ext_lib.build_ext):
             None,
             "The full argument string to pass to b2. This is parsed with shlex, to "
             "support arguments with spaces. For example: --b2-args 'variant=debug "
-            '"my-feature=a value with spaces"\'',
+            '"my-feature=a value with spaces"\'. '
+            "Note: shlex uses POSIX escaping rules, so on Windows a quoted path "
+            'with a single backslash (e.g. "C:\\Program Files\\...") survives, '
+            "but a UNC path (\\\\server\\share) or a path with a trailing "
+            "backslash before the closing quote will be mangled or fail to parse.",
         ),
         (
             "no-autoconf=",
@@ -269,7 +273,12 @@ class LibtorrentBuildExt(build_ext_lib.build_ext):
             )
 
         # shlex the args here to warn early on bad config
-        self._b2_args_split = shlex.split(self.b2_args or "")
+        # NB: shlex.split() applies POSIX backslash-escaping even on Windows, so
+        # quoted Windows paths with "\\" (UNC) or a trailing "\" before the
+        # closing quote will be mangled or raise ValueError; see --b2-args help.
+        self._b2_args_split = shlex.split(self.b2_args or "") + shlex.split(
+            os.environ.get("B2_EXTRA_ARGS", "")
+        )
         self._b2_args_configured.update(shlex.split(self.no_autoconf or ""))
 
         # In b2's arg system only single-character args can consume the next

--- a/deps/patch-libdatachannel-32bit-builds.patch
+++ b/deps/patch-libdatachannel-32bit-builds.patch
@@ -1,0 +1,62 @@
+diff --git a/Jamfile b/Jamfile
+index 9c740467..bba7864c 100644
+--- a/Jamfile
++++ b/Jamfile
+@@ -110,7 +110,14 @@ rule make_libusrsctp_msvc ( targets * : sources * : properties * )
+ {
+ 	local VARIANT = [ feature.get-values <variant> : $(properties) ] ;
+ 	VARIANT on $(targets) = $(VARIANT) ;
+-	BUILD_DIR on $(targets) = "build-$(VARIANT)" ;
++
++	local ADDRESS_MODEL = [ feature.get-values <address-model> : $(properties) ] ;
++	local ARCH = x64 ;
++	if $(ADDRESS_MODEL) = 32
++	{ ARCH = Win32 ; }
++	ARCH on $(targets) = $(ARCH) ;
++
++	BUILD_DIR on $(targets) = "build-$(ARCH)-$(VARIANT)" ;
+ }
+ actions make_libusrsctp_msvc
+ {
+@@ -118,7 +125,7 @@ actions make_libusrsctp_msvc
+     cd $(CWD)/deps/usrsctp
+     mkdir $(BUILD_DIR)
+     cd $(BUILD_DIR)
+-    cmake -G "Visual Studio 17 2022" -Dsctp_werror=0 -Dsctp_build_shared_lib=0 -Dsctp_build_programs=0 -Dsctp_inet=0 -Dsctp_inet6=0 ..
++    cmake -G "Visual Studio 17 2022" -A $(ARCH) -Dsctp_werror=0 -Dsctp_build_shared_lib=0 -Dsctp_build_programs=0 -Dsctp_inet=0 -Dsctp_inet6=0 ..
+     msbuild usrsctplib.sln /property:Configuration=$(VARIANT)
+     cd %OLDD%
+     cp $(CWD)/deps/usrsctp/$(BUILD_DIR)/usrsctplib/Release/usrsctp.lib $(<)
+@@ -165,14 +172,21 @@ rule make_libjuice_msvc ( targets * : sources * : properties * )
+ {
+ 	local VARIANT = [ feature.get-values <variant> : $(properties) ] ;
+ 	VARIANT on $(targets) = $(VARIANT) ;
++
++	local ADDRESS_MODEL = [ feature.get-values <address-model> : $(properties) ] ;
++	local ARCH = x64 ;
++	if $(ADDRESS_MODEL) = 32
++	{ ARCH = Win32 ; }
++	ARCH on $(targets) = $(ARCH) ;
++
+ 	if <gnutls>on in $(properties)
+ 	{
+-		BUILD_DIR on $(targets) += "build-gnutls-$(VARIANT)" ;
++		BUILD_DIR on $(targets) += "build-gnutls-$(ARCH)-$(VARIANT)" ;
+ 		CMAKEOPTS on $(targets) = "-DUSE_NETTLE=1" ;
+ 	}
+ 	else
+ 	{
+-		BUILD_DIR on $(targets) += "build-openssl-$(VARIANT)" ;
++		BUILD_DIR on $(targets) += "build-openssl-$(ARCH)-$(VARIANT)" ;
+ 		CMAKEOPTS on $(targets) = "-DUSE_NETTLE=0" ;
+ 	}
+ }
+@@ -182,7 +196,7 @@ actions make_libjuice_msvc
+     cd $(CWD)/deps/libjuice
+     mkdir $(BUILD_DIR)
+     cd $(BUILD_DIR)
+-    cmake -G "Visual Studio 17 2022" $(CMAKEOPTS) ..
++    cmake -G "Visual Studio 17 2022" -A $(ARCH) $(CMAKEOPTS) ..
+     msbuild libjuice.sln /property:Configuration=$(VARIANT)
+     cd %OLDD%
+     cp $(CWD)/deps/libjuice/$(BUILD_DIR)/Release/juice-static.lib $(<)

--- a/docs/hunspell/libtorrent.dic
+++ b/docs/hunspell/libtorrent.dic
@@ -293,6 +293,7 @@ toolset
 Wojciechowski
 GTK
 cmake
+CMake
 libsodium
 nightcracker's
 Siloti
@@ -646,6 +647,7 @@ base64
 google
 WebTorrent
 webtorrent
+Dwebtorrent
 WebRTC
 WebSocket
 bitfields

--- a/docs/upgrade_to_2.1.rst
+++ b/docs/upgrade_to_2.1.rst
@@ -25,7 +25,8 @@ The major new feature in libtorrent 2.1 is WebTorrent support. WebTorrent
 requires a stun server, it can be configured via the ``webtorrent_stun_server``
 configuration option. It defaults to "stun.l.google.com:19302".
 
-To enable webtorrent support, build with ``webtorrent=on``.
+WebTorrent support is enabled by default. To disable it, build with
+``webtorrent=off`` (or ``-Dwebtorrent=OFF`` with CMake).
 
 loading and saving torrents
 ===========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ select = "*-win_amd64"
 test-command = '''bash -c "cd '{project}/bindings/python' && python -m pip install -r test-requirements.txt && python -X dev -m pytest -v --log-level=DEBUG --log-cli-level=DEBUG && python -m mypy --config-file mypy-tox.ini tests"'''
 
 [tool.cibuildwheel.windows.environment]
+B2_EXTRA_ARGS = 'openssl-include=\"C:/Program Files/OpenSSL/include\" openssl-lib=\"C:/Program Files/OpenSSL/lib\"'
 BOOST_BUILD_PATH = 'c:/boost/tools/build'
 BOOST_ROOT = 'c:/boost'
 BOOST_VERSION = "1.83.0"

--- a/simulation/Jamfile
+++ b/simulation/Jamfile
@@ -28,6 +28,7 @@ project
 	<picker-debugging>on
 	<cxxstd>17
 	<crypto>built-in
+	<webtorrent>off
 	;
 
 run test_pause.cpp ;

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
 #   in the python directory, only run mypy on the tests dir.
 
 commands =
-    {envpython} setup.py build_ext --b2-args 'asserts=on invariant-checks=full debug-symbols=on {env:B2_EXTRA_ARGS:}' bdist_wheel
+    {envpython} setup.py build_ext --b2-args "asserts=on invariant-checks=full debug-symbols=on" bdist_wheel
     {envpython} -m pip install --upgrade --force-reinstall --ignore-installed --find-links=dist --no-index libtorrent
     {envpython} -m pip install -r test-requirements.txt
     {envpython} -m pytest -s -p no:faulthandler --log-level=DEBUG --log-cli-level=DEBUG

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
 #   in the python directory, only run mypy on the tests dir.
 
 commands =
-    {envpython} setup.py build_ext --b2-args "asserts=on invariant-checks=full debug-symbols=on" bdist_wheel
+    {envpython} setup.py build_ext --b2-args 'asserts=on invariant-checks=full debug-symbols=on {env:B2_EXTRA_ARGS:}' bdist_wheel
     {envpython} -m pip install --upgrade --force-reinstall --ignore-installed --find-links=dist --no-index libtorrent
     {envpython} -m pip install -r test-requirements.txt
     {envpython} -m pytest -s -p no:faulthandler --log-level=DEBUG --log-cli-level=DEBUG


### PR DESCRIPTION
* add cmake CI job to make sure it can build with webtorrent=ON
* fix path-length issue on windows runner (the build path became too long)
* fix warning with build configuration not handled by cmake (`TORRENT_DISK_LATENCY_STATS`)
* simulations don't work with SSL sockets, so webtorrent must still be disabled there