### PR TITLE
Websocket tracker fixes

### DIFF
--- a/include/libtorrent/aux_/websocket_stream.hpp
+++ b/include/libtorrent/aux_/websocket_stream.hpp
@@ -70,7 +70,13 @@ namespace libtorrent::aux {
 
 namespace websocket = boost::beast::websocket;
 
+#if defined TORRENT_BUILD_SIMULATOR
+namespace asio = sim::asio;
+using tcp = sim::asio::ip::tcp;
+#else
+namespace asio = boost::asio;
 using tcp = boost::asio::ip::tcp;
+#endif
 
 struct TORRENT_EXTRA_EXPORT websocket_stream
 	: std::enable_shared_from_this<websocket_stream>

--- a/include/libtorrent/aux_/websocket_tracker_connection.hpp
+++ b/include/libtorrent/aux_/websocket_tracker_connection.hpp
@@ -28,9 +28,9 @@ see LICENSE file.
 
 #include <boost/beast/core/flat_buffer.hpp>
 
+#include <deque>
 #include <map>
 #include <memory>
-#include <queue>
 #include <tuple>
 #include <variant>
 #include <optional>
@@ -61,6 +61,11 @@ struct TORRENT_EXTRA_EXPORT websocket_tracker_connection : tracker_connection
 	bool is_started() const;
 	bool is_open() const;
 
+	// aborts every non-stopped-event request on this connection (it may
+	// multiplex several torrents' requests). Returns true if a
+	// stopped-event request remains, meaning the connection must stay open.
+	bool prune_non_stopped_requests();
+
 	void queue_request(tracker_request req, std::weak_ptr<request_callback> cb);
 	void queue_answer(tracker_answer ans);
 
@@ -81,6 +86,11 @@ private:
 	void on_write(error_code const& ec, std::size_t bytes_written);
 	// wraps tracker_connection::fail
 	void fail(error_code const& ec, operation_t op);
+	// does the actual work of close(); takes the real failure reason so
+	// callers that just called fail(ec, op) can report it to every
+	// multiplexed torrent, instead of the generic reason close() uses on
+	// its own (e.g. session shutdown, where there is no specific error)
+	void close(error_code const& ec, operation_t op);
 
 	io_context& m_io_context;
 	ssl::context* m_ssl_context;
@@ -89,8 +99,28 @@ private:
 	std::string m_write_data;
 
 	using tracker_message = std::variant<tracker_request, tracker_answer>;
-	std::queue<std::tuple<tracker_message, std::weak_ptr<request_callback>>> m_pending;
-	std::map<sha1_hash, std::weak_ptr<request_callback>> m_callbacks;
+	std::deque<std::tuple<tracker_message, std::weak_ptr<request_callback>>> m_pending;
+
+	// pending is true from the point a request is sent until its first
+	// tracker_response is delivered. close() reports an error for any
+	// entry still pending, so a torrent multiplexed onto this connection
+	// (i.e. not the most recently sent request) still gets notified when
+	// the connection is torn down before it received a response. req is
+	// the entry's own request, since it may not be the most recently sent
+	// request on this connection (tracker_req()).
+	struct callback_entry
+	{
+		std::weak_ptr<request_callback> cb;
+		tracker_request req;
+		bool pending = true;
+	};
+	// on_read() holds an iterator into m_callbacks across a reentrant call
+	// into cb->on_rtc_offer()/on_rtc_answer(), which may indirectly insert
+	// into this same map (e.g. by queuing another request on this
+	// connection); this relies on stable iterators. Do not change this to
+	// an unordered_map without also fixing on_read() to not hold an
+	// iterator across that call.
+	std::map<sha1_hash, callback_entry> m_callbacks;
 
 	bool m_sending = false;
 };

--- a/simulation/Jamfile
+++ b/simulation/Jamfile
@@ -19,6 +19,7 @@ project
 	<source>disk_io.cpp
 	<source>transfer_sim.cpp
 	<source>http_server.cpp
+	<source>ws_tracker_server.cpp
 	<toolset>msvc:<cxxflags>/wd4275
 	<toolset>msvc:<cxxflags>/wd4005
 	<toolset>msvc:<cxxflags>/wd4268
@@ -41,6 +42,7 @@ run test_transfer_full_invalid_files.cpp ;
 run test_transfer_partial_valid_files.cpp ;
 run test_http_connection.cpp ;
 run test_https.cpp ;
+run test_websocket_tracker.cpp ;
 run test_web_seed.cpp ;
 run test_auto_manage.cpp ;
 run test_torrent_status.cpp ;

