### PR TITLE
Use libcrypto for peer encryption key exchange

### DIFF
--- a/.claude/rules/protocol-encryption.md
+++ b/.claude/rules/protocol-encryption.md
@@ -40,6 +40,9 @@ side (incoming).
 
 1. **`read_pe_dhkey`** (96 bytes) -- read client's DH public key, respond
    with our DH public key + random PadB, transition to `read_pe_synchash`.
+   Failure if the peer's key is degenerate (outside `[2, p-2]`):
+   `invalid_encrypt_handshake`. Failure if the local key exchange failed:
+   `no_memory`.
 2. **`read_pe_synchash`** (scans up to 512 bytes of PadA + the 20-byte hash) --
    scan received bytes for `hash('req1', S)` where S is the shared secret. The
    client may insert up to 512 bytes of PadA before this hash. Failure:
@@ -63,16 +66,20 @@ side (incoming).
 
 ### Outgoing (client) path
 
-1. **`on_connected`** -- send DH public key + random PadA,
-   transition to `read_pe_dhkey`.
+1. **`on_connected`** -- generate the local key pair, send DH public key +
+   random PadA, transition to `read_pe_dhkey`. Failure if generating the
+   key pair failed locally: `no_memory`.
 2. **`read_pe_dhkey`** (96 bytes) -- read server's DH public key, then send
    sync hash + SKEY hash + encrypted(VC + crypto_provide + len_pad + PadC +
    len_IA) + encrypted(IA = BT handshake). Also send the BT handshake
-   encrypted as IA. Transition to `read_pe_syncvc`.
+   encrypted as IA. Transition to `read_pe_syncvc`. Failure if the peer's
+   key is degenerate (outside `[2, p-2]`): `invalid_encrypt_handshake`.
+   Failure if computing the shared secret failed locally: `no_memory`.
 3. **`read_pe_syncvc`** (scans up to 512 bytes of PadB + the 8-byte VC) --
    scan for the encrypted 8-byte verification constant (all zeros encrypted
    with RC4). Failure if not found within the 512-byte pad window:
