### PR TITLE
Fix empty tracker tiers are incorrectly saved

### DIFF
--- a/src/write_resume_data.cpp
+++ b/src/write_resume_data.cpp
@@ -3,7 +3,7 @@
 Copyright (c) 2017-2018, 2020-2021, Alden Torres
 Copyright (c) 2017-2022, Arvid Norberg
 Copyright (c) 2017, Steven Siloti
-Copyright (c) 2021, Vladimir Golovnev (glassez)
+Copyright (c) 2021, 2026, Vladimir Golovnev (glassez)
 All rights reserved.
 
 You may use, distribute and modify this code under the terms of the BSD license,
@@ -42,7 +42,7 @@ namespace {
 				tier = std::clamp(std::size_t(*tier_it++), std::size_t{0}, std::size_t{1024});
 
 			if (tr_list.size() <= tier)
-				tr_list.resize(tier + 1);
+				tr_list.resize(tier + 1, entry(entry::list_t));
 
 			tr_list[tier].list().emplace_back(tr);
 		}


### PR DESCRIPTION
We need to explicitly specify entry type when resize trackers list. Otherwise the empty tiers are saved as empty strings (instead of empty lists) and skipped when read the resume data back.
Closes https://github.com/qbittorrent/qBittorrent/issues/24360.