### PR TITLE
cache Montgomery context for DH key exchange

### DIFF
--- a/include/libtorrent/aux_/pe_crypto.hpp
+++ b/include/libtorrent/aux_/pe_crypto.hpp
@@ -120,6 +120,7 @@ namespace libtorrent::aux {
 		// from multiple threads. Falls back to a single instance guarded by a
 		// mutex where thread_local isn't available.
 		static ::BN_CTX* ctx();
+		static ::BN_MONT_CTX* mont();
 #else
 		// also used for TORRENT_USE_WOLFSSL builds: wolfSSL's OpenSSL
 		// compatibility layer does not reliably provide the same BN_*

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -105,6 +105,24 @@ namespace libtorrent::aux {
 		return shared_ctx.get();
 	}
 
+	::BN_MONT_CTX* dh_key_exchange::mont()
+	{
+		auto make_mont = [] {
+			std::unique_ptr<::BN_MONT_CTX, void (*)(::BN_MONT_CTX*)> ret(
+				BN_MONT_CTX_new(), &BN_MONT_CTX_free);
+			if (!ret || !BN_MONT_CTX_set(ret.get(), dh_prime().get(), ctx()))
+				aux::throw_ex<system_error>(errors::no_memory);
+			return ret;
+		};
+#ifdef BOOST_NO_CXX11_THREAD_LOCAL
+		static std::unique_ptr<::BN_MONT_CTX, void (*)(::BN_MONT_CTX*)> shared_mont = make_mont();
+#else
+		thread_local static std::unique_ptr<::BN_MONT_CTX, void (*)(::BN_MONT_CTX*)> shared_mont
+			= make_mont();
+#endif
+		return shared_mont.get();
+	}
+
 	std::array<char, 96> dh_key_exchange::export_key(key_t const& k)
 	{
 		std::array<char, 96> ret;
@@ -139,8 +157,8 @@ namespace libtorrent::aux {
 #ifdef BOOST_NO_CXX11_THREAD_LOCAL
 			std::lock_guard<std::mutex> l(g_bn_ctx_mutex);
 #endif
-			if (!BN_mod_exp(
-					local_key.get(), two().get(), m_dh_local_secret.get(), dh_prime().get(), ctx()))
+			if (!BN_mod_exp_mont(local_key.get(), two().get(), m_dh_local_secret.get(),
+					dh_prime().get(), ctx(), mont()))
 				aux::throw_ex<system_error>(errors::no_memory);
 		}
 		m_dh_local_key = export_key(local_key);
@@ -167,8 +185,8 @@ namespace libtorrent::aux {
 #ifdef BOOST_NO_CXX11_THREAD_LOCAL
 			std::lock_guard<std::mutex> l(g_bn_ctx_mutex);
 #endif
-			if (!BN_mod_exp(
-					secret.get(), key.get(), m_dh_local_secret.get(), dh_prime().get(), ctx()))
+			if (!BN_mod_exp_mont(secret.get(), key.get(), m_dh_local_secret.get(),
+					dh_prime().get(), ctx(), mont()))
 				aux::throw_ex<system_error>(errors::no_memory);
 		}
 		m_dh_shared_secret = export_key(secret);


### PR DESCRIPTION
## Summary

- Cache one `BN_MONT_CTX` beside the existing per-thread `BN_CTX`.
- Use `BN_mod_exp_mont()` for both DH exponentiations.
- Preserve the existing shared-context fallback and lock when thread-local storage is unavailable.

The DH modulus is fixed, so reusing its Montgomery context avoids rebuilding modulus-specific state for each operation.

## Performance

Five alternating Release A/B runs with OpenSSL 3.6.3 improved median `dh_handshake` from 32.89 us to 31.24 us, about 5%. `dh_compute_secret` improved about 7.8%.

## Tests

- OpenSSL `test_pe_crypto`: 4 passed
- Built-in crypto `test_pe_crypto`: 4 passed
- OpenSSL with `BOOST_NO_CXX11_THREAD_LOCAL`: 4 passed
- `git diff --check`