### PR TITLE
fix Python stub CI

### DIFF
--- a/bindings/python/libtorrent/__init__.pyi
+++ b/bindings/python/libtorrent/__init__.pyi
@@ -579,7 +579,7 @@ class alert(metaclass=_BoostBaseClass):
 
     class category_t(metaclass=_BoostBaseClass):
         __instance_size__: int
-        all_categories: Literal[4294967295]
+        all_categories: int
         block_progress_notification: Literal[16777216]
         connect_notification: Literal[32]
         debug_notification: Literal[32]

--- a/bindings/python/libtorrent/__init__.pyi
+++ b/bindings/python/libtorrent/__init__.pyi
@@ -1912,6 +1912,10 @@ class io_buffer_mode_t(int):
         3: io_buffer_mode_t.write_through,  # noqa: F821
     }
 
+class ip_ban_alert(alert):
+    @property
+    def banned_address(self) -> str: ...
+
 class ip_filter(metaclass=_BoostBaseClass):
     __instance_size__: int
     def access(self, _ip: str) -> int:

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,9 @@ deps =
 #   be able to find them in the installed environment.
 # - To ensure mypy *only* looks for the packaged type stubs and not the files
 #   in the python directory, only run mypy on the tests dir.
+# - stubtest compares the installed .pyi against the actual compiled module,
+#   catching bindings (e.g. a new alert type) that were exposed in C++ but
+#   never added to __init__.pyi.
 
 commands =
     {envpython} setup.py build_ext --b2-args "asserts=on invariant-checks=full debug-symbols=on" bdist_wheel
@@ -60,3 +63,4 @@ commands =
     {envpython} -m pip install -r test-requirements.txt
     {envpython} -m pytest -s -p no:faulthandler --log-level=DEBUG --log-cli-level=DEBUG
     {envpython} -m mypy --config-file mypy-tox.ini tests
+    {envpython} -m mypy.stubtest libtorrent


### PR DESCRIPTION
stubcheck needs to run for every PR, not just the ones building cibuildwheel.