--- a/simulation/test_websocket_tracker.cpp
+++ b/simulation/test_websocket_tracker.cpp
@@ -1,0 +1,291 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#include "libtorrent/config.hpp"
+#include "test.hpp"
+
+#if TORRENT_USE_RTC
+
+#include "simulator/simulator.hpp"
+#include "ws_tracker_server.hpp"
+#include "libtorrent/aux_/tracker_manager.hpp"
+#include "libtorrent/aux_/session_interface.hpp"
+#include "libtorrent/performance_counters.hpp"
+#include "libtorrent/aux_/resolver.hpp"
+#include "libtorrent/aux_/deadline_timer.hpp"
+
+using namespace lt;
+using namespace lt::aux;
+using namespace sim;
+using namespace std::placeholders;
+using namespace std::chrono_literals;
+
+namespace {
+
+	struct tracker_manager_handler : lt::aux::session_logger
+	{
+		tracker_manager_handler(lt::io_context& ios, lt::aux::session_settings& sett)
+			: m_host_resolver(ios)
+			, m_tracker_manager(
+				  std::bind(&tracker_manager_handler::send_fn, this, _1, _2, _3, _4, _5),
+				  std::bind(
+					  &tracker_manager_handler::send_fn_hostname, this, _1, _2, _3, _4, _5, _6),
+				  m_stats_counters,
+				  m_host_resolver,
+				  sett
+#if !defined TORRENT_DISABLE_LOGGING || TORRENT_USE_ASSERTS
+				  ,
+				  *this
+#endif
+			  )
+		{}
+
+		virtual ~tracker_manager_handler() {}
+
+		void send_fn(lt::aux::listen_socket_handle const&,
+			udp::endpoint const&,
+			span<char const>,
+			error_code&,
+			lt::aux::udp_send_flags_t const)
+		{}
+
+		void send_fn_hostname(lt::aux::listen_socket_handle const&,
+			char const*,
+			int,
+			span<char const>,
+			error_code&,
+			lt::aux::udp_send_flags_t const)
+		{}
+
+#ifndef TORRENT_DISABLE_LOGGING
+		bool should_log() const override { return false; }
+		void session_log(char const*, ...) const override TORRENT_FORMAT(2, 3) {}
+#endif
+
+#if TORRENT_USE_ASSERTS
+		bool is_single_thread() const override { return false; }
+		bool has_peer(lt::aux::peer_connection const*) const override { return false; }
+		bool any_torrent_has_peer(lt::aux::peer_connection const*) const override { return false; }
+		bool is_posting_torrent_updates() const override { return false; }
+#endif
+
+		counters m_stats_counters;
+		lt::aux::resolver m_host_resolver;
+		tracker_manager m_tracker_manager;
+	};
+
+	struct ws_request_callback : request_callback
+	{
+		ws_request_callback() {}
+		virtual ~ws_request_callback() override {}
+		void tracker_warning(tracker_request const&, std::string const&) override {}
+		void tracker_scrape_response(tracker_request const&, int, int, int, int) override {}
+		void tracker_response(tracker_request const&,
+			address const&,
+			std::list<address> const&,
+			struct tracker_response const&) override
+		{}
+		void tracker_request_error(tracker_request const&,
+			error_code const&,
+			operation_t,
+			const std::string&,
+			seconds32) override
+		{}
+		void generate_rtc_offers(
+			int, std::function<void(error_code const&, std::vector<lt::aux::rtc_offer>)> handler)
+			override
+		{
+			handler(error_code(), {});
+		}
+		void on_rtc_offer(lt::aux::rtc_offer const&) override {}
+		void on_rtc_answer(lt::aux::rtc_answer const&) override {}
+#ifndef TORRENT_DISABLE_LOGGING
+		bool should_log() const override { return false; }
+		void debug_log(const char*, ...) const noexcept override TORRENT_FORMAT(2, 3) {}
+#endif
+	};
+
+	struct recording_callback : ws_request_callback
+	{
+		std::vector<tracker_request> responses;
+		std::vector<tracker_request> errors;
+		std::vector<error_code> error_codes;
+		std::vector<operation_t> error_ops;
+
+		void tracker_response(tracker_request const& r,
+			address const&,
+			std::list<address> const&,
+			struct tracker_response const&) override
+		{
+			responses.push_back(r);
+		}
+		void tracker_request_error(tracker_request const& r,
+			error_code const& ec,
+			operation_t op,
+			std::string const&,
+			seconds32) override
+		{
+			errors.push_back(r);
+			error_codes.push_back(ec);
+			error_ops.push_back(op);
+		}
+	};
+
+} // anonymous namespace
+
+// websocket_tracker_connection multiplexes several torrents' announces onto
+// one connection when they share a tracker URL. Reporting a torrent's
+// outcome requires that torrent's own tracker_request: torrent::
+// tracker_response() and torrent::tracker_request_error() key their
+// bookkeeping off its info_hash/event, not the connection's single "most
+// recently sent" request (tracker_req()), which generally belongs to a
+// different torrent by the time an earlier one's outcome is reported. This
+// drives 3 torrents' announces over one shared connection and checks each
+// callback receives its own info_hash, both on the success path (on_read())
+// and the close()-triggered error path.
+TORRENT_TEST(websocket_multiplexed_requests_get_correct_tracker_request)
+{
+	sim::default_config network_cfg;
+	sim::simulation sim{network_cfg};
+	sim::asio::io_context server_ios(sim, make_address_v4("10.0.0.2"));
+	sim::asio::io_context client_ios(sim, make_address_v4("10.0.0.1"));
+
+	int const port = 8080;
+	sim_ws_tracker tracker(server_ios, port);
+
+	lt::aux::session_settings sett;
+	tracker_manager_handler h{client_ios, sett};
+
+	std::string const url = "ws://10.0.0.2:" + std::to_string(port) + "/announce";
+
+	sha1_hash const hash_a("aaaaaaaaaaaaaaaaaaaa");
+	sha1_hash const hash_b("bbbbbbbbbbbbbbbbbbbb");
+	sha1_hash const hash_c("cccccccccccccccccccc");
+
+	auto cb_a = std::make_shared<recording_callback>();
+	auto cb_b = std::make_shared<recording_callback>();
+	auto cb_c = std::make_shared<recording_callback>();
+
+	auto queue = [&](sha1_hash const& ih, std::shared_ptr<recording_callback> const& cb) {
+		tracker_request r;
+		r.url = url;
+		r.info_hash = ih;
+		r.event = event_t::started;
+		r.num_want = 1;
+		h.m_tracker_manager.queue_request(client_ios, std::move(r), sett, cb);
+	};
+
+	// queued (and sent, in this order) as a, b, c, all onto the same
+	// connection: by the time all 3 are on the wire, the connection's
+	// "current" request (tracker_req()) is c's.
+	queue(hash_a, cb_a);
+	queue(hash_b, cb_b);
+	queue(hash_c, cb_c);
+
+	// safety net against an unexpected retry/reconnect keeping the simulation
+	// from ever converging (mirrors the "generous deadline" the real-socket
+	// version relied on); under normal operation this never fires because
+	// all 3 requests resolve (success or error) once sim_ws_tracker tears the
+	// connection down.
+	lt::aux::deadline_timer safety_timer(client_ios);
+	safety_timer.expires_after(10s);
+	safety_timer.async_wait([&](error_code const& ec) {
+		if (ec)
+			return;
+		h.m_tracker_manager.abort_all_requests(true);
+	});
+
+	sim.run();
+
+	// a's outcome arrives while the connection's "current" request
+	// (tracker_req()) is c's, so this only passes if a's callback_entry
+	// reports its own stored request.
+	TEST_EQUAL(cb_a->responses.size(), 1);
+	TEST_CHECK(cb_a->errors.empty());
+
+	// b and c's outcomes were reported via close()'s m_callbacks sweep
+	// after the connection was torn down without ever answering them.
+	TEST_EQUAL(cb_b->errors.size(), 1);
+	TEST_EQUAL(cb_c->errors.size(), 1);
+
+	// each callback must see its own info_hash, not whichever request
+	// happened to be "current" on the shared connection when its outcome
+	// was reported.
+	if (!cb_a->responses.empty())
+		TEST_CHECK(cb_a->responses[0].info_hash == hash_a);
+	if (!cb_b->errors.empty())
+		TEST_CHECK(cb_b->errors[0].info_hash == hash_b);
+	if (!cb_c->errors.empty())
+		TEST_CHECK(cb_c->errors[0].info_hash == hash_c);
+}
+
+// abort_all_requests(false) (a partial abort, e.g. session::pause(), as
+// opposed to full shutdown/the tracker_manager destructor) fails a
+// websocket connection with no stopped-event request in flight via fail()
+// immediately followed by close(ec, op) -- see the comment at that call
+// site in tracker_manager.cpp. fail() alone does not report anything or
+// tear the connection down; skipping the close(ec, op) call would leave
+// the connection registered in m_websocket_conns (and its socket open)
+// until tracker_connection::fail_impl() eventually runs its deferred,
+// argument-less close(), instead of synchronously as part of
+// abort_all_requests() returning. This checks the connection is
+// unregistered synchronously, before the io_context ever runs.
+TORRENT_TEST(websocket_partial_abort_closes_connection_synchronously)
+{
+	sim::default_config network_cfg;
+	sim::simulation sim{network_cfg};
+	sim::asio::io_context client_ios(sim, make_address_v4("10.0.0.1"));
+
+	lt::aux::session_settings sett;
+	tracker_manager_handler h{client_ios, sett};
+
+	std::string const url = "ws://10.0.0.2:8080/announce";
+	auto cb = std::make_shared<recording_callback>();
+
+	tracker_request r;
+	r.url = url;
+	r.info_hash = sha1_hash("aaaaaaaaaaaaaaaaaaaa");
+	r.event = event_t::started;
+	r.num_want = 1;
+	h.m_tracker_manager.queue_request(client_ios, std::move(r), sett, cb);
+
+	// the connection was created and registered synchronously; nothing has
+	// actually run on the (simulated) network yet.
+	TEST_CHECK(!h.m_tracker_manager.empty());
+
+	// no stopped-event request is in flight on this connection, so it must
+	// be failed and fully torn down.
+	h.m_tracker_manager.abort_all_requests(false);
+
+	// prune_non_stopped_requests() reports the specific reason for the
+	// still-outstanding request on its way in, before fail()/close() are
+	// even reached.
+	TEST_EQUAL(cb->errors.size(), 1);
+	if (!cb->errors.empty())
+	{
+		TEST_CHECK(cb->error_codes[0] == errors::announce_skipped);
+		TEST_CHECK(cb->error_ops[0] == operation_t::bittorrent);
+	}
+
+	// the connection itself must be unregistered synchronously, as part of
+	// abort_all_requests() returning -- not deferred until a later
+	// io_context turn.
+	TEST_CHECK(h.m_tracker_manager.empty());
+
+	// let the already-cancelled connect attempt's completion handler run,
+	// so nothing is left outstanding at teardown.
+	sim.run();
+}
+
+#else
+
+TORRENT_TEST(websocket_multiplexed_requests_get_correct_tracker_request) {}
+TORRENT_TEST(websocket_partial_abort_closes_connection_synchronously) {}
+
+#endif // TORRENT_USE_RTC

