### PR TITLE
abort trackers

### DIFF
--- a/include/libtorrent/aux_/tracker_manager.hpp
+++ b/include/libtorrent/aux_/tracker_manager.hpp
@@ -297,6 +297,15 @@ using tracker_request_flags_t = flags::bitfield_flag<std::uint8_t, struct tracke
 		tracker_request m_req;
 		std::weak_ptr<request_callback> m_requester;
 
+		// true whenever m_req's outcome (success or error) has not yet been
+		// reported to m_requester. fail_impl() clears it when it reports an
+		// error; subclasses clear it wherever else they report m_req's
+		// outcome. This is what makes fail_impl() and a subclass's own
+		// success path mutually exclusive, even when fail() was posted (by
+		// e.g. tracker_manager::abort_all_requests()) around the same time
+		// the connection's own logic independently reported an outcome.
+		bool m_req_pending = true;
+
 		tracker_manager& m_man;
 	};
 

--- a/simulation/test_tracker.cpp
+++ b/simulation/test_tracker.cpp
@@ -992,9 +992,78 @@ TORRENT_TEST(paused_session)
 	timeline += seconds(5);
 
 	// then shut down
-	sim::timer t4(sim, timeline
-		, [&ses,&zombie](boost::system::error_code const&)
-	{
+	sim::timer t4(sim, timeline, [&ses, &zombie](boost::system::error_code const&) {
+		zombie = ses->abort();
+		ses.reset();
+	});
+
+	sim.run();
+}
+
+// pausing a session while a tracker announce is genuinely in flight
+// (already dispatched, awaiting a response, as opposed to paused_session
+// above where the announce has already completed) must still report the
+// request being torn down, via tracker_manager::abort_all_requests(), so
+// announce_infohash::updating gets cleared and the tracker becomes
+// eligible to be announced to again once the session is resumed.
+TORRENT_TEST(paused_session_in_flight_announce)
+{
+	using sim::asio::ip::address_v4;
+	sim::default_config network_cfg;
+	sim::simulation sim{network_cfg};
+
+	sim::asio::io_context tracker_ios(sim, make_address_v4("123.0.0.2"));
+	sim::http_server http(tracker_ios, 8080);
+
+	// never respond, so the announce stays genuinely in flight when the
+	// session is paused.
+	http.register_stall_handler("/announce");
+
+	lt::session_proxy zombie;
+
+	asio::io_context ios(sim, make_address_v4("123.0.0.3"));
+	lt::settings_pack sett = settings();
+	auto ses = std::make_unique<lt::session>(sett, ios);
+
+	bool error_seen = false;
+	error_code got_error;
+	ses->set_alert_notify([&] {
+		post(ses->get_context(), [&] {
+			std::vector<lt::alert*> alerts;
+			ses->pop_alerts(&alerts);
+			for (lt::alert* a : alerts)
+			{
+				if (auto const* te = alert_cast<tracker_error_alert>(a))
+				{
+					error_seen = true;
+					got_error = te->error;
+				}
+			}
+		});
+	});
+
+	lt::add_torrent_params p;
+	p.name = "test-torrent";
+	p.save_path = ".";
+	p.info_hashes.v1.assign("abababababababababab");
+	p.trackers.push_back("http://123.0.0.2:8080/announce");
+	ses->async_add_torrent(p);
+
+	sim::timer t1(sim, lt::seconds(2), [&](boost::system::error_code const&) { ses->pause(); });
+
+	sim::timer t2(sim, lt::seconds(3), [&](boost::system::error_code const&) {
+		TEST_CHECK(error_seen);
+		TEST_CHECK(got_error == error_code(errors::announce_skipped));
+
+		std::vector<lt::torrent_handle> torrents = ses->get_torrents();
+		TEST_EQUAL(torrents.size(), 1);
+		std::vector<announce_entry> tr = torrents[0].trackers();
+		TEST_EQUAL(tr.size(), 1);
+		TEST_EQUAL(tr[0].endpoints.size(), 1);
+		TEST_CHECK(!tr[0].endpoints[0].info_hashes[protocol_version::V1].updating);
+	});
+
+	sim::timer t3(sim, lt::seconds(4), [&ses, &zombie](boost::system::error_code const&) {
 		zombie = ses->abort();
 		ses.reset();
 	});

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -422,6 +422,7 @@ namespace libtorrent::aux {
 		std::shared_ptr<request_callback> cb = requester();
 		if (!cb)
 		{
+			m_req_pending = false;
 			close();
 			return;
 		}
@@ -443,6 +444,12 @@ namespace libtorrent::aux {
 			close();
 			return;
 		}
+
+		// the response is about to be reported below; mark it as no longer
+		// pending first, so a fail() already posted (e.g. by
+		// tracker_manager::abort_all_requests() racing this response) finds
+		// nothing left to report when it runs.
+		m_req_pending = false;
 
 		// do slightly different things for scrape requests
 		if (tracker_req().kind & tracker_request::scrape_request)

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -148,9 +148,20 @@ namespace libtorrent::aux {
 	void tracker_connection::fail_impl(error_code const& ec, operation_t const op
 		, std::string const msg, seconds32 const interval, seconds32 const min_interval)
 	{
-		std::shared_ptr<request_callback> cb = requester();
-		if (cb) cb->tracker_request_error(m_req, ec, op, msg
-			, interval.count() == 0 ? min_interval : interval);
+		// fail() only posts this call, so m_req is not necessarily still
+		// pending by the time it runs: the connection's own logic may have
+		// already reported an outcome for it (e.g. a legitimate response
+		// arriving right as tracker_manager::abort_all_requests() posted
+		// this same call). Checking here, rather than in fail(), is what
+		// makes the two mutually exclusive.
+		if (m_req_pending)
+		{
+			m_req_pending = false;
+			std::shared_ptr<request_callback> cb = requester();
+			if (cb)
+				cb->tracker_request_error(
+					m_req, ec, op, msg, interval.count() == 0 ? min_interval : interval);
+		}
 		close();
 	}
 
@@ -464,31 +475,47 @@ namespace libtorrent::aux {
 		// this is called from the destructor too, which is not subject to the
 		// single-thread requirement.
 		TORRENT_ASSERT(all || is_single_thread());
-		// removes all connections except 'event=stopped'-requests
+		// removes all connections except 'event=stopped'-requests. Aborted
+		// requests are reported as a skipped announce, which clears the
+		// "updating" flag on the requester's end, so the tracker is
+		// eligible to be announced to again, e.g. once a paused session is
+		// resumed.
 
-		std::vector<std::shared_ptr<aux::http_tracker_connection>> close_http_connections;
+		std::vector<std::shared_ptr<aux::http_tracker_connection>> close_http_queued;
+		std::vector<std::shared_ptr<aux::http_tracker_connection>> close_http_started;
 		std::vector<std::shared_ptr<aux::udp_tracker_connection>> close_udp_connections;
 
-		for (auto const& c : m_queued)
+		// remove queued (not yet started) requests from the queue right
+		// away, rather than leaving that to the closing loop below.
+		// Otherwise, closing one of the started connections below would
+		// dequeue and start the next queued request, just to abort it
+		// again immediately after.
+		for (auto it = m_queued.begin(); it != m_queued.end();)
 		{
-			tracker_request const& req = c->tracker_req();
+			tracker_request const& req = (*it)->tracker_req();
 			if (req.event == event_t::stopped && !all)
+			{
+				++it;
 				continue;
-
-			close_http_connections.push_back(c);
+			}
 
 #ifndef TORRENT_DISABLE_LOGGING
-			std::shared_ptr<request_callback> rc = c->requester();
+			std::shared_ptr<request_callback> rc = (*it)->requester();
 			if (rc) rc->debug_log("aborting: %s", req.url.c_str());
 #endif
+			close_http_queued.push_back(*it);
+			it = m_queued.erase(it);
 		}
+		m_stats_counters.set_value(
+			counters::num_queued_tracker_announces, std::int64_t(m_queued.size()));
+
 		for (auto const& c : m_http_conns)
 		{
 			tracker_request const& req = c->tracker_req();
 			if (req.event == event_t::stopped && !all)
 				continue;
 
-			close_http_connections.push_back(c);
+			close_http_started.push_back(c);
 
 #ifndef TORRENT_DISABLE_LOGGING
 			std::shared_ptr<request_callback> rc = c->requester();
@@ -524,15 +551,44 @@ namespace libtorrent::aux {
 		}
 #endif
 
-		for (auto const& c : close_http_connections)
-			c->close();
-
-		for (auto const& c : close_udp_connections)
-			c->close();
+		// tearing everything down for good (the tracker_manager destructor)
+		// reports no outcome and closes synchronously: posting here would
+		// be unsafe, since the io_context is not guaranteed to run again
+		// before this object is destroyed. Otherwise, report each as a
+		// skipped announce (fail() posts, so this is safe to call while
+		// still iterating connection containers here) so the "updating"
+		// flag on the torrent's end is cleared and the tracker becomes
+		// eligible to be announced to again, e.g. once the session is
+		// resumed.
+		if (all)
+		{
+			for (auto const& c : close_http_queued)
+				c->close();
+			for (auto const& c : close_http_started)
+				c->close();
+			for (auto const& c : close_udp_connections)
+				c->close();
+		}
+		else
+		{
+			for (auto const& c : close_http_queued)
+				c->fail(errors::announce_skipped, operation_t::bittorrent);
+			for (auto const& c : close_http_started)
+				c->fail(errors::announce_skipped, operation_t::bittorrent);
+			for (auto const& c : close_udp_connections)
+				c->fail(errors::announce_skipped, operation_t::bittorrent);
+		}
 
 #if TORRENT_USE_RTC
 		for (auto const& c : close_websocket_connections)
-			c->close();
+		{
+			// websocket_tracker_connection::fail() takes its arguments in the
+			// opposite order (and hides tracker_connection::fail() by name).
+			if (all)
+				c->close();
+			else
+				c->fail(operation_t::bittorrent, errors::announce_skipped);
+		}
 #endif
 	}
 

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -119,9 +119,10 @@ namespace libtorrent::aux {
 
 		if (i != m_endpoints.end()) m_endpoints.erase(i);
 
-		// if that was the last one, or the listen socket was closed
-		// fail the whole announce
-		if (m_endpoints.empty() || !tracker_req().outgoing_socket)
+		// if we were explicitly told to give up (as opposed to this
+		// particular endpoint failing), if that was the last endpoint, or
+		// if the listen socket was closed, fail the whole announce
+		if (ec == errors::announce_skipped || m_endpoints.empty() || !tracker_req().outgoing_socket)
 		{
 			tracker_connection::fail(ec, op, msg, interval, min_interval);
 			return;

--- a/src/udp_tracker_connection.cpp
+++ b/src/udp_tracker_connection.cpp
@@ -578,6 +578,7 @@ namespace libtorrent::aux {
 
 		if (!cb)
 		{
+			m_req_pending = false;
 			close();
 			return true;
 		}
@@ -612,6 +613,11 @@ namespace libtorrent::aux {
 		std::transform(m_endpoints.begin(), m_endpoints.end(), std::back_inserter(ip_list)
 			, [](tcp::endpoint const& ep) { return ep.address(); } );
 
+		// about to report the response below; mark it as no longer pending
+		// first, so a fail() already posted (e.g. by
+		// tracker_manager::abort_all_requests() racing this response) finds
+		// nothing left to report when it runs.
+		m_req_pending = false;
 		cb->tracker_response(tracker_req(), m_target.address(), ip_list, resp);
 
 		close();
@@ -656,10 +662,13 @@ namespace libtorrent::aux {
 		std::shared_ptr<request_callback> cb = requester();
 		if (!cb)
 		{
+			m_req_pending = false;
 			close();
 			return true;
 		}
 
+		// see the equivalent comment in on_announce_response()
+		m_req_pending = false;
 		cb->tracker_scrape_response(tracker_req()
 			, complete, incomplete, downloaded, -1);
 


### PR DESCRIPTION
when aborting all trackers, previously the tracker manager would not post the tracker response handler back to the torrent object, but just cancel the announce and drop it from the queue.

This in turn would mean the torrent would still think the tracker was being announced to, which prevents to torrent from issuing another announce.

The fix is to always post the response handler, even when cancelling the announce.