### PR TITLE
use libcrypto's bignum in DH key exchange

### DIFF
--- a/fuzzers/src/pe_conn.cpp
+++ b/fuzzers/src/pe_conn.cpp
@@ -68,9 +68,8 @@ peer_fuzz_session g_fz;
 
 // Build RC4 keys for an outgoing (client-initiating) PE connection.
 // The client's send key is hash("keyA", S, SKEY); receive key is hash("keyB", S, SKEY).
-static std::shared_ptr<rc4_handler> make_rc4(lt::aux::key_t const& secret, sha1_hash const& skey)
+static std::shared_ptr<rc4_handler> make_rc4(span<char const> secret_buf, sha1_hash const& skey)
 {
-	std::array<char, 96> const secret_buf = export_key(secret);
 	static const char keyA[4] = {'k', 'e', 'y', 'A'};
 	static const char keyB[4] = {'k', 'e', 'y', 'B'};
 
@@ -132,7 +131,7 @@ extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size
 
 	// Generate a fresh DH key pair for this connection.
 	dh_key_exchange dh;
-	std::array<char, 96> const local_dh_key = export_key(dh.get_local_key());
+	auto const& local_dh_key = dh.get_local_key();
 
 	// Step 1: send our DH public key + PadA.
 	// PadA bytes come from fuzz input so libFuzzer can explore the sync-hash
@@ -161,13 +160,12 @@ extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size
 
 	// Compute DH shared secret and derive RC4 keys.
 	dh.compute_secret(reinterpret_cast<std::uint8_t const*>(srv_key.data()));
-	lt::aux::key_t const secret = dh.get_secret();
-	std::array<char, 96> const secret_buf = export_key(secret);
+	auto const& secret_buf = dh.get_secret();
 
 	// Use the v1 info hash as SKEY. The server's for_each loop tries both the
 	// v1 SHA-1 hash and the first 20 bytes of the v2 SHA-256 hash.
 	sha1_hash const& skey = g_fz.info_hash.v1;
-	auto const rc4 = make_rc4(secret, skey);
+	auto const rc4 = make_rc4(secret_buf, skey);
 
 	// Step 3: compute sync hash and obfuscated SKEY hash.
 

--- a/fuzzers/src/pe_crypto_state.cpp
+++ b/fuzzers/src/pe_crypto_state.cpp
@@ -37,9 +37,9 @@ extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size
 	lt::aux::dh_key_exchange a;
 	lt::aux::dh_key_exchange b;
 
-	auto const b_pub = lt::aux::export_key(b.get_local_key());
+	auto const& b_pub = b.get_local_key();
 	a.compute_secret(reinterpret_cast<std::uint8_t const*>(b_pub.data()));
-	auto const a_pub = lt::aux::export_key(a.get_local_key());
+	auto const& a_pub = a.get_local_key();
 	b.compute_secret(reinterpret_cast<std::uint8_t const*>(a_pub.data()));
 
 	auto key_in = make_key(data, size, 1);

--- a/include/libtorrent/aux_/pe_crypto.hpp
+++ b/include/libtorrent/aux_/pe_crypto.hpp
@@ -35,10 +35,6 @@ namespace libtorrent::aux {
 
 	namespace mp = boost::multiprecision;
 
-	using key_t = mp::number<mp::cpp_int_backend<768, 768, mp::unsigned_magnitude, mp::unchecked, void>>;
-
-	TORRENT_EXTRA_EXPORT std::array<char, 96> export_key(key_t const& k);
-
 	// RC4 state from libtomcrypt. buf holds a permutation of 0-255, stored
 	// widened to 32 bits per entry so every access is a whole-register
 	// load/store.
@@ -54,25 +50,31 @@ namespace libtorrent::aux {
 	public:
 		dh_key_exchange();
 
-		// Get local public key
-		key_t const& get_local_key() const { return m_dh_local_key; }
+		// Get local public key, DH-exported to a fixed-width 96 byte big
+		// endian buffer.
+		std::array<char, 96> const& get_local_key() const { return m_dh_local_key; }
 
 		// read remote_pubkey, generate and store shared secret in
 		// m_dh_shared_secret. Returns false if the remote public key is
 		// degenerate (i.e. outside the range [2, p-2]) and the shared
 		// secret was not computed.
 		bool compute_secret(std::uint8_t const* remote_pubkey);
-		bool compute_secret(key_t const& remote_pubkey);
 
-		key_t const& get_secret() const { return m_dh_shared_secret; }
+		std::array<char, 96> const& get_secret() const { return m_dh_shared_secret; }
 
 		sha1_hash const& get_hash_xor_mask() const { return m_xor_mask; }
 
 	private:
+		using key_t =
+			mp::number<mp::cpp_int_backend<768, 768, mp::unsigned_magnitude, mp::unchecked, void>>;
 
-		key_t m_dh_local_key;
+		static key_t const& dh_prime();
+		static std::array<char, 96> export_key(key_t const& k);
+
 		key_t m_dh_local_secret;
-		key_t m_dh_shared_secret;
+		std::array<char, 96> m_dh_local_key;
+		// only valid after a successful call to compute_secret()
+		std::array<char, 96> m_dh_shared_secret{};
 		sha1_hash m_xor_mask;
 	};
 

--- a/include/libtorrent/aux_/pe_crypto.hpp
+++ b/include/libtorrent/aux_/pe_crypto.hpp
@@ -17,7 +17,14 @@ see LICENSE file.
 #include "libtorrent/config.hpp"
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL
+extern "C"
+{
+#include <openssl/bn.h>
+}
+#else
 #include <boost/multiprecision/cpp_int.hpp>
+#endif
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
 #include "libtorrent/aux_/receive_buffer.hpp"
@@ -26,14 +33,19 @@ see LICENSE file.
 #include "libtorrent/assert.hpp"
 #include "libtorrent/span.hpp"
 #include "libtorrent/aux_/array.hpp"
+#include "libtorrent/aux_/throw.hpp"
+#include "libtorrent/error_code.hpp"
 
 #include <list>
 #include <array>
 #include <cstdint>
+#include <memory>
 
 namespace libtorrent::aux {
 
+#if !defined TORRENT_USE_LIBCRYPTO || defined TORRENT_USE_WOLFSSL
 	namespace mp = boost::multiprecision;
+#endif
 
 	// RC4 state from libtomcrypt. buf holds a permutation of 0-255, stored
 	// widened to 32 bits per entry so every access is a whole-register
@@ -65,8 +77,56 @@ namespace libtorrent::aux {
 		sha1_hash const& get_hash_xor_mask() const { return m_xor_mask; }
 
 	private:
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL
+		// Move-only RAII wrapper around a libcrypto BIGNUM. Used internally
+		// for the DH modular exponentiation. Throws system_error
+		// (error_code errors::no_memory) if the underlying BIGNUM
+		// allocation failed, so a successfully constructed key_t always
+		// wraps a valid BIGNUM.
+		class key_t
+		{
+		public:
+			key_t()
+				: key_t(BN_new())
+			{}
+			explicit key_t(::BIGNUM* b)
+				: m_b(b, &BN_free)
+			{
+				if (!m_b)
+					aux::throw_ex<system_error>(errors::no_memory);
+			}
+			key_t(key_t const&) = delete;
+			key_t(key_t&&) noexcept = default;
+			key_t& operator=(key_t const&) = delete;
+			key_t& operator=(key_t&&) noexcept = default;
+			~key_t() = default;
+
+			::BIGNUM* get() { return m_b.get(); }
+			::BIGNUM const* get() const { return m_b.get(); }
+
+		private:
+			std::unique_ptr<::BIGNUM, void (*)(::BIGNUM*)> m_b;
+		};
+
+		// the DH generator (also the lower bound of the valid public-key range)
+		static key_t const& two();
+		// upper bound (exclusive) of the valid public-key range
+		static key_t const& dh_prime_minus_1();
+
+		// scratch space for BN_mod_exp(), reused across calls rather than
+		// allocated fresh each time, since BN_CTX internally pools the
+		// temporary BIGNUMs it hands out. One instance per thread
+		// (thread_local), since a BN_CTX is not safe to use concurrently
+		// from multiple threads. Falls back to a single instance guarded by a
+		// mutex where thread_local isn't available.
+		static ::BN_CTX* ctx();
+#else
+		// also used for TORRENT_USE_WOLFSSL builds: wolfSSL's OpenSSL
+		// compatibility layer does not reliably provide the same BN_*
+		// function names/semantics as real libcrypto.
 		using key_t =
 			mp::number<mp::cpp_int_backend<768, 768, mp::unsigned_magnitude, mp::unchecked, void>>;
+#endif
 
 		static key_t const& dh_prime();
 		static std::array<char, 96> export_key(key_t const& k);

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -534,12 +534,7 @@ namespace {
 			peer_log(peer_log_alert::info, peer_log_alert::encryption, "initiating encrypted handshake");
 #endif
 
-		m_dh_key_exchange.reset(new (std::nothrow) dh_key_exchange);
-		if (!m_dh_key_exchange)
-		{
-			disconnect(errors::no_memory, operation_t::encryption);
-			return;
-		}
+		m_dh_key_exchange.reset(new dh_key_exchange);
 
 		int const pad_size = int(random(512));
 

--- a/src/bt_peer_connection.cpp
+++ b/src/bt_peer_connection.cpp
@@ -67,8 +67,8 @@ namespace {
 	// stream key (info hash of attached torrent)
 	// secret is the DH shared secret
 	// initializes m_enc_handler
-	std::shared_ptr<rc4_handler> init_pe_rc4_handler(key_t const& secret
-		, sha1_hash const& stream_key, bool const outgoing)
+	std::shared_ptr<rc4_handler> init_pe_rc4_handler(
+		span<char const> secret_buf, sha1_hash const& stream_key, bool const outgoing)
 	{
 		hasher h;
 		static const char keyA[] = {'k', 'e', 'y', 'A'};
@@ -77,8 +77,6 @@ namespace {
 		// encryption rc4 longkeys
 		// outgoing connection : hash ('keyA',S,SKEY)
 		// incoming connection : hash ('keyB',S,SKEY)
-
-		std::array<char, dh_key_len> const secret_buf = export_key(secret);
 
 		if (outgoing) h.update(keyA); else h.update(keyB);
 		h.update(secret_buf);
@@ -553,7 +551,7 @@ namespace {
 		char* ptr = msg;
 		int const buf_size = int(dh_key_len) + pad_size;
 
-		std::array<char, dh_key_len> const local_key = export_key(m_dh_key_exchange->get_local_key());
+		std::array<char, dh_key_len> const& local_key = m_dh_key_exchange->get_local_key();
 		std::memcpy(ptr, local_key.data(), dh_key_len);
 		ptr += dh_key_len;
 
@@ -576,8 +574,7 @@ namespace {
 
 		hasher h;
 		sha1_hash const& info_hash = associated_info_hash();
-		key_t const secret_key = m_dh_key_exchange->get_secret();
-		std::array<char, dh_key_len> const secret = export_key(secret_key);
+		std::array<char, dh_key_len> const& secret = m_dh_key_exchange->get_secret();
 
 		int const pad_size = int(random(512));
 
@@ -619,7 +616,7 @@ namespace {
 		ptr += 20;
 
 		// Discard DH key exchange data, setup RC4 keys
-		m_rc4 = init_pe_rc4_handler(secret_key, info_hash, is_outgoing());
+		m_rc4 = init_pe_rc4_handler(secret, info_hash, is_outgoing());
 #ifndef TORRENT_DISABLE_LOGGING
 		peer_log(peer_log_alert::info, peer_log_alert::encryption, "computed RC4 keys");
 #endif
@@ -2888,7 +2885,7 @@ namespace {
 
 				static char const req1[4] = {'r', 'e', 'q', '1'};
 				// compute synchash (hash('req1',S))
-				std::array<char, dh_key_len> const buffer = export_key(m_dh_key_exchange->get_secret());
+				std::array<char, dh_key_len> const& buffer = m_dh_key_exchange->get_secret();
 				hasher h(req1);
 				h.update(buffer);
 				m_sync_hash = std::make_unique<sha1_hash>(h.final());

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -19,16 +19,167 @@ see LICENSE file.
 #include <random>
 #include <utility>
 
+#if !defined TORRENT_USE_LIBCRYPTO || defined TORRENT_USE_WOLFSSL
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 #include <boost/multiprecision/integer.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
+
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL \
+	&& defined BOOST_NO_CXX11_THREAD_LOCAL
+#include <mutex>
+#endif
 
 #include "libtorrent/aux_/random.hpp"
 #include "libtorrent/aux_/alloca.hpp"
 #include "libtorrent/aux_/pe_crypto.hpp"
+#include "libtorrent/aux_/throw.hpp"
+#include "libtorrent/error_code.hpp"
 #include "libtorrent/hasher.hpp"
 
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL \
+	&& defined BOOST_NO_CXX11_THREAD_LOCAL
+namespace {
+	// if BN_CTX can't be thread_local, fall back to a single shared
+	// instance protected by a mutex (see src/random.cpp for the same
+	// fallback pattern used for the RNG state).
+	std::mutex g_bn_ctx_mutex;
+}
+#endif
+
 namespace libtorrent::aux {
+
+#if defined TORRENT_USE_LIBCRYPTO && !defined TORRENT_USE_WOLFSSL
+
+	dh_key_exchange::key_t const& dh_key_exchange::dh_prime()
+	{
+		static key_t const prime = [] {
+			BIGNUM* p = nullptr;
+			BN_hex2bn(&p,
+				"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B2251"
+				"4A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C"
+				"42E9A63A36210000000000090563");
+			return key_t(p);
+		}();
+		return prime;
+	}
+
+	dh_key_exchange::key_t const& dh_key_exchange::two()
+	{
+		static key_t const val = [] {
+			key_t v;
+			if (!BN_set_word(v.get(), 2))
+				aux::throw_ex<system_error>(errors::no_memory);
+			return v;
+		}();
+		return val;
+	}
+
+	dh_key_exchange::key_t const& dh_key_exchange::dh_prime_minus_1()
+	{
+		static key_t const val = [] {
+			key_t one;
+			if (!BN_set_word(one.get(), 1))
+				aux::throw_ex<system_error>(errors::no_memory);
+			key_t v;
+			if (!BN_sub(v.get(), dh_prime().get(), one.get()))
+				aux::throw_ex<system_error>(errors::no_memory);
+			return v;
+		}();
+		return val;
+	}
+
+	::BN_CTX* dh_key_exchange::ctx()
+	{
+		auto make_ctx = [] {
+			std::unique_ptr<::BN_CTX, void (*)(::BN_CTX*)> ret(BN_CTX_new(), &BN_CTX_free);
+			if (!ret)
+				aux::throw_ex<system_error>(errors::no_memory);
+			return ret;
+		};
+#ifdef BOOST_NO_CXX11_THREAD_LOCAL
+		static std::unique_ptr<::BN_CTX, void (*)(::BN_CTX*)> shared_ctx = make_ctx();
+#else
+		thread_local static std::unique_ptr<::BN_CTX, void (*)(::BN_CTX*)> shared_ctx = make_ctx();
+#endif
+		return shared_ctx.get();
+	}
+
+	std::array<char, 96> dh_key_exchange::export_key(key_t const& k)
+	{
+		std::array<char, 96> ret;
+		auto* begin = reinterpret_cast<unsigned char*>(ret.data());
+		int const len = BN_bn2bin(k.get(), begin);
+
+		// TODO: it would be nice to be able to export to a fixed width field, so
+		// we wouldn't have to shift it later
+		if (len < 96)
+		{
+			std::memmove(begin + 96 - len, begin, aux::numeric_cast<std::size_t>(len));
+			std::memset(begin, 0, aux::numeric_cast<std::size_t>(96 - len));
+		}
+		return ret;
+	}
+
+	// Set the prime P and the generator, generate local public key
+	dh_key_exchange::dh_key_exchange()
+	{
+		aux::array<std::uint8_t, 20> random_key;
+		aux::random_bytes({reinterpret_cast<char*>(random_key.data()),
+			static_cast<std::ptrdiff_t>(random_key.size())});
+
+		// create local key (random)
+		if (!BN_bin2bn(random_key.data(), int(random_key.size()), m_dh_local_secret.get()))
+			aux::throw_ex<system_error>(errors::no_memory);
+
+		// key = (2 ^ secret) % prime
+		key_t local_key;
+
+		{
+#ifdef BOOST_NO_CXX11_THREAD_LOCAL
+			std::lock_guard<std::mutex> l(g_bn_ctx_mutex);
+#endif
+			if (!BN_mod_exp(
+					local_key.get(), two().get(), m_dh_local_secret.get(), dh_prime().get(), ctx()))
+				aux::throw_ex<system_error>(errors::no_memory);
+		}
+		m_dh_local_key = export_key(local_key);
+	}
+
+	// compute shared secret given remote public key
+	bool dh_key_exchange::compute_secret(std::uint8_t const* remote_pubkey)
+	{
+		TORRENT_ASSERT(remote_pubkey);
+		key_t key;
+		if (!BN_bin2bn(remote_pubkey, 96, key.get()))
+			aux::throw_ex<system_error>(errors::no_memory);
+
+		// reject degenerate public keys. Any value outside [2, p-2] produces
+		// a shared secret in a small subgroup (0, 1, or +/-1), which
+		// effectively defeats the key exchange and would allow a
+		// man-in-the-middle to fix the shared secret.
+		if (BN_cmp(key.get(), two().get()) < 0 || BN_cmp(key.get(), dh_prime_minus_1().get()) >= 0)
+			return false;
+
+		// shared_secret = (remote_pubkey ^ local_secret) % prime
+		key_t secret;
+		{
+#ifdef BOOST_NO_CXX11_THREAD_LOCAL
+			std::lock_guard<std::mutex> l(g_bn_ctx_mutex);
+#endif
+			if (!BN_mod_exp(
+					secret.get(), key.get(), m_dh_local_secret.get(), dh_prime().get(), ctx()))
+				aux::throw_ex<system_error>(errors::no_memory);
+		}
+		m_dh_shared_secret = export_key(secret);
+
+		static char const req3[4] = {'r', 'e', 'q', '3'};
+		// calculate the xor mask for the obfuscated hash
+		m_xor_mask = hasher(req3).update(m_dh_shared_secret).final();
+		return true;
+	}
+
+#else // TORRENT_USE_LIBCRYPTO
 
 	dh_key_exchange::key_t const& dh_key_exchange::dh_prime()
 	{
@@ -102,6 +253,8 @@ namespace libtorrent::aux {
 		m_xor_mask = hasher(req3).update(m_dh_shared_secret).final();
 		return true;
 	}
+
+#endif // TORRENT_USE_LIBCRYPTO
 
 	void rc4_init(const unsigned char* in, std::size_t len, rc4* state);
 	std::size_t rc4_encrypt(unsigned char* out, std::size_t outlen, rc4* state);

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -30,13 +30,17 @@ see LICENSE file.
 
 namespace libtorrent::aux {
 
-	namespace {
+	dh_key_exchange::key_t const& dh_key_exchange::dh_prime()
+	{
 		// TODO: it would be nice to get the literal working
-		key_t const dh_prime
-			("0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A63A36210000000000090563");
+		static key_t const prime(
+			"0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A"
+			"08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A6"
+			"3A36210000000000090563");
+		return prime;
 	}
 
-	std::array<char, 96> export_key(key_t const& k)
+	std::array<char, 96> dh_key_exchange::export_key(key_t const& k)
 	{
 		std::array<char, 96> ret;
 		auto* begin = reinterpret_cast<std::uint8_t*>(ret.data());
@@ -60,9 +64,6 @@ namespace libtorrent::aux {
 		return ret;
 	}
 
-	void rc4_init(const unsigned char* in, std::size_t len, rc4 *state);
-	std::size_t rc4_encrypt(unsigned char *out, std::size_t outlen, rc4 *state);
-
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
 	{
@@ -74,7 +75,8 @@ namespace libtorrent::aux {
 		mp::import_bits(m_dh_local_secret, random_key.begin(), random_key.end());
 
 		// key = (2 ^ secret) % prime
-		m_dh_local_key = mp::powm(key_t(2), m_dh_local_secret, dh_prime);
+		key_t const local_key = mp::powm(key_t(2), m_dh_local_secret, dh_prime());
+		m_dh_local_key = export_key(local_key);
 	}
 
 	// compute shared secret given remote public key
@@ -83,27 +85,26 @@ namespace libtorrent::aux {
 		TORRENT_ASSERT(remote_pubkey);
 		key_t key;
 		mp::import_bits(key, remote_pubkey, remote_pubkey + 96);
-		return compute_secret(key);
-	}
 
-	bool dh_key_exchange::compute_secret(key_t const& remote_pubkey)
-	{
 		// reject degenerate public keys. Any value outside [2, p-2] produces
 		// a shared secret in a small subgroup (0, 1, or +/-1), which
 		// effectively defeats the key exchange and would allow a
 		// man-in-the-middle to fix the shared secret.
-		if (remote_pubkey < key_t(2) || remote_pubkey >= dh_prime - 1) return false;
+		if (key < key_t(2) || key >= dh_prime() - 1)
+			return false;
 
 		// shared_secret = (remote_pubkey ^ local_secret) % prime
-		m_dh_shared_secret = mp::powm(remote_pubkey, m_dh_local_secret, dh_prime);
-
-		std::array<char, 96> const buffer = export_key(m_dh_shared_secret);
+		key_t const secret = mp::powm(key, m_dh_local_secret, dh_prime());
+		m_dh_shared_secret = export_key(secret);
 
 		static char const req3[4] = {'r', 'e', 'q', '3'};
 		// calculate the xor mask for the obfuscated hash
-		m_xor_mask = hasher(req3).update(buffer).final();
+		m_xor_mask = hasher(req3).update(m_dh_shared_secret).final();
 		return true;
 	}
+
+	void rc4_init(const unsigned char* in, std::size_t len, rc4* state);
+	std::size_t rc4_encrypt(unsigned char* out, std::size_t outlen, rc4* state);
 
 	std::tuple<int, span<span<char const>>>
 	encryption_handler::encrypt(

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -137,8 +137,9 @@ TORRENT_TEST(diffie_hellman_degenerate_key)
 	auto const decremented = [](std::array<char, 96> v, int n) {
 		for (int i = int(v.size()) - 1; i >= 0 && n != 0; --i)
 		{
-			int const digit = int(std::uint8_t(v[i])) - n;
-			v[i] = char(digit);
+			auto const idx = static_cast<std::size_t>(i);
+			int const digit = int(std::uint8_t(v[idx])) - n;
+			v[idx] = char(digit);
 			n = (digit < 0) ? 1 : 0;
 		}
 		return v;

--- a/test/test_pe_crypto.cpp
+++ b/test/test_pe_crypto.cpp
@@ -12,6 +12,7 @@ see LICENSE file.
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 
@@ -100,64 +101,71 @@ TORRENT_TEST(diffie_hellman)
 	{
 		aux::dh_key_exchange DH1, DH2;
 
-		TEST_CHECK(DH1.compute_secret(DH2.get_local_key()));
-		TEST_CHECK(DH2.compute_secret(DH1.get_local_key()));
+		auto const& dh1_local = DH1.get_local_key();
+		auto const& dh2_local = DH2.get_local_key();
 
-		TEST_EQUAL(DH1.get_secret(), DH2.get_secret());
-		if (!DH1.get_secret() != DH2.get_secret())
+		TEST_CHECK(DH1.compute_secret(reinterpret_cast<std::uint8_t const*>(dh2_local.data())));
+		TEST_CHECK(DH2.compute_secret(reinterpret_cast<std::uint8_t const*>(dh1_local.data())));
+
+		auto const& secret1 = DH1.get_secret();
+		auto const& secret2 = DH2.get_secret();
+
+		TEST_EQUAL(aux::to_hex(secret1), aux::to_hex(secret2));
+		if (secret1 != secret2)
 		{
-			std::printf("DH1 local: ");
-			std::cout << DH1.get_local_key() << std::endl;
-
-			std::printf("DH2 local: ");
-			std::cout << DH2.get_local_key() << std::endl;
-
-			std::printf("DH1 shared_secret: ");
-			std::cout << DH1.get_secret() << std::endl;
-
-			std::printf("DH2 shared_secret: ");
-			std::cout << DH2.get_secret() << std::endl;
+			std::cout << "DH1 local: " << aux::to_hex(dh1_local) << std::endl;
+			std::cout << "DH2 local: " << aux::to_hex(dh2_local) << std::endl;
+			std::cout << "DH1 shared_secret: " << aux::to_hex(secret1) << std::endl;
+			std::cout << "DH2 shared_secret: " << aux::to_hex(secret2) << std::endl;
 		}
 	}
 }
 
 TORRENT_TEST(diffie_hellman_degenerate_key)
 {
+	using namespace lt;
+
 	// MODP DH prime (BEP 8) used by dh_key_exchange. The generator is 2.
-	lt::aux::key_t const dh_prime(
-		"0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020"
-		"BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D"
-		"6D51C245E485B576625E7EC6F44C42E9A63A36210000000000090563");
+	char const prime_hex[] = "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020"
+							 "BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D"
+							 "6D51C245E485B576625E7EC6F44C42E9A63A36210000000000090563";
+
+	std::array<char, 96> dh_prime{};
+	TEST_CHECK(aux::from_hex({prime_hex, int(sizeof(prime_hex) - 1)}, dh_prime.data()));
+
+	// subtract a small value (0-255) from a 96-byte big endian buffer
+	auto const decremented = [](std::array<char, 96> v, int n) {
+		for (int i = int(v.size()) - 1; i >= 0 && n != 0; --i)
+		{
+			int const digit = int(std::uint8_t(v[i])) - n;
+			v[i] = char(digit);
+			n = (digit < 0) ? 1 : 0;
+		}
+		return v;
+	};
+
+	auto const small_value = [](std::uint8_t const v) {
+		std::array<char, 96> ret{};
+		ret.back() = char(v);
+		return ret;
+	};
+
+	auto const compute = [](std::array<char, 96> const& key) {
+		aux::dh_key_exchange dh;
+		return dh.compute_secret(reinterpret_cast<std::uint8_t const*>(key.data()));
+	};
 
 	// public keys outside [2, p-2] are degenerate and must be rejected.
 	// Otherwise an attacker can fix the shared secret to a small set of
 	// known values, defeating the encryption.
-	{
-		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(lt::aux::key_t(0)));
-	}
-	{
-		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(lt::aux::key_t(1)));
-	}
-	{
-		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(dh_prime - 1));
-	}
-	{
-		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(!dh.compute_secret(dh_prime));
-	}
+	TEST_CHECK(!compute(small_value(0)));
+	TEST_CHECK(!compute(small_value(1)));
+	TEST_CHECK(!compute(decremented(dh_prime, 1)));
+	TEST_CHECK(!compute(dh_prime));
 
 	// boundary values inside the valid range must be accepted.
-	{
-		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(dh.compute_secret(lt::aux::key_t(2)));
-	}
-	{
-		lt::aux::dh_key_exchange dh;
-		TEST_CHECK(dh.compute_secret(dh_prime - 2));
-	}
+	TEST_CHECK(compute(small_value(2)));
+	TEST_CHECK(compute(decremented(dh_prime, 2)));
 }
 
 TORRENT_TEST(rc4)

--- a/tools/bencher.cpp
+++ b/tools/bencher.cpp
@@ -467,7 +467,7 @@ try
 	// a peer's public key to react to, exported the same way it would
 	// arrive off the wire
 	dh_key_exchange const peer;
-	std::array<char, 96> const peer_key = export_key(peer.get_local_key());
+	auto const& peer_key = peer.get_local_key();
 
 	// shared secret: (peer_pubkey ^ secret) % prime. this modexp is the
 	// operation that dominates the per-connection DH cost, isolated here


### PR DESCRIPTION
inspired by https://github.com/arvidn/libtorrent/pull/8637

| benchmark | before | after | speed-up |
| --- | --- | --- | --- |
| dh_key_exchange | 133636 | 30991 | 4.31 |
| dh_compute_secret | 141014 | 34868 | 4.04 |
| dh_handshake | 274607 | 67748 | 4.05 |