### PR TITLE
Normalize IPv4-mapped addresses in SSRF checks

### DIFF
--- a/include/libtorrent/aux_/ip_helpers.hpp
+++ b/include/libtorrent/aux_/ip_helpers.hpp
@@ -19,7 +19,9 @@ see LICENSE file.
 namespace libtorrent {
 namespace aux {
 
+	TORRENT_EXTRA_EXPORT address normalize_address(address const& a);
 	TORRENT_EXTRA_EXPORT bool is_global(address const& a);
+	TORRENT_EXTRA_EXPORT bool is_loopback(address const& a);
 	TORRENT_EXTRA_EXPORT bool is_local(address const& a);
 	TORRENT_EXTRA_EXPORT bool is_link_local(address const& addr);
 	TORRENT_EXTRA_EXPORT bool is_teredo(address const& addr);

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -35,6 +35,7 @@ see LICENSE file.
 #include "libtorrent/aux_/string_util.hpp" // for is_i2p_url
 #include "libtorrent/aux_/session_settings.hpp"
 #include "libtorrent/aux_/resolver_interface.hpp"
+#include "libtorrent/aux_/ip_helpers.hpp"
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/aux_/parse_url.hpp"
 #include "libtorrent/aux_/array.hpp"
@@ -60,7 +61,7 @@ namespace libtorrent::aux {
 		// go through on_filter() again).
 		bool ssrf_blocks(bool const ssrf_mitigation, address const& addr, string_view const path)
 		{
-			return ssrf_mitigation && addr.is_loopback() && path.substr(0, 9) != "/announce";
+			return ssrf_mitigation && aux::is_loopback(addr) && path.substr(0, 9) != "/announce";
 		}
 	}
 
@@ -590,8 +591,11 @@ namespace libtorrent::aux {
 
 		aux::session_settings const& settings = m_man.settings();
 		bool const ssrf_mitigation = settings.get_bool(settings_pack::ssrf_mitigation);
-		if (ssrf_mitigation && std::find_if(endpoints.begin(), endpoints.end()
-			, [](tcp::endpoint const& ep) { return ep.address().is_loopback(); }) != endpoints.end())
+		if (ssrf_mitigation
+			&& std::find_if(endpoints.begin(),
+				   endpoints.end(),
+				   [](tcp::endpoint const& ep) { return aux::is_loopback(ep.address()); })
+				!= endpoints.end())
 		{
 			// there is at least one loopback address in here. Parse the path
 			// once and remove any endpoint ssrf_blocks() rejects for it (see

--- a/src/ip_helpers.cpp
+++ b/src/ip_helpers.cpp
@@ -17,6 +17,13 @@ see LICENSE file.
 namespace libtorrent {
 namespace aux {
 
+	address normalize_address(address const& a)
+	{
+		if (a.is_v6() && a.to_v6().is_v4_mapped())
+			return make_address_v4(v4_mapped, a.to_v6());
+		return a;
+	}
+
 	bool is_ip_address(std::string const& host)
 	{
 		error_code ec;
@@ -24,8 +31,9 @@ namespace aux {
 		return !ec;
 	}
 
-	bool is_global(address const& a)
+	bool is_global(address const& addr)
 	{
+		address const a = normalize_address(addr);
 		if (a.is_v6())
 		{
 			// https://www.iana.org/assignments/ipv6-address-space/ipv6-address-space.xhtml
@@ -39,8 +47,11 @@ namespace aux {
 		}
 	}
 
-	bool is_link_local(address const& a)
+	bool is_loopback(address const& addr) { return normalize_address(addr).is_loopback(); }
+
+	bool is_link_local(address const& addr)
 	{
+		address const a = normalize_address(addr);
 		if (a.is_v6())
 		{
 			address_v6 const a6 = a.to_v6();
@@ -52,10 +63,11 @@ namespace aux {
 		return (ip & 0xffff0000) == 0xa9fe0000; // 169.254.x.x
 	}
 
-	bool is_local(address const& a)
+	bool is_local(address const& addr)
 	{
 		try
 		{
+			address const a = normalize_address(addr);
 			if (a.is_v6())
 			{
 				// NOTE: site local is deprecated but by
@@ -104,4 +116,3 @@ namespace aux {
 
 }
 }
-

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6988,10 +6988,13 @@ namespace {
 			return;
 		}
 
+		bool const is_ip = aux::is_ip_address(hostname);
+		if (is_ip)
+			a.address(make_address(hostname, ec));
+
 		// The SSRF mitigation for web seeds is that any HTTP server on the
 		// local network may not use any query string parameters
-		if (settings().get_bool(settings_pack::ssrf_mitigation)
-			&& aux::is_local(web->peer_info.addr)
+		if (settings().get_bool(settings_pack::ssrf_mitigation) && aux::is_local(a.address())
 			&& path.find('?') != std::string::npos)
 		{
 #ifndef TORRENT_DISABLE_LOGGING
@@ -7012,8 +7015,6 @@ namespace {
 			return;
 		}
 
-		bool const is_ip = aux::is_ip_address(hostname);
-		if (is_ip) a.address(make_address(hostname, ec));
 		bool const proxy_hostnames = settings().get_bool(settings_pack::proxy_hostnames)
 			&& !is_ip;
 

--- a/test/test_enum_net.cpp
+++ b/test/test_enum_net.cpp
@@ -19,6 +19,22 @@ see LICENSE file.
 using namespace lt;
 using namespace lt::aux;
 
+TORRENT_TEST(normalize_address)
+{
+	TEST_CHECK(normalize_address(make_address("::ffff:127.0.0.1")) == make_address("127.0.0.1"));
+	TEST_CHECK(
+		normalize_address(make_address("::ffff:192.168.0.1")) == make_address("192.168.0.1"));
+	TEST_CHECK(normalize_address(make_address("2001:db8::1")) == make_address("2001:db8::1"));
+}
+
+TORRENT_TEST(is_loopback)
+{
+	TEST_CHECK(is_loopback(make_address("127.0.0.1")));
+	TEST_CHECK(is_loopback(make_address("::1")));
+	TEST_CHECK(is_loopback(make_address("::ffff:127.0.0.1")));
+	TEST_CHECK(!is_loopback(make_address("::ffff:192.168.0.1")));
+}
+
 TORRENT_TEST(is_local)
 {
 	error_code ec;
@@ -31,6 +47,12 @@ TORRENT_TEST(is_local)
 	TEST_CHECK(is_local(make_address("100.127.255.255", ec)));
 	TEST_CHECK(!ec);
 	TEST_CHECK(!is_local(make_address("14.14.251.63", ec)));
+	TEST_CHECK(!ec);
+	TEST_CHECK(is_local(make_address("::ffff:127.0.0.1", ec)));
+	TEST_CHECK(!ec);
+	TEST_CHECK(is_local(make_address("::ffff:192.168.0.1", ec)));
+	TEST_CHECK(!ec);
+	TEST_CHECK(!is_local(make_address("::ffff:14.14.251.63", ec)));
 	TEST_CHECK(!ec);
 }
 


### PR DESCRIPTION
IPv4-mapped loopback addresses were classified as IPv6 and could bypass the tracker and web-seed SSRF restrictions. Web seeds also checked an IPv4-only accounting field instead of the selected endpoint, which skipped local-address checks for IPv6 destinations.

This normalizes IPv4-mapped addresses before scope classification, uses the normalized loopback check for trackers, and checks the actual web-seed endpoint.