### PR TITLE
set NO_EXAMPLES=ON for bundled libdatachannel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,6 +860,7 @@ if (webtorrent)
     set(LIBDATACHANNEL_INSTALL OFF CACHE BOOL "" FORCE)
     set(PLOG_INSTALL OFF CACHE BOOL "" FORCE)
     set(JUICE_INSTALL OFF CACHE BOOL "" FORCE)
+    set(NO_EXAMPLES ON CACHE BOOL "" FORCE)
 
 	add_subdirectory(deps/libdatachannel EXCLUDE_FROM_ALL)
 	set_target_properties(datachannel-static PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
The libdatachannel submodule's CMakeLists.txt has unconditional add_subdirectory() calls for examples/copy-paste and examples/copy-paste-capi (lines 616-617). These directories are themselves git submodules of libdatachannel and are not present in release tarballs generated from a shallow submodule checkout (e.g. `libtorrent-rasterbar-2.1.0.tar.gz`).

This causes CMake configure to fail with:

```
CMake Error at deps/libdatachannel/CMakeLists.txt:616 (add_subdirectory):
  add_subdirectory given source "examples/copy-paste" which is not an
  existing directory.
```

Other bundled examples (client, media-\*) already have option guards (NO_WEBSOCKET / NO_MEDIA) and we already set those to ON on lines 850-851. This adds NO_EXAMPLES=ON alongside them to disable the remaining unguarded example targets.

The underlying issue (missing guards in libdatachannel) should ideally be fixed upstream in [paullouisageneau/libdatachannel](https://github.com/paullouisageneau/libdatachannel), but this one-line change in libtorrent prevents the build breakage regardless.