### PR TITLE
Fix missing includes

### DIFF
--- a/include/libtorrent/aux_/io.hpp
+++ b/include/libtorrent/aux_/io.hpp
@@ -11,9 +11,11 @@ see LICENSE file.
 #ifndef TORRENT_AUX_IO_HPP_INCLUDED
 #define TORRENT_AUX_IO_HPP_INCLUDED
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <type_traits>
+
 #include "libtorrent/span.hpp"
 #include "libtorrent/aux_/numeric_cast.hpp"
 

--- a/include/libtorrent/flags.hpp
+++ b/include/libtorrent/flags.hpp
@@ -13,7 +13,7 @@ see LICENSE file.
 #include <type_traits> // for enable_if
 
 #if TORRENT_USE_IOSTREAM
-#include <iosfwd>
+#include <iostream>
 #include <iomanip>
 #endif
 


### PR DESCRIPTION
Fixes:
```
libtorrent/include/libtorrent/flags.hpp: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'ios_base &(ios_base &)')
  112 |         { return os << std::hex << std::uint64_t(static_cast<UnderlyingType>(val)); }
```

And

```
libtorrent/include/libtorrent/aux_/io.hpp:150:3: error: no member named 'copy' in namespace 'std'; did you mean 'bcopy'?
  150 |                 std::copy(str.begin(), str.end(), view.begin());
      |                 ^~~~~~~~~
```