### PR TITLE
fix consistency between hash_value() and operator==()

### DIFF
--- a/include/libtorrent/aux_/listen_socket_handle.hpp
+++ b/include/libtorrent/aux_/listen_socket_handle.hpp
@@ -14,6 +14,8 @@ see LICENSE file.
 
 #include "libtorrent/address.hpp"
 #include "libtorrent/socket.hpp" // for tcp::endpoint
+#include <cstdint>
+#include <functional>
 #include <memory>
 
 namespace libtorrent { namespace aux {
@@ -26,9 +28,7 @@ namespace libtorrent { namespace aux {
 
 		listen_socket_handle() = default;
 
-		listen_socket_handle(std::shared_ptr<listen_socket_t> s) // NOLINT
-			: m_sock(s)
-		{}
+		listen_socket_handle(std::shared_ptr<listen_socket_t> s); // NOLINT
 
 		listen_socket_handle(listen_socket_handle const& o) = default;
 		listen_socket_handle& operator=(listen_socket_handle const& o) = default;
@@ -45,25 +45,26 @@ namespace libtorrent { namespace aux {
 
 		bool is_ssl() const;
 
-		bool operator==(listen_socket_handle const& o) const
-		{
-			return !m_sock.owner_before(o.m_sock) && !o.m_sock.owner_before(m_sock);
-		}
+		// compares via m_id, not m_sock, so identity survives after the
+		// listen_socket_t is destroyed and m_sock has expired.
+		bool operator==(listen_socket_handle const& o) const { return m_id == o.m_id; }
 
 		bool operator!=(listen_socket_handle const& o) const
 		{
 			return !(*this == o);
 		}
 
-		bool operator<(listen_socket_handle const& o) const
-		{ return m_sock.owner_before(o.m_sock); }
+		bool operator<(listen_socket_handle const& o) const { return m_id < o.m_id; }
 
 		listen_socket_t* get() const;
 
 		std::weak_ptr<listen_socket_t> get_ptr() const { return m_sock; }
 
+		std::size_t hash_value() const { return std::hash<std::uint32_t>{}(m_id); }
+
 	private:
 		std::weak_ptr<listen_socket_t> m_sock;
+		std::uint32_t m_id = 0;
 	};
 
 } }

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -165,6 +165,10 @@ namespace aux {
 		listen_socket_t& operator=(listen_socket_t const&) = delete;
 		listen_socket_t& operator=(listen_socket_t&&) = delete;
 
+		// unlike this object's address, never reused by a later, unrelated
+		// listen_socket_t once this one is destroyed.
+		std::uint32_t const id = next_id();
+
 		udp::endpoint get_local_endpoint() override
 		{
 			error_code ec;
@@ -253,6 +257,15 @@ namespace aux {
 		// set to true when we receive an incoming connection from this listen
 		// socket
 		bool incoming_connection = false;
+
+	private:
+		// non-atomic is fine: listen_socket_t is only ever constructed on
+		// the network thread.
+		static std::uint32_t next_id()
+		{
+			static std::uint32_t next = 0;
+			return ++next;
+		}
 	};
 
 		struct TORRENT_EXTRA_EXPORT listen_endpoint_t

--- a/src/listen_socket_handle.cpp
+++ b/src/listen_socket_handle.cpp
@@ -13,13 +13,18 @@ see LICENSE file.
 
 namespace libtorrent { namespace aux {
 
-	address listen_socket_handle::get_external_address() const
-	{
-		auto s = m_sock.lock();
-		TORRENT_ASSERT(s);
-		if (!s) throw_ex<std::bad_weak_ptr>();
-		return s->external_address.external_address();
-	}
+		listen_socket_handle::listen_socket_handle(std::shared_ptr<listen_socket_t> s)
+			: m_sock(s)
+			, m_id(s ? s->id : 0)
+		{}
+
+		address listen_socket_handle::get_external_address() const
+		{
+			auto s = m_sock.lock();
+			TORRENT_ASSERT(s);
+			if (!s) throw_ex<std::bad_weak_ptr>();
+			return s->external_address.external_address();
+		}
 
 	tcp::endpoint listen_socket_handle::get_local_endpoint() const
 	{

--- a/test/test_listen_socket.cpp
+++ b/test/test_listen_socket.cpp
@@ -126,6 +126,40 @@ namespace
 
 } // anonymous namespace
 
+TORRENT_TEST(listen_socket_handle_hash_stable_after_destruction)
+{
+	// listen_socket_handle::hash_value() must stay the same for as long as a
+	// handle exists, even after the listen_socket_t it refers to is
+	// destroyed -- unlike get(), which collapses to nullptr once the object
+	// dies. tracker_manager::http_pool_key_hash relies on this: boost's
+	// hashed_unique index recomputes an element's hash during a rehash, so a
+	// hash that depends on pointee liveness would silently move the element
+	// to the wrong bucket the moment the object it refers to is destroyed.
+	aux::listen_socket_handle handle;
+	std::size_t hash_before_destruction;
+	{
+		auto s = sock("4.4.4.4", 6881);
+		handle = aux::listen_socket_handle(s);
+		hash_before_destruction = handle.hash_value();
+		TEST_CHECK(handle.get() == s.get());
+	}
+	// the listen_socket_t is destroyed here; handle still refers to it weakly
+	TEST_CHECK(handle.get() == nullptr);
+	TEST_EQUAL(handle.hash_value(), hash_before_destruction);
+}
+
+TORRENT_TEST(listen_socket_handle_hash_distinguishes_objects)
+{
+	// two handles referring to distinct, concurrently alive listen_socket_t
+	// objects must have distinct hashes.
+	auto s1 = sock("4.4.4.4", 6881);
+	auto s2 = sock("5.5.5.5", 6882);
+	aux::listen_socket_handle const h1(s1);
+	aux::listen_socket_handle const h2(s2);
+	TEST_CHECK(h1 != h2);
+	TEST_CHECK(h1.hash_value() != h2.hash_value());
+}
+
 TORRENT_TEST(partition_listen_sockets_wildcard2specific)
 {
 	std::vector<std::shared_ptr<aux::listen_socket_t>> sockets = {


### PR DESCRIPTION
for `listen_socket_handle`. If the `weak_ptr` expires, the hash value and operator== will change, violating an invariant for hash tables.