--- a/simulation/ws_tracker_server.cpp
+++ b/simulation/ws_tracker_server.cpp
@@ -1,0 +1,75 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#include "ws_tracker_server.hpp"
+
+#if TORRENT_USE_RTC
+
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/json.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+
+sim_ws_tracker::sim_ws_tracker(sim::asio::io_context& ios, int port)
+	: m_acceptor(ios)
+	, m_ws(ios)
+{
+	boost::system::error_code ec;
+	m_acceptor.open(sim_tcp::v4(), ec);
+	m_acceptor.bind(sim_tcp::endpoint(sim::asio::ip::address_v4::any(), std::uint16_t(port)), ec);
+	m_acceptor.listen(1, ec);
+
+	m_acceptor.async_accept(m_ws.next_layer(), [this](boost::system::error_code const& accept_ec) {
+		if (accept_ec)
+			return;
+		m_ws.async_accept([this](boost::system::error_code const& handshake_ec) {
+			if (handshake_ec)
+				return;
+			read_next();
+		});
+	});
+}
+
+std::string sim_ws_tracker::extract_info_hash(std::string const& msg)
+{
+	boost::system::error_code ec;
+	auto const val = boost::json::parse(msg, ec);
+	if (ec || !val.is_object())
+		return {};
+	auto const& obj = val.as_object();
+	auto const it = obj.find("info_hash");
+	if (it == obj.end() || !it->value().is_string())
+		return {};
+	return std::string(it->value().as_string());
+}
+
+void sim_ws_tracker::read_next()
+{
+	m_buffer.consume(m_buffer.size());
+	m_ws.async_read(m_buffer, [this](boost::system::error_code const& ec, std::size_t) {
+		if (ec)
+			return;
+
+		m_received.push_back(extract_info_hash(boost::beast::buffers_to_string(m_buffer.data())));
+		if (m_received.size() < 3)
+		{
+			read_next();
+			return;
+		}
+
+		m_response =
+			"{\"info_hash\":\"" + m_received.front() + "\",\"interval\":120,\"min_interval\":60}";
+		m_ws.async_write(
+			boost::asio::buffer(m_response), [this](boost::system::error_code const&, std::size_t) {
+				boost::system::error_code ignore;
+				m_ws.next_layer().close(ignore);
+			});
+	});
+}
+
+#endif // TORRENT_USE_RTC