-   `invalid_encryption_constant`.
+   `invalid_encryption_constant`. Failure if the 8-byte buffer could not be
+   allocated: `no_memory`.
 4. **`read_pe_cryptofield`** (6 bytes) -- read server's `crypto_select(4) +
    len_pad(2)`. Failure if selected mode not in our `allowed_enc_level`:
    `unsupported_encryption_mode_selected`.
@@ -87,11 +94,22 @@ side (incoming).
 spec). `key = 2^random % prime`.
 
 - `dh_key_exchange()` -- generate local key pair
+- `good()` -- false if the crypto library failed locally (e.g. out of
+  memory) generating the key pair or computing the shared secret. A
+  degenerate key from the peer does not clear it
 - `compute_secret(remote_pubkey)` -- compute shared secret S; also computes
-  `m_xor_mask = hash('req3', S)` used for SKEY obfuscation
+  `m_xor_mask = hash('req3', S)` used for SKEY obfuscation. Returns false
+  for a degenerate peer key (outside `[2, p-2]`) or on local failure
 - `get_local_key()` -- 96-byte DH public key to send
-- `get_secret()` -- shared secret S
-- `get_hash_xor_mask()` -- `hash('req3', S)` for SKEY obfuscation
+- `get_secret()` -- shared secret S, 96 bytes big-endian. Zeroed if
+  `compute_secret()` did not return true
+- `get_hash_xor_mask()` -- `hash('req3', S)` for SKEY obfuscation. Zeroed if
+  `compute_secret()` did not return true
+
+There are two implementations selected at compile time: one using libcrypto
+`BIGNUM` (when `TORRENT_USE_LIBCRYPTO` is defined and `TORRENT_USE_WOLFSSL`
+is not) and one using Boost.Multiprecision. Only the libcrypto one can fail
+locally, so `good()` is always true in the Boost build.
 
 ### RC4 Key Derivation
 
@@ -155,4 +173,5 @@ encrypt([8 bytes]  VC = 0x00 * 8
 | `unsupported_encryption_mode` | No overlap in crypto_provide vs allowed_enc_level |
 | `unsupported_encryption_mode_selected` | Server selected a mode not in our allowed list |
 | `invalid_pad_size` | len_pad_c > 512 |
-| `invalid_encrypt_handshake` | len_ia > 68 |
+| `invalid_encrypt_handshake` | len_ia > 68, or the peer's DH public key is degenerate (outside `[2, p-2]`) |
+| `no_memory` | a local allocation or crypto-library failure, never attributed to the peer: `dh_key_exchange` could not be allocated, the key exchange failed locally (`dh_key_exchange::good()` is false), or a handshake buffer could not be allocated |

--- a/fuzzers/src/pe_conn.cpp
+++ b/fuzzers/src/pe_conn.cpp
@@ -68,9 +68,9 @@ peer_fuzz_session g_fz;
 
 // Build RC4 keys for an outgoing (client-initiating) PE connection.
 // The client's send key is hash("keyA", S, SKEY); receive key is hash("keyB", S, SKEY).
-static std::shared_ptr<rc4_handler> make_rc4(lt::aux::key_t const& secret, sha1_hash const& skey)
+static std::shared_ptr<rc4_handler> make_rc4(
+	std::array<char, 96> const& secret_buf, sha1_hash const& skey)
 {
-	std::array<char, 96> const secret_buf = export_key(secret);
 	static const char keyA[4] = {'k', 'e', 'y', 'A'};
 	static const char keyB[4] = {'k', 'e', 'y', 'B'};
 
@@ -132,7 +132,12 @@ extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size
 
 	// Generate a fresh DH key pair for this connection.
 	dh_key_exchange dh;
-	std::array<char, 96> const local_dh_key = export_key(dh.get_local_key());
+	if (!dh.good())
+	{
+		s.close(ec);
+		return wait_for_disconnect(*g_fz.ses);
+	}
+	std::array<char, 96> const& local_dh_key = dh.get_local_key();
 
 	// Step 1: send our DH public key + PadA.
 	// PadA bytes come from fuzz input so libFuzzer can explore the sync-hash
@@ -160,14 +165,17 @@ extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size
 	}
 
 	// Compute DH shared secret and derive RC4 keys.
-	dh.compute_secret(reinterpret_cast<std::uint8_t const*>(srv_key.data()));
-	lt::aux::key_t const secret = dh.get_secret();
-	std::array<char, 96> const secret_buf = export_key(secret);
+	if (!dh.compute_secret(reinterpret_cast<std::uint8_t const*>(srv_key.data())))
+	{
+		s.close(ec);
+		return wait_for_disconnect(*g_fz.ses);
+	}
+	std::array<char, 96> const& secret_buf = dh.get_secret();
 
 	// Use the v1 info hash as SKEY. The server's for_each loop tries both the
 	// v1 SHA-1 hash and the first 20 bytes of the v2 SHA-256 hash.
 	sha1_hash const& skey = g_fz.info_hash.v1;
-	auto const rc4 = make_rc4(secret, skey);
+	auto const rc4 = make_rc4(secret_buf, skey);
 
 	// Step 3: compute sync hash and obfuscated SKEY hash.
 

--- a/fuzzers/src/pe_crypto_state.cpp
+++ b/fuzzers/src/pe_crypto_state.cpp
@@ -36,11 +36,13 @@ extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size
 {
 	lt::aux::dh_key_exchange a;
 	lt::aux::dh_key_exchange b;
+	if (!a.good() || !b.good())
+		return 0;
 
-	auto const b_pub = lt::aux::export_key(b.get_local_key());
-	a.compute_secret(reinterpret_cast<std::uint8_t const*>(b_pub.data()));
-	auto const a_pub = lt::aux::export_key(a.get_local_key());
-	b.compute_secret(reinterpret_cast<std::uint8_t const*>(a_pub.data()));
+	if (!a.compute_secret(reinterpret_cast<std::uint8_t const*>(b.get_local_key().data())))
+		return 0;
+	if (!b.compute_secret(reinterpret_cast<std::uint8_t const*>(a.get_local_key().data())))
+		return 0;
 
 	auto key_in = make_key(data, size, 1);
 	auto key_out = make_key(data, size, 7);

--- a/include/libtorrent/aux_/pe_crypto.hpp
+++ b/include/libtorrent/aux_/pe_crypto.hpp
@@ -16,14 +16,9 @@ see LICENSE file.
 
 #include "libtorrent/config.hpp"
 
-#include "libtorrent/aux_/disable_warnings_push.hpp"
-#include <boost/multiprecision/cpp_int.hpp>
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
 #include "libtorrent/aux_/receive_buffer.hpp"
 #include "libtorrent/sha1_hash.hpp"
 #include "libtorrent/extensions.hpp"
-#include "libtorrent/assert.hpp"
 #include "libtorrent/span.hpp"
 #include "libtorrent/aux_/array.hpp"
 
@@ -32,12 +27,6 @@ see LICENSE file.
 #include <cstdint>
 
 namespace libtorrent::aux {
-
-	namespace mp = boost::multiprecision;
-
-	using key_t = mp::number<mp::cpp_int_backend<768, 768, mp::unsigned_magnitude, mp::unchecked, void>>;
-
-	TORRENT_EXTRA_EXPORT std::array<char, 96> export_key(key_t const& k);
 
 	// RC4 state from libtomcrypt. buf holds a permutation of 0-255, stored
 	// widened to 32 bits per entry so every access is a whole-register
@@ -54,26 +43,41 @@ namespace libtorrent::aux {
 	public:
 		dh_key_exchange();
 
-		// Get local public key
-		key_t const& get_local_key() const { return m_dh_local_key; }
+		// false if the crypto library failed locally (out of memory) when
+		// generating the local key pair or computing the shared secret.
+		// The connection cannot proceed in that case. A degenerate key
+		// from the peer does not clear this
+		bool good() const { return m_good; }
 
-		// read remote_pubkey, generate and store shared secret in
-		// m_dh_shared_secret. Returns false if the remote public key is
-		// degenerate (i.e. outside the range [2, p-2]) and the shared
-		// secret was not computed.
+		// Get local public key, 96 bytes big-endian. All zeroes if
+		// generating the key pair failed, i.e. if good() was false before
+		// the first compute_secret() call. A later local failure clears
+		// good() but leaves this key, which has already gone out on the
+		// wire, intact
+		std::array<char, 96> const& get_local_key() const { return m_dh_local_key; }
+
+		// read the remote 96 byte public key, generate and store the
+		// shared secret in m_dh_shared_secret. Returns false if the
+		// remote public key is degenerate (i.e. outside the range
+		// [2, p-2]) or if the computation failed. The shared secret is
+		// not computed in that case.
 		bool compute_secret(std::uint8_t const* remote_pubkey);
-		bool compute_secret(key_t const& remote_pubkey);
 
-		key_t const& get_secret() const { return m_dh_shared_secret; }
+		// the shared secret, 96 bytes big-endian. Only meaningful after
+		// compute_secret() returned true; it is zeroed on failure
+		std::array<char, 96> const& get_secret() const { return m_dh_shared_secret; }
 
+		// hash('req3', S). Only meaningful after compute_secret() returned
+		// true; it is zeroed on failure
 		sha1_hash const& get_hash_xor_mask() const { return m_xor_mask; }
 
 	private:
-
-		key_t m_dh_local_key;
-		key_t m_dh_local_secret;
-		key_t m_dh_shared_secret;
+		// the 160 bit random secret exponent, big-endian
+		std::array<std::uint8_t, 20> m_dh_local_secret{};
+		std::array<char, 96> m_dh_local_key{};
+		std::array<char, 96> m_dh_shared_secret{};
 		sha1_hash m_xor_mask;
+		bool m_good = false;
 	};
 
 	struct TORRENT_EXTRA_EXPORT encryption_handler

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -65,10 +65,11 @@ namespace {
 	constexpr std::size_t dh_key_len = 96;
 
 	// stream key (info hash of attached torrent)
-	// secret is the DH shared secret
+	// secret_buf is the DH shared secret
 	// initializes m_enc_handler
-	std::shared_ptr<rc4_handler> init_pe_rc4_handler(key_t const& secret
-		, sha1_hash const& stream_key, bool const outgoing)
+	std::shared_ptr<rc4_handler> init_pe_rc4_handler(std::array<char, dh_key_len> const& secret_buf,
+		sha1_hash const& stream_key,
+		bool const outgoing)
 	{
 		hasher h;
 		static const char keyA[] = {'k', 'e', 'y', 'A'};
@@ -77,8 +78,6 @@ namespace {
 		// encryption rc4 longkeys
 		// outgoing connection : hash ('keyA',S,SKEY)
 		// incoming connection : hash ('keyB',S,SKEY)
-
-		std::array<char, dh_key_len> const secret_buf = export_key(secret);
 
 		if (outgoing) h.update(keyA); else h.update(keyB);
 		h.update(secret_buf);
@@ -537,7 +536,7 @@ namespace {
 #endif
 
 		m_dh_key_exchange.reset(new (std::nothrow) dh_key_exchange);
-		if (!m_dh_key_exchange)
+		if (!m_dh_key_exchange || !m_dh_key_exchange->good())
 		{
 			disconnect(errors::no_memory, operation_t::encryption);
 			return;
@@ -553,8 +552,7 @@ namespace {
 		char* ptr = msg;
 		int const buf_size = int(dh_key_len) + pad_size;
 
-		std::array<char, dh_key_len> const local_key = export_key(m_dh_key_exchange->get_local_key());
-		std::memcpy(ptr, local_key.data(), dh_key_len);
+		std::memcpy(ptr, m_dh_key_exchange->get_local_key().data(), dh_key_len);
 		ptr += dh_key_len;
 
 		aux::random_bytes({ptr, pad_size});
@@ -576,8 +574,8 @@ namespace {
 
 		hasher h;
 		sha1_hash const& info_hash = associated_info_hash();
-		key_t const secret_key = m_dh_key_exchange->get_secret();
-		std::array<char, dh_key_len> const secret = export_key(secret_key);
+		// a copy, since m_dh_key_exchange is reset before this function returns
+		std::array<char, dh_key_len> const secret = m_dh_key_exchange->get_secret();
 
 		int const pad_size = int(random(512));
 
@@ -619,7 +617,7 @@ namespace {
 		ptr += 20;
 
 		// Discard DH key exchange data, setup RC4 keys
-		m_rc4 = init_pe_rc4_handler(secret_key, info_hash, is_outgoing());
+		m_rc4 = init_pe_rc4_handler(secret, info_hash, is_outgoing());
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, peer_log_alert::encryption, "computed RC4 keys");
 #endif
@@ -2822,7 +2820,13 @@ namespace {
 			if (!m_dh_key_exchange->compute_secret(
 					reinterpret_cast<std::uint8_t const*>(recv_buffer.data())))
 			{
-				disconnect(errors::invalid_encrypt_handshake, operation_t::encryption, peer_error);
+				// distinguish the peer sending us a degenerate key from
+				// our own crypto library failing
+				if (!m_dh_key_exchange->good())
+					disconnect(errors::no_memory, operation_t::encryption);
+				else
+					disconnect(
+						errors::invalid_encrypt_handshake, operation_t::encryption, peer_error);
 				return;
 			}
 
@@ -2888,7 +2892,9 @@ namespace {
 
 				static char const req1[4] = {'r', 'e', 'q', '1'};
 				// compute synchash (hash('req1',S))
-				std::array<char, dh_key_len> const buffer = export_key(m_dh_key_exchange->get_secret());
+				// a copy, so it stays valid regardless of what happens to
+				// m_dh_key_exchange
+				std::array<char, dh_key_len> const buffer = m_dh_key_exchange->get_secret();
 				hasher h(req1);
 				h.update(buffer);
 				m_sync_hash = std::make_unique<sha1_hash>(h.final());

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -16,94 +16,346 @@ see LICENSE file.
 #include <cstdint>
 #include <cstring>
 #include <algorithm>
-#include <random>
+#include <iterator>
+#include <optional>
 #include <utility>
 
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL
 #include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <openssl/bn.h>
+#include <openssl/err.h>
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#else
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/integer.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 
 #include "libtorrent/aux_/random.hpp"
 #include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/pe_crypto.hpp"
+#include "libtorrent/aux_/scope_end.hpp"
 #include "libtorrent/hasher.hpp"
 
 namespace libtorrent::aux {
 
 	namespace {
-		// TODO: it would be nice to get the literal working
-		key_t const dh_prime
-			("0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A63A36210000000000090563");
+		// the prime P from the MSE spec, 768 bits big-endian. The
+		// generator is 2
+		// clang-format off
+		unsigned char const dh_prime_bytes[96] = {
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xc9, 0x0f, 0xda, 0xa2, 0x21, 0x68, 0xc2, 0x34,
+			0xc4, 0xc6, 0x62, 0x8b, 0x80, 0xdc, 0x1c, 0xd1,
+			0x29, 0x02, 0x4e, 0x08, 0x8a, 0x67, 0xcc, 0x74,
+			0x02, 0x0b, 0xbe, 0xa6, 0x3b, 0x13, 0x9b, 0x22,
+			0x51, 0x4a, 0x08, 0x79, 0x8e, 0x34, 0x04, 0xdd,
+			0xef, 0x95, 0x19, 0xb3, 0xcd, 0x3a, 0x43, 0x1b,
+			0x30, 0x2b, 0x0a, 0x6d, 0xf2, 0x5f, 0x14, 0x37,
+			0x4f, 0xe1, 0x35, 0x6d, 0x6d, 0x51, 0xc2, 0x45,
+			0xe4, 0x85, 0xb5, 0x76, 0x62, 0x5e, 0x7e, 0xc6,
+			0xf4, 0x4c, 0x42, 0xe9, 0xa6, 0x3a, 0x36, 0x21,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x05, 0x63
+		};
+		// clang-format on
+
+		char const req3[4] = {'r', 'e', 'q', '3'};
 	}
 
-	std::array<char, 96> export_key(key_t const& k)
-	{
-		std::array<char, 96> ret;
-		auto* begin = reinterpret_cast<std::uint8_t*>(ret.data());
-		std::uint8_t* end = mp::export_bits(k, begin, 8);
+	void rc4_init(const unsigned char* in, std::size_t len, rc4* state);
+	std::size_t rc4_encrypt(unsigned char* out, std::size_t outlen, rc4* state);
 
-		// TODO: it would be nice to be able to export to a fixed width field, so
-		// we wouldn't have to shift it later
-		if (end < begin + 96)
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL
+
+	namespace {
+
+		// per-thread libcrypto state: scratch space for BIGNUM math and
+		// constants derived from the prime, set up once and reused by
+		// every key exchange on the thread
+		struct openssl_context
 		{
-			int const len = int(end - begin);
-#if defined __GNUC__ && __GNUC__ == 12
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-			std::memmove(begin + 96 - len, begin, aux::numeric_cast<std::size_t>(len));
-#if defined __GNUC__ && __GNUC__ == 12
-#pragma GCC diagnostic pop
-#endif
-			std::memset(begin, 0, aux::numeric_cast<std::size_t>(96 - len));
-		}
-		return ret;
-	}
+			openssl_context() = default;
+			~openssl_context()
+			{
+				BN_MONT_CTX_free(montgomery);
+				BN_CTX_free(ctx);
+				BN_free(prime_minus_1);
+				BN_free(prime);
+			}
+			openssl_context(openssl_context const&) = delete;
+			openssl_context& operator=(openssl_context const&) = delete;
 
-	void rc4_init(const unsigned char* in, std::size_t len, rc4 *state);
-	std::size_t rc4_encrypt(unsigned char *out, std::size_t outlen, rc4 *state);
+			// these are initialized in declaration order, so prime_minus_1
+			// sees an already-initialized prime, and valid sees all four
+			BIGNUM* const prime = BN_bin2bn(dh_prime_bytes, int(sizeof(dh_prime_bytes)), nullptr);
+			BIGNUM* const prime_minus_1 = prime != nullptr ? BN_dup(prime) : nullptr;
+			BN_CTX* const ctx = BN_CTX_new();
+			BN_MONT_CTX* const montgomery = BN_MONT_CTX_new();
+			bool const valid = prime != nullptr && prime_minus_1 != nullptr && ctx != nullptr
+				&& montgomery != nullptr && BN_sub_word(prime_minus_1, 1) == 1
+				&& BN_MONT_CTX_set(montgomery, prime, ctx) == 1;
+		};
+
+		// export a BIGNUM as a 96 byte big-endian string, padded with
+		// leading zeroes. On failure "out" is left zeroed rather than
+		// holding a partial or stale value. The size check is what keeps
+		// BN_bn2bin (which takes no destination length) inside "out"
+		bool export_bignum(BIGNUM const* value, std::array<char, 96>& out)
+		{
+			out.fill(0);
+			int const size = int(BN_num_bytes(value));
+			// a zero value would export as an all-zero key, which is never
+			// a valid result of the modular exponentiation we do here
+			if (size <= 0 || size > int(out.size()))
+				return false;
+			if (int(BN_bn2bin(value,
+					reinterpret_cast<unsigned char*>(out.data()) + out.size() - std::size_t(size)))
+				== size)
+				return true;
+
+			// BN_bn2bin may already have written part of the value
+			out.fill(0);
+			return false;
+		}
+
+#if !defined BOOST_NO_CXX11_THREAD_LOCAL
+		// the thread's cached libcrypto state, set up on first use. If
+		// setting it up failed (out of memory), it is torn down and set up
+		// again on the next call, rather than leaving the thread unable to
+		// perform key exchanges forever. This is deliberately not a
+		// template, so there is exactly one context per thread
+		openssl_context const* thread_context()
+		{
+			static thread_local std::optional<openssl_context> storage;
+			if (!storage.has_value())
+				storage.emplace();
+			if (!storage->valid)
+			{
+				// don't hold on to a half-built context until the next call
+				storage.reset();
+				return nullptr;
+			}
+			return &*storage;
+		}
+#endif
+
+		// runs f with the thread's libcrypto state (or a fresh one, on
+		// compilers without thread_local), leaving the error queue the way
+		// we found it. Returns false if the state could not be set up or
+		// if f fails
+		template <typename F>
+		bool with_openssl_context(F f)
+		{
+			ERR_set_mark();
+			auto const restore_errors = aux::scope_end([] { ERR_pop_to_mark(); });
+#if defined BOOST_NO_CXX11_THREAD_LOCAL
+			openssl_context const storage;
+			return storage.valid && f(storage);
+#else
+			openssl_context const* const storage = thread_context();
+			return storage != nullptr && f(*storage);
+#endif
+		}
+	}
 
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
 	{
-		aux::array<std::uint8_t, 20> random_key;
-		aux::random_bytes({reinterpret_cast<char*>(random_key.data())
-			, static_cast<std::ptrdiff_t>(random_key.size())});
+		// create local secret (random)
+		aux::random_bytes({reinterpret_cast<char*>(m_dh_local_secret.data()),
+			static_cast<std::ptrdiff_t>(m_dh_local_secret.size())});
 
-		// create local key (random)
-		mp::import_bits(m_dh_local_secret, random_key.begin(), random_key.end());
+		m_good = with_openssl_context([&](openssl_context const& storage) {
+			// every BIGNUM below is owned by the context's stack frame, and
+			// is only valid until the matching BN_CTX_end()
+			BN_CTX_start(storage.ctx);
+			auto const frame = aux::scope_end([&] { BN_CTX_end(storage.ctx); });
 
-		// key = (2 ^ secret) % prime
-		m_dh_local_key = mp::powm(key_t(2), m_dh_local_secret, dh_prime);
+			BIGNUM* const generator = BN_CTX_get(storage.ctx);
+			BIGNUM* const exponent = BN_CTX_get(storage.ctx);
+			BIGNUM* const key = BN_CTX_get(storage.ctx);
+			if (generator == nullptr || exponent == nullptr || key == nullptr)
+				return false;
+
+			if (BN_set_word(generator, 2) != 1)
+				return false;
+			if (BN_bin2bn(m_dh_local_secret.data(), int(m_dh_local_secret.size()), exponent)
+				== nullptr)
+				return false;
+
+			// key = (2 ^ secret) % prime
+			if (BN_mod_exp_mont(
+					key, generator, exponent, storage.prime, storage.ctx, storage.montgomery)
+				!= 1)
+				return false;
+
+			return export_bignum(key, m_dh_local_key);
+		});
 	}
 
 	// compute shared secret given remote public key
 	bool dh_key_exchange::compute_secret(std::uint8_t const* remote_pubkey)
 	{
 		TORRENT_ASSERT(remote_pubkey);
-		key_t key;
-		mp::import_bits(key, remote_pubkey, remote_pubkey + 96);
-		return compute_secret(key);
+
+		// every failure path below shares one post-condition: no previous
+		// exchange's secret is left readable through the accessors
+		m_dh_shared_secret.fill(0);
+		m_xor_mask.clear();
+
+		// a previous call failed locally, or the key pair was never
+		// generated. Either way this object cannot produce a shared secret
+		if (!m_good)
+			return false;
+
+		bool degenerate = false;
+		bool const ok = with_openssl_context([&](openssl_context const& storage) {
+			// every BIGNUM below is owned by the context's stack frame, and
+			// is only valid until the matching BN_CTX_end()
+			BN_CTX_start(storage.ctx);
+			auto const frame = aux::scope_end([&] { BN_CTX_end(storage.ctx); });
+
+			BIGNUM* const pubkey = BN_CTX_get(storage.ctx);
+			BIGNUM* const exponent = BN_CTX_get(storage.ctx);
+			BIGNUM* const secret = BN_CTX_get(storage.ctx);
+			if (pubkey == nullptr || exponent == nullptr || secret == nullptr)
+				return false;
+
+			if (BN_bin2bn(remote_pubkey, 96, pubkey) == nullptr)
+				return false;
+
+			// reject degenerate public keys. Any value outside [2, p-2]
+			// produces a shared secret in a small subgroup (0, 1, or +/-1),
+			// which effectively defeats the key exchange and would allow a
+			// man-in-the-middle to fix the shared secret. 0 and 1 are the
+			// only values below 2. This is the peer's mistake, not a local
+			// failure
+			if (BN_is_zero(pubkey) || BN_is_one(pubkey)
+				|| BN_ucmp(pubkey, storage.prime_minus_1) >= 0)
+			{
+				degenerate = true;
+				return false;
+			}
+
+			if (BN_bin2bn(m_dh_local_secret.data(), int(m_dh_local_secret.size()), exponent)
+				== nullptr)
+				return false;
+
+			// shared_secret = (remote_pubkey ^ local_secret) % prime
+			if (BN_mod_exp_mont(
+					secret, pubkey, exponent, storage.prime, storage.ctx, storage.montgomery)
+				!= 1)
+				return false;
+
+			return export_bignum(secret, m_dh_shared_secret);
+		});
+		if (!ok)
+		{
+			// a failure other than the peer sending a degenerate key is a
+			// local crypto failure. Record it so the caller doesn't blame
+			// the peer
+			if (!degenerate)
+				m_good = false;
+			return false;
+		}
+
+		// calculate the xor mask for the obfuscated hash
+		m_xor_mask = hasher(req3).update(m_dh_shared_secret).final();
+		return true;
 	}
 
-	bool dh_key_exchange::compute_secret(key_t const& remote_pubkey)
+#else
+
+	namespace {
+
+		namespace mp = boost::multiprecision;
+		using key_t =
+			mp::number<mp::cpp_int_backend<768, 768, mp::unsigned_magnitude, mp::unchecked, void>>;
+
+		key_t make_dh_prime()
+		{
+			key_t ret;
+			mp::import_bits(ret, std::begin(dh_prime_bytes), std::end(dh_prime_bytes));
+			return ret;
+		}
+
+		key_t const dh_prime = make_dh_prime();
+
+		// export a bignum as a 96 byte big-endian string, padded with
+		// leading zeroes
+		void export_key(key_t const& value, std::array<char, 96>& out)
+		{
+			auto* const begin = reinterpret_cast<std::uint8_t*>(out.data());
+			std::uint8_t* const end = mp::export_bits(value, begin, 8);
+
+			if (end < begin + 96)
+			{
+				int const len = int(end - begin);
+#if defined __GNUC__ && __GNUC__ == 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+				std::memmove(begin + 96 - len, begin, aux::numeric_cast<std::size_t>(len));
+#if defined __GNUC__ && __GNUC__ == 12
+#pragma GCC diagnostic pop
+#endif
+				std::memset(begin, 0, aux::numeric_cast<std::size_t>(96 - len));
+			}
+		}
+	}
+
+	// Set the prime P and the generator, generate local public key
+	dh_key_exchange::dh_key_exchange()
 	{
+		// create local secret (random)
+		aux::random_bytes({reinterpret_cast<char*>(m_dh_local_secret.data()),
+			static_cast<std::ptrdiff_t>(m_dh_local_secret.size())});
+
+		key_t secret;
+		mp::import_bits(secret, m_dh_local_secret.begin(), m_dh_local_secret.end());
+
+		// key = (2 ^ secret) % prime
+		export_key(mp::powm(key_t(2), secret, dh_prime), m_dh_local_key);
+
+		// key_t is a fixed precision, unchecked integer with no allocator, so
+		// none of the operations above can fail. m_good is never cleared in
+		// this backend, unlike the libcrypto one
+		m_good = true;
+	}
+
+	// compute shared secret given remote public key
+	bool dh_key_exchange::compute_secret(std::uint8_t const* remote_pubkey)
+	{
+		TORRENT_ASSERT(remote_pubkey);
+
+		key_t pubkey;
+		mp::import_bits(pubkey, remote_pubkey, remote_pubkey + 96);
+
+		// every failure path below shares one post-condition: no previous
+		// exchange's secret is left readable through the accessors
+		m_dh_shared_secret.fill(0);
+		m_xor_mask.clear();
+
 		// reject degenerate public keys. Any value outside [2, p-2] produces
 		// a shared secret in a small subgroup (0, 1, or +/-1), which
 		// effectively defeats the key exchange and would allow a
 		// man-in-the-middle to fix the shared secret.
-		if (remote_pubkey < key_t(2) || remote_pubkey >= dh_prime - 1) return false;
+		if (pubkey < key_t(2) || pubkey >= dh_prime - 1)
+			return false;
+
+		key_t secret;
+		mp::import_bits(secret, m_dh_local_secret.begin(), m_dh_local_secret.end());
 
 		// shared_secret = (remote_pubkey ^ local_secret) % prime
-		m_dh_shared_secret = mp::powm(remote_pubkey, m_dh_local_secret, dh_prime);
+		export_key(mp::powm(pubkey, secret, dh_prime), m_dh_shared_secret);
 
-		std::array<char, 96> const buffer = export_key(m_dh_shared_secret);
-
-		static char const req3[4] = {'r', 'e', 'q', '3'};
 		// calculate the xor mask for the obfuscated hash
-		m_xor_mask = hasher(req3).update(buffer).final();
+		m_xor_mask = hasher(req3).update(m_dh_shared_secret).final();
 		return true;
 	}
+
+#endif // TORRENT_USE_LIBCRYPTO
 
 	std::tuple<int, span<span<char const>>>
 	encryption_handler::encrypt(

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -12,8 +12,9 @@ see LICENSE file.
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
-#include <iostream>
 
 #include "libtorrent/hasher.hpp"
 #include "libtorrent/hex.hpp"
@@ -99,65 +100,144 @@ TORRENT_TEST(diffie_hellman)
 	for (int rep = 0; rep < repcount; ++rep)
 	{
 		aux::dh_key_exchange DH1, DH2;
+		TEST_CHECK(DH1.good());
+		TEST_CHECK(DH2.good());
 
-		TEST_CHECK(DH1.compute_secret(DH2.get_local_key()));
-		TEST_CHECK(DH2.compute_secret(DH1.get_local_key()));
+		TEST_CHECK(
+			DH1.compute_secret(reinterpret_cast<std::uint8_t const*>(DH2.get_local_key().data())));
+		TEST_CHECK(
+			DH2.compute_secret(reinterpret_cast<std::uint8_t const*>(DH1.get_local_key().data())));
 
-		TEST_EQUAL(DH1.get_secret(), DH2.get_secret());
-		if (!DH1.get_secret() != DH2.get_secret())
+		TEST_CHECK(DH1.get_secret() == DH2.get_secret());
+		// guard against a backend that "succeeds" without writing anything:
+		// two all-zero buffers would compare equal
+		std::array<char, 96> const zero{};
+		TEST_CHECK(DH1.get_secret() != zero);
+		if (DH1.get_secret() != DH2.get_secret())
 		{
-			std::printf("DH1 local: ");
-			std::cout << DH1.get_local_key() << std::endl;
-
-			std::printf("DH2 local: ");
-			std::cout << DH2.get_local_key() << std::endl;
-
-			std::printf("DH1 shared_secret: ");
-			std::cout << DH1.get_secret() << std::endl;
-
-			std::printf("DH2 shared_secret: ");
-			std::cout << DH2.get_secret() << std::endl;
+			std::printf("DH1 local: %s\n", aux::to_hex(DH1.get_local_key()).c_str());
+			std::printf("DH2 local: %s\n", aux::to_hex(DH2.get_local_key()).c_str());
+			std::printf("DH1 shared_secret: %s\n", aux::to_hex(DH1.get_secret()).c_str());
+			std::printf("DH2 shared_secret: %s\n", aux::to_hex(DH2.get_secret()).c_str());
 		}
 	}
 }
 
 TORRENT_TEST(diffie_hellman_degenerate_key)
 {
-	// MODP DH prime (BEP 8) used by dh_key_exchange. The generator is 2.
-	lt::aux::key_t const dh_prime(
-		"0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020"
+	// MODP DH prime (BEP 8) used by dh_key_exchange, 96 bytes big-endian.
+	// The generator is 2.
+	char const dh_prime_hex[] =
+		"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020"
 		"BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D"
-		"6D51C245E485B576625E7EC6F44C42E9A63A36210000000000090563");
+		"6D51C245E485B576625E7EC6F44C42E9A63A36210000000000090563";
+
+	std::array<std::uint8_t, 96> prime{};
+	TEST_CHECK(lt::aux::from_hex(
+		{dh_prime_hex, int(sizeof(dh_prime_hex)) - 1}, reinterpret_cast<char*>(prime.data())));
+
+	// the prime ends in 0x63, so nearby values can be formed by patching
+	// the last byte
+	auto const patched = [&prime](std::uint8_t const last) {
+		std::array<std::uint8_t, 96> ret = prime;
+		ret[95] = last;
+		return ret;
+	};
+
+	std::array<std::uint8_t, 96> key{};
 
 	// public keys outside [2, p-2] are degenerate and must be rejected.
 	// Otherwise an attacker can fix the shared secret to a small set of
 	// known values, defeating the encryption.
 	{
 		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(lt::aux::key_t(0)));
+		TEST_CHECK(!dh.compute_secret(key.data())); // 0
+		// a degenerate peer key is the peer's fault, not a local failure
+		TEST_CHECK(dh.good());
 	}
 	{
 		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(lt::aux::key_t(1)));
+		key[95] = 1;
+		TEST_CHECK(!dh.compute_secret(key.data()));
+		TEST_CHECK(dh.good());
 	}
 	{
 		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(dh_prime - 1));
+		auto const p_minus_1 = patched(0x62);
+		TEST_CHECK(!dh.compute_secret(p_minus_1.data()));
+		TEST_CHECK(dh.good());
 	}
 	{
 		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(dh_prime));
+		TEST_CHECK(!dh.compute_secret(prime.data()));
+		TEST_CHECK(dh.good());
+	}
+	{
+		// p+1 is congruent to 1, so accepting it would fix the shared
+		// secret to 1 regardless of our secret exponent
+		lt::aux::dh_key_exchange dh;
+		auto const p_plus_1 = patched(0x64);
+		TEST_CHECK(!dh.compute_secret(p_plus_1.data()));
+		TEST_CHECK(dh.good());
 	}
 
 	// boundary values inside the valid range must be accepted.
 	{
 		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(dh.compute_secret(lt::aux::key_t(2)));
+		key[95] = 2;
+		TEST_CHECK(dh.compute_secret(key.data()));
 	}
 	{
 		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(dh.compute_secret(dh_prime - 2));
+		auto const p_minus_2 = patched(0x61);
+		TEST_CHECK(dh.compute_secret(p_minus_2.data()));
 	}
+}
+
+// a rejected peer key must not leave the previous exchange's shared secret
+// readable through the accessors
+TORRENT_TEST(diffie_hellman_failure_clears_secret)
+{
+	lt::aux::dh_key_exchange dh, peer;
+	TEST_CHECK(dh.good());
+	TEST_CHECK(peer.good());
+
+	TEST_CHECK(
+		dh.compute_secret(reinterpret_cast<std::uint8_t const*>(peer.get_local_key().data())));
+
+	std::array<char, 96> const zero{};
+	TEST_CHECK(dh.get_secret() != zero);
+	TEST_CHECK(!dh.get_hash_xor_mask().is_all_zeros());
+
+	// 1 is degenerate, so this exchange must fail -- and must not leave the
+	// secret from the successful exchange above readable
+	std::array<std::uint8_t, 96> degenerate{};
+	degenerate[95] = 1;
+	TEST_CHECK(!dh.compute_secret(degenerate.data()));
+	// a degenerate peer key is the peer's fault, so the object is still good
+	TEST_CHECK(dh.good());
+	TEST_CHECK(dh.get_secret() == zero);
+	TEST_CHECK(dh.get_hash_xor_mask().is_all_zeros());
+}
+
+// the xor mask must be hash('req3', S) over exactly what get_secret()
+// returns. This pins the 'req3' label and the identity of the hashed
+// buffer. It pins neither the width, the endianness, nor the padding of
+// that buffer, since both sides of the comparison would change together
+TORRENT_TEST(diffie_hellman_xor_mask)
+{
+	static char const req3[4] = {'r', 'e', 'q', '3'};
+
+	lt::aux::dh_key_exchange dh, peer;
+	TEST_CHECK(dh.good());
+	TEST_CHECK(peer.good());
+	if (!dh.good() || !peer.good())
+		return;
+
+	TEST_CHECK(
+		dh.compute_secret(reinterpret_cast<std::uint8_t const*>(peer.get_local_key().data())));
+
+	TEST_CHECK(dh.get_hash_xor_mask() == lt::hasher(req3).update(dh.get_secret()).final());
 }
 
 TORRENT_TEST(rc4)

--- a/tools/bencher.cpp
+++ b/tools/bencher.cpp
@@ -461,20 +461,32 @@ try
 #if !defined TORRENT_DISABLE_ENCRYPTION
 	using namespace lt::aux;
 
-	// key generation: random secret + (2 ^ secret) % prime
-	results.emplace_back("dh_key_exchange", analyze([] { dh_key_exchange const dh; }));
+	// every DH benchmark below fails loudly rather than timing a failing
+	// backend, which would look like a bogus speedup
 
-	// a peer's public key to react to, exported the same way it would
-	// arrive off the wire
+	// key generation: random secret + (2 ^ secret) % prime
+	results.emplace_back("dh_key_exchange", analyze([] {
+		dh_key_exchange const dh;
+		if (!dh.good())
+			throw std::runtime_error("DH key generation failed");
+	}));
+
+	// a peer's public key to react to, in the same wire format it would
+	// arrive in
 	dh_key_exchange const peer;
-	std::array<char, 96> const peer_key = export_key(peer.get_local_key());
+	if (!peer.good())
+		throw std::runtime_error("DH key generation failed");
+	std::array<char, 96> const& peer_key = peer.get_local_key();
 
 	// shared secret: (peer_pubkey ^ secret) % prime. this modexp is the
 	// operation that dominates the per-connection DH cost, isolated here
 	// from key generation and from hashing the resulting secret
 	dh_key_exchange dh;
+	if (!dh.good())
+		throw std::runtime_error("DH key generation failed");
 	results.emplace_back("dh_compute_secret", analyze([&] {
-		dh.compute_secret(reinterpret_cast<std::uint8_t const*>(peer_key.data()));
+		if (!dh.compute_secret(reinterpret_cast<std::uint8_t const*>(peer_key.data())))
+			throw std::runtime_error("DH shared secret failed");
 	}));
 
 	// the total DH cost incurred by one side of a PE handshake: generate
@@ -482,7 +494,9 @@ try
 	// key
 	results.emplace_back("dh_handshake", analyze([&] {
 		dh_key_exchange local;
-		local.compute_secret(reinterpret_cast<std::uint8_t const*>(peer_key.data()));
+		if (!local.good()
+			|| !local.compute_secret(reinterpret_cast<std::uint8_t const*>(peer_key.data())))
+			throw std::runtime_error("DH key exchange failed");
 	}));
 
 	// RC4 stream cipher throughput, encrypting a single 16 kiB buffer (the


### PR DESCRIPTION
## Summary

This follows the 160-bit exponent optimization merged in #8565 and offloads MSE
modular exponentiation to libcrypto when OpenSSL is available.

`dh_key_exchange` now has two implementations selected at compile time: a
libcrypto BIGNUM one (when `TORRENT_USE_LIBCRYPTO` is defined and
`TORRENT_USE_WOLFSSL` is not) and the existing Boost.Multiprecision one for
every other build.

- keys are stored and exposed in wire format (96-byte big-endian arrays), so
  the boost-int -> bytes -> BIGNUM round-trips are gone. `key_t` and
  `export_key()` are now private to `pe_crypto.cpp`, and `pe_crypto.hpp` no
  longer includes `<boost/multiprecision/cpp_int.hpp>` at all
- uses `BN_mod_exp_mont()` with a per-thread cached `BN_CTX`, `BN_MONT_CTX`
  and prime. Constant-time exponentiation and `OPENSSL_cleanse()` are
  deliberately not used, per review -- PE is obfuscation, not confidentiality,
  and the exponent is single-use
- sticks to BN APIs that LibreSSL also declares (no `BN_mod_exp_mont_word`),
  and keeps `BN_bn2bin` + manual left-pad rather than `BN_bn2binpad`, so
  OpenSSL 1.0 still builds
- `BN_CTX_start`/`BN_CTX_end` and `ERR_set_mark`/`ERR_pop_to_mark` are paired
  with `aux::scope_end`, so the shared per-thread context cannot be left
  unbalanced by an early return
- the degenerate-key rejection (outside `[2, p-2]`) is preserved in both
  backends, and the prime now has a single byte-array definition shared by
  both
- there is no `powm()` fallback in libcrypto builds: a local crypto failure
  fails the handshake. `good()` reports it, and the caller distinguishes it
  from a hostile peer key so our own failure isn't attributed to the peer at
  `peer_error` severity

The OpenSSL error queue is preserved across the whole operation via
`ERR_set_mark()`/`ERR_pop_to_mark()`, since the network thread shares it with
SSL torrents and HTTPS trackers.

## Benchmarks

`tools/bencher`, Release, AppleClang, OpenSSL 3.6, Apple silicon, measured
against this branch's merge base:

| benchmark | RC_2_1 | this branch |
|---|---:|---:|
| dh_key_exchange | 166 us | 24 us |
| dh_compute_secret | 183 us | 26 us |
| dh_handshake | 339-409 us | 52 us |

That is roughly a 7x improvement on the full per-connection DH cost. The
baseline varied noticeably run to run on a busy laptop, so treat these as
indicative -- now that #8637's base is `RC_2_1` and bencher thresholds are
configured, CI should produce the authoritative numbers.

## Tests

- `test_pe_crypto` (6 tests) passes with `crypto=openssl` and with the
  built-in/Boost backend, under ASan+UBSan, and with asserts and
  invariant-checks enabled
- new tests: a failed exchange must not leave the previous shared secret
  readable, and the xor mask must be `hash('req3', S)` over exactly what
  `get_secret()` returns. The degenerate-key test gained a `p+1` case, since
  `p+1` is congruent to 1 and would otherwise fix the shared secret
- cross-backend check: a libcrypto-built and a Boost-built binary perform DH
  with each other and agree on the shared secret, which pins the prime,
  endianness and zero-padding against the previous implementation rather than
  only against itself
- both PE fuzzers and `tools/bencher` updated to the new interface

Caveat worth stating: all of the above was run through CMake. I don't have
`b2` available locally, so the boost-build path -- including its warning set --
is only covered by CI here.

## Open questions

- `dh_key_exchange` is `aux_`-internal but `TORRENT_EXTRA_EXPORT`; its layout
  changes here. I've assumed `aux_` types sit outside the `RC_*` ABI contract,
  but say the word if that should target `master` instead.
- `errors::no_memory` now covers any local libcrypto failure, not just
  allocation. `no_entropy = 200` looks like precedent for giving this its own
  code -- happy to add one if you'd prefer.
