### PR TITLE
Fix Fast Extension piece validation after metadata

### DIFF
--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -716,7 +716,7 @@ namespace {
 		m_have_piece.resize(t->torrent_file().num_pieces(), m_have_all);
 		m_num_pieces = m_have_piece.count();
 
-		piece_index_t const limit(m_num_pieces);
+		piece_index_t const limit = t->torrent_file().end_piece();
 
 		// now that we know how many pieces there are
 		// remove any invalid allowed_fast and suggest pieces

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -193,6 +193,16 @@ void send_unchoke(tcp::socket& s)
 	if (ec) TEST_ERROR(ec.message());
 }
 
+void send_choke(tcp::socket& s)
+{
+	log("==> choke");
+	char msg[] = "\0\0\0\x01\0";
+	error_code ec;
+	boost::asio::write(s, boost::asio::buffer(msg, 5)
+		, boost::asio::transfer_all(), ec);
+	if (ec) TEST_ERROR(ec.message());
+}
+
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 void send_interested(tcp::socket& s)
 {
@@ -642,13 +652,14 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	piece_index_t const invalid_piece = ti->end_piece();
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
+	send_bitfield(s, bitfield.c_str());
 	send_allow_fast(s, static_cast<int>(allowed_piece));
 	send_allow_fast(s, static_cast<int>(invalid_piece));
-	send_bitfield(s, bitfield.c_str());
+	send_choke(s);
 
-	if (!wait_for_counter(*ses, "ses.num_incoming_bitfield", 1))
+	if (!wait_for_counter(*ses, "ses.num_incoming_choke", 1))
 	{
-		TEST_ERROR("expected bitfield message");
+		TEST_ERROR("expected choke message");
 		s.close();
 		return;
 	}
@@ -698,13 +709,14 @@ TORRENT_TEST(suggested_piece_survives_metadata)
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[0] = '1';
 	bitfield[std::size_t(static_cast<int>(suggested_piece))] = '1';
+	send_bitfield(s, bitfield.c_str());
 	send_suggest_piece(s, static_cast<int>(suggested_piece));
 	send_suggest_piece(s, static_cast<int>(invalid_piece));
-	send_bitfield(s, bitfield.c_str());
+	send_choke(s);
 
-	if (!wait_for_counter(*ses, "ses.num_incoming_bitfield", 1))
+	if (!wait_for_counter(*ses, "ses.num_incoming_choke", 1))
 	{
-		TEST_ERROR("expected bitfield message");
+		TEST_ERROR("expected choke message");
 		s.close();
 		return;
 	}

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -152,10 +152,12 @@ piece_index_t read_request_piece(tcp::socket& s, span<char> buffer)
 	for (;;)
 	{
 		int const len = read_message(s, buffer);
-		if (len == -1) return piece_index_t(-1);
+		if (len == -1)
+			return piece_index_t(-1);
 		auto const message = buffer.first(len);
 		print_message(message);
-		if (len != 13 || message[0] != 0x6) continue;
+		if (len != 13 || message[0] != 0x6)
+			continue;
 
 		char const* ptr = message.data() + 1;
 		return piece_index_t(aux::read_int32(ptr));
@@ -213,9 +215,9 @@ void send_choke(tcp::socket& s)
 	log("==> choke");
 	char msg[] = "\0\0\0\x01\0";
 	error_code ec;
-	boost::asio::write(s, boost::asio::buffer(msg, 5)
-		, boost::asio::transfer_all(), ec);
-	if (ec) TEST_ERROR(ec.message());
+	boost::asio::write(s, boost::asio::buffer(msg, 5), boost::asio::transfer_all(), ec);
+	if (ec)
+		TEST_ERROR(ec.message());
 }
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
@@ -277,7 +279,7 @@ void send_bitfield(tcp::socket& s, char const* bits)
 	log("==> bitfield [%s]", bits);
 	for (int i = 0; i < num_pieces; ++i)
 	{
-		ptr[i/8] |= (bits[i] == '1' ? 1 : 0) << (7 - i % 8);
+		ptr[i / 8] |= (bits[i] == '1' ? 1 : 0) << (7 - i % 8);
 	}
 	error_code ec;
 	boost::asio::write(s, boost::asio::buffer(msg.data(), std::size_t(msg.size()))
@@ -657,8 +659,7 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	std::shared_ptr<lt::session> ses;
 	io_context ios;
 	tcp::socket s(ios);
-	auto const ti = setup_peer(s, ios, ih, ses, true, true, false
-		, torrent_flags_t{}, &th);
+	auto const ti = setup_peer(s, ios, ih, ses, true, true, false, torrent_flags_t{}, &th);
 
 	char recv_buffer[1000];
 	do_handshake(s, ih, recv_buffer);
@@ -700,8 +701,8 @@ TORRENT_TEST(suggested_piece_survives_metadata)
 	std::shared_ptr<lt::session> ses;
 	io_context ios;
 	tcp::socket s(ios);
-	auto const ti = setup_peer(s, ios, ih, ses, true, true, false
-		, torrent_flags::sequential_download, &th);
+	auto const ti =
+		setup_peer(s, ios, ih, ses, true, true, false, torrent_flags::sequential_download, &th);
 
 	char recv_buffer[1000];
 	do_handshake(s, ih, recv_buffer);

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -23,6 +23,8 @@ see LICENSE file.
 #include "libtorrent/bdecode.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/entry.hpp"
+#include "libtorrent/extensions.hpp"
+#include "libtorrent/peer_connection_handle.hpp"
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/session.hpp"
@@ -32,6 +34,7 @@ see LICENSE file.
 
 #include <cstring>
 #include <functional>
+#include <future>
 #include <iostream>
 #include <fstream>
 #include <cstdarg>
@@ -42,6 +45,26 @@ using namespace std::placeholders;
 using namespace std::chrono_literals;
 
 namespace {
+
+#ifndef TORRENT_DISABLE_EXTENSIONS
+struct peer_capture final : torrent_plugin
+{
+	std::shared_ptr<peer_plugin> new_connection(peer_connection_handle const& peer) override
+	{
+		m_peer = peer.native_handle();
+		return {};
+	}
+
+	void on_files_checked() override
+	{
+		allowed_pieces.set_value(m_peer ? m_peer->allowed_fast()
+			: std::vector<piece_index_t>{});
+	}
+
+	std::promise<std::vector<piece_index_t>> allowed_pieces;
+	std::shared_ptr<aux::peer_connection> m_peer;
+};
+#endif
 
 void log(char const* fmt, ...)
 {
@@ -220,6 +243,19 @@ void send_have_none(tcp::socket& s)
 	char msg[] = "\0\0\0\x01\x0f"; // have_none
 	error_code ec;
 	boost::asio::write(s, boost::asio::buffer(msg, 5)
+		, boost::asio::transfer_all(), ec);
+	if (ec) TEST_ERROR(ec.message());
+}
+
+void send_have(tcp::socket& s, int const piece)
+{
+	log("==> have: %d", piece);
+	using namespace lt::aux;
+	char msg[] = "\0\0\0\x05\x04\0\0\0\0";
+	char* ptr = msg + 5;
+	write_int32(piece, ptr);
+	error_code ec;
+	boost::asio::write(s, boost::asio::buffer(msg, 9)
 		, boost::asio::transfer_all(), ec);
 	if (ec) TEST_ERROR(ec.message());
 }
@@ -537,6 +573,7 @@ void post_torrent(lt::session& ses, torrent_handle const& th, Fun fun)
 	auto const tor = th.native_handle();
 	post(ses.native_handle()->get_context(), [tor, fun] { fun(*tor); });
 }
+#endif
 
 bool wait_for_counter(lt::session& ses, char const* name, std::int64_t const value)
 {
@@ -549,7 +586,6 @@ bool wait_for_counter(lt::session& ses, char const* name, std::int64_t const val
 	}
 	return false;
 }
-#endif
 
 } // anonymous namespace
 
@@ -624,6 +660,53 @@ TORRENT_TEST(reject_fast)
 	wait_for_disconnect(*ses, "ses");
 	print_session_log(*ses);
 }
