### PR TITLE
fixes related to force-reannounce and priority announce

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.1.0 release
 
+	* fix tracker force announce
 	* add max_directory_depth limit to load_torrent_limits to bound file path depth when loading torrents
 	* fix race in wait_for_alert(), and update its return value
 	* optimize torrent_handle::torrent_file()

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -827,15 +827,14 @@ namespace libtorrent::aux {
 		// populates the fields of a tracker_request that describe this
 		// torrent's state, i.e. everything that's the same regardless of
 		// which tracker it's being sent to. The caller still needs to set
-		// the per-tracker fields (trackerid, url, i2p bit, event).
+		// the per-tracker fields (trackerid, url, i2p bit).
 		tracker_request build_tracker_request(event_t e);
 
 		// resolves the event type, sends req to the tracker for a single
 		// endpoint/info-hash, and updates that endpoint's announce state
 		// (updating, next_announce, min_announce) and posts the
 		// tracker_announce_alert. Does not touch any tier-selection state;
-		// callers that have one (announce_with_tracker) update it themselves
-		// based on the return value.
+		// callers that have one (announce_with_tracker) update it themselves.
 		void send_tracker_request(tracker_request& req,
 			aux::announce_endpoint& aep,
 			aux::announce_infohash& a,

--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -822,6 +822,27 @@ namespace libtorrent::aux {
 		void scrape_tracker_url(std::string url, bool user_triggered);
 		void scrape_tracker_impl(aux::announce_entry& ae, bool user_triggered);
 		void announce_with_tracker(event_t = event_t::none, bool high_priority = false);
+		void announce_tracker_now(aux::announce_entry& ae, event_t e, bool high_priority);
+
+		// populates the fields of a tracker_request that describe this
+		// torrent's state, i.e. everything that's the same regardless of
+		// which tracker it's being sent to. The caller still needs to set
+		// the per-tracker fields (trackerid, url, i2p bit, event).
+		tracker_request build_tracker_request(event_t e);
+
+		// resolves the event type, sends req to the tracker for a single
+		// endpoint/info-hash, and updates that endpoint's announce state
+		// (updating, next_announce, min_announce) and posts the
+		// tracker_announce_alert. Does not touch any tier-selection state;
+		// callers that have one (announce_with_tracker) update it themselves
+		// based on the return value.
+		void send_tracker_request(tracker_request& req,
+			aux::announce_endpoint& aep,
+			aux::announce_infohash& a,
+			protocol_version ih,
+			event_t e,
+			bool high_priority,
+			time_point32 now);
 
 #ifndef TORRENT_DISABLE_DHT
 		void dht_announce();

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -1304,6 +1304,160 @@ TORRENT_TEST(clear_error)
 	TEST_EQUAL(num_announces, 2);
 }
 
+// make sure a tracker announce forced with the high_priority flag jumps
+// ahead of an announce that's already waiting in the tracker queue,
+// instead of waiting behind it for a free announce slot.
+//
+// this uses 3 separate single-tracker torrents sharing the session-wide
+// tracker queue:
+// - "fast" completes a normal announce right away, so its tracker is no
+//   longer in flight (not "updating") and is eligible to be re-announced
+//   on demand, like any tracker that's already been talked to once.
+// - "hold" is added next and occupies the only available announce slot
+//   forever (its tracker never responds), so anything announced after it
+//   has to wait in the queue.
+// - "low" is added after "hold" and queues normally, behind "hold".
+// - "fast" is then force-reannounced with the high_priority flag. Since
+//   its tracker isn't in flight anymore, this queues a new request for
+//   it, which should jump ahead of "low" in the queue.
+void test_force_reannounce_high_priority_skips_queue(bool const by_url)
+{
+	using sim::asio::ip::address_v4;
+	sim::default_config network_cfg;
+	sim::simulation sim{network_cfg};
+
+	sim::asio::io_context fast_ios(sim, make_address_v4("3.0.0.1"));
+	sim::asio::io_context hold_ios(sim, make_address_v4("3.0.0.2"));
+	sim::asio::io_context low_ios(sim, make_address_v4("3.0.0.3"));
+
+	sim::http_server fast_http(fast_ios, 8080);
+	sim::http_server hold_http(hold_ios, 8080);
+	sim::http_server low_http(low_ios, 8080);
+
+	// never respond. This ties up the single available announce slot
+	// until it eventually times out.
+	hold_http.register_stall_handler("/announce");
+
+	// only record announces once "tracking" is turned on, i.e. after
+	// "fast"'s initial (unforced) announce has already completed
+	bool tracking = false;
+	std::vector<std::string> announce_order;
+
+	fast_http.register_handler(
+		"/announce", [&](std::string, std::string, std::map<std::string, std::string>&) {
+			if (tracking) announce_order.push_back("fast");
+			std::string const ret = "d8:intervali1800e5:peers0:e";
+			return sim::send_response(200, "OK", int(ret.size())) + ret;
+		});
+
+	low_http.register_handler(
+		"/announce", [&](std::string, std::string, std::map<std::string, std::string>&) {
+			if (tracking) announce_order.push_back("low");
+			std::string const ret = "d8:intervali1800e5:peers0:e";
+			return sim::send_response(200, "OK", int(ret.size())) + ret;
+		});
+
+	lt::session_proxy zombie;
+
+	asio::io_context ios(sim, make_address_v4("123.0.0.3"));
+	lt::settings_pack sett = settings();
+	sett.set_str(settings_pack::listen_interfaces, "123.0.0.3:6881");
+	// only one HTTP tracker announce may be in flight at a time, so
+	// whichever one doesn't get the slot has to queue
+	sett.set_int(settings_pack::max_concurrent_http_announces, 1);
+	// don't let the initial connect boost make the very first announces
+	// high priority, that would confuse this test
+	sett.set_int(settings_pack::torrent_connect_boost, 0);
+	// give up on the stalled announce quickly so the queue can drain
+	// within the lifetime of this test
+	sett.set_int(settings_pack::tracker_completion_timeout, 2);
+
+	auto ses = std::make_unique<lt::session>(sett, ios);
+	ses->set_alert_notify(std::bind(&on_alert_notify, ses.get()));
+
+	auto make_params = [](char const* name, char const* info_hash, char const* url) {
+		lt::add_torrent_params p;
+		p.name = name;
+		p.save_path = ".";
+		p.info_hashes.v1.assign(info_hash);
+		p.trackers.push_back(url);
+		// start announcing right away, instead of waiting for the auto
+		// manager to un-pause the torrent half a second in
+		p.flags &= ~lt::torrent_flags::auto_managed;
+		p.flags &= ~lt::torrent_flags::paused;
+		return p;
+	};
+
+	auto find_handle = [&](char const* name) {
+		for (auto const& h : ses->get_torrents())
+			if (h.status().name == name) return h;
+		return torrent_handle();
+	};
+
+	// "fast" is added first and gets the only announce slot to itself,
+	// so its first announce completes right away
+	ses->async_add_torrent(
+		make_params("fast-torrent", "aaaaaaaaaaaaaaaaaaaa", "http://3.0.0.1:8080/announce"));
+
+	// 1 second in, "fast" has long since completed its announce and
+	// freed up the only slot. "hold" grabs it and ties it up, then "low"
+	// queues behind "hold". Finally "fast" is force-reannounced with the
+	// high_priority flag, and should queue ahead of "low".
+	sim::timer t1(sim, lt::seconds(1), [&](boost::system::error_code const&) {
+		ses->async_add_torrent(
+			make_params("hold-torrent", "bbbbbbbbbbbbbbbbbbbb", "http://3.0.0.2:8080/announce"));
+	});
+
+	sim::timer t2(
+		sim, lt::seconds(1) + lt::milliseconds(100), [&](boost::system::error_code const&) {
+			ses->async_add_torrent(
+				make_params("low-torrent", "cccccccccccccccccccc", "http://3.0.0.3:8080/announce"));
+		});
+
+	sim::timer t3(
+		sim, lt::seconds(1) + lt::milliseconds(200), [&](boost::system::error_code const&) {
+			tracking = true;
+			reannounce_flags_t const flags =
+				torrent_handle::ignore_min_interval | torrent_handle::high_priority;
+			torrent_handle fast = find_handle("fast-torrent");
+			TEST_CHECK(fast.is_valid());
+			if (by_url)
+				fast.force_reannounce(0, "http://3.0.0.1:8080/announce", flags);
+			else
+				fast.force_reannounce(0, 0, flags);
+		});
+
+	// by 6 seconds in, "hold" has timed out (after 2s) and both "fast"
+	// and "low" should have been serviced, in that order
+	sim::timer t4(sim, lt::seconds(6), [&](boost::system::error_code const&) {
+		TEST_EQUAL(announce_order.size(), std::size_t(2));
+		if (announce_order.size() == 2)
+		{
+			TEST_EQUAL(announce_order[0], "fast");
+			TEST_EQUAL(announce_order[1], "low");
+		}
+	});
+
+	sim::timer t5(sim, lt::seconds(10), [&](boost::system::error_code const&) {
+		zombie = ses->abort();
+		ses.reset();
+	});
+
+	sim.run();
+}
+
+TORRENT_TEST(force_reannounce_high_priority_skips_queue)
+{
+	test_force_reannounce_high_priority_skips_queue(false);
+}
+
+// this covers the same behavior via the tracker-url overload of
+// force_reannounce()
+TORRENT_TEST(force_reannounce_url_high_priority_skips_queue)
+{
+	test_force_reannounce_high_priority_skips_queue(true);
+}
+
 lt::add_torrent_params make_torrent(bool priv)
 {
 	std::vector<lt::create_file_entry> fs;

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3184,83 +3184,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		if (e == event_t::none && is_finished() && !is_seed())
 			e = event_t::paused;
 
-		tracker_request req;
-		if (settings().get_bool(settings_pack::apply_ip_filter_to_trackers)
-			&& m_apply_ip_filter)
-		{
-			req.filter = m_ip_filter;
-		}
-
-		req.private_torrent = m_torrent_file && m_torrent_file->priv();
-
-		req.pid = m_peer_id;
-		req.downloaded = m_stat.total_payload_download() - m_total_failed_bytes;
-		req.uploaded = m_stat.total_payload_upload();
-		req.corrupt = m_total_failed_bytes;
-		req.left = bytes_left().value_or(16 * 1024);
-#ifdef TORRENT_SSL_PEERS
-		// if this torrent contains an SSL certificate, make sure
-		// any SSL tracker presents a certificate signed by it
-		req.ssl_ctx = m_ssl_ctx.get();
-#endif
-
-		req.redundant = m_total_redundant_bytes;
-		// exclude redundant bytes if we should
-		if (!settings().get_bool(settings_pack::report_true_downloaded))
-		{
-			req.downloaded -= m_total_redundant_bytes;
-
-			// if the torrent is complete we know that all incoming pieces will be
-			// marked redundant so add them to the redundant count
-			// this is mainly needed to cover the case where a torrent has just completed
-			// but still has partially downloaded pieces
-			// if the incoming pieces are not accounted for it could cause the downloaded
-			// amount to exceed the total size of the torrent which upsets some trackers
-			if (is_seed())
-			{
-				for (auto const& c : m_connections)
-				{
-					TORRENT_INCREMENT(m_iterating_connections);
-					auto const pbp = c->downloading_piece_progress();
-					if (pbp.bytes_downloaded > 0)
-					{
-						req.downloaded -= pbp.bytes_downloaded;
-						req.redundant += pbp.bytes_downloaded;
-					}
-				}
-			}
-		}
-		if (req.downloaded < 0) req.downloaded = 0;
-
-		req.event = e;
-
-		// since sending our IPv4/v6 address to the tracker may be sensitive. Only
-		// do that if we're not in anonymous mode and if it's a private torrent
-		if (!settings().get_bool(settings_pack::anonymous_mode)
-			&& m_torrent_file
-			&& m_torrent_file->priv())
-		{
-			m_ses.for_each_listen_socket([&](aux::listen_socket_handle const& s)
-			{
-				if (s.is_ssl() != is_ssl_torrent()) return;
-				tcp::endpoint const ep = s.get_local_endpoint();
-				if (ep.address().is_unspecified()) return;
-				if (aux::is_v6(ep))
-				{
-					if (!aux::is_local(ep.address()) && !ep.address().is_loopback())
-						req.ipv6.push_back(ep.address().to_v6());
-				}
-				else
-				{
-					if (!aux::is_local(ep.address()) && !ep.address().is_loopback())
-						req.ipv4.push_back(ep.address().to_v4());
-				}
-			});
-		}
-
-		// if we are aborting. we don't want any new peers
-		req.num_want = (req.event == event_t::stopped)
-			? 0 : settings().get_int(settings_pack::num_want);
+		tracker_request req = build_tracker_request(e);
 
 // some older versions of clang had a bug where it would fire this warning here
 #ifdef __clang__
@@ -3393,73 +3317,7 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 						continue;
 					}
 
-					req.event = e;
-					if (req.event == event_t::none)
-					{
-						if (!a.start_sent) req.event = event_t::started;
-						else if (!m_complete_sent
-							&& !a.complete_sent
-							&& is_seed())
-						{
-							req.event = event_t::completed;
-						}
-					}
-
-					req.triggered_manually = a.triggered_manually;
-					a.triggered_manually = false;
-
-#if TORRENT_ABI_VERSION == 1
-					req.auth = tracker_login();
-#endif
-					req.key = tracker_key();
-
-					req.outgoing_socket = aep.socket;
-					req.info_hash = m_torrent_file->info_hashes().get(ih);
-					if (high_priority) req.kind |= tracker_request::high_priority;
-
-#ifndef TORRENT_DISABLE_LOGGING
-					if (should_log())
-					{
-						debug_log("==> TRACKER REQUEST \"%s\" event: %s abort: %d ssl: %p "
-							"port: %d ssl-port: %d fails: %d upd: %d ep: %s"
-							, req.url.c_str()
-							, (req.event == event_t::stopped ? "stopped"
-								: req.event == event_t::started ? "started" : "")
-							, m_abort
-#ifdef TORRENT_SSL_PEERS
-							, static_cast<void*>(req.ssl_ctx)
-#else
-							, static_cast<void*>(nullptr)
-#endif
-							, m_ses.listen_port()
-							, m_ses.ssl_listen_port()
-							, a.fails
-							, a.updating
-							, print_endpoint(aep.local_endpoint).c_str());
-					}
-
-					// if we're not logging session logs, don't bother creating an
-					// observer object just for logging
-					if (m_abort && m_ses.should_log())
-					{
-						auto tl = std::make_shared<aux::tracker_logger>(m_ses);
-						m_ses.queue_tracker_request(req, tl);
-					}
-					else
-#endif
-					{
-						m_ses.queue_tracker_request(req, shared_from_this());
-					}
-
-					a.updating = true;
-					a.next_announce = now;
-					a.min_announce = now;
-
-					if (m_ses.alerts().should_post<tracker_announce_alert>())
-					{
-						m_ses.alerts().emplace_alert<tracker_announce_alert>(
-							get_handle(), aep.local_endpoint, req.url, ih, req.event);
-					}
+					send_tracker_request(req, aep, a, ih, e, high_priority, now);
 
 					state.sent_announce = true;
 					if (a.is_working()
@@ -3483,6 +3341,211 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 				break;
 		}
 		update_tracker_timer(now);
+	}
+
+	tracker_request torrent::build_tracker_request(event_t const e)
+	{
+		tracker_request req;
+		if (settings().get_bool(settings_pack::apply_ip_filter_to_trackers) && m_apply_ip_filter)
+		{
+			req.filter = m_ip_filter;
+		}
+
+		req.private_torrent = m_torrent_file && m_torrent_file->priv();
+
+		req.pid = m_peer_id;
+		req.downloaded = m_stat.total_payload_download() - m_total_failed_bytes;
+		req.uploaded = m_stat.total_payload_upload();
+		req.corrupt = m_total_failed_bytes;
+		req.left = bytes_left().value_or(16 * 1024);
+#ifdef TORRENT_SSL_PEERS
+		// if this torrent contains an SSL certificate, make sure
+		// any SSL tracker presents a certificate signed by it
+		req.ssl_ctx = m_ssl_ctx.get();
+#endif
+
+		req.redundant = m_total_redundant_bytes;
+		// exclude redundant bytes if we should
+		if (!settings().get_bool(settings_pack::report_true_downloaded))
+		{
+			req.downloaded -= m_total_redundant_bytes;
+
+			// if the torrent is complete we know that all incoming pieces will be
+			// marked redundant so add them to the redundant count
+			// this is mainly needed to cover the case where a torrent has just completed
+			// but still has partially downloaded pieces
+			// if the incoming pieces are not accounted for it could cause the downloaded
+			// amount to exceed the total size of the torrent which upsets some trackers
+			if (is_seed())
+			{
+				for (auto const& c : m_connections)
+				{
+					TORRENT_INCREMENT(m_iterating_connections);
+					auto const pbp = c->downloading_piece_progress();
+					if (pbp.bytes_downloaded > 0)
+					{
+						req.downloaded -= pbp.bytes_downloaded;
+						req.redundant += pbp.bytes_downloaded;
+					}
+				}
+			}
+		}
+		if (req.downloaded < 0) req.downloaded = 0;
+
+		req.event = e;
+
+		// since sending our IPv4/v6 address to the tracker may be sensitive. Only
+		// do that if we're not in anonymous mode and if it's a private torrent
+		if (!settings().get_bool(settings_pack::anonymous_mode) && m_torrent_file
+			&& m_torrent_file->priv())
+		{
+			m_ses.for_each_listen_socket([&](aux::listen_socket_handle const& s) {
+				if (s.is_ssl() != is_ssl_torrent()) return;
+				tcp::endpoint const ep = s.get_local_endpoint();
+				if (ep.address().is_unspecified()) return;
+				if (aux::is_v6(ep))
+				{
+					if (!aux::is_local(ep.address()) && !ep.address().is_loopback())
+						req.ipv6.push_back(ep.address().to_v6());
+				}
+				else
+				{
+					if (!aux::is_local(ep.address()) && !ep.address().is_loopback())
+						req.ipv4.push_back(ep.address().to_v4());
+				}
+			});
+		}
+
+		// if we are aborting. we don't want any new peers
+		req.num_want =
+			(req.event == event_t::stopped) ? 0 : settings().get_int(settings_pack::num_want);
+
+		return req;
+	}
+
+	void torrent::send_tracker_request(tracker_request& req,
+		aux::announce_endpoint& aep,
+		aux::announce_infohash& a,
+		protocol_version const ih,
+		event_t const e,
+		bool const high_priority,
+		time_point32 const now)
+	{
+		req.event = e;
+		if (req.event == event_t::none)
+		{
+			if (!a.start_sent)
+				req.event = event_t::started;
+			else if (!m_complete_sent && !a.complete_sent && is_seed())
+			{
+				req.event = event_t::completed;
+			}
+		}
+
+		req.triggered_manually = a.triggered_manually;
+		a.triggered_manually = false;
+
+#if TORRENT_ABI_VERSION == 1
+		req.auth = tracker_login();
+#endif
+		req.key = tracker_key();
+
+		req.outgoing_socket = aep.socket;
+		req.info_hash = m_torrent_file->info_hashes().get(ih);
+		if (high_priority) req.kind |= tracker_request::high_priority;
+
+#ifndef TORRENT_DISABLE_LOGGING
+		if (should_log())
+		{
+			debug_log("==> TRACKER REQUEST \"%s\" event: %s abort: %d ssl: %p "
+					  "port: %d ssl-port: %d fails: %d upd: %d ep: %s",
+				req.url.c_str(),
+				(req.event == event_t::stopped			? "stopped"
+						: req.event == event_t::started ? "started"
+														: ""),
+				m_abort
+#ifdef TORRENT_SSL_PEERS
+				,
+				static_cast<void*>(req.ssl_ctx)
+#else
+				,
+				static_cast<void*>(nullptr)
+#endif
+					,
+				m_ses.listen_port(),
+				m_ses.ssl_listen_port(),
+				a.fails,
+				a.updating,
+				print_endpoint(aep.local_endpoint).c_str());
+		}
+
+		// if we're not logging session logs, don't bother creating an
+		// observer object just for logging
+		if (m_abort && m_ses.should_log())
+		{
+			auto tl = std::make_shared<aux::tracker_logger>(m_ses);
+			m_ses.queue_tracker_request(req, tl);
+		}
+		else
+#endif
+		{
+			m_ses.queue_tracker_request(req, shared_from_this());
+		}
+
+		a.updating = true;
+		a.next_announce = now;
+		a.min_announce = now;
+
+		if (m_ses.alerts().should_post<tracker_announce_alert>())
+		{
+			m_ses.alerts().emplace_alert<tracker_announce_alert>(
+				get_handle(), aep.local_endpoint, req.url, ih, req.event);
+		}
+	}
+
+	// unlike announce_with_tracker(), this only considers a single,
+	// specific tracker, and does not defer to other trackers based on
+	// tier or "is one tracker already working" bookkeeping. This is used
+	// to force-announce a specific tracker (by index), since the whole
+	// point of asking for a specific tracker is to reach that tracker,
+	// regardless of the state of any other tracker in the list.
+	void torrent::announce_tracker_now(
+		aux::announce_entry& ae, event_t const e, bool const high_priority)
+	{
+		TORRENT_ASSERT(is_single_thread());
+
+		if (m_abort) return;
+		if (e != event_t::stopped && (!m_announce_to_trackers || m_paused)) return;
+
+		tracker_request req = build_tracker_request(e);
+		time_point32 const now = aux::time_now32();
+
+		refresh_endpoint_list(m_ses, is_ssl_torrent(), bool(m_complete_sent), ae);
+		req.trackerid = ae.trackerid.empty() ? m_trackerid : ae.trackerid;
+		req.url = ae.url;
+
+#if TORRENT_USE_I2P
+		if (!i2p_compatible_tracker(ae)) return;
+		if (ae.i2p) req.kind |= tracker_request::i2p;
+#endif
+
+		for (auto& aep : ae.endpoints)
+		{
+			if (!aep.enabled) continue;
+
+			for (protocol_version const ih : all_versions)
+			{
+				if (ih == protocol_version::V1 && !m_info_hash.has_v1()) continue;
+				if (ih == protocol_version::V2 && !m_info_hash.has_v2()) continue;
+
+				auto& a = aep.info_hashes[ih];
+
+				if (!a.start_sent && e == event_t::stopped) continue;
+				if (!a.can_announce(now, is_seed(), ae.fail_limit)) continue;
+
+				send_tracker_request(req, aep, a, ih, e, high_priority, now);
+			}
+		}
 	}
 
 	void torrent::scrape_tracker(int idx, bool const user_triggered)
@@ -3978,7 +4041,14 @@ namespace {
 				a.next_announce = (flags & torrent_handle::ignore_min_interval)
 					? time_point_cast<seconds32>(t) + seconds32(1)
 					: std::max(time_point_cast<seconds32>(t), a.min_announce) + seconds32(1);
-				a.min_announce = a.next_announce;
+				// ignore_min_interval means the caller explicitly wants to
+				// bypass the tracker's requested minimum interval, so clear
+				// it. Otherwise leave it as-is (e.g. reflecting a real
+				// interval requested by the tracker) rather than pushing it
+				// a second into the future, which would make can_announce()
+				// falsely report this endpoint as not yet eligible.
+				if (flags & torrent_handle::ignore_min_interval)
+					a.min_announce = (time_point32::min)();
 				a.triggered_manually = true;
 				ret = true;
 			}
@@ -3998,42 +4068,57 @@ namespace {
 			|| tracker_idx == -1);
 
 		if (is_paused()) return;
-		bool found_one = false;
+
 		if (tracker_idx == -1)
 		{
+			bool found_one = false;
 			for (auto& e : m_trackers)
 			{
 				// make sure we check for new endpoints from the listen sockets
 				refresh_endpoint_list(m_ses, is_ssl_torrent(), bool(m_complete_sent), e);
 				found_one |= trigger_announce(m_ses, is_ssl_torrent(), bool(m_complete_sent), flags, t, e);
 			}
+
+#ifndef TORRENT_DISABLE_LOGGING
+			if (!found_one)
+			{
+				debug_log("*** found no tracker endpoints to announce");
+			}
+#else
+			TORRENT_UNUSED(found_one);
+#endif
+
+			if (flags & torrent_handle::high_priority)
+			{
+				announce_with_tracker(event_t::none, true);
+			}
+			else
+			{
+				update_tracker_timer(aux::time_now32());
+			}
+			return;
 		}
-		else
-		{
-			if (tracker_idx < 0 || tracker_idx >= int(m_trackers.size()))
-				return;
-			auto* e = m_trackers.find(tracker_idx);
-			if (e == nullptr) return;
-			found_one |= trigger_announce(m_ses, is_ssl_torrent(), bool(m_complete_sent), flags, t, *e);
-		}
+
+		if (tracker_idx < 0 || tracker_idx >= int(m_trackers.size())) return;
+		auto* e = m_trackers.find(tracker_idx);
+		if (e == nullptr) return;
+		bool const found_one =
+			trigger_announce(m_ses, is_ssl_torrent(), bool(m_complete_sent), flags, t, *e);
 
 #ifndef TORRENT_DISABLE_LOGGING
 		if (!found_one)
 		{
 			debug_log("*** found no tracker endpoints to announce");
 		}
-#else
-		TORRENT_UNUSED(found_one);
 #endif
 
-		if (flags & torrent_handle::high_priority)
-		{
-			announce_with_tracker(event_t::none, true);
-		}
-		else
-		{
-			update_tracker_timer(aux::time_now32());
-		}
+		// unlike the "reannounce to all trackers" case above, forcing a
+		// specific tracker must actually reach that tracker, regardless of
+		// whether some other tracker earlier in the list hasn't failed yet.
+		// announce_with_tracker() would silently skip this tracker in that
+		// case, so use the single-tracker path instead.
+		if (found_one)
+			announce_tracker_now(*e, event_t::none, bool(flags & torrent_handle::high_priority));
 	}
 
 	// this is the entry point for the client to force a re-announce. It's