--- a/simulation/ws_tracker_server.hpp
+++ b/simulation/ws_tracker_server.hpp
@@ -1,0 +1,64 @@
+/*
+
+Copyright (c) 2026, Arvid Norberg
+All rights reserved.
+
+You may use, distribute and modify this code under the terms of the BSD license,
+see LICENSE file.
+*/
+
+#ifndef TORRENT_SIMULATION_WS_TRACKER_SERVER_HPP_INCLUDED
+#define TORRENT_SIMULATION_WS_TRACKER_SERVER_HPP_INCLUDED
+
+#include "libtorrent/config.hpp"
+
+#if TORRENT_USE_RTC
+
+#include "simulator/simulator.hpp"
+// pulls in the beast teardown()/async_teardown()/beast_close_socket()
+// customization point overloads for sim::asio::ip::tcp::socket (needed by
+// websocket::stream<sim_tcp::socket> below; without them beast's generic
+// teardown template static_asserts on an "unknown socket type").
+#include "libtorrent/aux_/websocket_stream.hpp"
+
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+
+#include <string>
+#include <vector>
+
+// a minimal, single-connection WebSocket "tracker" used to drive
+// websocket_tracker_connection through a multiplexing scenario that can't
+// otherwise be triggered deterministically: several torrents' announces in
+// flight on one shared connection at once. Only handles the exact protocol
+// shape websocket_tracker_connection::do_send() produces; it is not a
+// general-purpose WebSocket server. Driven entirely by the simulator's
+// deterministic event loop rather than a background thread.
+struct sim_ws_tracker
+{
+	using sim_tcp = sim::asio::ip::tcp;
+
+	sim_ws_tracker(sim::asio::io_context& ios, int port);
+
+private:
+	static std::string extract_info_hash(std::string const& msg);
+
+	// reads up to 3 announces, answering only the first one received, then
+	// tears the connection down without ever answering the other two --
+	// this exercises both the on_read() success path (for the one we
+	// answer, once a later request has become the connection's "current"
+	// one) and the close() error path (for the two left hanging).
+	void read_next();
+
+	sim_tcp::acceptor m_acceptor;
+	boost::beast::websocket::stream<sim_tcp::socket> m_ws;
+	boost::beast::flat_buffer m_buffer;
+	std::vector<std::string> m_received;
+	std::string m_response;
+};
+
+#endif // TORRENT_USE_RTC
+
+#endif // TORRENT_SIMULATION_WS_TRACKER_SERVER_HPP_INCLUDED

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -12,6 +12,7 @@ see LICENSE file.
 
 #include <algorithm>
 #include <cctype>
