### PR TITLE
fix out of bounds write in hashes_rejected on block hash requests

### DIFF
--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -356,13 +356,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 	void hash_picker::hashes_rejected(hash_request const& req)
 	{
 		// only requests at the piece layer are recorded in
-		// m_piece_hash_requested. The index of a request at any other layer
-		// counts nodes in that layer rather than pieces, so it would index the
-		// wrong bucket, or one past the end of the vector. pick_hashes() issues
-		// base 0 requests for the block hashes of a failed piece, and
-		// on_hash_reject() only matches the reject against an outstanding
-		// request, it does not validate it. This mirrors the check in
-		// add_hashes().
+		// m_piece_hash_requested.
 		if (req.base != m_piece_layer || req.index % 512 != 0 || req.count > 512
 			|| req.index >= m_files.file_num_pieces(req.file))
 			return;

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -355,7 +355,17 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 
 	void hash_picker::hashes_rejected(hash_request const& req)
 	{
-		TORRENT_ASSERT(req.base == m_piece_layer && req.index % 512 == 0);
+		// only requests at the piece layer are recorded in
+		// m_piece_hash_requested. The index of a request at any other layer
+		// counts nodes in that layer rather than pieces, so it would index the
+		// wrong bucket, or one past the end of the vector. pick_hashes() issues
+		// base 0 requests for the block hashes of a failed piece, and
+		// on_hash_reject() only matches the reject against an outstanding
+		// request, it does not validate it. This mirrors the check in
+		// add_hashes().
+		if (req.base != m_piece_layer || req.index % 512 != 0 || req.count > 512
+			|| req.index >= m_files.file_num_pieces(req.file))
+			return;
 
 		for (int i = req.index; i < req.index + req.count; i += 512)
 		{

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -193,6 +193,35 @@ TORRENT_TEST(reject_piece_request)
 	TEST_CHECK(picked == picked2);
 }
 
+TORRENT_TEST(reject_block_hash_request)
+{
+	file_storage fs;
+	// 16 blocks per piece, so a block index is 16 times the piece index
+	fs.set_piece_length(16 * default_block_size);
+
+	// 100 pieces means m_piece_hash_requested only has a single 512-piece bucket
+	fs.add_file("test/tmp1", 100 * 16 * default_block_size);
+
+	aux::vector<aux::merkle_tree, file_index_t> trees;
+	auto const root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
+	trees.emplace_back(100 * 16, 16, root.data());
+
+	hash_picker picker(fs, trees);
+
+	// a failed piece hash makes the picker ask for the block hashes of that
+	// piece, which is a request at the block layer (base 0)
+	picker.verify_block_hashes(piece_index_t{40});
+
+	typed_bitfield<piece_index_t> const pieces(100, true);
+
+	auto const picked = picker.pick_hashes(pieces);
+	TEST_EQUAL(picked.base, 0);
+
+	// the index of a base 0 request counts blocks, not pieces, so it must not
+	// be used to index the piece-layer bookkeeping
+	picker.hashes_rejected(picked);
+}
+
 TORRENT_TEST(add_leaf_hashes)
 {
 	file_storage fs;


### PR DESCRIPTION
hashes_rejected() indexes m_piece_hash_requested by req.index / 512, which is only a piece index when req.base is the piece layer. After a v2 piece fails its hash check, pick_hashes() issues a base 0 request whose index counts blocks instead, and a peer that rejects that request rather than answering it walks the bucket index past the end of the vector, since on_hash_reject() only matches the reject against an outstanding request without validating it. Added the runtime check add_hashes() already has for the same bookkeeping, since the assert that documented the invariant is compiled out in release builds.