### PR TITLE
fix external_ip_alert not being posted when UPnP/NAT-PMP succeeds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.0.14 not released
 
+	* fix external_ip_alert not being posted under some conditions when UPnP/NAT-PMP is enabled
 	* fix issue with stuck trackers on session pause
 	* fix windows disk read, possibly causing short-read errors
 	* fix blocking UDP socket in LSD and NAT-PMP

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -5740,7 +5740,10 @@ namespace {
 		{
 			// TODO: 1 report the proper address of the router as the source IP of
 			// this vote of our external address, instead of the empty address
-			listen_socket->external_address.cast_vote(external_ip, source_router, address());
+			auto sock = ls.m_sock.lock();
+			TORRENT_ASSERT(sock);
+			if (sock)
+				set_external_address(sock, external_ip, source_router, address());
 		}
 
 		// need to check whether this mapping is for one of session ports (it could also be a user mapping)


### PR DESCRIPTION
## Bug

`external_ip_alert` is not posted when UPnP/NAT-PMP successfully maps a
port and reports an external IP.

## Cause

`on_port_mapping` called `cast_vote` directly with `address()` as the
voter, bypassing `set_external_address`, which is where
`external_ip_alert` is posted.

## Fix

Call `set_external_address` instead, with the router/gateway address as
the vote source.

## Test

Tested with qBittorrent (uses libtorrent), with UPnP/NAT-PMP enabled.

Before:

```
UPnP/NAT-PMP port mapping succeeded. Message: "successfully mapped port using NAT-PMP. local: 10.0.0.128 external port: TCP/47191"
UPnP/NAT-PMP port mapping succeeded. Message: "successfully mapped port using NAT-PMP. local: 10.0.0.128 external port: UDP/47191"
Detected external IP. IP: "2001:ac8:a:2::18"
```

Port mapping succeeds, but no IPv4 external IP from NAT-PMP.

After:

```
UPnP/NAT-PMP port mapping succeeded. Message: "successfully mapped port using NAT-PMP. local: 10.0.0.128 external port: TCP/63027"
Detected external IP. IP: "146.70.113.106"
UPnP/NAT-PMP port mapping succeeded. Message: "successfully mapped port using NAT-PMP. local: 10.0.0.128 external port: UDP/63027"
Detected external IP. IP: "2001:ac8:a:2::18"
```

Both IPv4 and IPv6 external addresses are reported.

Closes issue #8041 