+#include <iterator>
 
 #include "libtorrent/aux_/io.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
@@ -352,7 +353,9 @@ namespace libtorrent::aux {
 	{
 		TORRENT_ASSERT(is_single_thread());
 		tracker_request const& req = c->tracker_req();
-		m_websocket_conns.erase(req.url);
+		auto const it = m_websocket_conns.find(req.url);
+		if (it != m_websocket_conns.end() && it->second.get() == c)
+			m_websocket_conns.erase(it);
 	}
 #endif
 
@@ -469,6 +472,26 @@ namespace libtorrent::aux {
 					, std::vector<aux::rtc_offer> offers) mutable
 			{
 				if (!ec) request.offers = std::move(offers);
+
+				// m_abort may have been set (session shutdown) while this
+				// offer generation was in flight; the guard at the top of
+				// queue_request() only protects requests queued before
+				// m_abort was set, so re-check here before (re-)establishing
+				// a persistent connection, for the same reason the
+				// num_want==0 branch above avoids doing so during shutdown.
+				if (m_abort && request.event != event_t::stopped)
+				{
+					if (auto rc = c.lock())
+						post(ios,
+							std::bind(&request_callback::tracker_request_error,
+								rc,
+								std::move(request),
+								errors::torrent_aborted,
+								operation_t::connect,
+								"",
+								seconds32(0)));
+					return;
+				}
 
 				auto it = m_websocket_conns.find(request.url);
 				if (it != m_websocket_conns.end() && it->second->is_started()) {
@@ -651,20 +674,6 @@ namespace libtorrent::aux {
 #endif
 		}
 
-#if TORRENT_USE_RTC
-		std::vector<std::shared_ptr<aux::websocket_tracker_connection>> close_websocket_connections;
-		for (auto const& p : m_websocket_conns)
-		{
-			auto const& c = p.second;
-			close_websocket_connections.push_back(c);
-
-#ifndef TORRENT_DISABLE_LOGGING
-			std::shared_ptr<request_callback> rc = c->requester();
-			if (rc) rc->debug_log("aborting: %s", c->tracker_req().url.c_str());
-#endif
-		}
-#endif
-
 		// followers were already pruned above; close() re-dispatches any kept
 		// stop-requests onto a fresh connection.
 		//
@@ -695,12 +704,47 @@ namespace libtorrent::aux {
 		}
 
 #if TORRENT_USE_RTC
-		for (auto const& c : close_websocket_connections)
+		// close() erases its own entry from this map synchronously (via
+		// remove_request()), so capture the next iterator before calling
+		// it. Deliberately not collected into a vector first (unlike
+		// close_http_started/close_udp_connections above): this function
+		// runs from ~tracker_manager() too, whose implicit noexcept means
+		// a bad_alloc from that allocation would call std::terminate().
+		for (auto it = m_websocket_conns.begin(); it != m_websocket_conns.end();)
 		{
+			auto const& c = it->second;
+			auto const next = std::next(it);
+
 			if (all)
+			{
 				c->close();
-			else
-				c->fail(errors::announce_skipped, operation_t::bittorrent);
+				it = next;
+				continue;
+			}
+
+			// leaves the connection running if it still has a
+			// stopped-event request queued or in flight on it.
+			if (c->prune_non_stopped_requests())
+			{
+				it = next;
+				continue;
+			}
+
+#ifndef TORRENT_DISABLE_LOGGING
+			std::shared_ptr<request_callback> rc = c->requester();
+			if (rc)
+				rc->debug_log("aborting: %s", c->tracker_req().url.c_str());
+#endif
+			// fail() alone does not report anything: it suppresses
+			// fail_impl()'s single-request report (see its definition) so
+			// that close(ec, op), below, is the only thing that reports an
+			// outcome, with the right reason, to every multiplexed
+			// request. Skipping the close(ec, op) call here would silently
+			// fall back to fail_impl()'s deferred, argument-less close(),
+			// reporting operation_aborted/unknown instead.
+			c->fail(errors::announce_skipped, operation_t::bittorrent);
+			c->close(errors::announce_skipped, operation_t::bittorrent);
+			it = next;
 		}
 #endif
 	}

--- a/src/websocket_stream.cpp
+++ b/src/websocket_stream.cpp
@@ -159,18 +159,16 @@ void websocket_stream::do_tcp_connect(std::vector<tcp::endpoint> endpoints)
 {
 	m_endpoints = std::move(endpoints);
 
-	auto* tcp_stream = std::visit(rtc::overloaded
-		{
-			[&](stream_type &stream) { return &stream.next_layer(); }
-			, [&](ssl_stream_type &stream) { return &stream.next_layer().next_layer(); }
-		}
-		, m_stream);
+	auto* tcp_stream =
+		std::visit(rtc::overloaded{[&](stream_type& stream) { return &stream.next_layer(); },
+					   [&](ssl_stream_type& stream) { return &stream.next_layer().next_layer(); }},
+			m_stream);
 
 	ADD_OUTSTANDING_ASYNC("websocket_stream::on_tcp_connect");
-	boost::asio::async_connect(*tcp_stream
-		, m_endpoints.rbegin()
-		, m_endpoints.rend()
-		, std::bind(&websocket_stream::on_tcp_connect, shared_from_this(), _1));
+	asio::async_connect(*tcp_stream,
+		m_endpoints.rbegin(),
+		m_endpoints.rend(),
+		std::bind(&websocket_stream::on_tcp_connect, shared_from_this(), _1));
 }
 
 void websocket_stream::on_tcp_connect(error_code const& ec)

--- a/src/websocket_tracker_connection.cpp
+++ b/src/websocket_tracker_connection.cpp
@@ -42,6 +42,7 @@ see LICENSE file.
 #include <locale>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace libtorrent::aux {
@@ -59,6 +60,14 @@ std::string utf8_latin1(json::string const& sv)
 	return aux::utf8_latin1(std::string_view{sv.data(), sv.size()});
 }
 
+void report_error(std::weak_ptr<request_callback> const& cb,
+	tracker_request const& req,
+	error_code const& ec,
+	operation_t const op)
+{
+	if (auto c = cb.lock())
+		c->tracker_request_error(req, ec, op, ec.message(), seconds32(120));
+}
 }
 
 websocket_tracker_connection::websocket_tracker_connection(
@@ -102,25 +111,46 @@ void websocket_tracker_connection::start()
 
 void websocket_tracker_connection::close()
 {
+	// no specific failure triggered this (e.g. session shutdown)
+	close(error::operation_aborted, operation_t::unknown);
+}
+
+void websocket_tracker_connection::close(error_code const& ec, operation_t const op)
+{
 	if (m_websocket)
 	{
 		m_websocket->close();
 		m_websocket.reset();
 	}
 
-	error_code const ec = error::operation_aborted;
 	while (!m_pending.empty())
 	{
 		auto [msg, callback] = std::move(m_pending.front());
-		TORRENT_UNUSED(msg);
-		m_pending.pop();
-		if (auto cb = callback.lock())
-			cb->tracker_request_error(
-					tracker_req()
-					, ec
-					, operation_t::unknown
-					, ec.message()
-					, seconds32(120));
+		m_pending.pop_front();
+		if (callback.lock())
+		{
+			// only tracker_request messages ever carry a non-empty
+			// callback (queue_answer() always passes an empty one). These
+			// were never sent, so they were aborted rather than failed,
+			// regardless of what ec/op close() was called with.
+			auto const* req = std::get_if<tracker_request>(&msg);
+			TORRENT_ASSERT(req);
+			report_error(callback, *req, error::operation_aborted, operation_t::unknown);
+		}
+	}
+
+	// any request still marked pending here never got a response. This is
+	// the only place that reports it, whether it's the connection's
+	// current request or another torrent multiplexed onto this same
+	// connection. Unlike m_pending above, these were actually sent, so
+	// they genuinely experienced ec/op (the reason this connection is
+	// closing) rather than merely being aborted.
+	for (auto& e : m_callbacks)
+	{
+		if (!e.second.pending)
+			continue;
+		e.second.pending = false;
+		report_error(e.second.cb, e.second.req, ec, op);
 	}
 
 	m_callbacks.clear();
@@ -137,15 +167,59 @@ bool websocket_tracker_connection::is_open() const
 	return m_websocket && m_websocket->is_open();
 }
 
+bool websocket_tracker_connection::prune_non_stopped_requests()
+{
+	error_code const ec = errors::announce_skipped;
+	bool has_stopped = false;
+
+	// erasing is the common case, so do it in one pass rather than paying
+	// for an O(n) shift on every deque::erase() of a single element.
+	auto const pending_end =
+		std::remove_if(m_pending.begin(), m_pending.end(), [&](auto const& item) {
+			auto const* req = std::get_if<tracker_request>(&std::get<0>(item));
+			if (!req)
+				return false;
+			if (req->event == event_t::stopped)
+			{
+				has_stopped = true;
+				return false;
+			}
+
+			report_error(std::get<1>(item), *req, ec, operation_t::bittorrent);
+			return true;
+		});
+	m_pending.erase(pending_end, m_pending.end());
+
+	for (auto it = m_callbacks.begin(); it != m_callbacks.end();)
+	{
+		if (!it->second.pending)
+		{
+			++it;
+			continue;
+		}
+		if (it->second.req.event == event_t::stopped)
+		{
+			has_stopped = true;
+			++it;
+			continue;
+		}
+
+		report_error(it->second.cb, it->second.req, ec, operation_t::bittorrent);
+		it = m_callbacks.erase(it);
+	}
+
+	return has_stopped;
+}
+
 void websocket_tracker_connection::queue_request(tracker_request req, std::weak_ptr<request_callback> cb)
 {
-	m_pending.emplace(tracker_message{std::move(req)}, cb);
+	m_pending.emplace_back(tracker_message{std::move(req)}, cb);
 	if (is_open()) send_pending();
 }
 
 void websocket_tracker_connection::queue_answer(tracker_answer ans)
 {
-	m_pending.emplace(tracker_message{std::move(ans)}, std::weak_ptr<request_callback>{});
+	m_pending.emplace_back(tracker_message{std::move(ans)}, std::weak_ptr<request_callback>{});
 	if (is_open()) send_pending();
 }
 
@@ -156,25 +230,37 @@ void websocket_tracker_connection::send_pending()
 	m_sending = true;
 
 	auto [msg, callback] = std::move(m_pending.front());
-	m_pending.pop();
+	m_pending.pop_front();
 
-	std::visit([this, cb = callback](auto const& m)
-		{
-			// Update requester and store callback
-			if (cb.lock())
+	std::visit(
+		[this, cb = callback](auto const& m) {
+			// record every sent request, even ones whose callback has
+			// already expired, so m_callbacks always reflects whether the
+			// connection's current request is still pending (used by
+			// prune_non_stopped_requests()); a dead callback just means
+			// nothing is invoked when its outcome is reported.
+			if constexpr (std::is_same_v<std::decay_t<decltype(m)>, tracker_request>)
 			{
-				m_requester = cb;
-				m_callbacks[m.info_hash] = std::move(cb);
+			// torrent invariants ensure at most one request per info_hash
+			// is ever in flight at a time, so this must never overwrite a
+			// still-pending entry
+#if TORRENT_USE_ASSERTS
+				auto const existing = m_callbacks.find(m.info_hash);
+				TORRENT_ASSERT(existing == m_callbacks.end() || !existing->second.pending);
+#endif
+				m_callbacks[m.info_hash] = callback_entry{cb, m};
 			}
 
+			if (cb.lock())
+				m_requester = cb;
+
 			do_send(m);
-		}
-		, msg);
+		},
+		msg);
 }
 
 void websocket_tracker_connection::do_send(tracker_request const& req)
 {
-	// Update request
 	m_req = req;
 
 	json::object payload;
@@ -279,7 +365,7 @@ void websocket_tracker_connection::on_timeout(error_code const& ec)
 #endif
 
 	fail(error_code(error::timed_out), operation_t::sock_read);
-	close();
+	close(error_code(error::timed_out), operation_t::sock_read);
 }
 
 void websocket_tracker_connection::on_connect(error_code const& ec)
