### PR TITLE
fix undefined std::toupper on signed char in base32decode

### DIFF
--- a/src/escape_string.cpp
+++ b/src/escape_string.cpp
@@ -36,7 +36,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/config.hpp"
 
 #include <string>
-#include <cctype>
 #include <algorithm>
 #include <mutex>
 #include <cstring>
@@ -418,7 +417,13 @@ namespace {
 			inbuf.fill(0);
 			for (int j = 0; j < available_input; ++j)
 			{
-				char const in = char(std::toupper(*i++));
+				// uppercase the ASCII range directly. the input can come from
+				// untrusted sources (e.g. the base32 info-hash in a magnet link)
+				// and may contain bytes with the high bit set, which are left
+				// untouched here and rejected as invalid base32 below. this keeps
+				// the decoding independent of the current locale.
+				char const c = *i++;
+				char const in = (c >= 'a' && c <= 'z') ? char(c - 'a' + 'A') : c;
 				if (in >= 'A' && in <= 'Z')
 					inbuf[j] = (in - 'A') & 0xff;
 				else if (in >= '2' && in <= '7')

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -301,6 +301,11 @@ TORRENT_TEST(base32)
 
 	// make sure invalid encoding returns the empty string
 	TEST_CHECK(base32decode("mZXw6yTBO1{#&*()=") == "");
+
+	// bytes with the high bit set (e.g. from a percent-encoded magnet link)
+	// are not valid base32 and decode to the empty string
+	TEST_CHECK(base32decode("MZXW6YT\x80") == "");
+	TEST_CHECK(base32decode(std::string("MZXW\xffYTBO")) == "");
 }
 
 TORRENT_TEST(escape_string)


### PR DESCRIPTION
base32decode passes each input character straight to std::toupper, but the byte can come from an untrusted source such as the percent-decoded base32 info-hash in a magnet link (xt=urn:btih:). When char is signed a byte above 127 is negative, and std::toupper is only defined for arguments representable as unsigned char or EOF, so that call is undefined behavior, and it is locale dependent besides. Uppercase the ASCII range directly the way to_lower already does, which keeps decoding of valid input unchanged.