### PR TITLE
don't report a utf8 sequence length longer than the input

### DIFF
--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -118,11 +118,11 @@ namespace {
 		if (sequence_len == 0)
 			return std::make_pair(-1, 1);
 
-		if (sequence_len > 4)
-			return std::make_pair(-1, sequence_len);
-
 		if (sequence_len > int(str.size()))
 			return std::make_pair(-1, static_cast<int>(str.size()));
+
+		if (sequence_len > 4)
+			return std::make_pair(-1, sequence_len);
 
 		std::int32_t ch = 0;
 		// first byte

--- a/test/test_utf8.cpp
+++ b/test/test_utf8.cpp
@@ -139,6 +139,13 @@ TORRENT_TEST(parse_utf8_fail)
 	// invalid continuation character
 	parse_error("\xc0\x7f");
 
+	// truncated 5-byte sequences. The reported length must stay within the
+	// buffer we were handed
+	parse_error("\xf8");
+	parse_error("\xf8\x80");
+	parse_error("\xf8\x80\x80");
+	parse_error("\xf8\x80\x80\x80");
+
 	// codepoint too high
 	parse_error("\xf5\x8f\xbf\xbf");
 	parse_error("\xf4\xbf\xbf\xbf");


### PR DESCRIPTION
**Truncated 5-byte sequence reports a length past the end of the input**

`utf8_sequence_length` returns 5 for the lead bytes 0xf8-0xfb, and the `sequence_len > 4` test runs ahead of the one against `str.size()`, so a 1 to 4 byte string starting with one of those comes back with len=5. That is the invariant `parse_error()` in test_utf8 already asserts, and it only slipped through because every existing 0xf8 case in that corpus happens to be 5 or 6 bytes long; `verify_encoding` clamps the same value with `std::min`, but `convert_to_native` advances with a bare `ptr.substr(len)`, so on a non-UTF-8 locale a name ending in one of those bytes throws out of `convert_to_native_path_string`. Swapped the two checks so the reported length can never exceed the buffer, which leaves every sequence whose input is at least as long as the lead byte claims decoding exactly as before.