@@ -288,7 +374,7 @@ void websocket_tracker_connection::on_connect(error_code const& ec)
 	if (ec)
 	{
 		fail(ec, operation_t::connect);
-		close();
+		close(ec, operation_t::connect);
 		return;
 	}
 
@@ -302,8 +388,14 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 	if (ec)
 	{
 		if (ec != websocket::error::closed)
+		{
 			fail(ec, operation_t::sock_read);
-		close();
+			close(ec, operation_t::sock_read);
+		}
+		else
+		{
+			close();
+		}
 		return;
 	}
 
@@ -326,7 +418,7 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 		}
 #endif
 		fail(ec, operation_t::handshake);
-		close();
+		close(ec, operation_t::handshake);
 		return;
 	}
 
@@ -334,8 +426,9 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 	auto response = std::move(std::get<websocket_tracker_response>(ret));
 
 	std::shared_ptr<request_callback> cb;
-	if (auto cit = m_callbacks.find(response.info_hash); cit != m_callbacks.end())
-		cb = cit->second.lock();
+	auto const cit = m_callbacks.find(response.info_hash);
+	if (cit != m_callbacks.end())
+		cb = cit->second.cb.lock();
 
 	if (cb)
 	{
@@ -366,7 +459,12 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 			response.resp->interval = std::max(response.resp->interval
 				, seconds32{m_man.settings().get_int(settings_pack::min_websocket_announce_interval)});
 
-			cb->tracker_response(tracker_req(), {}, {}, *response.resp);
+			// this request's outcome has just been reported to its
+			// requester; mark it so close() won't also report an error
+			// for it.
+			cit->second.pending = false;
+
+			cb->tracker_response(cit->second.req, {}, {}, *response.resp);
 		}
 	}
 	else
