### PR TITLE
cleanup is_in_range()

### DIFF
--- a/include/libtorrent/aux_/packet_buffer.hpp
+++ b/include/libtorrent/aux_/packet_buffer.hpp
@@ -54,6 +54,8 @@ namespace aux {
 	class TORRENT_EXTRA_EXPORT packet_buffer
 	{
 	public:
+		// valid values are in the range [0, 0xffff]; this wraps at 0x10000,
+		// matching the 16-bit sequence number space used by the wire protocol
 		using index_type = std::uint32_t;
 
 		packet_ptr insert(index_type idx, packet_ptr value);
@@ -80,6 +82,10 @@ namespace aux {
 #endif
 
 	private:
+		// grows the buffer and/or shifts m_first backward so idx falls
+		// within the valid window
+		void grow_to_include(index_type idx);
+
 		aux::unique_ptr<packet_ptr[], index_type> m_storage;
 		std::uint32_t m_capacity = 0;
 

--- a/src/packet_buffer.cpp
+++ b/src/packet_buffer.cpp
@@ -26,8 +26,7 @@ namespace aux {
 			packet_buffer::index_type const first,
 			packet_buffer::index_type const capacity)
 		{
-			if (idx > index_mask)
-				return false;
+			TORRENT_ASSERT_VAL(idx <= index_mask, idx);
 			return ((idx - first) & index_mask) < capacity;
 		}
 
@@ -45,6 +44,38 @@ namespace aux {
 	}
 #endif
 
+	void packet_buffer::grow_to_include(index_type idx)
+	{
+		if (compare_less_wrap(idx, m_first, 0xffff))
+		{
+			// Index comes before m_first. If we have room, we can simply
+			// adjust m_first backward.
+
+			std::uint32_t free_space = 0;
+
+			for (index_type i = (m_first - 1) & (m_capacity - 1); i != (m_first & (m_capacity - 1));
+				 i = (i - 1) & (m_capacity - 1))
+			{
+				if (m_storage[i & (m_capacity - 1)])
+					break;
+				++free_space;
+			}
+
+			if (((m_first - idx) & 0xffff) > free_space)
+				reserve(((m_first - idx) & 0xffff) + m_capacity - free_space);
+
+			m_first = idx;
+		}
+		else
+		{
+			// idx is beyond the current window; grow forward to include it.
+			// (idx - m_first) & 0xffff is the wrapped distance to idx, which
+			// stays correct even once m_first + m_capacity overflows past
+			// 0xffff.
+			reserve(((idx - m_first) & 0xffff) + 1);
+		}
+	}
+
 	packet_ptr packet_buffer::insert(index_type idx, packet_ptr value)
 	{
 		INVARIANT_CHECK;
@@ -57,38 +88,8 @@ namespace aux {
 
 		if (m_size != 0)
 		{
-			if (compare_less_wrap(idx, m_first, 0xffff))
-			{
-				// Index comes before m_first. If we have room, we can simply
-				// adjust m_first backward.
-
-				std::uint32_t free_space = 0;
-
-				for (index_type i = (m_first - 1) & (m_capacity - 1);
-						i != (m_first & (m_capacity - 1)); i = (i - 1) & (m_capacity - 1))
-				{
-					if (m_storage[i & (m_capacity - 1)])
-						break;
-					++free_space;
-				}
-
-				if (((m_first - idx) & 0xffff) > free_space)
-					reserve(((m_first - idx) & 0xffff) + m_capacity - free_space);
-
-				m_first = idx;
-			}
-			else if (idx >= m_first + m_capacity)
-			{
-				reserve(idx - m_first + 1);
-			}
-			else if (idx < m_first)
-			{
-				// We have wrapped.
-				if (idx >= ((m_first + m_capacity) & 0xffff) && m_capacity < 0xffff)
-				{
-					reserve(m_capacity + (idx + 1 - ((m_first + m_capacity) & 0xffff)));
-				}
-			}
+			if (!is_in_range(idx, m_first, m_capacity))
+				grow_to_include(idx);
 			if (compare_less_wrap(m_last, (idx + 1) & 0xffff, 0xffff))
 				m_last = (idx + 1) & 0xffff;
 		}

--- a/test/test_packet_buffer.cpp
+++ b/test/test_packet_buffer.cpp
@@ -131,22 +131,48 @@ TORRENT_TEST(wrap_range_boundaries)
 
 	auto const before = packet_buffer::index_type((first - 1) & 0xffff);
 	auto const after = packet_buffer::index_type((first + capacity) & 0xffff);
-	auto const out_of_domain = packet_buffer::index_type(first + 0x10000);
 
 	TEST_EQUAL(get_val(pb.at(first)), 1);
 	TEST_EQUAL(get_val(pb.at(last)), 2);
 	TEST_CHECK(pb.at(before) == nullptr);
 	TEST_CHECK(pb.at(after) == nullptr);
-	TEST_CHECK(pb.at(out_of_domain) == nullptr);
 
 	TEST_CHECK(pb.remove(before) == nullptr);
 	TEST_CHECK(pb.remove(after) == nullptr);
-	TEST_CHECK(pb.remove(out_of_domain) == nullptr);
 	TEST_EQUAL(pb.size(), 2);
 	TEST_EQUAL(pb.cursor(), first);
 	TEST_EQUAL(pb.span(), capacity);
 	TEST_EQUAL(get_val(pb.at(first)), 1);
 	TEST_EQUAL(get_val(pb.at(last)), 2);
+}
+
+TORRENT_TEST(insert_large_capacity_far_index)
+{
+	// covers capacity growing to the full 0x10000-element span, and an
+	// idx that's within the current window but more than 0x8000 "behind"
+	// cursor() by the wrapped half-circle heuristic insert() uses for
+	// out-of-range decisions
+	packet_pool pool;
+	packet_buffer pb;
+
+	// the first insert takes the m_size == 0 path, which sets m_first
+	// directly and doesn't go through insert()'s growth/shift decision, so
+	// this reliably establishes cursor() == 0
+	pb.insert(packet_buffer::index_type(0), make_pkt(pool, 1));
+	// reserve()'s size argument is capped at 0xffff (the largest valid
+	// index); the resulting capacity still rounds up to the full 0x10000
+	pb.reserve(0xffff);
+	TEST_EQUAL(pb.cursor(), packet_buffer::index_type(0));
+	TEST_EQUAL(pb.capacity(), 0x10000);
+
+	auto const idx = packet_buffer::index_type(0x9000);
+	pb.insert(idx, make_pkt(pool, 2));
+
+	// idx is within the full-span window, so cursor() must stay put
+	TEST_EQUAL(pb.cursor(), packet_buffer::index_type(0));
+	TEST_EQUAL(pb.size(), 2);
+	TEST_EQUAL(get_val(pb.at(packet_buffer::index_type(0))), 1);
+	TEST_EQUAL(get_val(pb.at(idx)), 2);
 }
 
 TORRENT_TEST(wrap2)


### PR DESCRIPTION
packet_buffer::index_type is limited to the range [0, 0xffff], which means one of the checks in `is_in_range()` is really just an assert.

Also update `packet_buffer::insert()` to use the new `is_in_range()`.