+
+#ifndef TORRENT_DISABLE_EXTENSIONS
+TORRENT_TEST(allowed_fast_survives_metadata)
+{
+	info_hash_t ih;
+	torrent_handle th;
+	std::shared_ptr<lt::session> ses;
+	io_context ios;
+	tcp::socket s(ios);
+	auto const ti = setup_peer(s, ios, ih, ses, true, true, false
+		, torrent_flags_t{}, &th);
+	auto const capture = std::make_shared<peer_capture>();
+	auto allowed_pieces = capture->allowed_pieces.get_future();
+	th.add_extension([capture](torrent_handle const&, client_data_t)
+		{ return capture; });
+
+	char recv_buffer[1000];
+	do_handshake(s, ih, recv_buffer);
+
+	piece_index_t const allowed_piece(ti->num_pieces() - 1);
+	std::string bitfield(std::size_t(ti->num_pieces()), '0');
+	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
+	send_bitfield(s, bitfield.c_str());
+	send_allow_fast(s, static_cast<int>(allowed_piece));
+	send_have(s, 0);
+
+	if (!wait_for_counter(*ses, "ses.num_incoming_have", 1))
+	{
+		TEST_ERROR("expected have message");
+		s.close();
+		return;
+	}
+
+	th.set_metadata(ti->info_section());
+	wait_for_downloading(*ses, "ses");
+
+	if (allowed_pieces.wait_for(5s) != std::future_status::ready)
+	{
+		TEST_ERROR("expected allowed-fast state");
+		s.close();
+		return;
+	}
+
+	TEST_CHECK(allowed_pieces.get() == std::vector<piece_index_t>{allowed_piece});
+	s.close();
+}
+#endif
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 TORRENT_TEST(reject_predictive_piece_requests)

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -687,11 +687,14 @@ TORRENT_TEST(fast_piece_messages_survive_metadata)
 	do_handshake(s, ih, recv_buffer);
 
 	piece_index_t const allowed_piece(ti->num_pieces() - 1);
