### PR TITLE
fix webtorrent tracker announces to post response handlers reliably

### DIFF
--- a/include/libtorrent/aux_/websocket_tracker_connection.hpp
+++ b/include/libtorrent/aux_/websocket_tracker_connection.hpp
@@ -28,9 +28,9 @@ see LICENSE file.
 
 #include <boost/beast/core/flat_buffer.hpp>
 
+#include <deque>
 #include <map>
 #include <memory>
-#include <queue>
 #include <tuple>
 #include <variant>
 #include <optional>
@@ -61,6 +61,11 @@ struct TORRENT_EXTRA_EXPORT websocket_tracker_connection : tracker_connection
 	bool is_started() const;
 	bool is_open() const;
 
+	// aborts every non-stopped-event request on this connection (it may
+	// multiplex several torrents' requests). Returns true if a
+	// stopped-event request remains, meaning the connection must stay open.
+	bool prune_non_stopped_requests();
+
 	void queue_request(tracker_request req, std::weak_ptr<request_callback> cb);
 	void queue_answer(tracker_answer ans);
 
@@ -81,6 +86,11 @@ private:
 	void on_write(error_code const& ec, std::size_t bytes_written);
 	// wraps tracker_connection::fail
 	void fail(error_code const& ec, operation_t op);
+	// does the actual work of close(); takes the real failure reason so
+	// callers that just called fail(ec, op) can report it to every
+	// multiplexed torrent, instead of the generic reason close() uses on
+	// its own (e.g. session shutdown, where there is no specific error)
+	void close(error_code const& ec, operation_t op);
 
 	io_context& m_io_context;
 	ssl::context* m_ssl_context;
@@ -89,8 +99,28 @@ private:
 	std::string m_write_data;
 
 	using tracker_message = std::variant<tracker_request, tracker_answer>;
-	std::queue<std::tuple<tracker_message, std::weak_ptr<request_callback>>> m_pending;
-	std::map<sha1_hash, std::weak_ptr<request_callback>> m_callbacks;
+	std::deque<std::tuple<tracker_message, std::weak_ptr<request_callback>>> m_pending;
+
+	// pending is true from the point a request is sent until its first
+	// tracker_response is delivered. close() reports an error for any
+	// entry still pending, so a torrent multiplexed onto this connection
+	// (i.e. not the most recently sent request) still gets notified when
+	// the connection is torn down before it received a response. req is
+	// the entry's own request, since it may not be the most recently sent
+	// request on this connection (tracker_req()).
+	struct callback_entry
+	{
+		std::weak_ptr<request_callback> cb;
+		tracker_request req;
+		bool pending = true;
+	};
+	// on_read() holds an iterator into m_callbacks across a reentrant call
+	// into cb->on_rtc_offer()/on_rtc_answer(), which may indirectly insert
+	// into this same map (e.g. by queuing another request on this
+	// connection); this relies on stable iterators. Do not change this to
+	// an unordered_map without also fixing on_read() to not hold an
+	// iterator across that call.
+	std::map<sha1_hash, callback_entry> m_callbacks;
 
 	bool m_sending = false;
 };

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -12,6 +12,7 @@ see LICENSE file.
 
 #include <algorithm>
 #include <cctype>
+#include <iterator>
 
 #include "libtorrent/aux_/io.hpp"
 #include "libtorrent/aux_/session_interface.hpp"
