### PR TITLE
reject all-zero node hashes in merkle_validate_and_insert_proofs

### DIFF
--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -316,6 +316,12 @@ namespace libtorrent {
 	bool merkle_validate_and_insert_proofs(span<sha256_hash> target_tree
 		, int const target_node_idx, sha256_hash const& node, span<sha256_hash const> uncle_hashes)
 	{
+		// all-zeros is the sentinel for a node we don't know yet. it is never a
+		// valid node hash, and it compares equal to the empty target slot
+		// below, which would return success without looking at a single proof
+		if (node.is_all_zeros())
+			return false;
+
 		if (target_tree[target_node_idx] == node)
 			return true;
 

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -1451,3 +1451,28 @@ TORRENT_TEST(validate_and_insert_proofs_existing_sibling_short_uncles)
 	  o,    o,   o,    o,
 	o, o, o, o,o, f, o, o}));
 }
+
+// an all-zero hash is the sentinel for "this node is unknown" throughout the
+// tree, so it must never be accepted as a node hash, no matter what proof
+// comes with it
+TORRENT_TEST(validate_and_insert_proofs_zero_node)
+{
+	// full tree:
+	//       ah
+	//    ad      eh
+	//  ab  cd  ef  gh
+	// a b c d  e f g h
+
+	v tree(15);
+	tree[0] = ah;
+
+	v const proofs{f, gh, ad};
+
+	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, o, proofs));
+
+	TEST_CHECK((tree == v{
+	          ah,
+	      o,        o,
+	  o,    o,   o,    o,
+	o, o, o, o,o, o, o, o}));
+}

--- a/test/test_merkle_tree.cpp
+++ b/test/test_merkle_tree.cpp
@@ -996,3 +996,18 @@ TORRENT_TEST(load_piece_layer_clears_verified_bits)
 // TODO: add test for add_hashes() with an odd number of blocks
 // TODO: add test for set_block() (setting the last block) with an odd number of blocks
 
+TORRENT_TEST(add_hashes_zero_block_hash)
+{
+	// a peer can ask us to insert a single block hash of all zeros. that's the
+	// same value an unknown node has, so the insert must be rejected rather
+	// than silently marking the block as verified
+	aux::merkle_tree t(num_blocks, 4, f[0].data());
+
+	std::vector<sha256_hash> const hashes{sha256_hash{}};
+	std::vector<sha256_hash> const proofs{rand_sha256()};
+
+	auto const result = t.add_hashes(merkle_first_leaf(num_leafs) + 1, pdiff(0), hashes, proofs);
+
+	TEST_CHECK(!result);
+	TEST_CHECK(t.verified_leafs() == none_set(num_blocks));
+}


### PR DESCRIPTION
merkle_validate_and_insert_proofs() opens with a fast path for a node we already know, but all-zeros is the sentinel the merkle tree uses for an unknown node, so an all-zero node hash compares equal to the empty slot it is being inserted into and the function returns success without reading a single uncle hash. A v2 peer reaches it with a hashes message of base 0, count 1, proof_layers 0 and a payload of 32 zero bytes plus one arbitrary uncle: that is the one shape where leaf_count is 1, so tree[0] in merkle_tree::add_hashes is the peer's raw bytes rather than a computed interior hash. The insert then runs normally and sets the block's verified bit while storing a hash that has_node() reports as unknown, which trips check_invariant() and, without asserts, lets a peer drive the whole block layer to zeros. Rejecting an all-zero node up front matches hash_picker::set_block_hash(), which already refuses one on the sibling path.