### PR TITLE
fix out of bounds read in from_hex on odd number of digits

### DIFF
--- a/src/hex.cpp
+++ b/src/hex.cpp
@@ -64,6 +64,7 @@ namespace libtorrent {
 			if (t1 == -1) return false;
 			*out = char(t1 << 4);
 			++i;
+			if (i == end) return false;
 			int const t2 = aux::hex_to_int(*i);
 			if (t2 == -1) return false;
 			*out |= t2 & 15;

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -69,6 +69,13 @@ TORRENT_TEST(hex)
 	TEST_CHECK(aux::to_hex({"\x55\x73",2}) == "5573");
 	TEST_CHECK(aux::to_hex({"\xaB\xd0",2}) == "abd0");
 
+	// an odd number of digits leaves the last one unpaired. The buffer is
+	// sized exactly, so there is no terminator to stop the loop early
+	char odd[39];
+	std::memset(odd, '0', sizeof(odd));
+	char odd_bin[(sizeof(odd) + 1) / 2];
+	TEST_CHECK(!aux::from_hex(odd, odd_bin));
+
 	static char const hex_chars[] = "0123456789abcdefABCDEF";
 
 	for (int i = 1; i < 255; ++i)


### PR DESCRIPTION
from_hex steps to the second nibble with ++i but never re-checks it against end, so an odd number of digits reads the byte just past the input, and when that byte happens to be a hex digit the loop does not stop there either: ++i moves i to end+1, the i != end condition stays true, and it keeps reading while ++out walks the caller's buffer past the (len + 1) / 2 bytes hex.hpp promises. The in-tree callers all happen to pass 40 or 64 digits, so this is about the exported helper and its documented contract rather than a live wire path, but (len + 1) / 2 is the odd-length formula, and both unescape_string and the copy of from_hex in tools/dht_put.cpp already carry the same guard. Added that end check so an unpaired digit is rejected as invalid hex, along with a regression case whose buffer is sized exactly, which trips ASAN in test_string without the fix.