@@ -251,7 +252,9 @@ namespace libtorrent::aux {
 	{
 		TORRENT_ASSERT(is_single_thread());
 		tracker_request const& req = c->tracker_req();
-		m_websocket_conns.erase(req.url);
+		auto const it = m_websocket_conns.find(req.url);
+		if (it != m_websocket_conns.end() && it->second.get() == c)
+			m_websocket_conns.erase(it);
 	}
 #endif
 
@@ -344,6 +347,26 @@ namespace libtorrent::aux {
 					, std::vector<aux::rtc_offer> offers) mutable
 			{
 				if (!ec) request.offers = std::move(offers);
+
+				// m_abort may have been set (session shutdown) while this
+				// offer generation was in flight; the guard at the top of
+				// queue_request() only protects requests queued before
+				// m_abort was set, so re-check here before (re-)establishing
+				// a persistent connection, for the same reason the
+				// num_want==0 branch above avoids doing so during shutdown.
+				if (m_abort && request.event != event_t::stopped)
+				{
+					if (auto rc = c.lock())
+						post(ios,
+							std::bind(&request_callback::tracker_request_error,
+								rc,
+								std::move(request),
+								errors::torrent_aborted,
+								operation_t::connect,
+								"",
+								seconds32(0)));
+					return;
+				}
 
 				auto it = m_websocket_conns.find(request.url);
 				if (it != m_websocket_conns.end() && it->second->is_started()) {
@@ -536,20 +559,6 @@ namespace libtorrent::aux {
 #endif
 		}
 
-#if TORRENT_USE_RTC
-		std::vector<std::shared_ptr<aux::websocket_tracker_connection>> close_websocket_connections;
-		for (auto const& p : m_websocket_conns)
-		{
-			auto const& c = p.second;
-			close_websocket_connections.push_back(c);
-
-#ifndef TORRENT_DISABLE_LOGGING
-			std::shared_ptr<request_callback> rc = c->requester();
-			if (rc) rc->debug_log("aborting: %s", c->tracker_req().url.c_str());
-#endif
-		}
-#endif
-
 		// tearing everything down for good (the tracker_manager destructor)
 		// reports no outcome and closes synchronously: posting here would
 		// be unsafe, since the io_context is not guaranteed to run again
@@ -579,12 +588,47 @@ namespace libtorrent::aux {
 		}
 
 #if TORRENT_USE_RTC
-		for (auto const& c : close_websocket_connections)
+		// close() erases its own entry from this map synchronously (via
+		// remove_request()), so capture the next iterator before calling
+		// it. Deliberately not collected into a vector first (unlike
+		// close_http_started/close_udp_connections above): this function
+		// runs from ~tracker_manager() too, whose implicit noexcept means
+		// a bad_alloc from that allocation would call std::terminate().
+		for (auto it = m_websocket_conns.begin(); it != m_websocket_conns.end();)
 		{
+			auto const& c = it->second;
+			auto const next = std::next(it);
+
 			if (all)
+			{
 				c->close();
-			else
-				c->fail(errors::announce_skipped, operation_t::bittorrent);
+				it = next;
+				continue;
+			}
+
+			// leaves the connection running if it still has a
+			// stopped-event request queued or in flight on it.
+			if (c->prune_non_stopped_requests())
+			{
+				it = next;
+				continue;
+			}
+
+#ifndef TORRENT_DISABLE_LOGGING
+			std::shared_ptr<request_callback> rc = c->requester();
+			if (rc)
+				rc->debug_log("aborting: %s", c->tracker_req().url.c_str());
+#endif
+			// fail() alone does not report anything: it suppresses
+			// fail_impl()'s single-request report (see its definition) so
+			// that close(ec, op), below, is the only thing that reports an
+			// outcome, with the right reason, to every multiplexed
+			// request. Skipping the close(ec, op) call here would silently
+			// fall back to fail_impl()'s deferred, argument-less close(),
+			// reporting operation_aborted/unknown instead.
+			c->fail(errors::announce_skipped, operation_t::bittorrent);
+			c->close(errors::announce_skipped, operation_t::bittorrent);
+			it = next;
 		}
 #endif
 	}

--- a/src/websocket_tracker_connection.cpp
+++ b/src/websocket_tracker_connection.cpp
@@ -42,6 +42,7 @@ see LICENSE file.
 #include <locale>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace libtorrent::aux {
@@ -59,6 +60,14 @@ std::string utf8_latin1(json::string const& sv)
 	return aux::utf8_latin1(std::string_view{sv.data(), sv.size()});
 }
 
+void report_error(std::weak_ptr<request_callback> const& cb,
+	tracker_request const& req,
+	error_code const& ec,
+	operation_t const op)
+{
+	if (auto c = cb.lock())
+		c->tracker_request_error(req, ec, op, ec.message(), seconds32(120));
+}
 }
 
 websocket_tracker_connection::websocket_tracker_connection(
@@ -102,25 +111,46 @@ void websocket_tracker_connection::start()
 
 void websocket_tracker_connection::close()
 {
+	// no specific failure triggered this (e.g. session shutdown)
+	close(error::operation_aborted, operation_t::unknown);
+}
+
+void websocket_tracker_connection::close(error_code const& ec, operation_t const op)
+{
 	if (m_websocket)
 	{
 		m_websocket->close();
 		m_websocket.reset();
 	}
 
-	error_code const ec = error::operation_aborted;
 	while (!m_pending.empty())
 	{
 		auto [msg, callback] = std::move(m_pending.front());
-		TORRENT_UNUSED(msg);
-		m_pending.pop();
-		if (auto cb = callback.lock())
-			cb->tracker_request_error(
-					tracker_req()
-					, ec
-					, operation_t::unknown
-					, ec.message()
-					, seconds32(120));
+		m_pending.pop_front();
+		if (callback.lock())
+		{
+			// only tracker_request messages ever carry a non-empty
+			// callback (queue_answer() always passes an empty one). These
+			// were never sent, so they were aborted rather than failed,
+			// regardless of what ec/op close() was called with.
+			auto const* req = std::get_if<tracker_request>(&msg);
+			TORRENT_ASSERT(req);
+			report_error(callback, *req, error::operation_aborted, operation_t::unknown);
+		}
+	}
+
+	// any request still marked pending here never got a response. This is
+	// the only place that reports it, whether it's the connection's
+	// current request or another torrent multiplexed onto this same
+	// connection. Unlike m_pending above, these were actually sent, so
+	// they genuinely experienced ec/op (the reason this connection is
+	// closing) rather than merely being aborted.
+	for (auto& e : m_callbacks)
+	{
+		if (!e.second.pending)
+			continue;
+		e.second.pending = false;
+		report_error(e.second.cb, e.second.req, ec, op);
 	}
 
 	m_callbacks.clear();
@@ -137,15 +167,59 @@ bool websocket_tracker_connection::is_open() const
 	return m_websocket && m_websocket->is_open();
 }
 
+bool websocket_tracker_connection::prune_non_stopped_requests()
+{
+	error_code const ec = errors::announce_skipped;
+	bool has_stopped = false;
+
+	// erasing is the common case, so do it in one pass rather than paying
+	// for an O(n) shift on every deque::erase() of a single element.
+	auto const pending_end =
+		std::remove_if(m_pending.begin(), m_pending.end(), [&](auto const& item) {
+			auto const* req = std::get_if<tracker_request>(&std::get<0>(item));
+			if (!req)
+				return false;
+			if (req->event == event_t::stopped)
+			{
+				has_stopped = true;
+				return false;
+			}
+
+			report_error(std::get<1>(item), *req, ec, operation_t::bittorrent);
+			return true;
+		});
+	m_pending.erase(pending_end, m_pending.end());
+
+	for (auto it = m_callbacks.begin(); it != m_callbacks.end();)
+	{
+		if (!it->second.pending)
+		{
+			++it;
+			continue;
+		}
+		if (it->second.req.event == event_t::stopped)
+		{
+			has_stopped = true;
+			++it;
+			continue;
+		}
+
+		report_error(it->second.cb, it->second.req, ec, operation_t::bittorrent);
+		it = m_callbacks.erase(it);
+	}
+
+	return has_stopped;
+}
+
 void websocket_tracker_connection::queue_request(tracker_request req, std::weak_ptr<request_callback> cb)
 {
-	m_pending.emplace(tracker_message{std::move(req)}, cb);
+	m_pending.emplace_back(tracker_message{std::move(req)}, cb);
 	if (is_open()) send_pending();
 }
 
 void websocket_tracker_connection::queue_answer(tracker_answer ans)
 {
-	m_pending.emplace(tracker_message{std::move(ans)}, std::weak_ptr<request_callback>{});
+	m_pending.emplace_back(tracker_message{std::move(ans)}, std::weak_ptr<request_callback>{});
 	if (is_open()) send_pending();
 }
 
@@ -156,25 +230,37 @@ void websocket_tracker_connection::send_pending()
 	m_sending = true;
 
 	auto [msg, callback] = std::move(m_pending.front());
-	m_pending.pop();
+	m_pending.pop_front();
 
-	std::visit([this, cb = callback](auto const& m)
-		{
-			// Update requester and store callback
-			if (cb.lock())
+	std::visit(
+		[this, cb = callback](auto const& m) {
+			// record every sent request, even ones whose callback has
+			// already expired, so m_callbacks always reflects whether the
+			// connection's current request is still pending (used by
+			// prune_non_stopped_requests()); a dead callback just means
+			// nothing is invoked when its outcome is reported.
+			if constexpr (std::is_same_v<std::decay_t<decltype(m)>, tracker_request>)
 			{
-				m_requester = cb;
-				m_callbacks[m.info_hash] = std::move(cb);
+			// torrent invariants ensure at most one request per info_hash
+			// is ever in flight at a time, so this must never overwrite a
+			// still-pending entry
+#if TORRENT_USE_ASSERTS
+				auto const existing = m_callbacks.find(m.info_hash);
+				TORRENT_ASSERT(existing == m_callbacks.end() || !existing->second.pending);
+#endif
+				m_callbacks[m.info_hash] = callback_entry{cb, m};
 			}
 
+			if (cb.lock())
+				m_requester = cb;
+
 			do_send(m);
-		}
-		, msg);
+		},
+		msg);
 }
 
 void websocket_tracker_connection::do_send(tracker_request const& req)
 {
-	// Update request
 	m_req = req;
 
 	json::object payload;
@@ -279,7 +365,7 @@ void websocket_tracker_connection::on_timeout(error_code const& ec)
 #endif
 
 	fail(error_code(error::timed_out), operation_t::sock_read);
-	close();
+	close(error_code(error::timed_out), operation_t::sock_read);
 }
 
 void websocket_tracker_connection::on_connect(error_code const& ec)