+	piece_index_t const invalid_piece(ti->num_pieces());
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
 	send_bitfield(s, bitfield.c_str());
 	send_allow_fast(s, static_cast<int>(allowed_piece));
 	send_suggest_piece(s, static_cast<int>(allowed_piece));
+	send_allow_fast(s, static_cast<int>(invalid_piece));
+	send_suggest_piece(s, static_cast<int>(invalid_piece));
 	send_have(s, 0);
 
 	if (!wait_for_counter(*ses, "ses.num_incoming_have", 1))

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -147,6 +147,21 @@ void print_message(span<char const> buffer)
 	log("<== %s %s", message.str().c_str(), extra);
 }
 
+piece_index_t read_request_piece(tcp::socket& s, span<char> buffer)
+{
+	for (;;)
+	{
+		int const len = read_message(s, buffer);
+		if (len == -1) return piece_index_t(-1);
+		auto const message = buffer.first(len);
+		print_message(message);
+		if (len != 13 || message[0] != 0x6) continue;
+
+		char const* ptr = message.data() + 1;
+		return piece_index_t(aux::read_int32(ptr));
+	}
+}
+
 void send_allow_fast(tcp::socket& s, int piece)
 {
 	log("==> allow fast: %d", piece);
@@ -674,18 +689,7 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 		return;
 	}
 
-	for (;;)
-	{
-		int const len = read_message(s, recv_buffer);
-		if (len == -1) break;
-		auto const buffer = span<char const>(recv_buffer).first(len);
-		print_message(buffer);
-		if (len != 13 || buffer[0] != 0x6) continue;
-
-		char const* ptr = buffer.data() + 1;
-		TEST_EQUAL(piece_index_t(aux::read_int32(ptr)), allowed_piece);
-		break;
-	}
+	TEST_EQUAL(read_request_piece(s, recv_buffer), allowed_piece);
 	s.close();
 }
 
@@ -728,18 +732,7 @@ TORRENT_TEST(suggested_piece_survives_metadata)
 		return;
 	}
 