@@ -4054,9 +4139,12 @@ namespace {
 
 		bool const found = trigger_announce(m_ses, is_ssl_torrent(), bool(m_complete_sent), flags, t, *e);
 
+		// see the comment in force_tracker_request() above: this must reach
+		// this specific tracker regardless of the state of any other one,
+		// so use the single-tracker path rather than announce_with_tracker().
 		if (found)
 		{
-			update_tracker_timer(aux::time_now32());
+			announce_tracker_now(*e, event_t::none, bool(flags & torrent_handle::high_priority));
 		}
 #ifndef TORRENT_DISABLE_LOGGING
 		else

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -3546,6 +3546,12 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 				send_tracker_request(req, aep, a, ih, e, high_priority, now);
 			}
 		}
+
+		// if the tracker wasn't immediately eligible to announce (e.g. its
+		// min_interval hasn't expired), make sure the timer is (re)armed so
+		// the forced announce isn't silently dropped, and instead happens
+		// as soon as the tracker becomes eligible.
+		update_tracker_timer(now);
 	}
 
 	void torrent::scrape_tracker(int idx, bool const user_triggered)


### PR DESCRIPTION
fix:
1. `force_tracker_request_url()` ignoring high-priority flag
2. `force_reannounce()` would still honor tiers and possibly not trigger an announce
3. `force_reannounce()` would trip over its own update of `min_announce` and always end up deferring


Fixing 2 is the main change, as it also required factoring out some common code.