### PR TITLE
Fix wrapped packet buffer range checks

### DIFF
--- a/src/packet_buffer.cpp
+++ b/src/packet_buffer.cpp
@@ -22,11 +22,12 @@ namespace aux {
 
 		constexpr packet_buffer::index_type index_mask = 0xffff;
 
-		bool is_in_range(packet_buffer::index_type const idx
-			, packet_buffer::index_type const first
-			, packet_buffer::index_type const capacity)
+		bool is_in_range(packet_buffer::index_type const idx,
+			packet_buffer::index_type const first,
+			packet_buffer::index_type const capacity)
 		{
-			if (idx > index_mask) return false;
+			if (idx > index_mask)
+				return false;
 			return ((idx - first) & index_mask) < capacity;
 		}
 
@@ -114,7 +115,8 @@ namespace aux {
 	packet* packet_buffer::at(index_type idx) const
 	{
 		INVARIANT_CHECK;
-		if (!is_in_range(idx, m_first, m_capacity)) return nullptr;
+		if (!is_in_range(idx, m_first, m_capacity))
+			return nullptr;
 
 		std::size_t const mask = m_capacity - 1;
 		return m_storage[idx & mask].get();
@@ -141,7 +143,8 @@ namespace aux {
 	packet_ptr packet_buffer::remove(index_type idx)
 	{
 		INVARIANT_CHECK;
-		if (!is_in_range(idx, m_first, m_capacity)) return {};
+		if (!is_in_range(idx, m_first, m_capacity))
+			return {};
 
 		std::size_t const mask = m_capacity - 1;
 		packet_ptr old_value = std::move(m_storage[idx & mask]);

--- a/src/packet_buffer.cpp
+++ b/src/packet_buffer.cpp
@@ -18,6 +18,20 @@ namespace aux {
 	bool compare_less_wrap(std::uint32_t lhs, std::uint32_t rhs
 		, std::uint32_t mask);
 
+	namespace {
+
+		constexpr packet_buffer::index_type index_mask = 0xffff;
+
+		bool is_in_range(packet_buffer::index_type const idx
+			, packet_buffer::index_type const first
+			, packet_buffer::index_type const capacity)
+		{
+			if (idx > index_mask) return false;
+			return ((idx - first) & index_mask) < capacity;
+		}
+
+	}
+
 #if TORRENT_USE_INVARIANT_CHECKS
 	void packet_buffer::check_invariant() const
 	{
@@ -100,11 +114,7 @@ namespace aux {
 	packet* packet_buffer::at(index_type idx) const
 	{
 		INVARIANT_CHECK;
-		if (idx >= m_first + m_capacity)
-			return nullptr;
-
-		if (compare_less_wrap(idx, m_first, 0xffff))
-			return nullptr;
+		if (!is_in_range(idx, m_first, m_capacity)) return nullptr;
 
 		std::size_t const mask = m_capacity - 1;
 		return m_storage[idx & mask].get();
@@ -131,12 +141,7 @@ namespace aux {
 	packet_ptr packet_buffer::remove(index_type idx)
 	{
 		INVARIANT_CHECK;
-		// TODO: use compare_less_wrap for this comparison as well
-		if (idx >= m_first + m_capacity)
-			return {};
-
-		if (compare_less_wrap(idx, m_first, 0xffff))
-			return {};
+		if (!is_in_range(idx, m_first, m_capacity)) return {};
 
 		std::size_t const mask = m_capacity - 1;
 		packet_ptr old_value = std::move(m_storage[idx & mask]);

--- a/test/test_packet_buffer.cpp
+++ b/test/test_packet_buffer.cpp
@@ -118,6 +118,21 @@ TORRENT_TEST(wrap)
 	TEST_EQUAL(get_val(pb.at(2)), 2);
 }
 
+TORRENT_TEST(wrap_outside_range)
+{
+	packet_pool pool;
+	packet_buffer pb;
+
+	pb.insert(0xfffe, make_pkt(pool, 1));
+	auto const outside = packet_buffer::index_type(
+		(0xfffe + pb.capacity()) & 0xffff);
+
+	TEST_CHECK(pb.at(outside) == nullptr);
+	TEST_CHECK(pb.remove(outside) == nullptr);
+	TEST_EQUAL(pb.size(), 1);
+	TEST_EQUAL(get_val(pb.at(0xfffe)), 1);
+}
+
 TORRENT_TEST(wrap2)
 {
 	// test wrapping the indices

--- a/test/test_packet_buffer.cpp
+++ b/test/test_packet_buffer.cpp
@@ -126,8 +126,7 @@ TORRENT_TEST(wrap_range_boundaries)
 
 	pb.insert(first, make_pkt(pool, 1));
 	auto const capacity = pb.capacity();
-	auto const last = packet_buffer::index_type(
-		(first + capacity - 1) & 0xffff);
+	auto const last = packet_buffer::index_type((first + capacity - 1) & 0xffff);
 	pb.insert(last, make_pkt(pool, 2));
 
 	auto const before = packet_buffer::index_type((first - 1) & 0xffff);

--- a/test/test_packet_buffer.cpp
+++ b/test/test_packet_buffer.cpp
@@ -118,19 +118,36 @@ TORRENT_TEST(wrap)
 	TEST_EQUAL(get_val(pb.at(2)), 2);
 }
 
-TORRENT_TEST(wrap_outside_range)
+TORRENT_TEST(wrap_range_boundaries)
 {
 	packet_pool pool;
 	packet_buffer pb;
+	auto const first = packet_buffer::index_type{0xfffe};
 
-	pb.insert(0xfffe, make_pkt(pool, 1));
-	auto const outside = packet_buffer::index_type(
-		(0xfffe + pb.capacity()) & 0xffff);
+	pb.insert(first, make_pkt(pool, 1));
+	auto const capacity = pb.capacity();
+	auto const last = packet_buffer::index_type(
+		(first + capacity - 1) & 0xffff);
+	pb.insert(last, make_pkt(pool, 2));
 
-	TEST_CHECK(pb.at(outside) == nullptr);
-	TEST_CHECK(pb.remove(outside) == nullptr);
-	TEST_EQUAL(pb.size(), 1);
-	TEST_EQUAL(get_val(pb.at(0xfffe)), 1);
+	auto const before = packet_buffer::index_type((first - 1) & 0xffff);
+	auto const after = packet_buffer::index_type((first + capacity) & 0xffff);
+	auto const out_of_domain = packet_buffer::index_type(first + 0x10000);
+
+	TEST_EQUAL(get_val(pb.at(first)), 1);
+	TEST_EQUAL(get_val(pb.at(last)), 2);
+	TEST_CHECK(pb.at(before) == nullptr);
+	TEST_CHECK(pb.at(after) == nullptr);
+	TEST_CHECK(pb.at(out_of_domain) == nullptr);
+
+	TEST_CHECK(pb.remove(before) == nullptr);
+	TEST_CHECK(pb.remove(after) == nullptr);
+	TEST_CHECK(pb.remove(out_of_domain) == nullptr);
+	TEST_EQUAL(pb.size(), 2);
+	TEST_EQUAL(pb.cursor(), first);
+	TEST_EQUAL(pb.span(), capacity);
+	TEST_EQUAL(get_val(pb.at(first)), 1);
+	TEST_EQUAL(get_val(pb.at(last)), 2);
 }
 
 TORRENT_TEST(wrap2)


### PR DESCRIPTION
Fix packet_buffer range checks so at() and remove() reject indices outside the active 16-bit sequence window instead of aliasing occupied storage slots.

Both operations now share the same modular range check. The regression test covers wrapped boundaries, out-of-domain indices, and state preservation after invalid removals.

Validated with test_packet_buffer and test_utp under CMake and Boost.Build.