-	for (;;)
-	{
-		int const len = read_message(s, recv_buffer);
-		if (len == -1) break;
-		auto const buffer = span<char const>(recv_buffer).first(len);
-		print_message(buffer);
-		if (len != 13 || buffer[0] != 0x6) continue;
-
-		char const* ptr = buffer.data() + 1;
-		TEST_EQUAL(piece_index_t(aux::read_int32(ptr)), suggested_piece);
-		break;
-	}
+	TEST_EQUAL(read_request_piece(s, recv_buffer), suggested_piece);
 	s.close();
 }
 

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -23,8 +23,6 @@ see LICENSE file.
 #include "libtorrent/bdecode.hpp"
 #include "libtorrent/bencode.hpp"
 #include "libtorrent/entry.hpp"
-#include "libtorrent/extensions.hpp"
-#include "libtorrent/peer_connection_handle.hpp"
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/session.hpp"
@@ -34,7 +32,6 @@ see LICENSE file.
 
 #include <cstring>
 #include <functional>
-#include <future>
 #include <iostream>
 #include <fstream>
 #include <cstdarg>
@@ -45,33 +42,6 @@ using namespace std::placeholders;
 using namespace std::chrono_literals;
 
 namespace {
-
-#ifndef TORRENT_DISABLE_EXTENSIONS
-struct fast_piece_state
-{
-	std::vector<piece_index_t> allowed;
-	std::vector<piece_index_t> suggested;
-};
-
-struct peer_capture final : torrent_plugin
-{
-	std::shared_ptr<peer_plugin> new_connection(peer_connection_handle const& peer) override
-	{
-		m_peer = peer.native_handle();
-		return {};
-	}
-
-	void on_files_checked() override
-	{
-		pieces.set_value(m_peer
-			? fast_piece_state{m_peer->allowed_fast(), m_peer->suggested_pieces()}
-			: fast_piece_state{});
-	}
-
-	std::promise<fast_piece_state> pieces;
-	std::shared_ptr<aux::peer_connection> m_peer;
-};
-#endif
 
 void log(char const* fmt, ...)
 {
@@ -668,8 +638,7 @@ TORRENT_TEST(reject_fast)
 	print_session_log(*ses);
 }
 
-#ifndef TORRENT_DISABLE_EXTENSIONS
-TORRENT_TEST(fast_piece_messages_survive_metadata)
+TORRENT_TEST(allowed_fast_survives_metadata)
 {
 	info_hash_t ih;
 	torrent_handle th;
@@ -678,22 +647,73 @@ TORRENT_TEST(fast_piece_messages_survive_metadata)
 	tcp::socket s(ios);
 	auto const ti = setup_peer(s, ios, ih, ses, true, true, false
 		, torrent_flags_t{}, &th);
-	auto const capture = std::make_shared<peer_capture>();
-	auto fast_pieces = capture->pieces.get_future();
-	th.add_extension([capture](torrent_handle const&, client_data_t)
-		{ return capture; });
 
 	char recv_buffer[1000];
 	do_handshake(s, ih, recv_buffer);
 
-	piece_index_t const allowed_piece(ti->num_pieces() - 1);
-	piece_index_t const invalid_piece(ti->num_pieces());
+	piece_index_t const allowed_piece = ti->last_piece();
+	piece_index_t const invalid_piece = ti->end_piece();
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
 	send_bitfield(s, bitfield.c_str());
 	send_allow_fast(s, static_cast<int>(allowed_piece));
-	send_suggest_piece(s, static_cast<int>(allowed_piece));
 	send_allow_fast(s, static_cast<int>(invalid_piece));
+	send_have(s, 0);
+
+	if (!wait_for_counter(*ses, "ses.num_incoming_have", 1))
+	{
+		TEST_ERROR("expected have message");
+		s.close();
+		return;
+	}
+
+	th.set_metadata(ti->info_section());
+	wait_for_downloading(*ses, "ses");
+	th.piece_priority(allowed_piece, dont_download);
+	th.piece_priority(allowed_piece, default_priority);
+
+	if (!wait_for_counter(*ses, "ses.num_outgoing_request", 1))
+	{
+		TEST_ERROR("expected an allowed-fast request");
+		s.close();
+		return;
+	}
+
+	for (;;)
+	{
+		int const len = read_message(s, recv_buffer);
+		if (len == -1) break;
+		auto const buffer = span<char const>(recv_buffer).first(len);
+		print_message(buffer);
+		if (len != 13 || buffer[0] != 0x6) continue;
+
+		char const* ptr = buffer.data() + 1;
+		TEST_EQUAL(piece_index_t(aux::read_int32(ptr)), allowed_piece);
+		break;
+	}
+	s.close();
+}
+
+TORRENT_TEST(suggested_piece_survives_metadata)
+{
+	info_hash_t ih;
+	torrent_handle th;
+	std::shared_ptr<lt::session> ses;
+	io_context ios;
+	tcp::socket s(ios);
+	auto const ti = setup_peer(s, ios, ih, ses, true, true, false
+		, torrent_flags::sequential_download, &th);
+
+	char recv_buffer[1000];
+	do_handshake(s, ih, recv_buffer);
+
+	piece_index_t const suggested_piece = ti->last_piece();
+	piece_index_t const invalid_piece = ti->end_piece();
+	std::string bitfield(std::size_t(ti->num_pieces()), '0');
+	bitfield[0] = '1';
+	bitfield[std::size_t(static_cast<int>(suggested_piece))] = '1';
+	send_bitfield(s, bitfield.c_str());
+	send_suggest_piece(s, static_cast<int>(suggested_piece));
 	send_suggest_piece(s, static_cast<int>(invalid_piece));
 	send_have(s, 0);
 
@@ -706,20 +726,29 @@ TORRENT_TEST(fast_piece_messages_survive_metadata)
 
 	th.set_metadata(ti->info_section());
 	wait_for_downloading(*ses, "ses");
+	send_unchoke(s);
 
-	if (fast_pieces.wait_for(5s) != std::future_status::ready)
+	if (!wait_for_counter(*ses, "ses.num_outgoing_request", 1))
 	{
-		TEST_ERROR("expected fast piece state");
+		TEST_ERROR("expected a suggested-piece request");
 		s.close();
 		return;
 	}
 
-	auto const pieces = fast_pieces.get();
-	TEST_CHECK(pieces.allowed == std::vector<piece_index_t>{allowed_piece});
-	TEST_CHECK(pieces.suggested == std::vector<piece_index_t>{allowed_piece});
+	for (;;)
+	{
+		int const len = read_message(s, recv_buffer);
+		if (len == -1) break;
+		auto const buffer = span<char const>(recv_buffer).first(len);
+		print_message(buffer);
+		if (len != 13 || buffer[0] != 0x6) continue;
+
+		char const* ptr = buffer.data() + 1;
+		TEST_EQUAL(piece_index_t(aux::read_int32(ptr)), suggested_piece);
+		break;
+	}
 	s.close();
 }
-#endif
 
 #ifndef TORRENT_DISABLE_PREDICTIVE_PIECES
 TORRENT_TEST(reject_predictive_piece_requests)

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -47,6 +47,12 @@ using namespace std::chrono_literals;
 namespace {
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
+struct fast_piece_state
+{
+	std::vector<piece_index_t> allowed;
+	std::vector<piece_index_t> suggested;
+};
+
 struct peer_capture final : torrent_plugin
 {
 	std::shared_ptr<peer_plugin> new_connection(peer_connection_handle const& peer) override
@@ -57,11 +63,12 @@ struct peer_capture final : torrent_plugin
 
 	void on_files_checked() override
 	{
-		allowed_pieces.set_value(m_peer ? m_peer->allowed_fast()
-			: std::vector<piece_index_t>{});
+		pieces.set_value(m_peer
+			? fast_piece_state{m_peer->allowed_fast(), m_peer->suggested_pieces()}
+			: fast_piece_state{});
 	}
 
-	std::promise<std::vector<piece_index_t>> allowed_pieces;
+	std::promise<fast_piece_state> pieces;
 	std::shared_ptr<aux::peer_connection> m_peer;
 };
 #endif
@@ -662,7 +669,7 @@ TORRENT_TEST(reject_fast)
 }
 
 #ifndef TORRENT_DISABLE_EXTENSIONS
-TORRENT_TEST(allowed_fast_survives_metadata)
+TORRENT_TEST(fast_piece_messages_survive_metadata)
 {
 	info_hash_t ih;
 	torrent_handle th;
@@ -672,7 +679,7 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	auto const ti = setup_peer(s, ios, ih, ses, true, true, false
 		, torrent_flags_t{}, &th);
 	auto const capture = std::make_shared<peer_capture>();
-	auto allowed_pieces = capture->allowed_pieces.get_future();
+	auto fast_pieces = capture->pieces.get_future();
 	th.add_extension([capture](torrent_handle const&, client_data_t)
 		{ return capture; });
 
@@ -684,6 +691,7 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
 	send_bitfield(s, bitfield.c_str());
 	send_allow_fast(s, static_cast<int>(allowed_piece));
+	send_suggest_piece(s, static_cast<int>(allowed_piece));
 	send_have(s, 0);
 
 	if (!wait_for_counter(*ses, "ses.num_incoming_have", 1))
@@ -696,14 +704,16 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	th.set_metadata(ti->info_section());
 	wait_for_downloading(*ses, "ses");
 
-	if (allowed_pieces.wait_for(5s) != std::future_status::ready)
+	if (fast_pieces.wait_for(5s) != std::future_status::ready)
 	{
-		TEST_ERROR("expected allowed-fast state");
+		TEST_ERROR("expected fast piece state");
 		s.close();
 		return;
 	}
 
-	TEST_CHECK(allowed_pieces.get() == std::vector<piece_index_t>{allowed_piece});
+	auto const pieces = fast_pieces.get();
+	TEST_CHECK(pieces.allowed == std::vector<piece_index_t>{allowed_piece});
+	TEST_CHECK(pieces.suggested == std::vector<piece_index_t>{allowed_piece});
 	s.close();
 }
 #endif

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -453,6 +453,7 @@ std::shared_ptr<torrent_info const> setup_peer(tcp::socket& s, io_context& ioc
 	add_torrent_params p = ::create_torrent(file);
 	out_file.close();
 	ih = p.ti->info_hashes();
+	auto const ti = p.ti;
 
 	settings_pack sett = settings();
 	sett.set_str(settings_pack::listen_interfaces, test_listen_interface());
@@ -473,7 +474,10 @@ std::shared_ptr<torrent_info const> setup_peer(tcp::socket& s, io_context& ioc
 	p.flags &= ~torrent_flags::auto_managed;
 	p.flags |= flags;
 	if (magnet_link)
+	{
 		p.info_hashes = ih;
+		p.ti.reset();
+	}
 	p.save_path = "tmp1_fast";
 
 	torrent_handle ret = ses->add_torrent(p);
@@ -484,7 +488,7 @@ std::shared_ptr<torrent_info const> setup_peer(tcp::socket& s, io_context& ioc
 	// for "downloading" here would always time out for it.
 	if (flags & torrent_flags::seed_mode)
 		wait_for_seeding(*ses, "ses");
-	else
+	else if (!magnet_link)
 		wait_for_downloading(*ses, "ses");
 
 	if (incoming)
@@ -508,7 +512,7 @@ std::shared_ptr<torrent_info const> setup_peer(tcp::socket& s, io_context& ioc
 
 	print_session_log(*ses);
 
-	return p.ti;
+	return ti;
 }
 
 // polls get_peer_info() until pred() holds for the (single) connected peer,

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -252,7 +252,7 @@ void send_bitfield(tcp::socket& s, char const* bits)
 	log("==> bitfield [%s]", bits);
 	for (int i = 0; i < num_pieces; ++i)
 	{
-		ptr[i/8] |= (bits[i] == '1' ? 1 : 0) << i % 8;
+		ptr[i/8] |= (bits[i] == '1' ? 1 : 0) << (7 - i % 8);
 	}
 	error_code ec;
 	boost::asio::write(s, boost::asio::buffer(msg.data(), std::size_t(msg.size()))

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -649,12 +649,10 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	do_handshake(s, ih, recv_buffer);
 
 	piece_index_t const allowed_piece = ti->last_piece();
-	piece_index_t const invalid_piece = ti->end_piece();
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
 	send_bitfield(s, bitfield.c_str());
 	send_allow_fast(s, static_cast<int>(allowed_piece));
-	send_allow_fast(s, static_cast<int>(invalid_piece));
 	send_choke(s);
 
 	if (!wait_for_counter(*ses, "ses.num_incoming_choke", 1))
@@ -705,13 +703,11 @@ TORRENT_TEST(suggested_piece_survives_metadata)
 	do_handshake(s, ih, recv_buffer);
 
 	piece_index_t const suggested_piece = ti->last_piece();
-	piece_index_t const invalid_piece = ti->end_piece();
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[0] = '1';
 	bitfield[std::size_t(static_cast<int>(suggested_piece))] = '1';
 	send_bitfield(s, bitfield.c_str());
 	send_suggest_piece(s, static_cast<int>(suggested_piece));
-	send_suggest_piece(s, static_cast<int>(invalid_piece));
 	send_choke(s);
 
 	if (!wait_for_counter(*ses, "ses.num_incoming_choke", 1))

--- a/test/test_fast_extension.cpp
+++ b/test/test_fast_extension.cpp
@@ -224,19 +224,6 @@ void send_have_none(tcp::socket& s)
 	if (ec) TEST_ERROR(ec.message());
 }
 
-void send_have(tcp::socket& s, int const piece)
-{
-	log("==> have: %d", piece);
-	using namespace lt::aux;
-	char msg[] = "\0\0\0\x05\x04\0\0\0\0";
-	char* ptr = msg + 5;
-	write_int32(piece, ptr);
-	error_code ec;
-	boost::asio::write(s, boost::asio::buffer(msg, 9)
-		, boost::asio::transfer_all(), ec);
-	if (ec) TEST_ERROR(ec.message());
-}
-
 void send_dht_port(tcp::socket& s, int port)
 {
 	using namespace lt::aux;
@@ -655,14 +642,13 @@ TORRENT_TEST(allowed_fast_survives_metadata)
 	piece_index_t const invalid_piece = ti->end_piece();
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[std::size_t(static_cast<int>(allowed_piece))] = '1';
-	send_bitfield(s, bitfield.c_str());
 	send_allow_fast(s, static_cast<int>(allowed_piece));
 	send_allow_fast(s, static_cast<int>(invalid_piece));
-	send_have(s, 0);
+	send_bitfield(s, bitfield.c_str());
 
-	if (!wait_for_counter(*ses, "ses.num_incoming_have", 1))
+	if (!wait_for_counter(*ses, "ses.num_incoming_bitfield", 1))
 	{
-		TEST_ERROR("expected have message");
+		TEST_ERROR("expected bitfield message");
 		s.close();
 		return;
 	}
@@ -712,14 +698,13 @@ TORRENT_TEST(suggested_piece_survives_metadata)
 	std::string bitfield(std::size_t(ti->num_pieces()), '0');
 	bitfield[0] = '1';
 	bitfield[std::size_t(static_cast<int>(suggested_piece))] = '1';
-	send_bitfield(s, bitfield.c_str());
 	send_suggest_piece(s, static_cast<int>(suggested_piece));
 	send_suggest_piece(s, static_cast<int>(invalid_piece));
-	send_have(s, 0);
+	send_bitfield(s, bitfield.c_str());
 
-	if (!wait_for_counter(*ses, "ses.num_incoming_have", 1))
+	if (!wait_for_counter(*ses, "ses.num_incoming_bitfield", 1))
 	{
-		TEST_ERROR("expected have message");
+		TEST_ERROR("expected bitfield message");
 		s.close();
 		return;
 	}


### PR DESCRIPTION
Preserve valid allowed-fast and suggested piece indices when metadata arrives for a sparse peer.

The metadata transition now validates these indices against the torrent piece range instead of the peer's piece count. The regression tests cover allowed-fast requests while choked and suggested-piece ordering over the wire.

Validated with test_fast_extension, predictive-pieces disabled, and the related metadata, Fast Extension, and peer-connection simulations.