### PR TITLE
update udp_socket to avoid creating a `select_reactor` in boost.asio

### DIFF
--- a/include/libtorrent/aux_/allocating_handler.hpp
+++ b/include/libtorrent/aux_/allocating_handler.hpp
@@ -60,8 +60,8 @@ namespace libtorrent::aux {
 
 	constexpr std::size_t read_handler_max_size = tracking + debug_read_iter + openssl_read_cost + 102 + 9 * sizeof(void*);
 	constexpr std::size_t write_handler_max_size = tracking + debug_write_iter + openssl_write_cost + 102 + 9 * sizeof(void*);
-	constexpr std::size_t udp_handler_max_size = tracking + debug_tick + 144 + 9 * sizeof(void*);
-	constexpr std::size_t utp_handler_max_size = tracking + debug_tick + 168 + 9 * sizeof(void*);
+	constexpr std::size_t udp_handler_max_size = tracking + debug_tick + 144 + 17 * sizeof(void*);
+	constexpr std::size_t utp_handler_max_size = tracking + debug_tick + 168 + 17 * sizeof(void*);
 	constexpr std::size_t tick_handler_max_size = tracking + debug_tick + 168;
 	constexpr std::size_t abort_handler_max_size = tracking + debug_tick + 104;
 	constexpr std::size_t submit_handler_max_size = tracking + debug_tick + 104;

--- a/include/libtorrent/aux_/noexcept_movable.hpp
+++ b/include/libtorrent/aux_/noexcept_movable.hpp
@@ -53,8 +53,22 @@ namespace aux {
 		noexcept_movable(T const& rhs) : T(rhs) {} // NOLINT
 		noexcept_movable& operator=(noexcept_movable const& rhs) = default;
 		noexcept_movable& operator=(noexcept_movable&& rhs) = default;
+		// declared as plain member functions, not name-imported from T, so
+		// their bodies (and thus the accessibility of T::operator=) are only
+		// checked when actually called. T's copy-assignment may be a private,
+		// deleted member (e.g. boost.asio socket types) that is never
+		// actually invoked this way for such T.
+		noexcept_movable& operator=(T&& rhs) noexcept
+		{
+			T::operator=(std::forward<T>(rhs));
+			return *this;
+		}
+		noexcept_movable& operator=(T const& rhs)
+		{
+			T::operator=(rhs);
+			return *this;
+		}
 		using T::T;
-		using T::operator=;
 	};
 
 	template <typename T>

--- a/include/libtorrent/aux_/proxy_base.hpp
+++ b/include/libtorrent/aux_/proxy_base.hpp
@@ -111,17 +111,19 @@ struct proxy_base
 	}
 
 #if BOOST_VERSION >= 106600 && !defined TORRENT_BUILD_SIMULATOR
-	// Compatibility with the async_wait method introduced in boost 1.66
-
+	// Compatibility with the async_wait method introduced in boost 1.66.
+	// This only exists to satisfy the interface required by
+	// boost::asio::gnutls::stream when instantiated with proxy_base (e.g.
+	// socks5_stream) as its next_layer_type. It is not expected to actually
+	// be called, since proxy_base is not used as an event-driven reactor.
 	static constexpr auto wait_read = tcp::socket::wait_read;
 	static constexpr auto wait_write = tcp::socket::wait_write;
 	static constexpr auto wait_error = tcp::socket::wait_error;
 
 	template <class Handler>
-	void async_wait(tcp::socket::wait_type type, Handler handler)
+	void async_wait(tcp::socket::wait_type, Handler)
 	{
-		TORRENT_ASSERT(m_magic == 0x1337);
-		m_sock.async_wait(type, std::move(handler));
+		TORRENT_ASSERT_FAIL();
 	}
 #endif
 

--- a/include/libtorrent/aux_/proxy_base.hpp
+++ b/include/libtorrent/aux_/proxy_base.hpp
@@ -112,18 +112,18 @@ struct proxy_base
 
 #if BOOST_VERSION >= 106600 && !defined TORRENT_BUILD_SIMULATOR
 	// Compatibility with the async_wait method introduced in boost 1.66.
-	// This only exists to satisfy the interface required by
-	// boost::asio::gnutls::stream when instantiated with proxy_base (e.g.
-	// socks5_stream) as its next_layer_type. It is not expected to actually
-	// be called, since proxy_base is not used as an event-driven reactor.
+	// boost::asio::gnutls::stream calls this on its next_layer_type (e.g.
+	// proxy_base/socks5_stream, when a proxy is used underneath SSL) to wait
+	// for read/write readiness while driving the TLS state machine.
 	static constexpr auto wait_read = tcp::socket::wait_read;
 	static constexpr auto wait_write = tcp::socket::wait_write;
 	static constexpr auto wait_error = tcp::socket::wait_error;
 
 	template <class Handler>
