### PR TITLE
reject invalid chunk sizes in web_peer_connection::on_receive

### DIFF
--- a/src/web_peer_connection.cpp
+++ b/src/web_peer_connection.cpp
@@ -19,6 +19,7 @@ see LICENSE file.
 #include <cstdlib>
 #include <cstdio> // for snprintf
 #include <cinttypes> // for PRId64 et.al.
+#include <limits>
 
 #include "libtorrent/aux_/web_peer_connection.hpp"
 #include "libtorrent/session.hpp"
@@ -1035,6 +1036,20 @@ void web_peer_connection::on_receive(error_code const& error
 #endif
 				received_bytes(0, header_size - m_partial_chunk_header);
 				m_partial_chunk_header = 0;
+
+				// parse_chunk_header() reports a malformed chunk header by
+				// setting chunk_size to a negative value, and it accepts sizes
+				// all the way up to int64 max, which don't fit in m_chunk_pos.
+				// http_parser::incoming() applies the same check to the chunk
+				// headers it parses itself
+				if (chunk_size < 0
+					|| chunk_size > std::numeric_limits<int>::max() - m_chunk_pos)
+				{
+					received_bytes(0, int(recv_buffer.size()));
+					disconnect(errors::http_parse_error, operation_t::bittorrent, peer_error);
+					return;
+				}
+
 				TORRENT_ASSERT(chunk_size != 0
 					|| int(chunk_start.size()) <= header_size || chunk_start[header_size] == 'H');
 				TORRENT_ASSERT(m_body_start + m_chunk_pos < INT_MAX);


### PR DESCRIPTION
parse_chunk_header() reports a bad chunk header by setting chunk_size to -1, and it otherwise accepts hex sizes all the way up to int64 max, but on_receive() adds the value straight into the int m_chunk_pos without looking at it. A web seed answering a range request with Transfer-Encoding: chunked and a header of "1z" or "80000000" drives m_chunk_pos negative, which is the same value this function uses to mean "response complete", so the chunk loop exits with the receive buffer still non-empty and the enclosing for(;;) spins doing no work. I reproduced it against the fuzzers' web seed harness: 5.1s of CPU burned in 5s of wall time with no disconnect, and 0.04s with the peer dropped as "Invalid HTTP header" afterwards. http_parser::incoming() already applies the same check to the chunk headers it parses itself, so this just gives the web seed path the matching guard; test_web_seed_chunked still passes.