### PR TITLE
fix DSCP marking on outgoing TCP peers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
 	* improve dont-count-slow-torrents
 	* improve performance of checking files
 	* add ip_ban_alert for IPs banned internally by libtorrent
+	* fix peer DSCP marking on outgoing TCP connections
 
 2.1.0 release
 

--- a/simulation/test_outgoing_interfaces.cpp
+++ b/simulation/test_outgoing_interfaces.cpp
@@ -29,8 +29,8 @@ namespace {
 	// src/enum_net.cpp).
 	constexpr char const* device_name = "eth0";
 
-	template <typename Settings, typename Test>
-	void run_test(Settings const& make_settings, Test const& test)
+	template <typename Settings, typename Alert, typename Test>
+	void run_test(Settings const& make_settings, Alert const& on_alert, Test const& test)
 	{
 		// setup the simulation
 		sim::default_config network_cfg;
@@ -56,12 +56,13 @@ namespace {
 		params.flags &= ~lt::torrent_flags::paused;
 		ses->async_add_torrent(params);
 
-		print_alerts(*ses, [](lt::session&, lt::alert const* a) {
+		print_alerts(*ses, [&](lt::session&, lt::alert const* a) {
 			if (auto at = lt::alert_cast<lt::add_torrent_alert>(a))
 			{
 				lt::torrent_handle h = at->handle;
 				add_fake_peer(h, 0);
 			}
+			on_alert(a);
 		});
 
 		sim::timer t(sim, lt::seconds(60), [&](boost::system::error_code const&) {
@@ -74,6 +75,12 @@ namespace {
 		});
 
 		sim.run();
+	}
+
+	template <typename Settings, typename Test>
+	void run_test(Settings const& make_settings, Test const& test)
+	{
+		run_test(make_settings, [](lt::alert const*) {}, test);
 	}
 
 } // anonymous namespace
@@ -123,3 +130,37 @@ TORRENT_TEST(outgoing_interfaces_matching_device_allowed_with_proxy)
 		},
 		[](fake_peer& p) { TEST_EQUAL(p.connected(), true); });
 }
+
+#ifndef TORRENT_DISABLE_LOGGING
+// peer_dscp must be applied after opening the socket but before initiating
+// the outgoing TCP connection. Otherwise set_traffic_class() fails with
+// error::bad_descriptor and the SYN is sent without the configured DSCP.
+TORRENT_TEST(outgoing_peer_dscp)
+{
+	bool socket_opened = false;
+	bool dscp_error = false;
+	run_test(
+		[](lt::settings_pack& pack) {
+			pack.set_int(lt::settings_pack::peer_dscp, 0x04);
+			pack.set_bool(lt::settings_pack::enable_outgoing_utp, false);
+		},
+		[&](lt::alert const* a) {
+			auto const* pl = lt::alert_cast<lt::peer_log_alert>(a);
+			if (pl == nullptr)
+				return;
+
+			if (pl->event_type == lt::peer_log_alert::open)
+				socket_opened = true;
+			else if (pl->event_type == lt::peer_log_alert::set_dscp)
+			{
+				TEST_EQUAL(socket_opened, true);
+				dscp_error = true;
+			}
+		},
+		[&](fake_peer& p) {
+			TEST_EQUAL(p.connected(), true);
+			TEST_EQUAL(socket_opened, true);
+			TEST_EQUAL(dscp_error, false);
+		});
+}
+#endif

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -309,10 +309,13 @@ namespace {
 				int const value = m_settings.get_int(settings_pack::peer_dscp);
 				aux::set_traffic_class(m_socket, value, ec);
 #ifndef TORRENT_DISABLE_LOGGING
-				if (ec && should_log(peer_log_alert::outgoing))
+				if (ec && should_log(peer_log_alert::incoming))
 				{
-					peer_log(peer_log_alert::outgoing, peer_log_alert::set_dscp, "value: %d e: %s"
-						, value, ec.message().c_str());
+					peer_log(peer_log_alert::incoming,
+						peer_log_alert::set_dscp,
+						"value: %d e: %s",
+						value,
+						ec.message().c_str());
 				}
 #endif
 			}
@@ -347,20 +350,6 @@ namespace {
 			init();
 		}
 
-		if (m_settings.get_int(settings_pack::peer_dscp) != 0)
-		{
-			int const value = m_settings.get_int(settings_pack::peer_dscp);
-			error_code ec;
-			aux::set_traffic_class(m_socket, value, ec);
-#ifndef TORRENT_DISABLE_LOGGING
-			if (ec && should_log(peer_log_alert::outgoing))
-			{
-				peer_log(peer_log_alert::outgoing, peer_log_alert::set_dscp, "value: %d e: %s"
-					, value, ec.message().c_str());
-			}
-#endif
-		}
-
 		// if this is an incoming connection, we're done here
 		if (!m_connecting)
 		{
@@ -391,6 +380,23 @@ namespace {
 		{
 			disconnect(ec, operation_t::sock_open);
 			return;
+		}
+
+		if (m_settings.get_int(settings_pack::peer_dscp) != 0)
+		{
+			int const value = m_settings.get_int(settings_pack::peer_dscp);
+			error_code err;
+			aux::set_traffic_class(m_socket, value, err);
+#ifndef TORRENT_DISABLE_LOGGING
+			if (err && should_log(peer_log_alert::outgoing))
+			{
+				peer_log(peer_log_alert::outgoing,
+					peer_log_alert::set_dscp,
+					"value: %d e: %s",
+					value,
+					err.message().c_str());
+			}
+#endif
 		}
 
 		tcp::endpoint const bound_ip = m_ses.bind_outgoing_socket(m_socket


### PR DESCRIPTION
## Problem

PR #7696 moved `peer_dscp` setup before `connect()` so that the TCP SYN would carry the configured traffic class. However, on the current `RC_2_1` branch the call is made before `m_socket.open()`.

An outgoing Boost.Asio TCP socket is only constructed at that point; it has no native descriptor yet. On Linux, `set_traffic_class()` therefore fails with `bad_descriptor`. `open()` subsequently creates the descriptor with the default traffic class (0), so the SYN and the rest of the connection remain unmarked.

This addresses the outgoing TCP part of #6812 and is a follow-up to #7696.

## Change

- Keep the existing single `peer_dscp` setup for incoming sockets, which have already been opened by `accept()`, and report any failure as incoming.
- For outgoing TCP peers, apply it after `open()` and before `bind()` / `async_connect()`.
- Use a separate error code so a DSCP failure cannot affect the bind path.
- Add a libsimulator regression test and a ChangeLog entry.

This leaves one DSCP setup site for each connection direction. The regression test disables outgoing uTP and specifically covers an ordinary outgoing TCP peer connection.

## Standalone POC

The relevant POC sequence is:

```cpp
boost::asio::io_context io;
boost::asio::ip::tcp::socket socket(io); // constructed, but not open
boost::system::error_code ec;

// Current RC_2_1 order
libtorrent_like_set_traffic_class(socket, 0x04, ec);
std::cout << ec.value() << " " << ec.message() << "\n";
socket.open(boost::asio::ip::tcp::v4(), ec);
socket.connect(server, ec);

// Correct order
boost::asio::ip::tcp::socket marked_socket(io);
marked_socket.open(boost::asio::ip::tcp::v4(), ec);
libtorrent_like_set_traffic_class(marked_socket, 0x04, ec);
marked_socket.connect(server, ec);
```

`libtorrent_like_set_traffic_class()` in the POC mirrors the relevant `local_endpoint()` and `set_option(IP_TOS)` flow in `aux::set_traffic_class()`.

Tested on Debian 13, Linux 6.12.90, Boost 1.83:

```text
[BAD: set DSCP -> open -> connect]
  initially is_open=0
  set_traffic_class before open: ec=9 ("Bad file descriptor")
  open: ec=0 ("Success")
  IP_TOS after open: raw ToS=0x0, decoded DSCP=0
  connect: ec=0 ("Success")

[GOOD: open -> set DSCP -> connect]
  initially is_open=0
  open: ec=0 ("Success")
  set_traffic_class after open: ec=0 ("Success")
  IP_TOS before connect: raw ToS=0x4, decoded DSCP=1
  connect: ec=0 ("Success")
```

The corresponding SYN packets captured with tcpdump were:

```text
IP (tos 0x0, ...) 127.0.0.1.35872 > 127.0.0.1.45432: Flags [S]
IP (tos 0x4, ...) 127.0.0.1.35882 > 127.0.0.1.45432: Flags [S]
```

## Regression test

Before the production change, the new test fails with:

```text
SET_DSCP [ value: 4 e: Bad file descriptor ]
OPEN [ protocol: IPv4 ]
ASYNC_CONNECT
TEST_ERROR: dscp_error: 1 expected: 0
```

With this change:

```text
$ cd simulation
$ b2 test_outgoing_interfaces -j2
**passed** .../test_outgoing_interfaces.test
```

Additional checks:

```text
git diff --check
git-clang-format-18 --binary clang-format-18 --diff HEAD -- \
  src/peer_connection.cpp simulation/test_outgoing_interfaces.cpp
clang-format did not modify any files
```
