### PR TITLE
fix duplicate filenames in magnet links

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@
 	* added support for WebTorrent
 	* removed support for BEP 17 web seeds (in favor of BEP 19)
 
+	* fix duplicate filenames in magnet links
 	* fix corruption bug in mmap_storage
 	* fix bug where torrent_status::total was not set for seeds
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -87,6 +87,7 @@ see LICENSE file.
 #include "libtorrent/aux_/resolver_interface.hpp"
 #include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/resolve_links.hpp"
+#include "libtorrent/aux_/resolve_duplicate_filenames.hpp"
 #include "libtorrent/aux_/file_progress.hpp"
 #include "libtorrent/aux_/has_block.hpp"
 #include "libtorrent/aux_/alert_manager.hpp"
@@ -8140,11 +8141,28 @@ namespace {
 			, sett.get_int(settings_pack::metadata_token_limit));
 
 		std::shared_ptr<torrent_info> info;
+		std::map<file_index_t, std::string> renamed_files;
 		if (!ec)
 		{
 			load_torrent_limits cfg;
 			cfg.max_pieces = sett.get_int(settings_pack::max_piece_count);
 			info = std::make_shared<torrent_info>(metadata, ec, cfg, from_info_section);
+			// ec is an output parameter set by torrent_info's constructor on
+			// parse failure; cppcheck doesn't see the constructor definition
+			// (in torrent_info.cpp) from this translation unit
+			// cppcheck-suppress identicalInnerCondition
+			if (!ec)
+			{
+				renamed_files = aux::resolve_duplicate_filenames(
+					info->layout(), cfg.max_duplicate_filenames, ec);
+#if TORRENT_ABI_VERSION < 4
+				// for backwards compatibility, make sure the file_storage
+				// returned by the deprecated files() has updated filenames
+				// as well
+				for (auto const& entry : renamed_files)
+					info->rename_file(entry.first, entry.second);
+#endif
+			}
 		}
 
 		if (ec)
@@ -8199,6 +8217,7 @@ namespace {
 
 		m_name_idx.clear();
 		m_torrent_file = info;
+		m_renamed_files.import_filenames(m_torrent_file->layout(), renamed_files);
 		m_info_hash = m_torrent_file->info_hashes();
 		{
 			std::lock_guard<std::mutex> l(m_torrent_file_mutex);

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -27,6 +27,8 @@ see LICENSE file.
 #include "libtorrent/aux_/piece_picker.hpp"
 #include "libtorrent/hex.hpp" // to_hex
 #include "libtorrent/write_resume_data.hpp" // write_torrent_file
+#include "libtorrent/session.hpp"
+#include "libtorrent/alert_types.hpp"
 
 #include <iostream>
 
@@ -1679,6 +1681,98 @@ TORRENT_TEST(resolve_duplicates)
 {
 	for (auto const& t : test_cases)
 		test_resolve_duplicates(t);
+}
+
+namespace {
+
+	// a small number of test_torrents entries validate fields that live
+	// outside the info dict:
+	// * creation_date.torrent / no_creation_date.torrent check the deprecated
+	//   torrent_info::creation_date(), which is only ever populated when
+	//   parsing a full .torrent file
+	// * similar.torrent / collection.torrent put their "similar"/"collections"
+	//   lists at the top level of the .torrent file, per BEP38 (the ".2"
+	//   variants of these fixtures put the same lists inside the info dict
+	//   instead, and are not skipped)
+	// Metadata received at run-time (via ut_metadata / set_metadata()) only
+	// ever contains the info dict, so those specific checks cannot pass
+	// through this path, and they are unrelated to filename sanitization or
+	// deduplication, so they are skipped here.
+	bool skip_set_metadata_test(char const* file)
+	{
+		return file == "creation_date.torrent"_sv || file == "no_creation_date.torrent"_sv
+			|| file == "similar.torrent"_sv || file == "collection.torrent"_sv;
+	}
+
+	// metadata received at run-time (e.g. via the ut_metadata extension, here
+	// simulated with torrent_handle::set_metadata()) must go through the same
+	// filename sanitization and duplicate-filename resolution as loading the
+	// same .torrent file from disk. Re-use each test_torrents entry's own
+	// validation callback to check that.
+	void test_set_metadata_resolve_duplicate_filenames(
+		lt::session& ses, test_torrent_t const& t, std::string const& filename)
+	{
+		lt::add_torrent_params const ref = lt::load_torrent_file(filename);
+
+		auto const is = ref.ti->info_section();
+		std::vector<char> const info_section(is.begin(), is.end());
+
+		// simulate a genuine magnet link add: no metadata (and none of the
+		// knowledge, like the disambiguated file names, that only comes from
+		// having already parsed a full .torrent file), but keep the fields
+		// that come from outside the info dict (trackers, web seeds, DHT
+		// nodes, ...), the same way a real magnet URI might supply them
+		lt::add_torrent_params atp = ref;
+		atp.ti.reset();
+		atp.renamed_files.clear();
+		atp.save_path = ".";
+
+		lt::torrent_handle h = ses.add_torrent(atp);
+		TEST_CHECK(h.is_valid());
+		h.set_metadata(info_section);
+
+		lt::alert const* m = wait_for_alert(ses, lt::metadata_received_alert::alert_type, t.file);
+		TEST_CHECK(m);
+
+		// query the actual file names the torrent would use, the same way an
+		// application resuming this torrent later would see them
+		h.save_resume_data(lt::torrent_handle::save_info_dict);
+		lt::alert const* r = wait_for_alert(ses, lt::save_resume_data_alert::alert_type, t.file);
+		TEST_CHECK(r);
+		auto const* rda = lt::alert_cast<lt::save_resume_data_alert>(r);
+		TEST_CHECK(rda);
+		TEST_CHECK(rda->params.ti);
+
+		if (t.test && rda->params.ti)
+		{
+			lt::add_torrent_params result = atp;
+			result.ti = rda->params.ti;
+			result.renamed_files = rda->params.renamed_files;
+			t.test(std::move(result));
+		}
+
+		ses.remove_torrent(h);
+	}
+
+} // anonymous namespace
+
+TORRENT_TEST(set_metadata_resolve_duplicate_filenames)
+{
+	std::string const root_dir = parent_path(current_working_directory());
+
+	lt::session_params p = settings();
+	p.settings.set_int(lt::settings_pack::alert_mask,
+		lt::alert_category::status | lt::alert_category::error | lt::alert_category::storage);
+	p.settings.set_str(lt::settings_pack::listen_interfaces, "127.0.0.1:6881");
+	lt::session ses(p);
+
+	for (auto const& t : test_torrents)
+	{
+		if (skip_set_metadata_test(t.file)) continue;
+		std::printf("set_metadata: %s\n", t.file);
+		std::string const filename = combine_path(combine_path(root_dir, "test_torrents"), t.file);
+		test_set_metadata_resolve_duplicate_filenames(ses, t, filename);
+	}
 }
 
 TORRENT_TEST(empty_file)


### PR DESCRIPTION
`resolve_duplicate_filenames()` was not run on metadata received via `ut_metadata`