### PR TITLE
fixup IP filter being applied to the DHT

### DIFF
--- a/include/libtorrent/kademlia/traversal_algorithm.hpp
+++ b/include/libtorrent/kademlia/traversal_algorithm.hpp
@@ -57,6 +57,12 @@ struct TORRENT_EXTRA_EXPORT traversal_algorithm
 	void resort_result(observer*);
 	void add_entry(node_id const& id, udp::endpoint const& addr, observer_flags_t flags);
 
+	// returns true if addr is blocked by the DHT IP filter, i.e.
+	// settings_pack::apply_filter_to_dht is enabled and the observer's IP
+	// filter blocks it. add_entry() does not perform this check itself;
+	// callers are expected to have filtered addr first
+	bool filtered(udp::endpoint const& addr) const;
+
 	traversal_algorithm(node& dht_node, node_id const& target);
 	traversal_algorithm(traversal_algorithm const&) = delete;
 	traversal_algorithm& operator=(traversal_algorithm const&) = delete;

--- a/include/libtorrent/session_handle.hpp
+++ b/include/libtorrent/session_handle.hpp
@@ -414,7 +414,8 @@ namespace aux { struct torrent; }
 		// those nodes will be used as backups. Nodes in the router node list
 		// will also never be added to the regular routing table, which
 		// effectively means they are only used for bootstrapping, to keep the
-		// load off them.
+		// load off them. Router nodes are trusted bootstrap endpoints, and as
+		// such are not subject to the ``ip_filter``.
 		//
 		// An example routing node that you could typically add is
 		// ``router.bittorrent.com``.
@@ -523,6 +524,8 @@ namespace aux { struct torrent; }
 		// with the response (if any) and the userdata pointer passed in here.
 		// Since this alert is a response to an explicit call, it will always be
 		// posted, regardless of the alert mask.
+		// Note that this request is not subject to the IP filter; ``ep`` is
+		// queried even if it is blocked by the current ``ip_filter``.
 		void dht_direct_request(udp::endpoint const& ep, entry const& e, client_data_t userdata = {});
 
 #if TORRENT_ABI_VERSION == 1

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -385,6 +385,10 @@ namespace aux {
 			// ``router.bittorrent.com:6881``,
 			// ``dht.transmissionbt.com:6881``
 			// ``router.bt.ouinet.work:6881``,
+			//
+			// These nodes are added as DHT router nodes, which are trusted
+			// bootstrap endpoints. As such, they are not subject to the
+			// ``ip_filter``.
 			dht_bootstrap_nodes,
 
 			// Overrides the NAT-PMP service gateway. When set, libtorrent won't try

--- a/src/kademlia/node.cpp
+++ b/src/kademlia/node.cpp
@@ -37,6 +37,7 @@ see LICENSE file.
 #include "libtorrent/alert_types.hpp" // for dht_lookup
 #include "libtorrent/performance_counters.hpp" // for counters
 #include "libtorrent/aux_/ip_helpers.hpp" // for is_v4
+#include "libtorrent/ip_filter.hpp"
 
 #include "libtorrent/kademlia/node.hpp"
 #include "libtorrent/kademlia/dht_observer.hpp"
@@ -211,6 +212,11 @@ void node::bootstrap(std::vector<udp::endpoint> const& nodes
 
 	for (auto const& n : nodes)
 	{
+		// these come from persisted dht_state (or session config), so, unlike
+		// nodes discovered via traverse(), they have not been filtered yet
+		if (r->filtered(n))
+			continue;
+
 #ifndef TORRENT_DISABLE_LOGGING
 		++count;
 #endif
@@ -400,6 +406,14 @@ void node::add_router_node(udp::endpoint const& router)
 void node::add_node(udp::endpoint const& node)
 {
 	if (!native_address(node)) return;
+
+	if (m_observer != nullptr && m_settings.get_bool(settings_pack::apply_filter_to_dht))
+	{
+		ip_filter const* filter = m_observer->get_dht_ip_filter();
+		if (filter && filter->access(node.address()) == ip_filter::blocked)
+			return;
+	}
+
 	// ping the node, and if we get a reply, it
 	// will be added to the routing table
 	send_single_refresh(node, m_table.num_active_buckets());

--- a/src/kademlia/traversal_algorithm.cpp
+++ b/src/kademlia/traversal_algorithm.cpp
@@ -288,18 +288,23 @@ void traversal_algorithm::traverse(node_id const& id, udp::endpoint const& addr)
 	}
 #endif
 
+	if (filtered(addr))
+		return;
+
 	// let the routing table know this node may exist
 	m_node.m_table.heard_about(id, addr);
 
-	if (m_node.observer() != nullptr
-		&& m_node.settings().get_bool(settings_pack::apply_filter_to_dht))
-	{
-		ip_filter const* filter = m_node.observer()->get_dht_ip_filter();
-		if (filter && filter->access(addr.address()) == ip_filter::blocked)
-			return;
-	}
-
 	add_entry(id, addr, {});
+}
+
+bool traversal_algorithm::filtered(udp::endpoint const& addr) const
+{
+	if (m_node.observer() == nullptr)
+		return false;
+	if (!m_node.settings().get_bool(settings_pack::apply_filter_to_dht))
+		return false;
+	ip_filter const* filter = m_node.observer()->get_dht_ip_filter();
+	return filter != nullptr && filter->access(addr.address()) == ip_filter::blocked;
 }
 
 void traversal_algorithm::finished(observer_ptr o)
@@ -574,6 +579,9 @@ void traversal_algorithm::add_router_entries()
 			, m_id, int(std::distance(m_node.m_table.begin(), m_node.m_table.end())));
 	}
 #endif
+	// router nodes are explicitly configured, trusted bootstrap endpoints;
+	// like add_router_node(), they are intentionally exempt from the DHT IP
+	// filter
 	for (auto const& n : m_node.m_table)
 		add_entry(node_id(), n, observer::flag_initial);
 }

--- a/test/test_dht.cpp
+++ b/test/test_dht.cpp
@@ -3644,6 +3644,31 @@ TORRENT_TEST(dht_tracker_ip_filter)
 	TEST_EQUAL(sent, true);
 }
 
+TORRENT_TEST(dht_node_add_node_ip_filter)
+{
+	ip_filter filter;
+	filter.add_rule(addr("4.4.4.4"), addr("4.4.4.4"), ip_filter::blocked);
+
+	dht_test_setup t(udp::endpoint(rand_v4(), 20));
+	t.observer.m_ip_filter = &filter;
+
+	g_sent_packets.clear();
+
+	// blocked by the ip filter, node::add_node() must not ping it
+	t.dht_node.add_node(udp::endpoint(addr("4.4.4.4"), 4));
+	TEST_CHECK(g_sent_packets.empty());
+
+	// not blocked, node::add_node() should send a ping
+	t.dht_node.add_node(udp::endpoint(addr("5.5.5.5"), 4));
+	TEST_EQUAL(g_sent_packets.size(), 1);
+
+	// disabling the setting lets the blocked address through too
+	g_sent_packets.clear();
+	t.sett.set_bool(settings_pack::apply_filter_to_dht, false);
+	t.dht_node.add_node(udp::endpoint(addr("4.4.4.4"), 4));
+	TEST_EQUAL(g_sent_packets.size(), 1);
+}
+
 TORRENT_TEST(generate_prefix_mask)
 {
 	std::vector<std::pair<int, char const*>> const test = {


### PR DESCRIPTION
nodes being added via the .torrent file or magnet link were not subject to the filter.
some IPs were checked twice in the DHT