@@ -389,7 +487,7 @@ void websocket_tracker_connection::on_write(error_code const& ec, std::size_t /*
 	if (ec)
 	{
 		fail(ec, operation_t::sock_write);
-		close();
+		close(ec, operation_t::sock_write);
 		return;
 	}
 
@@ -399,6 +497,15 @@ void websocket_tracker_connection::on_write(error_code const& ec, std::size_t /*
 
 void websocket_tracker_connection::fail(error_code const& ec, operation_t const op)
 {
+	// suppress tracker_connection::fail_impl()'s own report: it would
+	// report m_req to requester(), but this connection multiplexes several
+	// torrents' requests, so m_req may not even belong to the torrent whose
+	// outcome this is. Callers follow fail() with close(ec, op), which
+	// reports every still-pending m_callbacks entry using each request's
+	// own stored data and the real ec/op, superseding fail_impl()'s report
+	// (and its generic, no-args close()) entirely.
+	m_req_pending = false;
+
 	tracker_connection::fail(ec, op, ec.message().c_str(), seconds32{120}, seconds32{120});
 }
 


### PR DESCRIPTION
this fixes issues related to websocket tracker connections being reused for multiple announces.

when shutting down, and stopping all trackers, it didn't quite abort all requests correctly. It was modeled after the original libtorrent logic where one connection = one announce. It would also not quite map the responses to the correct request, in case they were overlapping.

The main part, however, is to introduce a simulated websocket tracker to enable deterministic simulation tests.