### PR TITLE
don't install vendored headers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -141,6 +141,11 @@ jobs:
           cd build-cmake
           ctest --output-on-failure
 
+      - name: cmake install (installed headers are self-sufficient)
+        run: |
+          cmake --install build-cmake --prefix "$PWD/install-test"
+          ./tools/check_installed_headers.py "$PWD/install-test"
+
 
    fuzzers:
       name: Fuzzers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
           b2 install --prefix=test-install-root webtorrent=on
           cat test-install-root/lib/pkgconfig/libtorrent-rasterbar.pc
 
+      - name: test-tarball (installed headers are self-sufficient)
+        run: |
+          cd libtorrent-rasterbar-*/
+          ./tools/check_installed_headers.py test-install-root
+
       - name: test-tarball (b2 tests)
         run: |
           cd libtorrent-rasterbar-*/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -995,11 +995,6 @@ install(TARGETS ${LIBTORRENT_EXPORT_TARGETS}
 )
 install(DIRECTORY include/libtorrent DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h*")
 
-if (webtorrent)
-    install(DIRECTORY deps/libdatachannel/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-	install(DIRECTORY deps/libdatachannel/deps/plog/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-endif()
-
 # === generate a CMake Config File ===
 include(CMakePackageConfigHelpers)
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/LibtorrentRasterbar)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -979,7 +979,11 @@ if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 set(LIBTORRENT_EXPORT_TARGETS torrent-rasterbar)
-if (webtorrent)
+if (webtorrent AND NOT BUILD_SHARED_LIBS)
+    # these are only linked PUBLIC (and therefore need to be installed and
+    # part of the export set) when torrent-rasterbar itself is static; for a
+    # shared build they're linked PRIVATE and are already embedded in
+    # libtorrent-rasterbar.so, so consumers never need them
     list(APPEND LIBTORRENT_EXPORT_TARGETS datachannel-static juice-static plog usrsctp)
 	if (TARGET usrsctp)
         set_target_properties(usrsctp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ TOOLS_FILES= \
   parse_sample.py        \
   parse_session_stats.py \
   parse_utp_log.py       \
+  check_installed_headers.py \
   session_log_alerts.cpp
 
 KADEMLIA_SOURCES = \

--- a/Makefile
+++ b/Makefile
@@ -506,6 +506,7 @@ HEADERS = \
   portmap.hpp                  \
   posix_disk_io.hpp            \
   pread_disk_io.hpp            \
+  random.hpp                   \
   read_resume_data.hpp         \
   session.hpp                  \
   session_handle.hpp           \

--- a/tools/check_installed_headers.py
+++ b/tools/check_installed_headers.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# vim: tabstop=4 noexpandtab shiftwidth=4 softtabstop=4
+
+# Regression test for the "install" targets in the Jamfile and CMakeLists.txt:
+# the installed include tree must contain only libtorrent's own public
+# headers, and those headers must be self-sufficient, with no access to any
+# vendored third-party headers.
+#
+# Usage:
+#   check_installed_headers.py <install-prefix>
+
+import argparse
+import glob
+import os
+import shlex
+import subprocess
+import sys
+
+
+def check_no_vendored_headers(include_dir: str) -> None:
+    if not os.path.isdir(include_dir):
+        sys.exit(f"error: {include_dir} does not exist")
+    entries = sorted(os.listdir(include_dir))
+    if entries != ["libtorrent"]:
+        sys.exit(
+            f"error: {include_dir} must contain exactly libtorrent/, found: {entries}"
+        )
+    print(f"OK: {include_dir} contains only libtorrent/")
+
+
+def find_pc_file(prefix: str) -> str:
+    # CMAKE_INSTALL_LIBDIR (and therefore where the .pc file ends up) varies
+    # by distro/prefix -- e.g. lib, lib64, lib/x86_64-linux-gnu -- so search
+    # for it rather than assuming a fixed layout.
+    matches = glob.glob(
+        os.path.join(prefix, "**", "pkgconfig", "libtorrent-rasterbar.pc"),
+        recursive=True,
+    )
+    if len(matches) != 1:
+        sys.exit(
+            f"error: expected exactly one libtorrent-rasterbar.pc under {prefix}, "
+            f"found {matches}"
+        )
+    return matches[0]
+
+
+def check_public_headers_compile(prefix: str) -> None:
+    pc_file = find_pc_file(prefix)
+    cflags = shlex.split(
+        subprocess.run(
+            ["pkg-config", "--cflags", pc_file],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+
+    header = os.path.join(prefix, "include", "libtorrent", "libtorrent.hpp")
+    cxx = os.environ.get("CXX", "c++")
+    subprocess.run([cxx, "-std=c++17", "-fsyntax-only", *cflags, header], check=True)
+    print(f"OK: {header} compiles using only the installed headers")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="verify an installed libtorrent include/ tree contains "
+        "only libtorrent's own headers, and that they are self-sufficient"
+    )
+    parser.add_argument("prefix", help="install prefix to check")
+    args = parser.parse_args()
+
+    prefix = os.path.abspath(args.prefix)
+    check_no_vendored_headers(os.path.join(prefix, "include"))
+    check_public_headers_compile(prefix)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
fix issue in `CMakeLists.txt` that would install vendored libraries' headers.

add CI checks to ensure we don't in the future, and that no public header depends ona vendored library's header.