### PR TITLE
reject out-of-range numbers instead of truncating them with atoi

### DIFF
--- a/include/libtorrent/aux_/http_stream.hpp
+++ b/include/libtorrent/aux_/http_stream.hpp
@@ -178,8 +178,8 @@ private:
 
 			status++;
 			auto const status_len = m_buffer.size() - std::size_t(status - m_buffer.data());
-			int const code = parse_decimal({status, status_len});
-			if (code != 200)
+			auto const code = parse_decimal({status, status_len});
+			if (!code || *code != 200)
 			{
 				h(boost::asio::error::operation_not_supported);
 				error_code ec;

--- a/include/libtorrent/aux_/http_stream.hpp
+++ b/include/libtorrent/aux_/http_stream.hpp
@@ -177,7 +177,8 @@ private:
 			}
 
 			status++;
-			int const code = std::atoi(status);
+			auto const status_len = m_buffer.size() - std::size_t(status - m_buffer.data());
+			int const code = parse_decimal({status, status_len});
 			if (code != 200)
 			{
 				h(boost::asio::error::operation_not_supported);

--- a/include/libtorrent/aux_/string_util.hpp
+++ b/include/libtorrent/aux_/string_util.hpp
@@ -22,6 +22,7 @@ see LICENSE file.
 #include <string>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <array> // for std::array
 
 namespace libtorrent::aux {
@@ -33,11 +34,12 @@ namespace libtorrent::aux {
 		to_string(std::int64_t n);
 
 	// parses the leading decimal digits of the string and returns the value.
-	// Returns -1 if the string doesn't start with a number, or if the number
-	// doesn't fit in an int. std::atoi() is undefined for out-of-range values,
-	// and in practice truncates them into the valid range, which defeats any
-	// range check made on the result.
-	TORRENT_EXTRA_EXPORT int parse_decimal(string_view str);
+	// Returns an empty optional if the string doesn't start with a number, or
+	// if the number doesn't fit in an int. std::atoi() is undefined for
+	// out-of-range values, and in practice truncates them into the valid range,
+	// which defeats any range check made on the result. Unlike atoi(), a
+	// successful parse of a negative number is distinguishable from a failure.
+	TORRENT_EXTRA_EXPORT std::optional<int> parse_decimal(string_view str);
 
 	// internal
 	inline bool is_digit(char c)

--- a/include/libtorrent/aux_/string_util.hpp
+++ b/include/libtorrent/aux_/string_util.hpp
@@ -32,6 +32,13 @@ namespace libtorrent::aux {
 		std::array<char, 4 + std::numeric_limits<std::int64_t>::digits10>
 		to_string(std::int64_t n);
 
+	// parses the leading decimal digits of the string and returns the value.
+	// Returns -1 if the string doesn't start with a number, or if the number
+	// doesn't fit in an int. std::atoi() is undefined for out-of-range values,
+	// and in practice truncates them into the valid range, which defeats any
+	// range check made on the result.
+	TORRENT_EXTRA_EXPORT int parse_decimal(string_view str);
+
 	// internal
 	inline bool is_digit(char c)
 	{ return c >= '0' && c <= '9'; }

--- a/include/libtorrent/aux_/string_util.hpp
+++ b/include/libtorrent/aux_/string_util.hpp
@@ -33,14 +33,6 @@ namespace libtorrent::aux {
 		std::array<char, 4 + std::numeric_limits<std::int64_t>::digits10>
 		to_string(std::int64_t n);
 
-	// parses the leading decimal digits of the string and returns the value.
-	// Returns an empty optional if the string doesn't start with a number, or
-	// if the number doesn't fit in an int. std::atoi() is undefined for
-	// out-of-range values, and in practice truncates them into the valid range,
-	// which defeats any range check made on the result. Unlike atoi(), a
-	// successful parse of a negative number is distinguishable from a failure.
-	TORRENT_EXTRA_EXPORT std::optional<int> parse_decimal(string_view str);
-
 	// internal
 	inline bool is_digit(char c)
 	{ return c >= '0' && c <= '9'; }
@@ -52,6 +44,14 @@ namespace libtorrent::aux {
 
 	// internal
 	TORRENT_EXTRA_EXPORT string_view strip_string(string_view in);
+
+	// parses the leading decimal digits of the string and returns the value.
+	// Returns an empty optional if the string doesn't start with a number, or
+	// if the number doesn't fit in an int. std::atoi() is undefined for
+	// out-of-range values, and in practice truncates them into the valid range,
+	// which defeats any range check made on the result. Unlike atoi(), a
+	// successful parse of a negative number is distinguishable from a failure.
+	TORRENT_EXTRA_EXPORT std::optional<int> parse_decimal(string_view str);
 
 	TORRENT_EXTRA_EXPORT bool is_print(char c);
 	TORRENT_EXTRA_EXPORT bool is_space(char c);

--- a/include/libtorrent/bencode.hpp
+++ b/include/libtorrent/bencode.hpp
@@ -273,7 +273,12 @@ namespace aux {
 				if (err) return;
 				TORRENT_ASSERT(*in == ':');
 				++in; // ':'
-				int len = atoi(len_s.c_str());
+				int const len = aux::parse_decimal(len_s);
+				if (len < 0)
+				{
+					err = true;
+					return;
+				}
 				ret = entry(entry::string_t);
 				read_string(in, end, len, ret.string(), err);
 				if (err) return;

--- a/include/libtorrent/bencode.hpp
+++ b/include/libtorrent/bencode.hpp
@@ -273,14 +273,14 @@ namespace aux {
 				if (err) return;
 				TORRENT_ASSERT(*in == ':');
 				++in; // ':'
-				int const len = aux::parse_decimal(len_s);
-				if (len < 0)
+				auto const len = aux::parse_decimal(len_s);
+				if (!len || *len < 0)
 				{
 					err = true;
 					return;
 				}
 				ret = entry(entry::string_t);
-				read_string(in, end, len, ret.string(), err);
+				read_string(in, end, *len, ret.string(), err);
 				if (err) return;
 			}
 			else

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -475,8 +475,7 @@ namespace libtorrent {
 				if (divider != std::string::npos)
 				{
 					auto const port = aux::parse_decimal(value.substr(divider + 1));
-					if (port && *port > 0
-						&& *port < int(std::numeric_limits<std::uint16_t>::max()))
+					if (port && *port > 0 && *port < int(std::numeric_limits<std::uint16_t>::max()))
 						p.dht_nodes.emplace_back(value.substr(0, divider), *port);
 				}
 			}

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -433,10 +433,10 @@ namespace libtorrent {
 						if (divider == token.size() - 1) // no end index
 							continue;
 
-						idx1 = std::atoi(std::string(token.substr(0, divider)).c_str());
+						idx1 = aux::parse_decimal(token.substr(0, divider));
 						if (idx1 < 0 || idx1 > max_index) // invalid index
 							continue;
-						idx2 = std::atoi(std::string(token.substr(divider + 1)).c_str());
+						idx2 = aux::parse_decimal(token.substr(divider + 1));
 						if (idx2 < 0 || idx2 > max_index) // invalid index
 							continue;
 
@@ -445,7 +445,7 @@ namespace libtorrent {
 					}
 					else // it's an index
 					{
-						idx1 = std::atoi(std::string(token).c_str());
+						idx1 = aux::parse_decimal(token);
 						if (idx1 < 0 || idx1 > max_index) // invalid index
 							continue;
 						idx2 = idx1;
@@ -471,7 +471,7 @@ namespace libtorrent {
 				auto const divider = value.find_last_of(':');
 				if (divider != std::string::npos)
 				{
-					int const port = std::atoi(std::string(value.substr(divider + 1)).c_str());
+					int const port = aux::parse_decimal(value.substr(divider + 1));
 					if (port > 0 && port < int(std::numeric_limits<std::uint16_t>::max()))
 						p.dht_nodes.emplace_back(value.substr(0, divider), port);
 				}

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -433,21 +433,24 @@ namespace libtorrent {
 						if (divider == token.size() - 1) // no end index
 							continue;
 
-						idx1 = aux::parse_decimal(token.substr(0, divider));
-						if (idx1 < 0 || idx1 > max_index) // invalid index
+						auto const first = aux::parse_decimal(token.substr(0, divider));
+						if (!first || *first < 0 || *first > max_index) // invalid index
 							continue;
-						idx2 = aux::parse_decimal(token.substr(divider + 1));
-						if (idx2 < 0 || idx2 > max_index) // invalid index
+						auto const last = aux::parse_decimal(token.substr(divider + 1));
+						if (!last || *last < 0 || *last > max_index) // invalid index
 							continue;
+						idx1 = *first;
+						idx2 = *last;
 
 						if (idx1 > idx2) // wrong range limits
 							continue;
 					}
 					else // it's an index
 					{
-						idx1 = aux::parse_decimal(token);
-						if (idx1 < 0 || idx1 > max_index) // invalid index
+						auto const idx = aux::parse_decimal(token);
+						if (!idx || *idx < 0 || *idx > max_index) // invalid index
 							continue;
+						idx1 = *idx;
 						idx2 = idx1;
 					}
 
@@ -471,9 +474,10 @@ namespace libtorrent {
 				auto const divider = value.find_last_of(':');
 				if (divider != std::string::npos)
 				{
-					int const port = aux::parse_decimal(value.substr(divider + 1));
-					if (port > 0 && port < int(std::numeric_limits<std::uint16_t>::max()))
-						p.dht_nodes.emplace_back(value.substr(0, divider), port);
+					auto const port = aux::parse_decimal(value.substr(divider + 1));
+					if (port && *port > 0
+						&& *port < int(std::numeric_limits<std::uint16_t>::max()))
+						p.dht_nodes.emplace_back(value.substr(0, divider), *port);
 				}
 			}
 #endif

--- a/src/parse_url.cpp
+++ b/src/parse_url.cpp
@@ -124,7 +124,7 @@ namespace libtorrent::aux {
 				ec = errors::invalid_port;
 				goto exit;
 			}
-			port = std::atoi(std::string(port_pos, end).c_str());
+			port = parse_decimal({port_pos, std::size_t(end - port_pos)});
 		}
 
 		start = end;

--- a/src/parse_url.cpp
+++ b/src/parse_url.cpp
@@ -124,7 +124,8 @@ namespace libtorrent::aux {
 				ec = errors::invalid_port;
 				goto exit;
 			}
-			auto const port_num = parse_decimal({port_pos, std::size_t(end - port_pos)});
+			auto const port_num = parse_decimal(
+				url.substr(std::size_t(port_pos - url.begin()), std::size_t(end - port_pos)));
 			if (!port_num)
 			{
 				ec = errors::invalid_port;

--- a/src/parse_url.cpp
+++ b/src/parse_url.cpp
@@ -124,7 +124,13 @@ namespace libtorrent::aux {
 				ec = errors::invalid_port;
 				goto exit;
 			}
-			port = parse_decimal({port_pos, std::size_t(end - port_pos)});
+			auto const port_num = parse_decimal({port_pos, std::size_t(end - port_pos)});
+			if (!port_num)
+			{
+				ec = errors::invalid_port;
+				goto exit;
+			}
+			port = *port_num;
 		}
 
 		start = end;

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -119,8 +119,7 @@ namespace libtorrent::aux {
 		}
 
 		auto const port_num = parse_decimal(port);
-		if (!port_num || *port_num <= 0
-			|| *port_num > std::numeric_limits<std::uint16_t>::max())
+		if (!port_num || *port_num <= 0 || *port_num > std::numeric_limits<std::uint16_t>::max())
 		{
 			ec = errors::invalid_port;
 			return ret;

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -17,6 +17,7 @@ see LICENSE file.
 #include "libtorrent/aux_/io_bytes.hpp" // for write_uint16
 #include "libtorrent/hasher.hpp" // for hasher
 #include "libtorrent/aux_/escape_string.hpp" // for trim
+#include "libtorrent/aux_/string_util.hpp" // for parse_decimal
 
 namespace libtorrent::aux {
 
@@ -117,7 +118,7 @@ namespace libtorrent::aux {
 			return ret;
 		}
 
-		int const port_num = std::atoi(std::string(port).c_str());
+		int const port_num = parse_decimal(port);
 		if (port_num <= 0 || port_num > std::numeric_limits<std::uint16_t>::max())
 		{
 			ec = errors::invalid_port;

--- a/src/socket_io.cpp
+++ b/src/socket_io.cpp
@@ -118,13 +118,14 @@ namespace libtorrent::aux {
 			return ret;
 		}
 
-		int const port_num = parse_decimal(port);
-		if (port_num <= 0 || port_num > std::numeric_limits<std::uint16_t>::max())
+		auto const port_num = parse_decimal(port);
+		if (!port_num || *port_num <= 0
+			|| *port_num > std::numeric_limits<std::uint16_t>::max())
 		{
 			ec = errors::invalid_port;
 			return ret;
 		}
-		ret.port(static_cast<std::uint16_t>(port_num));
+		ret.port(static_cast<std::uint16_t>(*port_num));
 		return ret;
 	}
 

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -19,9 +19,18 @@ see LICENSE file.
 #include "libtorrent/assert.hpp"
 
 #include <algorithm> // for search
+#include <charconv> // for from_chars
 #include <utility> // for move
 
 namespace libtorrent::aux {
+
+	int parse_decimal(string_view const str)
+	{
+		int ret = 0;
+		auto const r = std::from_chars(str.data(), str.data() + str.size(), ret);
+		if (r.ec != std::errc{}) return -1;
+		return ret;
+	}
 
 	// We need well defined results that don't depend on locale
 	std::array<char, 4 + std::numeric_limits<std::int64_t>::digits10>
@@ -227,7 +236,7 @@ namespace libtorrent::aux {
 				continue;
 			}
 
-			iface.port = std::atoi(port_str.c_str());
+			iface.port = parse_decimal(port_str);
 			if (iface.port < 0 || iface.port > 65535)
 			{
 				err.emplace_back(element);
@@ -279,7 +288,8 @@ namespace libtorrent::aux {
 
 			if (colon != std::string::npos && colon > start)
 			{
-				int port = std::atoi(in.substr(colon + 1, end - colon - 1).c_str());
+				int const port = parse_decimal(strip_string(
+					string_view(in).substr(colon + 1, end - colon - 1)));
 
 				// skip trailing spaces
 				std::string::size_type soft_end = colon;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -28,7 +28,8 @@ namespace libtorrent::aux {
 	{
 		int ret = 0;
 		auto const r = std::from_chars(str.data(), str.data() + str.size(), ret);
-		if (r.ec != std::errc{}) return std::nullopt;
+		if (r.ec != std::errc{})
+			return std::nullopt;
 		return ret;
 	}
 

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -24,11 +24,11 @@ see LICENSE file.
 
 namespace libtorrent::aux {
 
-	int parse_decimal(string_view const str)
+	std::optional<int> parse_decimal(string_view const str)
 	{
 		int ret = 0;
 		auto const r = std::from_chars(str.data(), str.data() + str.size(), ret);
-		if (r.ec != std::errc{}) return -1;
+		if (r.ec != std::errc{}) return std::nullopt;
 		return ret;
 	}
 
@@ -236,12 +236,13 @@ namespace libtorrent::aux {
 				continue;
 			}
 
-			iface.port = parse_decimal(port_str);
-			if (iface.port < 0 || iface.port > 65535)
+			auto const port_num = parse_decimal(port_str);
+			if (!port_num || *port_num < 0 || *port_num > 65535)
 			{
 				err.emplace_back(element);
 				continue;
 			}
+			iface.port = *port_num;
 
 			port.remove_prefix(port_str.size());
 			port = strip_string(port);
@@ -288,8 +289,13 @@ namespace libtorrent::aux {
 
 			if (colon != std::string::npos && colon > start)
 			{
-				int const port = parse_decimal(strip_string(
+				auto const port = parse_decimal(strip_string(
 					string_view(in).substr(colon + 1, end - colon - 1)));
+				if (!port)
+				{
+					start = end + 1;
+					continue;
+				}
 
 				// skip trailing spaces
 				std::string::size_type soft_end = colon;
@@ -302,7 +308,7 @@ namespace libtorrent::aux {
 				if (in[start] == '[') ++start;
 				if (soft_end > start && in[soft_end-1] == ']') --soft_end;
 
-				out.emplace_back(in.substr(start, soft_end - start), port);
+				out.emplace_back(in.substr(start, soft_end - start), *port);
 			}
 
 			start = end + 1;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -289,8 +289,8 @@ namespace libtorrent::aux {
 
 			if (colon != std::string::npos && colon > start)
 			{
-				auto const port = parse_decimal(strip_string(
-					string_view(in).substr(colon + 1, end - colon - 1)));
+				auto const port =
+					parse_decimal(strip_string(string_view(in).substr(colon + 1, end - colon - 1)));
 				if (!port)
 				{
 					start = end + 1;

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1220,8 +1220,7 @@ void find_error_code(int const type, string_view string, error_code_parse_state&
 	{
 		// leave error_code at -1 if the device sent something that isn't a
 		// number, or a number that doesn't fit in an int
-		if (auto const code = aux::parse_decimal(string))
-			state.error_code = *code;
+		if (auto const code = aux::parse_decimal(string)) state.error_code = *code;
 		state.exit = true;
 	}
 }

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1220,7 +1220,8 @@ void find_error_code(int const type, string_view string, error_code_parse_state&
 	{
 		// leave error_code at -1 if the device sent something that isn't a
 		// number, or a number that doesn't fit in an int
-		if (auto const code = aux::parse_decimal(string)) state.error_code = *code;
+		if (auto const code = aux::parse_decimal(string))
+			state.error_code = *code;
 		state.exit = true;
 	}
 }

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1218,7 +1218,10 @@ void find_error_code(int const type, string_view string, error_code_parse_state&
 	}
 	else if (type == xml_string && state.in_error_code)
 	{
-		state.error_code = aux::parse_decimal(string);
+		// leave error_code at -1 if the device sent something that isn't a
+		// number, or a number that doesn't fit in an int
+		if (auto const code = aux::parse_decimal(string))
+			state.error_code = *code;
 		state.exit = true;
 	}
 }

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1218,7 +1218,7 @@ void find_error_code(int const type, string_view string, error_code_parse_state&
 	}
 	else if (type == xml_string && state.in_error_code)
 	{
-		state.error_code = std::atoi(std::string(string).c_str());
+		state.error_code = aux::parse_decimal(string);
 		state.exit = true;
 	}
 }

--- a/test/test_socket_io.cpp
+++ b/test/test_socket_io.cpp
@@ -103,6 +103,15 @@ TORRENT_TEST(parse_invalid_ipv4_endpoint)
 	TEST_CHECK(ec);
 	ec.clear();
 
+	// a port that wraps into the valid range when truncated to an int
+	endp = parse_endpoint("127.0.0.1:4294967376", ec);
+	TEST_CHECK(ec);
+	ec.clear();
+
+	endp = parse_endpoint("127.0.0.1:99999999999999999999", ec);
+	TEST_CHECK(ec);
+	ec.clear();
+
 	endp = parse_endpoint("127.0.0.1:abc", ec);
 	TEST_CHECK(ec);
 	ec.clear();

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -198,26 +198,30 @@ TORRENT_TEST(to_string)
 
 TORRENT_TEST(parse_decimal)
 {
-	TEST_EQUAL(parse_decimal("0"), 0);
-	TEST_EQUAL(parse_decimal("80"), 80);
-	TEST_EQUAL(parse_decimal("65535"), 65535);
-	TEST_EQUAL(parse_decimal("2147483647"), 2147483647);
-	TEST_EQUAL(parse_decimal("-4"), -4);
+	TEST_EQUAL(parse_decimal("0").value(), 0);
+	TEST_EQUAL(parse_decimal("80").value(), 80);
+	TEST_EQUAL(parse_decimal("65535").value(), 65535);
+	TEST_EQUAL(parse_decimal("2147483647").value(), 2147483647);
+
+	// a negative number parses successfully, and is distinguishable from a
+	// parse failure
+	TEST_EQUAL(parse_decimal("-4").value(), -4);
+	TEST_EQUAL(parse_decimal("-1").value(), -1);
 
 	// only the leading digits are parsed
-	TEST_EQUAL(parse_decimal("200 OK"), 200);
-	TEST_EQUAL(parse_decimal("80/announce"), 80);
+	TEST_EQUAL(parse_decimal("200 OK").value(), 200);
+	TEST_EQUAL(parse_decimal("80/announce").value(), 80);
 
 	// not a number
-	TEST_EQUAL(parse_decimal(""), -1);
-	TEST_EQUAL(parse_decimal("abc"), -1);
-	TEST_EQUAL(parse_decimal(" 80"), -1);
+	TEST_CHECK(!parse_decimal(""));
+	TEST_CHECK(!parse_decimal("abc"));
+	TEST_CHECK(!parse_decimal(" 80"));
 
 	// out of range. These must not wrap into the valid range
-	TEST_EQUAL(parse_decimal("2147483648"), -1);
-	TEST_EQUAL(parse_decimal("4294967376"), -1);
-	TEST_EQUAL(parse_decimal("4294967496 Forbidden"), -1);
-	TEST_EQUAL(parse_decimal("99999999999999999999"), -1);
+	TEST_CHECK(!parse_decimal("2147483648"));
+	TEST_CHECK(!parse_decimal("4294967376"));
+	TEST_CHECK(!parse_decimal("4294967496 Forbidden"));
+	TEST_CHECK(!parse_decimal("99999999999999999999"));
 }
 
 #if TORRENT_USE_I2P

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -196,6 +196,30 @@ TORRENT_TEST(to_string)
 	TEST_CHECK(to_string(-999999999999999999).data() == std::string("-999999999999999999"));
 }
 
+TORRENT_TEST(parse_decimal)
+{
+	TEST_EQUAL(parse_decimal("0"), 0);
+	TEST_EQUAL(parse_decimal("80"), 80);
+	TEST_EQUAL(parse_decimal("65535"), 65535);
+	TEST_EQUAL(parse_decimal("2147483647"), 2147483647);
+	TEST_EQUAL(parse_decimal("-4"), -4);
+
+	// only the leading digits are parsed
+	TEST_EQUAL(parse_decimal("200 OK"), 200);
+	TEST_EQUAL(parse_decimal("80/announce"), 80);
+
+	// not a number
+	TEST_EQUAL(parse_decimal(""), -1);
+	TEST_EQUAL(parse_decimal("abc"), -1);
+	TEST_EQUAL(parse_decimal(" 80"), -1);
+
+	// out of range. These must not wrap into the valid range
+	TEST_EQUAL(parse_decimal("2147483648"), -1);
+	TEST_EQUAL(parse_decimal("4294967376"), -1);
+	TEST_EQUAL(parse_decimal("4294967496 Forbidden"), -1);
+	TEST_EQUAL(parse_decimal("99999999999999999999"), -1);
+}
+
 #if TORRENT_USE_I2P
 namespace {
 


### PR DESCRIPTION
Repro: `aux::parse_endpoint("127.0.0.1:4294967376", ec)` returns port 80 with no error, and a proxy answering `HTTP/1.1 4294967496 Forbidden` gets past the `code != 200` check in `http_stream::handshake2`.

Cause: `std::atoi` is undefined for values that don't fit in an int, and in practice truncates them, so the number wraps into exactly the range the check afterwards accepts. Both of those inputs land on 200 / 80 after truncation. The port one is reachable from a magnet `x.pe=` and from `dht_bootstrap_nodes`; the same construct is used for the URL port, the UPnP SOAP `errorCode`, the magnet select-only indices, and the deprecated bdecode string length.

Fix: added `aux::parse_decimal()` on top of `std::from_chars`, which reports out-of-range input rather than wrapping it, and switched every one of those call sites over. `src/http_parser.cpp` already parses HTTP status codes this way, so this just brings the rest in line. Valid input parses identically.

The new `parse_decimal` test and the two extra cases in `parse_invalid_ipv4_endpoint` both fail before the change. `test_string`, `test_socket_io`, `test_magnet`, `test_bencoding`, `test_http_parser`, `test_settings_pack`, `test_upnp`, `test_bdecode` and `test_torrent_info` pass after it, and the deprecated `bdecode_recursive` path still compiles under `TORRENT_ABI_VERSION=1`.

I targeted RC_2_1 rather than RC_2_0 this time because RC_2_0 is C++14 and has no `<charconv>`, so the helper there would need a hand-rolled parser instead. Happy to write that version too if you'd rather take it downstream first and merge forward.