-	void async_wait(tcp::socket::wait_type, Handler)
+	void async_wait(tcp::socket::wait_type type, Handler handler)
 	{
-		TORRENT_ASSERT_FAIL();
+		TORRENT_ASSERT(m_magic == 0x1337);
+		m_sock.async_wait(type, std::move(handler));
 	}
 #endif
 

--- a/include/libtorrent/aux_/udp_socket.hpp
+++ b/include/libtorrent/aux_/udp_socket.hpp
@@ -22,6 +22,15 @@ see LICENSE file.
 #include "libtorrent/aux_/listen_socket_handle.hpp"
 #include "libtorrent/aux_/resolver_interface.hpp"
 
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+#include "libtorrent/aux_/deadline_timer.hpp"
+#include "libtorrent/aux_/proxy_base.hpp" // for aux::wrap_allocator
+#include "libtorrent/time.hpp"
+#include "libtorrent/error.hpp"
+#include <winsock2.h> // for select(), FD_SET, TIMEVAL
+#include <type_traits> // for std::decay_t
+#endif
+
 #include <array>
 #include <memory>
 
@@ -52,13 +61,61 @@ namespace libtorrent::aux {
 		template <typename Handler>
 		void async_read(Handler&& h)
 		{
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+			// boost.asio's Windows IOCP backend implements socket::async_wait()
+			// (readiness notification without performing I/O) by falling back to
+			// a select_reactor, running an extra background thread. Avoid that by
+			// issuing a real overlapped receive and caching its result; read()
+			// consumes it instead of calling receive_from() for the first packet.
+			// aux::wrap_allocator (see proxy_base.hpp) forwards h's associated
+			// allocator and executor, so this doesn't have to be a plain lambda.
+			// m_recv_from is a persistent member, not a fresh local, and an
+			// errored completion does not populate it; reset it so a failed
+			// receive can't be attributed to whatever peer the previous,
+			// unrelated successful receive happened to be from.
+			m_recv_from = udp::endpoint();
+			ADD_OUTSTANDING_ASYNC("udp_socket::async_read");
+			m_socket.async_receive_from(boost::asio::buffer(*m_buf),
+				m_recv_from,
+				aux::wrap_allocator(
+					[this, alive = std::weak_ptr<void>(m_alive_token)](
+						error_code const& ec, std::size_t const bytes, std::decay_t<Handler> hn) {
+						COMPLETE_ASYNC("udp_socket::async_read");
+						bool const fatal =
+							ec == error::operation_aborted || ec == error::bad_descriptor;
+						// a cancelled receive's completion can still run after this
+						// udp_socket has been destroyed (e.g. its listen socket was
+						// removed while the receive was outstanding). In that case
+						// alive.lock() fails and member state must not be touched.
+						if (alive.lock())
+						{
+							m_recv_ec = ec;
+							m_recv_bytes = bytes;
+							m_recv_valid = true;
+						}
+						hn(fatal ? ec : error_code());
+					},
+					std::forward<Handler>(h)));
+#else
 			m_socket.async_wait(udp::socket::wait_read, std::forward<Handler>(h));
+#endif
 		}
 
 		template <typename Handler>
 		void async_write(Handler&& h)
 		{
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+			// there's no overlapped-I/O equivalent of "notify me when writable"
+			// that doesn't involve a select_reactor (see async_read() above).
+			// Approximate it with a retry timer, checked against a single,
+			// immediate, non-blocking select() call each time it fires (see
+			// poll_writable() / is_writable() below); unlike async_wait(), a
+			// one-shot select() call doesn't run through boost.asio's reactor
+			// and doesn't spin up a background thread.
+			poll_writable(std::forward<Handler>(h));
+#else
 			m_socket.async_wait(udp::socket::wait_write, std::forward<Handler>(h));
+#endif
 		}
 
 		struct packet
@@ -135,6 +192,55 @@ namespace libtorrent::aux {
 			udp_send_flags_t flags
 		);
 
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+		// see async_write(). Reschedules itself on m_write_retry_timer until
+		// is_writable() reports the socket is actually writable, select()
+		// itself fails, or the wait is cancelled, instead of unconditionally
+		// waking the caller every time the timer fires. alive guards against
+		// this udp_socket being destroyed while a retry is outstanding, the
+		// same hazard async_read()'s completion handler guards against above.
+		template <typename Handler>
+		void poll_writable(Handler&& h)
+		{
+			m_write_retry_timer.expires_after(milliseconds(100));
+			ADD_OUTSTANDING_ASYNC("udp_socket::poll_writable");
+			m_write_retry_timer.async_wait(
+				[this, alive = std::weak_ptr<void>(m_alive_token), h = std::forward<Handler>(h)](
+					error_code const& ec) mutable {
+					COMPLETE_ASYNC("udp_socket::poll_writable");
+					if (ec || !alive.lock())
+					{
+						h(ec);
+						return;
+					}
+					error_code select_ec;
+					bool const writable = is_writable(select_ec);
+					if (writable || select_ec)
+					{
+						h(select_ec);
+						return;
+					}
+					poll_writable(std::move(h));
+				});
+		}
+
+		// single, immediate, non-blocking query of this socket's writability.
+		// Deliberately calls select() directly rather than going through
+		// boost.asio, since asio's Windows async_wait() is what this whole
+		// mechanism exists to avoid. Not const: native_handle() isn't. On
+		// failure to query, sets ec and returns false.
+		bool is_writable(error_code& ec)
+		{
+			fd_set write_fds;
+			FD_ZERO(&write_fds);
+			FD_SET(m_socket.native_handle(), &write_fds);
+			TIMEVAL tv{0, 0};
+			int const ret = ::select(0, nullptr, &write_fds, nullptr, &tv);
+			if (ret == SOCKET_ERROR) ec = error_code(WSAGetLastError(), system_category());
+			return ret > 0;
+		}
+#endif
+
 		udp::socket m_socket;
 
 		io_context& m_ioc;
@@ -150,6 +256,26 @@ namespace libtorrent::aux {
 		std::shared_ptr<socks5> m_socks5_connection;
 
 		bool m_abort:1;
+
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+		// result of the last completed async_receive_from(), consumed by
+		// read() in place of a synchronous receive_from() for the first
+		// packet of a batch. See async_read().
+		udp::endpoint m_recv_from;
+		std::size_t m_recv_bytes = 0;
+		error_code m_recv_ec;
+		bool m_recv_valid = false;
+
+		// used by async_write() to poll for the socket becoming writable
+		// again, instead of waiting on a select_reactor. See async_write().
+		aux::deadline_timer m_write_retry_timer;
+
+		// weak_ptr'd from async_read()'s and async_write()'s completion
+		// handlers, to detect whether this udp_socket has already been
+		// destroyed by the time a cancelled operation's completion runs.
+		// See async_read() and poll_writable().
+		std::shared_ptr<void> m_alive_token = std::make_shared<char>(0);
+#endif
 	};
 
 	// unwrap a SOCKS5-wrapped UDP datagram in-place. Returns false if the packet

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -170,6 +170,9 @@ udp_socket::udp_socket(io_context& ios, aux::listen_socket_handle ls)
 	, m_listen_socket(std::move(ls))
 	, m_bind_port(0)
 	, m_abort(true)
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+	, m_write_retry_timer(ios)
+#endif
 {}
 
 int udp_socket::read(span<packet> pkts, error_code& ec)
@@ -180,8 +183,25 @@ int udp_socket::read(span<packet> pkts, error_code& ec)
 
 	while (ret < num)
 	{
-		int const len = int(m_socket.receive_from(boost::asio::buffer(*m_buf)
-			, p.from, 0, ec));
+		int len;
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+		if (m_recv_valid)
+		{
+			// use the result of the async_receive_from() issued by async_read()
+			// instead of a synchronous receive_from(), to avoid boost.asio
+			// instantiating a select_reactor on this platform. Subsequent
+			// iterations of this loop (draining the rest of a batch) fall
+			// through to the synchronous receive_from() below, same as POSIX.
+			m_recv_valid = false;
+			len = int(m_recv_bytes);
+			p.from = m_recv_from;
+			ec = m_recv_ec;
+		}
+		else
+#endif
+		{
+			len = int(m_socket.receive_from(boost::asio::buffer(*m_buf), p.from, 0, ec));
+		}
 
 		if (ec == error::would_block
 			|| ec == error::try_again
@@ -443,6 +463,9 @@ void udp_socket::close()
 	error_code ec;
 	m_socket.close(ec);
 	TORRENT_ASSERT_VAL(!ec || ec == error::bad_descriptor, ec);
+#if defined TORRENT_WINDOWS && !defined TORRENT_BUILD_SIMULATOR
+	m_write_retry_timer.cancel();
+#endif
 	if (m_socks5_connection)
 	{
 		m_socks5_connection->close();


### PR DESCRIPTION
by using `async_receive_from()` instead of `async_wait()`.

This is an attempt to fix https://github.com/chriskohlhoff/asio/issues/1061 and https://github.com/qbittorrent/qBittorrent/issues/17082