### PR TITLE
Bound incoming TLS handshakes

### DIFF
--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -436,8 +436,10 @@ namespace aux {
 
 			void incoming_connection(socket_type);
 			std::int64_t num_connections_with_pending() const;
+			std::int64_t connection_limit(
+				tcp::endpoint const& endp, socket_type_t type);
 			void reject_incoming_connection(
-				tcp::endpoint const& endp, socket_type_t socket_type, std::int64_t limit);
+				tcp::endpoint const& endp, socket_type_t type, std::int64_t limit);
 
 			std::weak_ptr<torrent> find_torrent(info_hash_t const&) const override;
 #if TORRENT_ABI_VERSION == 1
@@ -1086,7 +1088,7 @@ namespace aux {
 #endif
 #ifdef TORRENT_SSL_PEERS
 			void on_incoming_utp_ssl(socket_type s);
-			bool can_accept_peer() const;
+			bool can_accept_peer(tcp::endpoint const& endp, socket_type_t type);
 			void arm_ssl_handshake_timer(
 				socket_type* s, std::shared_ptr<deadline_timer> const& timer);
 			void ssl_handshake(error_code const& ec, socket_type* s);

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -77,12 +77,12 @@ see LICENSE file.
 #include <algorithm>
 #include <vector>
 #include <set>
+#include <map>
 #include <list>
 #include <deque>
 #include <condition_variable>
 #include <mutex>
 #include <cstdarg> // for va_start, va_end
-#include <unordered_map>
 
 namespace libtorrent {
 
@@ -435,6 +435,9 @@ namespace aux {
 				, std::weak_ptr<tcp::acceptor>, transport);
 
 			void incoming_connection(socket_type);
+			std::int64_t num_connections_with_pending() const;
+			void reject_incoming_connection(
+				tcp::endpoint const& endp, socket_type_t socket_type, std::int64_t limit);
 
 			std::weak_ptr<torrent> find_torrent(info_hash_t const&) const override;
 #if TORRENT_ABI_VERSION == 1
@@ -1016,11 +1019,12 @@ namespace aux {
 			connection_map m_connections;
 
 #ifdef TORRENT_SSL_PEERS
-			// this list holds incoming connections while they
+			// this map holds incoming connections while they
 			// are performing SSL handshake. When we shut down
 			// the session, all of these are disconnected, otherwise
 			// they would linger and stall or hang session shutdown
-			std::set<std::unique_ptr<socket_type>, unique_ptr_less> m_incoming_sockets;
+			std::map<std::unique_ptr<socket_type>, std::shared_ptr<deadline_timer>, unique_ptr_less>
+				m_incoming_sockets;
 #endif
 
 			// maps IP ranges to bitfields representing peer class IDs
@@ -1082,7 +1086,11 @@ namespace aux {
 #endif
 #ifdef TORRENT_SSL_PEERS
 			void on_incoming_utp_ssl(socket_type s);
+			bool can_accept_peer() const;
+			void arm_ssl_handshake_timer(
+				socket_type* s, std::shared_ptr<deadline_timer> const& timer);
 			void ssl_handshake(error_code const& ec, socket_type* s);
+			void ssl_handshake_timeout(error_code const& ec, socket_type* s);
 #endif
 
 			// round-robin index into m_outgoing_interfaces

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -77,12 +77,12 @@ see LICENSE file.
 #include <algorithm>
 #include <vector>
 #include <set>
+#include <map>
 #include <list>
 #include <deque>
 #include <condition_variable>
 #include <mutex>
 #include <cstdarg> // for va_start, va_end
-#include <unordered_map>
 
 namespace libtorrent {
 
@@ -435,6 +435,9 @@ namespace aux {
 				, std::weak_ptr<tcp::acceptor>, transport);
 
 			void incoming_connection(socket_type);
+			std::int64_t num_connections_with_pending() const;
+			void reject_incoming_connection(
+				tcp::endpoint const& endp, socket_type_t socket_type, std::int64_t limit);
 
 			std::weak_ptr<torrent> find_torrent(info_hash_t const&) const override;
 #if TORRENT_ABI_VERSION == 1
@@ -1012,11 +1015,12 @@ namespace aux {
 			connection_map m_connections;
 
 #ifdef TORRENT_SSL_PEERS
-			// this list holds incoming connections while they
+			// this map holds incoming connections while they
 			// are performing SSL handshake. When we shut down
 			// the session, all of these are disconnected, otherwise
 			// they would linger and stall or hang session shutdown
-			std::set<std::unique_ptr<socket_type>, unique_ptr_less> m_incoming_sockets;
+			std::map<std::unique_ptr<socket_type>, std::shared_ptr<deadline_timer>, unique_ptr_less>
+				m_incoming_sockets;
 #endif
 
 			// maps IP ranges to bitfields representing peer class IDs
@@ -1078,7 +1082,11 @@ namespace aux {
 #endif
 #ifdef TORRENT_SSL_PEERS
 			void on_incoming_utp_ssl(socket_type s);
+			bool can_accept_peer() const;
+			void arm_ssl_handshake_timer(
+				socket_type* s, std::shared_ptr<deadline_timer> const& timer);
 			void ssl_handshake(error_code const& ec, socket_type* s);
+			void ssl_handshake_timeout(error_code const& ec, socket_type* s);
 #endif
 
 			// round-robin index into m_outgoing_interfaces

--- a/include/libtorrent/aux_/session_impl.hpp
+++ b/include/libtorrent/aux_/session_impl.hpp
@@ -436,8 +436,7 @@ namespace aux {
 
 			void incoming_connection(socket_type);
 			std::int64_t num_connections_with_pending() const;
-			std::int64_t connection_limit(
-				tcp::endpoint const& endp, socket_type_t type);
+			std::int64_t connection_limit(tcp::endpoint const& endp, socket_type_t type);
 			void reject_incoming_connection(
 				tcp::endpoint const& endp, socket_type_t type, std::int64_t limit);
 

--- a/simulation/test_ssl.cpp
+++ b/simulation/test_ssl.cpp
@@ -50,6 +50,7 @@ see LICENSE file.
 #include <memory>
 #include <functional>
 #include <utility>
+#include <vector>
 
 using namespace lt;
 using namespace sim;
@@ -739,6 +740,112 @@ namespace {
 		sim.run();
 	}
 
+	// pending SSL handshakes must be bounded by connections_limit (+
+	// connections_slack), the same way incoming_connection() already bounds
+	// plain TCP accepts synchronously, at accept time. A peer that never starts
+	// the TLS handshake must not be able to occupy more than that many slots.
+	void run_ssl_pending_handshake_limit()
+	{
+		address const peer0 = addr("50.0.0.1");
+		int const port = 6881;
+		int const connections_limit = 5;
+		int const connections_slack = 0;
+		int const allowed = connections_limit + connections_slack;
+		int const num_attackers = 4 * connections_limit;
+
+		sim::default_config network_cfg;
+		sim::simulation sim{network_cfg};
+		sim::asio::io_context ios0{sim, peer0};
+
+		lt::session_proxy zombie;
+
+		lt::session_params params;
+		lt::settings_pack& pack = params.settings;
+		pack = settings();
+		pack.set_int(settings_pack::connections_limit, connections_limit);
+		pack.set_int(settings_pack::connections_slack, connections_slack);
+
+		// this session only ever listens on its SSL port, like
+		// run_malicious_peer_attack() above
+		char iface[50];
+		std::snprintf(iface, sizeof(iface), "50.0.0.1:%ds", port);
+		pack.set_str(settings_pack::listen_interfaces, iface);
+
+		params.disk_io_constructor = test_disk().set_seed(true);
+		auto ses = std::make_shared<lt::session>(params, ios0);
+
+		std::string const root_cert = read_file("root_ca_cert.pem");
+		lt::add_torrent_params const atp = make_ssl_test_torrent(root_cert);
+
+		// attacker sockets: connect to the SSL port, then never send the
+		// TLS ClientHello that ssl_stream::async_accept_handshake() is waiting
+		// for. Reserved up front so these vectors never reallocate and
+		// invalidate async_connect's captured reference below.
+		std::size_t const num_attackers_sz = std::size_t(num_attackers);
+		std::vector<std::unique_ptr<sim::asio::io_context>> attacker_ios;
+		std::vector<lt::tcp::socket> attacker_socks;
+		attacker_ios.reserve(num_attackers_sz);
+		attacker_socks.reserve(num_attackers_sz);
+		int connected = 0;
+		int rejected = 0;
+
+		print_alerts(*ses, [&](lt::session&, lt::alert const* a) {
+			if (auto* ta = alert_cast<add_torrent_alert>(a))
+			{
+				torrent_handle h = ta->handle;
+				h.set_ssl_certificate(ssl_fixture_path("peer_certificate.pem"),
+					ssl_fixture_path("peer_private_key.pem"),
+					ssl_fixture_path("dhparams.pem"),
+					"test");
+			}
+			else if (alert_cast<torrent_finished_alert>(a))
+			{
+				// note: i starts at 1, since make_io_context(sim, 0) would
+				// collide with the seed's own address, 50.0.0.1
+				for (int i = 1; i <= num_attackers; ++i)
+				{
+					attacker_ios.push_back(make_io_context(sim, i));
+					attacker_socks.emplace_back(*attacker_ios.back());
+					attacker_socks.back().async_connect(
+						lt::tcp::endpoint(peer0, std::uint16_t(port)),
+						[&](error_code const& ec) {
+							TEST_CHECK(!ec);
+							if (!ec) ++connected;
+						});
+				}
+			}
+			else if (auto const* e = alert_cast<peer_disconnected_alert>(a))
+			{
+				if (e->error == error_code(errors::too_many_connections))
+					++rejected;
+			}
+		});
+
+		ses->async_add_torrent(atp);
+
+		sim::timer give_up(sim, lt::seconds(30), [&](boost::system::error_code const&) {
+			std::printf("attackers: %d allowed: %d connected: %d rejected: %d\n"
+				, num_attackers, allowed, connected, rejected);
+
+			TEST_CHECK(num_attackers > allowed);
+
+			// the TCP accept itself always succeeds, rejection happens
+			// afterwards by closing the socket, so every attacker connects
+			// regardless of the limit
+			TEST_EQUAL(connected, num_attackers);
+
+			// Assert the rejection alert rather than client-side socket closure.
+			// The simulator's socket destructor does not propagate a close to its
+			// peer.
+			TEST_EQUAL(rejected, num_attackers - allowed);
+
+			zombie = ses->abort();
+			ses.reset();
+		});
+
+		sim.run();
+	}
+
 } // anonymous namespace
 
 TORRENT_TEST(ssl_transfer_matrix)
@@ -774,6 +881,11 @@ TORRENT_TEST(ssl_handshake_connection_limit)
 {
 	std::string const root_cert = read_file("root_ca_cert.pem");
 	run_ssl_handshake_connection_limit_test(make_ssl_test_torrent(root_cert));
+}
+
+TORRENT_TEST(ssl_pending_handshake_limit)
+{
+	run_ssl_pending_handshake_limit();
 }
 
 #else

--- a/simulation/test_ssl.cpp
+++ b/simulation/test_ssl.cpp
@@ -807,10 +807,10 @@ namespace {
 					attacker_ios.push_back(make_io_context(sim, i));
 					attacker_socks.emplace_back(*attacker_ios.back());
 					attacker_socks.back().async_connect(
-						lt::tcp::endpoint(peer0, std::uint16_t(port)),
-						[&](error_code const& ec) {
+						lt::tcp::endpoint(peer0, std::uint16_t(port)), [&](error_code const& ec) {
 							TEST_CHECK(!ec);
-							if (!ec) ++connected;
+							if (!ec)
+								++connected;
 						});
 				}
 			}
@@ -824,8 +824,11 @@ namespace {
 		ses->async_add_torrent(atp);
 
 		sim::timer give_up(sim, lt::seconds(30), [&](boost::system::error_code const&) {
-			std::printf("attackers: %d allowed: %d connected: %d rejected: %d\n"
-				, num_attackers, allowed, connected, rejected);
+			std::printf("attackers: %d allowed: %d connected: %d rejected: %d\n",
+				num_attackers,
+				allowed,
+				connected,
+				rejected);
 
 			TEST_CHECK(num_attackers > allowed);
 
@@ -883,10 +886,7 @@ TORRENT_TEST(ssl_handshake_connection_limit)
 	run_ssl_handshake_connection_limit_test(make_ssl_test_torrent(root_cert));
 }
 
-TORRENT_TEST(ssl_pending_handshake_limit)
-{
-	run_ssl_pending_handshake_limit();
-}
+TORRENT_TEST(ssl_pending_handshake_limit) { run_ssl_pending_handshake_limit(); }
 
 #else
 

--- a/simulation/test_ssl.cpp
+++ b/simulation/test_ssl.cpp
@@ -709,15 +709,15 @@ namespace {
 				first = std::make_unique<stalled_ssl_peer>(
 					sim, peer1, lt::tcp::endpoint(peer0, std::uint16_t(port)));
 				first->start([&] {
-						start_second = std::make_unique<sim::timer>(
-							sim, lt::seconds(1), [&](boost::system::error_code const& ec) {
-								if (ec)
-									return;
-								second = std::make_unique<stalled_ssl_peer>(
-									sim, peer2, lt::tcp::endpoint(peer0, std::uint16_t(port)));
-								second->start([] {});
-							});
-					});
+					start_second = std::make_unique<sim::timer>(
+						sim, lt::seconds(1), [&](boost::system::error_code const& ec) {
+							if (ec)
+								return;
+							second = std::make_unique<stalled_ssl_peer>(
+								sim, peer2, lt::tcp::endpoint(peer0, std::uint16_t(port)));
+							second->start([] {});
+						});
+				});
 			}
 			else if (auto const* e = alert_cast<peer_disconnected_alert>(a))
 			{

--- a/simulation/test_ssl.cpp
+++ b/simulation/test_ssl.cpp
@@ -561,6 +561,40 @@ namespace {
 		std::function<void(bool)> m_done;
 	};
 
+	// opens a TCP connection to an SSL listener but deliberately never sends a
+	// TLS ClientHello. This keeps one incoming handshake pending on the server.
+	struct stalled_ssl_peer
+	{
+		stalled_ssl_peer(
+			sim::simulation& sim, address const& source, lt::tcp::endpoint const& target)
+			: m_ios(sim, source)
+			, m_sock(m_ios)
+			, m_target(target)
+		{}
+
+		void start(std::function<void()> on_connected)
+		{
+			m_connected = std::move(on_connected);
+			m_sock.async_connect(m_target, [this](error_code const& ec) { on_connect(ec); });
+		}
+
+	private:
+		void on_connect(error_code const& ec)
+		{
+			TEST_CHECK(!ec);
+			if (ec)
+				return;
+
+			if (m_connected)
+				m_connected();
+		}
+
+		sim::asio::io_context m_ios;
+		lt::tcp::socket m_sock;
+		lt::tcp::endpoint m_target;
+		std::function<void()> m_connected;
+	};
+
 	void run_malicious_peer_attack(
 		attack_config const& atk, lt::add_torrent_params const& atp_template)
 	{
@@ -630,6 +664,81 @@ namespace {
 		sim.run();
 	}
 
+	void run_ssl_handshake_connection_limit_test(lt::add_torrent_params const& atp_template)
+	{
+		address const peer0 = addr("50.0.0.1");
+		address const peer1 = addr("50.0.0.2");
+		address const peer2 = addr("50.0.0.3");
+		int const port = 6881;
+
+		sim::default_config network_cfg;
+		sim::simulation sim{network_cfg};
+		sim::asio::io_context ios0{sim, peer0};
+
+		lt::session_proxy zombie;
+
+		lt::session_params params;
+		lt::settings_pack& pack = params.settings;
+		pack = settings();
+		pack.set_int(settings_pack::connections_limit, 1);
+		pack.set_int(settings_pack::connections_slack, 0);
+
+		char iface[50];
+		std::snprintf(iface, sizeof(iface), "50.0.0.1:%ds", port);
+		pack.set_str(settings_pack::listen_interfaces, iface);
+
+		params.disk_io_constructor = test_disk().set_seed(true);
+		auto ses = std::make_shared<lt::session>(params, ios0);
+
+		std::unique_ptr<stalled_ssl_peer> first;
+		std::unique_ptr<stalled_ssl_peer> second;
+		std::unique_ptr<sim::timer> start_second;
+		bool connection_rejected = false;
+
+		print_alerts(*ses, [&](lt::session&, lt::alert const* a) {
+			if (auto* ta = alert_cast<add_torrent_alert>(a))
+			{
+				torrent_handle h = ta->handle;
+				h.set_ssl_certificate(ssl_fixture_path("peer_certificate.pem"),
+					ssl_fixture_path("peer_private_key.pem"),
+					ssl_fixture_path("dhparams.pem"),
+					"test");
+			}
+			else if (alert_cast<torrent_finished_alert>(a))
+			{
+				first = std::make_unique<stalled_ssl_peer>(
+					sim, peer1, lt::tcp::endpoint(peer0, std::uint16_t(port)));
+				first->start([&] {
+						start_second = std::make_unique<sim::timer>(
+							sim, lt::seconds(1), [&](boost::system::error_code const& ec) {
+								if (ec)
+									return;
+								second = std::make_unique<stalled_ssl_peer>(
+									sim, peer2, lt::tcp::endpoint(peer0, std::uint16_t(port)));
+								second->start([] {});
+							});
+					});
+			}
+			else if (auto const* e = alert_cast<peer_disconnected_alert>(a))
+			{
+				if (e->error == error_code(errors::too_many_connections))
+					connection_rejected = true;
+			}
+		});
+
+		ses->async_add_torrent(atp_template);
+
+		sim::timer give_up(sim, lt::seconds(5), [&](boost::system::error_code const&) {
+			TEST_CHECK(second);
+			TEST_CHECK(connection_rejected);
+
+			zombie = ses->abort();
+			ses.reset();
+		});
+
+		sim.run();
+	}
+
 } // anonymous namespace
 
 TORRENT_TEST(ssl_transfer_matrix)
@@ -659,6 +768,12 @@ TORRENT_TEST(ssl_malicious_peer)
 		run_malicious_peer_attack(atk, atp_template);
 		std::cout << "::endgroup::\n";
 	}
+}
+
+TORRENT_TEST(ssl_handshake_connection_limit)
+{
+	std::string const root_cert = read_file("root_ca_cert.pem");
+	run_ssl_handshake_connection_limit_test(make_ssl_test_torrent(root_cert));
 }
 
 #else

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1075,7 +1075,8 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 			auto const sockets = std::move(m_incoming_sockets);
 			for (auto const& s : sockets)
 			{
-				s->close(ec);
+				s.second->cancel();
+				s.first->close(ec);
 				TORRENT_ASSERT(!ec);
 			}
 		}
@@ -2886,6 +2887,19 @@ retry:
 		if (listen != m_listen_sockets.end())
 			(*listen)->incoming_connection = true;
 
+#ifdef TORRENT_SSL_PEERS
+		if (ssl == transport::ssl && !can_accept_peer())
+		{
+			error_code endpoint_ec;
+			tcp::endpoint const endp = s.remote_endpoint(endpoint_ec);
+			if (!endpoint_ec)
+				reject_incoming_connection(endp,
+					socket_type_t::tcp_ssl,
+					m_settings.get_int(settings_pack::connections_limit));
+			return;
+		}
+#endif
+
 		socket_type c = [&]{
 #ifdef TORRENT_SSL_PEERS
 			if (ssl == transport::ssl)
@@ -2913,15 +2927,18 @@ retry:
 			TORRENT_ASSERT(is_ssl(c));
 
 			// save the socket so we can cancel the handshake
-			// TODO: this size need to be capped
-			auto iter = m_incoming_sockets.emplace(std::make_unique<socket_type>(std::move(c))).first;
+			auto socket = std::make_unique<socket_type>(std::move(c));
+			auto sock = socket.get();
+			auto timer = std::make_shared<deadline_timer>(m_io_context);
+			auto iter = m_incoming_sockets.emplace(std::move(socket), timer).first;
 
-			auto sock = iter->get();
+			arm_ssl_handshake_timer(sock, timer);
 			// for SSL connections, incoming_connection() is called
 			// after the handshake is done
 			ADD_OUTSTANDING_ASYNC("session_impl::ssl_handshake");
-			std::get<ssl_stream<tcp::socket>>(**iter).async_accept_handshake(
-				[this, sock] (error_code const& err) { ssl_handshake(err, sock); });
+			std::get<ssl_stream<tcp::socket>>(*iter->first)
+				.async_accept_handshake(
+					[this, sock](error_code const& err) { ssl_handshake(err, sock); });
 		}
 		else
 #endif
@@ -2936,17 +2953,31 @@ retry:
 	{
 		TORRENT_ASSERT(is_ssl(s));
 
+		if (!can_accept_peer())
+		{
+			error_code ec;
+			tcp::endpoint const endp = s.remote_endpoint(ec);
+			if (!ec)
+				reject_incoming_connection(endp,
+					socket_type_t::utp_ssl,
+					m_settings.get_int(settings_pack::connections_limit));
+			return;
+		}
+
 		// save the socket so we can cancel the handshake
 
-		// TODO: this size need to be capped
-		auto iter = m_incoming_sockets.emplace(std::make_unique<socket_type>(std::move(s))).first;
-		auto sock = iter->get();
+		auto socket = std::make_unique<socket_type>(std::move(s));
+		auto sock = socket.get();
+		auto timer = std::make_shared<deadline_timer>(m_io_context);
+		auto iter = m_incoming_sockets.emplace(std::move(socket), timer).first;
+		arm_ssl_handshake_timer(sock, timer);
 
 		// for SSL connections, incoming_connection() is called
 		// after the handshake is done
 		ADD_OUTSTANDING_ASYNC("session_impl::ssl_handshake");
-		std::get<ssl_stream<utp_stream>>(**iter).async_accept_handshake(
-			[this, sock] (error_code const& err) { ssl_handshake(err, sock); });
+		std::get<ssl_stream<utp_stream>>(*iter->first)
+			.async_accept_handshake(
+				[this, sock](error_code const& err) { ssl_handshake(err, sock); });
 	}
 
 	// to test SSL connections, one can use this openssl command template:
@@ -2954,6 +2985,28 @@ retry:
 	// openssl s_client -cert <client-cert>.pem -key <client-private-key>.pem
 	//   -CAfile <torrent-cert>.pem  -debug -connect 127.0.0.1:4433 -tls1
 	//   -servername <hex-encoded-info-hash>
+
+	bool session_impl::can_accept_peer() const
+	{
+		std::int64_t const limit =
+			std::int64_t(m_settings.get_int(settings_pack::connections_limit))
+			+ m_settings.get_int(settings_pack::connections_slack);
+		return num_connections_with_pending() < limit;
+	}
+
+	void session_impl::arm_ssl_handshake_timer(
+		socket_type* const sock, std::shared_ptr<deadline_timer> const& timer)
+	{
+		timer->expires_after(seconds(m_settings.get_int(settings_pack::handshake_timeout)));
+
+		ADD_OUTSTANDING_ASYNC("session_impl::ssl_handshake_timeout");
+		// ssl_handshake() may erase the map entry before this canceled handler
+		// runs. Keep the timer alive until the handler completes.
+		timer->async_wait([this, sock, timer](error_code const& ec) {
+			TORRENT_UNUSED(timer);
+			ssl_handshake_timeout(ec, sock);
+		});
+	}
 
 	void session_impl::ssl_handshake(error_code const& ec, socket_type* sock)
 	{
@@ -2965,7 +3018,8 @@ retry:
 		// down
 		if (iter == m_incoming_sockets.end()) return;
 
-		socket_type s(std::move(**iter));
+		iter->second->cancel();
+		socket_type s(std::move(*iter->first));
 		TORRENT_ASSERT(is_ssl(s));
 		m_incoming_sockets.erase(iter);
 
@@ -2994,7 +3048,59 @@ retry:
 		incoming_connection(std::move(s));
 	}
 
+	void session_impl::ssl_handshake_timeout(error_code const& ec, socket_type* sock)
+	{
+		COMPLETE_ASYNC("session_impl::ssl_handshake_timeout");
+
+		if (ec)
+			return;
+
+		auto const iter = m_incoming_sockets.find(sock);
+		if (iter == m_incoming_sockets.end())
+			return;
+
+		// Keep the entry alive until the cancelled handshake handler runs. The
+		// handler uses this pointer to find its socket.
+		error_code close_ec;
+		iter->first->close(close_ec);
+	}
+
 #endif // TORRENT_SSL_PEERS
+
+	std::int64_t session_impl::num_connections_with_pending() const
+	{
+		std::int64_t ret = num_connections();
+#ifdef TORRENT_SSL_PEERS
+		ret += std::int64_t(m_incoming_sockets.size());
+#endif
+		return ret;
+	}
+
+	void session_impl::reject_incoming_connection(
+		tcp::endpoint const& endp, socket_type_t const socket_type, std::int64_t const limit)
+	{
+		TORRENT_UNUSED(limit);
+		if (m_alerts.should_post<peer_disconnected_alert>())
+		{
+			m_alerts.emplace_alert<peer_disconnected_alert>(torrent_handle(),
+				endp,
+				peer_id(),
+				operation_t::bittorrent,
+				socket_type,
+				error_code(errors::too_many_connections),
+				close_reason_t::none);
+		}
+#ifndef TORRENT_DISABLE_LOGGING
+		if (should_log())
+		{
+			session_log("<== INCOMING CONNECTION [ connections limit exceeded, conns: %d, "
+						"limit: %d, slack: %d ]",
+				int(num_connections_with_pending()),
+				int(limit),
+				m_settings.get_int(settings_pack::connections_slack));
+		}
+#endif
+	}
 
 	void session_impl::incoming_connection(socket_type s)
 	{
@@ -3155,25 +3261,12 @@ retry:
 
 		// don't allow more connections than the max setting
 		// weighed by the peer class' setting
-		bool reject = num_connections() >= limit + m_settings.get_int(settings_pack::connections_slack);
+		bool reject = num_connections_with_pending()
+			>= limit + m_settings.get_int(settings_pack::connections_slack);
 
 		if (reject)
 		{
-			if (m_alerts.should_post<peer_disconnected_alert>())
-			{
-				m_alerts.emplace_alert<peer_disconnected_alert>(torrent_handle(), endp, peer_id()
-						, operation_t::bittorrent, socket_type_idx(s)
-						, error_code(errors::too_many_connections)
-						, close_reason_t::none);
-			}
-#ifndef TORRENT_DISABLE_LOGGING
-			if (should_log())
-			{
-				session_log("<== INCOMING CONNECTION [ connections limit exceeded, conns: %d, limit: %d, slack: %d ]"
-					, num_connections(), m_settings.get_int(settings_pack::connections_limit)
-					, m_settings.get_int(settings_pack::connections_slack));
-			}
-#endif
+			reject_incoming_connection(endp, socket_type_idx(s), limit);
 			return;
 		}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2888,15 +2888,18 @@ retry:
 			(*listen)->incoming_connection = true;
 
 #ifdef TORRENT_SSL_PEERS
-		if (ssl == transport::ssl && !can_accept_peer())
+		if (ssl == transport::ssl)
 		{
 			error_code endpoint_ec;
 			tcp::endpoint const endp = s.remote_endpoint(endpoint_ec);
-			if (!endpoint_ec)
+			if (endpoint_ec) return;
+
+			bool const reject = !can_accept_peer(endp, socket_type_t::tcp_ssl);
+			if (reject)
 				reject_incoming_connection(endp,
 					socket_type_t::tcp_ssl,
-					m_settings.get_int(settings_pack::connections_limit));
-			return;
+					connection_limit(endp, socket_type_t::tcp_ssl));
+			if (reject) return;
 		}
 #endif
 
@@ -2953,14 +2956,15 @@ retry:
 	{
 		TORRENT_ASSERT(is_ssl(s));
 
-		if (!can_accept_peer())
+		error_code ec;
+		tcp::endpoint const endp = s.remote_endpoint(ec);
+		if (ec) return;
+
+		if (!can_accept_peer(endp, socket_type_t::utp_ssl))
 		{
-			error_code ec;
-			tcp::endpoint const endp = s.remote_endpoint(ec);
-			if (!ec)
-				reject_incoming_connection(endp,
-					socket_type_t::utp_ssl,
-					m_settings.get_int(settings_pack::connections_limit));
+			reject_incoming_connection(endp,
+				socket_type_t::utp_ssl,
+				connection_limit(endp, socket_type_t::utp_ssl));
 			return;
 		}
 
@@ -2986,10 +2990,10 @@ retry:
 	//   -CAfile <torrent-cert>.pem  -debug -connect 127.0.0.1:4433 -tls1
 	//   -servername <hex-encoded-info-hash>
 
-	bool session_impl::can_accept_peer() const
+	bool session_impl::can_accept_peer(tcp::endpoint const& endp, socket_type_t const type)
 	{
 		std::int64_t const limit =
-			std::int64_t(m_settings.get_int(settings_pack::connections_limit))
+			connection_limit(endp, type)
 			+ m_settings.get_int(settings_pack::connections_slack);
 		return num_connections_with_pending() < limit;
 	}
@@ -3052,8 +3056,15 @@ retry:
 	{
 		COMPLETE_ASYNC("session_impl::ssl_handshake_timeout");
 
+		TORRENT_UNUSED(ec);
 		if (ec)
+		{
+#ifndef TORRENT_DISABLE_LOGGING
+			if (ec != boost::asio::error::operation_aborted && should_log())
+				session_log("SSL handshake timer failed: %s", ec.message().c_str());
+#endif
 			return;
+		}
 
 		auto const iter = m_incoming_sockets.find(sock);
 		if (iter == m_incoming_sockets.end())
@@ -3076,8 +3087,20 @@ retry:
 		return ret;
 	}
 
+	std::int64_t session_impl::connection_limit(
+		tcp::endpoint const& endp, socket_type_t const type)
+	{
+		peer_class_set pcs;
+		set_peer_classes(&pcs, endp.address(), type);
+		int connection_limit_factor = m_rates.max_connection_limit_factor(pcs);
+		if (connection_limit_factor == 0) connection_limit_factor = 100;
+
+		return std::int64_t(m_settings.get_int(settings_pack::connections_limit))
+			* 100 / connection_limit_factor;
+	}
+
 	void session_impl::reject_incoming_connection(
-		tcp::endpoint const& endp, socket_type_t const socket_type, std::int64_t const limit)
+		tcp::endpoint const& endp, socket_type_t const type, std::int64_t const limit)
 	{
 		TORRENT_UNUSED(limit);
 		if (m_alerts.should_post<peer_disconnected_alert>())
@@ -3086,7 +3109,7 @@ retry:
 				endp,
 				peer_id(),
 				operation_t::bittorrent,
-				socket_type,
+				type,
 				error_code(errors::too_many_connections),
 				close_reason_t::none);
 		}
@@ -3249,15 +3272,7 @@ retry:
 			return;
 		}
 
-		// figure out which peer classes this is connections has,
-		// to get connection_limit_factor
-		peer_class_set pcs;
-		set_peer_classes(&pcs, endp.address(), socket_type_idx(s));
-		int connection_limit_factor = m_rates.max_connection_limit_factor(pcs);
-		if (connection_limit_factor == 0) connection_limit_factor = 100;
-
-		std::int64_t limit = m_settings.get_int(settings_pack::connections_limit);
-		limit = limit * 100 / connection_limit_factor;
+		std::int64_t const limit = connection_limit(endp, socket_type_idx(s));
 
 		// don't allow more connections than the max setting
 		// weighed by the peer class' setting

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -2892,14 +2892,15 @@ retry:
 		{
 			error_code endpoint_ec;
 			tcp::endpoint const endp = s.remote_endpoint(endpoint_ec);
-			if (endpoint_ec) return;
+			if (endpoint_ec)
+				return;
 
 			bool const reject = !can_accept_peer(endp, socket_type_t::tcp_ssl);
 			if (reject)
-				reject_incoming_connection(endp,
-					socket_type_t::tcp_ssl,
-					connection_limit(endp, socket_type_t::tcp_ssl));
-			if (reject) return;
+				reject_incoming_connection(
+					endp, socket_type_t::tcp_ssl, connection_limit(endp, socket_type_t::tcp_ssl));
+			if (reject)
+				return;
 		}
 #endif
 
@@ -2958,13 +2959,13 @@ retry:
 
 		error_code ec;
 		tcp::endpoint const endp = s.remote_endpoint(ec);
-		if (ec) return;
+		if (ec)
+			return;
 
 		if (!can_accept_peer(endp, socket_type_t::utp_ssl))
 		{
-			reject_incoming_connection(endp,
-				socket_type_t::utp_ssl,
-				connection_limit(endp, socket_type_t::utp_ssl));
+			reject_incoming_connection(
+				endp, socket_type_t::utp_ssl, connection_limit(endp, socket_type_t::utp_ssl));
 			return;
 		}
 
@@ -2993,8 +2994,7 @@ retry:
 	bool session_impl::can_accept_peer(tcp::endpoint const& endp, socket_type_t const type)
 	{
 		std::int64_t const limit =
-			connection_limit(endp, type)
-			+ m_settings.get_int(settings_pack::connections_slack);
+			connection_limit(endp, type) + m_settings.get_int(settings_pack::connections_slack);
 		return num_connections_with_pending() < limit;
 	}
 
@@ -3087,16 +3087,16 @@ retry:
 		return ret;
 	}
 
-	std::int64_t session_impl::connection_limit(
-		tcp::endpoint const& endp, socket_type_t const type)
+	std::int64_t session_impl::connection_limit(tcp::endpoint const& endp, socket_type_t const type)
 	{
 		peer_class_set pcs;
 		set_peer_classes(&pcs, endp.address(), type);
 		int connection_limit_factor = m_rates.max_connection_limit_factor(pcs);
-		if (connection_limit_factor == 0) connection_limit_factor = 100;
+		if (connection_limit_factor == 0)
+			connection_limit_factor = 100;
 
-		return std::int64_t(m_settings.get_int(settings_pack::connections_limit))
-			* 100 / connection_limit_factor;
+		return std::int64_t(m_settings.get_int(settings_pack::connections_limit)) * 100
+			/ connection_limit_factor;
 	}
 
 	void session_impl::reject_incoming_connection(

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1067,7 +1067,8 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 			auto const sockets = std::move(m_incoming_sockets);
 			for (auto const& s : sockets)
 			{
-				s->close(ec);
+				s.second->cancel();
+				s.first->close(ec);
 				TORRENT_ASSERT(!ec);
 			}
 		}
@@ -2848,6 +2849,19 @@ retry:
 		if (listen != m_listen_sockets.end())
 			(*listen)->incoming_connection = true;
 
+#ifdef TORRENT_SSL_PEERS
+		if (ssl == transport::ssl && !can_accept_peer())
+		{
+			error_code endpoint_ec;
+			tcp::endpoint const endp = s.remote_endpoint(endpoint_ec);
+			if (!endpoint_ec)
+				reject_incoming_connection(endp,
+					socket_type_t::tcp_ssl,
+					m_settings.get_int(settings_pack::connections_limit));
+			return;
+		}
+#endif
+
 		socket_type c = [&]{
 #ifdef TORRENT_SSL_PEERS
 			if (ssl == transport::ssl)
@@ -2875,15 +2889,18 @@ retry:
 			TORRENT_ASSERT(is_ssl(c));
 
 			// save the socket so we can cancel the handshake
-			// TODO: this size need to be capped
-			auto iter = m_incoming_sockets.emplace(std::make_unique<socket_type>(std::move(c))).first;
+			auto socket = std::make_unique<socket_type>(std::move(c));
+			auto sock = socket.get();
+			auto timer = std::make_shared<deadline_timer>(m_io_context);
+			auto iter = m_incoming_sockets.emplace(std::move(socket), timer).first;
 
-			auto sock = iter->get();
+			arm_ssl_handshake_timer(sock, timer);
 			// for SSL connections, incoming_connection() is called
 			// after the handshake is done
 			ADD_OUTSTANDING_ASYNC("session_impl::ssl_handshake");
-			std::get<ssl_stream<tcp::socket>>(**iter).async_accept_handshake(
-				[this, sock] (error_code const& err) { ssl_handshake(err, sock); });
+			std::get<ssl_stream<tcp::socket>>(*iter->first)
+				.async_accept_handshake(
+					[this, sock](error_code const& err) { ssl_handshake(err, sock); });
 		}
 		else
 #endif
@@ -2898,17 +2915,31 @@ retry:
 	{
 		TORRENT_ASSERT(is_ssl(s));
 
+		if (!can_accept_peer())
+		{
+			error_code ec;
+			tcp::endpoint const endp = s.remote_endpoint(ec);
+			if (!ec)
+				reject_incoming_connection(endp,
+					socket_type_t::utp_ssl,
+					m_settings.get_int(settings_pack::connections_limit));
+			return;
+		}
+
 		// save the socket so we can cancel the handshake
 
-		// TODO: this size need to be capped
-		auto iter = m_incoming_sockets.emplace(std::make_unique<socket_type>(std::move(s))).first;
-		auto sock = iter->get();
+		auto socket = std::make_unique<socket_type>(std::move(s));
+		auto sock = socket.get();
+		auto timer = std::make_shared<deadline_timer>(m_io_context);
+		auto iter = m_incoming_sockets.emplace(std::move(socket), timer).first;
+		arm_ssl_handshake_timer(sock, timer);
 
 		// for SSL connections, incoming_connection() is called
 		// after the handshake is done
 		ADD_OUTSTANDING_ASYNC("session_impl::ssl_handshake");
-		std::get<ssl_stream<utp_stream>>(**iter).async_accept_handshake(
-			[this, sock] (error_code const& err) { ssl_handshake(err, sock); });
+		std::get<ssl_stream<utp_stream>>(*iter->first)
+			.async_accept_handshake(
+				[this, sock](error_code const& err) { ssl_handshake(err, sock); });
 	}
 
 	// to test SSL connections, one can use this openssl command template:
@@ -2916,6 +2947,28 @@ retry:
 	// openssl s_client -cert <client-cert>.pem -key <client-private-key>.pem
 	//   -CAfile <torrent-cert>.pem  -debug -connect 127.0.0.1:4433 -tls1
 	//   -servername <hex-encoded-info-hash>
+
+	bool session_impl::can_accept_peer() const
+	{
+		std::int64_t const limit =
+			std::int64_t(m_settings.get_int(settings_pack::connections_limit))
+			+ m_settings.get_int(settings_pack::connections_slack);
+		return num_connections_with_pending() < limit;
+	}
+
+	void session_impl::arm_ssl_handshake_timer(
+		socket_type* const sock, std::shared_ptr<deadline_timer> const& timer)
+	{
+		timer->expires_after(seconds(m_settings.get_int(settings_pack::handshake_timeout)));
+
+		ADD_OUTSTANDING_ASYNC("session_impl::ssl_handshake_timeout");
+		// ssl_handshake() may erase the map entry before this canceled handler
+		// runs. Keep the timer alive until the handler completes.
+		timer->async_wait([this, sock, timer](error_code const& ec) {
+			TORRENT_UNUSED(timer);
+			ssl_handshake_timeout(ec, sock);
+		});
+	}
 
 	void session_impl::ssl_handshake(error_code const& ec, socket_type* sock)
 	{
@@ -2927,7 +2980,8 @@ retry:
 		// down
 		if (iter == m_incoming_sockets.end()) return;
 
-		socket_type s(std::move(**iter));
+		iter->second->cancel();
+		socket_type s(std::move(*iter->first));
 		TORRENT_ASSERT(is_ssl(s));
 		m_incoming_sockets.erase(iter);
 
@@ -2956,7 +3010,59 @@ retry:
 		incoming_connection(std::move(s));
 	}
 
+	void session_impl::ssl_handshake_timeout(error_code const& ec, socket_type* sock)
+	{
+		COMPLETE_ASYNC("session_impl::ssl_handshake_timeout");
+
+		if (ec)
+			return;
+
+		auto const iter = m_incoming_sockets.find(sock);
+		if (iter == m_incoming_sockets.end())
+			return;
+
+		// Keep the entry alive until the cancelled handshake handler runs. The
+		// handler uses this pointer to find its socket.
+		error_code close_ec;
+		iter->first->close(close_ec);
+	}
+
 #endif // TORRENT_SSL_PEERS
+
+	std::int64_t session_impl::num_connections_with_pending() const
+	{
+		std::int64_t ret = num_connections();
+#ifdef TORRENT_SSL_PEERS
+		ret += std::int64_t(m_incoming_sockets.size());
+#endif
+		return ret;
+	}
+
+	void session_impl::reject_incoming_connection(
+		tcp::endpoint const& endp, socket_type_t const socket_type, std::int64_t const limit)
+	{
+		TORRENT_UNUSED(limit);
+		if (m_alerts.should_post<peer_disconnected_alert>())
+		{
+			m_alerts.emplace_alert<peer_disconnected_alert>(torrent_handle(),
+				endp,
+				peer_id(),
+				operation_t::bittorrent,
+				socket_type,
+				error_code(errors::too_many_connections),
+				close_reason_t::none);
+		}
+#ifndef TORRENT_DISABLE_LOGGING
+		if (should_log())
+		{
+			session_log("<== INCOMING CONNECTION [ connections limit exceeded, conns: %d, "
+						"limit: %d, slack: %d ]",
+				int(num_connections_with_pending()),
+				int(limit),
+				m_settings.get_int(settings_pack::connections_slack));
+		}
+#endif
+	}
 
 	void session_impl::incoming_connection(socket_type s)
 	{
@@ -3117,25 +3223,12 @@ retry:
 
 		// don't allow more connections than the max setting
 		// weighed by the peer class' setting
-		bool reject = num_connections() >= limit + m_settings.get_int(settings_pack::connections_slack);
+		bool reject = num_connections_with_pending()
+			>= limit + m_settings.get_int(settings_pack::connections_slack);
 
 		if (reject)
 		{
-			if (m_alerts.should_post<peer_disconnected_alert>())
-			{
-				m_alerts.emplace_alert<peer_disconnected_alert>(torrent_handle(), endp, peer_id()
-						, operation_t::bittorrent, socket_type_idx(s)
-						, error_code(errors::too_many_connections)
-						, close_reason_t::none);
-			}
-#ifndef TORRENT_DISABLE_LOGGING
-			if (should_log())
-			{
-				session_log("<== INCOMING CONNECTION [ connections limit exceeded, conns: %d, limit: %d, slack: %d ]"
-					, num_connections(), m_settings.get_int(settings_pack::connections_limit)
-					, m_settings.get_int(settings_pack::connections_slack));
-			}
-#endif
+			reject_incoming_connection(endp, socket_type_idx(s), limit);
 			return;
 		}
 

--- a/src/session_impl.cpp
+++ b/src/session_impl.cpp
@@ -1072,7 +1072,7 @@ bool ssl_server_name_callback(ssl::stream_handle_type stream_handle, std::string
 
 #ifdef TORRENT_SSL_PEERS
 		{
-			auto const sockets = std::move(m_incoming_sockets);
+			auto const& sockets = m_incoming_sockets;
 			for (auto const& s : sockets)
 			{
 				s.second->cancel();


### PR DESCRIPTION
Incoming TLS peer sockets were retained outside the global connection count while their handshakes were pending, and the handshake operation had no timeout. A remote client could open connections without sending a ClientHello and keep listener resources occupied indefinitely.

This counts pending TLS handshakes against the incoming connection allowance and gives each TCP and uTP handshake a timer based on `handshake_timeout`. Completion cancels the timer, expiry closes the socket, and session shutdown cancels all pending timers.