### PR TITLE
Optimize CPU usage in the DH key exchange hot path

### DIFF
--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -92,7 +92,7 @@ namespace libtorrent {
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
 	{
-		aux::array<std::uint8_t, 96> random_key;
+		aux::array<std::uint8_t, 20> random_key;
 		aux::random_bytes({reinterpret_cast<char*>(random_key.data())
 			, static_cast<std::ptrdiff_t>(random_key.size())});
 


### PR DESCRIPTION
This is a two commit series focused on reducing CPU usage during "connection storms" where a large number of peers are connecting at the same time. 

My measurements show this reduces CPU usage by 30% for all users, and 35% for users where libtorrent configured with openssl. Improvements translated into both qBittorrent and Deluge (as testable downstream consumers of this library).

Feedback welcome!