@@ -288,7 +374,7 @@ void websocket_tracker_connection::on_connect(error_code const& ec)
 	if (ec)
 	{
 		fail(ec, operation_t::connect);
-		close();
+		close(ec, operation_t::connect);
 		return;
 	}
 
@@ -302,8 +388,14 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 	if (ec)
 	{
 		if (ec != websocket::error::closed)
+		{
 			fail(ec, operation_t::sock_read);
-		close();
+			close(ec, operation_t::sock_read);
+		}
+		else
+		{
+			close();
+		}
 		return;
 	}
 
@@ -326,7 +418,7 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 		}
 #endif
 		fail(ec, operation_t::handshake);
-		close();
+		close(ec, operation_t::handshake);
 		return;
 	}
 
@@ -334,8 +426,9 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 	auto response = std::move(std::get<websocket_tracker_response>(ret));
 
 	std::shared_ptr<request_callback> cb;
-	if (auto cit = m_callbacks.find(response.info_hash); cit != m_callbacks.end())
-		cb = cit->second.lock();
+	auto const cit = m_callbacks.find(response.info_hash);
+	if (cit != m_callbacks.end())
+		cb = cit->second.cb.lock();
 
 	if (cb)
 	{
@@ -366,7 +459,12 @@ void websocket_tracker_connection::on_read(error_code ec, std::size_t /* bytes_r
 			response.resp->interval = std::max(response.resp->interval
 				, seconds32{m_man.settings().get_int(settings_pack::min_websocket_announce_interval)});
 
-			cb->tracker_response(tracker_req(), {}, {}, *response.resp);
+			// this request's outcome has just been reported to its
+			// requester; mark it so close() won't also report an error
+			// for it.
+			cit->second.pending = false;
+
+			cb->tracker_response(cit->second.req, {}, {}, *response.resp);
 		}
 	}
 	else
@@ -389,7 +487,7 @@ void websocket_tracker_connection::on_write(error_code const& ec, std::size_t /*
 	if (ec)
 	{
 		fail(ec, operation_t::sock_write);
-		close();
+		close(ec, operation_t::sock_write);
 		return;
 	}
 
@@ -399,6 +497,15 @@ void websocket_tracker_connection::on_write(error_code const& ec, std::size_t /*
 
 void websocket_tracker_connection::fail(error_code const& ec, operation_t const op)
 {
+	// suppress tracker_connection::fail_impl()'s own report: it would
+	// report m_req to requester(), but this connection multiplexes several
+	// torrents' requests, so m_req may not even belong to the torrent whose
+	// outcome this is. Callers follow fail() with close(ec, op), which
+	// reports every still-pending m_callbacks entry using each request's
+	// own stored data and the real ec/op, superseding fail_impl()'s report
+	// (and its generic, no-args close()) entirely.
+	m_req_pending = false;
+
 	tracker_connection::fail(ec, op, ec.message().c_str(), seconds32{120}, seconds32{120});
 }
 


### PR DESCRIPTION
back-port of https://github.com/arvidn/libtorrent/pull/8615