### PR TITLE
fix piece-picker invariant

### DIFF
--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -3498,24 +3498,18 @@ get_out:
 		}
 
 		// prevent this hash job from actually completing
-		// this piece, by setting the failure state.
-		// the piece is unlocked in the call to restore_piece()
+		// this piece, by setting the failure state. Do not erase the
+		// downloading_piece entry here even if no blocks are left
+		// outstanding (finished + writing + requested + hashing == 0):
+		// the piece must stay locked, and tracked, until the disk thread
+		// has actually finished discarding the failed state and
+		// restore_piece() is called. Erasing it here would make the piece
+		// pickable again before that has happened, racing a fresh
+		// download of the same piece against the still-outstanding
+		// disk-side cleanup.
 		i->locked = true;
 
-		i = update_piece_state(i);
-
-		if (i->finished + i->writing + i->requested + i->hashing == 0)
-		{
-			piece_pos& p = m_piece_map[block.piece_index];
-			int const prev_priority = p.priority(this);
-			erase_download_piece(i);
-			int const new_priority = p.priority(this);
-
-			if (m_dirty) return;
-			if (new_priority == prev_priority) return;
-			if (prev_priority == -1) add(block.piece_index);
-			else update(prev_priority, p.index);
-		}
+		update_piece_state(i);
 	}
 
 	void piece_picker::mark_as_canceled(piece_block const block, aux::torrent_peer* peer)

--- a/test/test_piece_picker.cpp
+++ b/test/test_piece_picker.cpp
@@ -2113,6 +2113,16 @@ TORRENT_TEST(write_failed_clear_piece)
 
 	p->write_failed({1_piece, 0});
 
+	// even though there are no blocks left outstanding for this piece,
+	// it must stay locked and tracked as downloading until restore_piece()
+	// is called. Otherwise it would become pickable again before the disk
+	// thread has finished discarding the failed write, racing a fresh
+	// download of the same piece against that cleanup.
+	stat = p->piece_stats(1_piece);
+	TEST_EQUAL(stat.downloading, 1);
+
+	p->restore_piece(1_piece);
+
 	stat = p->piece_stats(1_piece);
 	TEST_EQUAL(stat.downloading, 0);
 }


### PR DESCRIPTION
A locked piece must not be removed, even when all blocks have a cleared state