### PR TITLE
avoid calling async_hash() on the same piece simultaneously

### DIFF
--- a/include/libtorrent/aux_/torrent.hpp
+++ b/include/libtorrent/aux_/torrent.hpp
@@ -604,6 +604,17 @@ namespace libtorrent::aux {
 		bool is_paused() const;
 		bool is_torrent_paused() const { return m_paused; }
 		void force_recheck();
+
+	private:
+		// shared implementation of force_recheck(), also used by
+		// hash_job_completed() to resume a deferred recheck once
+		// m_num_outstanding_hash_jobs drains. clear_error_first is false
+		// only for that resumption, since a disk error may have just been
+		// reported by the job that triggered it and must survive, not be
+		// cleared again here.
+		void force_recheck_impl(bool clear_error_first);
+
+	public:
 		void save_resume_data(resume_data_flags_t flags);
 
 		bool need_save_resume_data(resume_data_flags_t flags) const
@@ -1290,10 +1301,22 @@ namespace libtorrent::aux {
 		{
 			TORRENT_ASSERT(m_verifying.get_bit(piece) == false);
 			m_verifying.set_bit(piece);
+			// this is a hash job too (dispatched directly by peer_connection
+			// for an on-demand seed-mode check), it must be accounted for the
+			// same way as verify_piece()'s jobs; see m_num_outstanding_hash_jobs.
+			++m_num_outstanding_hash_jobs;
 		}
 		bool verified_piece(piece_index_t piece) const
 		{ return m_verified.get_bit(piece); }
 		void verified(piece_index_t piece);
+
+		// called when a hash job (verify_piece() or the on-demand
+		// seed-mode check, verifying()) completes. Decrements
+		// m_num_outstanding_hash_jobs and, if it just dropped to zero and a
+		// force_recheck() was deferred, carries it out. Returns true if it
+		// did, meaning the recheck supersedes this piece's own completion
+		// handling; callers must call this first and skip the rest if so.
+		bool hash_job_completed();
 
 		// this is called once periodically for torrents
 		// that are not private
@@ -1625,6 +1648,21 @@ namespace libtorrent::aux {
 
 		// the number of pieces we completed the check of
 		piece_index_t m_num_checked_pieces{0};
+
+		// the number of hash jobs that have been dispatched but not completed
+		// yet (hash_job_completed() has not been called for them): jobs
+		// dispatched by verify_piece() (completed via on_piece_verified()),
+		// and on-demand seed-mode jobs dispatched by peer_connection
+		// (verifying(), completed via peer_connection::on_seed_mode_hashed()).
+		// force_recheck() must not reset the piece picker while this is
+		// non-zero, since start_checking() has no way of knowing about those
+		// jobs and would dispatch redundant ones for the same pieces.
+		int m_num_outstanding_hash_jobs = 0;
+
+		// set when force_recheck() is called while m_num_outstanding_hash_jobs
+		// is non-zero. The recheck is carried out from hash_job_completed()
+		// once the count drops to zero.
+		bool m_pending_force_recheck = false;
 
 		// if the error occurred on a file, this is the index of that file
 		// there are a few special cases, when this is negative. See

--- a/simulation/disk_io.cpp
+++ b/simulation/disk_io.cpp
@@ -535,6 +535,10 @@ struct test_disk_io final : lt::disk_interface
 					, m_files->piece_size(piece)
 					, m_files->piece_size2(piece)
 					, block_hashes, pads_in_piece(m_pad_bytes, piece));
+
+			if (piece == m_state.corrupt_piece_idx)
+				hash = rand_sha1();
+
 			post(m_ioc, [h=std::move(h), piece, hash]{ h(piece, hash, lt::storage_error{}); });
 		});
 	}

--- a/simulation/disk_io.hpp
+++ b/simulation/disk_io.hpp
@@ -69,6 +69,18 @@ struct test_disk
 		ret.corrupt_data_in = blocks;
 		return ret;
 	}
+	// makes async_hash() return a wrong hash for this one piece, regardless
+	// of the "files" mode. Unlike send_corrupt_data() (which affects
+	// async_read(), globally, after N blocks), this lets a single specific
+	// piece fail its hash check while the rest of a full_valid torrent stays
+	// valid, e.g. to make a seed_mode torrent's on-demand check fail for one
+	// piece.
+	test_disk corrupt_piece(lt::piece_index_t const p) const
+	{
+		auto ret = *this;
+		ret.corrupt_piece_idx = p;
+		return ret;
+	}
 
 	// the number of blocks/write jobs in the queue before we exceed the write
 	// queue size. Once the level drops below the low watermark, we allow writes
@@ -100,6 +112,10 @@ struct test_disk
 
 	// after sending this many blocks, send corrupt data
 	int corrupt_data_in = std::numeric_limits<int>::max();
+
+	// if set, async_hash() always returns a wrong hash for this piece. See
+	// corrupt_piece().
+	lt::piece_index_t corrupt_piece_idx{-1};
 
 	// after having written this many bytes, fail with disk-full
 	int space_left = std::numeric_limits<int>::max();

--- a/simulation/test_peer_connection.cpp
+++ b/simulation/test_peer_connection.cpp
@@ -10,18 +10,21 @@ see LICENSE file.
 #include <functional>
 
 #include "libtorrent/session.hpp"
+#include "libtorrent/session_params.hpp"
 #include "libtorrent/torrent_handle.hpp"
 #include "libtorrent/settings_pack.hpp"
 #include "libtorrent/alert_types.hpp"
 #include "libtorrent/disabled_disk_io.hpp"
 #include "libtorrent/aux_/random.hpp"
 #include "libtorrent/torrent_flags.hpp"
+#include "libtorrent/create_torrent.hpp"
 #include "settings.hpp"
 #include "fake_peer.hpp"
 #include "utils.hpp"
 #include "test_utils.hpp"
 #include "setup_transfer.hpp"
 #include "create_torrent.hpp"
+#include "disk_io.hpp"
 #include "simulator/simulator.hpp"
 #include "simulator/utils.hpp"
 #include "simulator/queue.hpp"
@@ -334,4 +337,159 @@ TORRENT_TEST(disconnect_unknown_info_hash)
 	sim.run();
 
 	TEST_CHECK(d.alerts == vec{lt::errors::invalid_info_hash});
+}
+
+// Regression test for the seed_mode + force_recheck() race in
+// torrent::force_recheck()/hash_job_completed(). While a deferred
+// force_recheck() (m_pending_force_recheck) waits for outstanding hash
+// jobs to drain, m_files_checked must stay false for the whole wait, not
+// just once the recheck itself starts, since are_files_checked() is what
+// gates new block requests (request_blocks.cpp). Otherwise a
+// newly-connecting peer could complete a piece via verify_piece() while
+// an on-demand seed-mode hash job (verifying()) is still outstanding for
+// it, colliding at the disk_cache layer.
+//
+// Uses test_disk (deterministic, FIFO-ordered async_hash(), see
+// disk_io.hpp/.cpp) instead of TORRENT_SIMULATE_SLOW_HASH, so dispatch
+// order alone makes the race deterministic.
+TORRENT_TEST(seed_mode_recheck_defer_blocks_new_downloads)
+{
+	sim::default_config cfg;
+	sim::simulation sim{cfg};
+	auto ios_seed = std::make_unique<sim::asio::io_context>(sim, lt::make_address_v4("50.0.0.1"));
+	auto ios_peer3 = std::make_unique<sim::asio::io_context>(sim, lt::make_address_v4("50.0.0.2"));
+	lt::session_proxy zombie_seed;
+	lt::session_proxy zombie_peer3;
+
+	lt::piece_index_t const bad_piece(0);
+	lt::piece_index_t const good_piece(1);
+
+	lt::add_torrent_params atp =
+		::create_test_torrent(lt::default_block_size, 4, lt::create_torrent::v1_only);
+	atp.save_path = ".";
+	atp.flags &= ~lt::torrent_flags::auto_managed;
+	atp.flags &= ~lt::torrent_flags::paused;
+	lt::sha1_hash const info_hash = atp.ti->info_hash();
+
+	// the seed under test: seed_mode, with "bad_piece" corrupted so its
+	// on-demand check fails once requested.
+	lt::session_params sp_seed;
+	sp_seed.settings = settings();
+	sp_seed.settings.set_int(
+		lt::settings_pack::alert_mask, lt::alert_category::all & ~lt::alert_category::stats);
+	sp_seed.settings.set_str(lt::settings_pack::listen_interfaces, "50.0.0.1:6881");
+	// disk_seek() treats sequential access as free (0 delay), and piece 0,
+	// being the very first disk operation on a fresh test_disk_io instance,
+	// always lands exactly on the expected next offset. Use hash_time
+	// instead, which is added per block unconditionally, to reliably widen
+	// the window regardless of that optimization.
+	test_disk seed_disk = test_disk().set_seed(true).corrupt_piece(bad_piece);
+	// wide enough to comfortably outlast torrent::connect_peer()'s normal
+	// per-tick outgoing-connection scheduling latency (observed to take a
+	// few real seconds), so peer3's connection has time to land and be
+	// evaluated for requests while the wait is still genuinely ongoing.
+	seed_disk.hash_time = lt::seconds(5);
+	sp_seed.disk_io_constructor = seed_disk;
+	auto ses_seed = std::make_shared<lt::session>(sp_seed, *ios_seed);
+
+	// peer3: an ordinary, fully-seeded peer with the *correct* data for
+	// every piece, including "good_piece". Connected mid-wait, to see
+	// whether the seed illegitimately downloads "good_piece" from it before
+	// that piece's own on-demand job has completed.
+	lt::session_params sp_peer3;
+	sp_peer3.settings = settings();
+	sp_peer3.settings.set_int(
+		lt::settings_pack::alert_mask, lt::alert_category::all & ~lt::alert_category::stats);
+	sp_peer3.settings.set_str(lt::settings_pack::listen_interfaces, "50.0.0.2:6881");
+	sp_peer3.disk_io_constructor = test_disk().set_seed(true);
+	auto ses_peer3 = std::make_shared<lt::session>(sp_peer3, *ios_peer3);
+
+	lt::add_torrent_params atp_seed = atp;
+	atp_seed.flags |= lt::torrent_flags::seed_mode;
+	ses_seed->async_add_torrent(atp_seed);
+	ses_peer3->async_add_torrent(atp);
+
+	auto const peer1 = std::make_unique<fake_peer>(sim, "60.0.0.1");
+	auto const peer2 = std::make_unique<fake_peer>(sim, "60.0.0.2");
+
+	lt::torrent_handle seed_handle;
+	bool hash_failed_seen = false;
+	bool recheck_started = false;
+	bool good_piece_finished_before_recheck = false;
+
+	print_alerts(*ses_seed, [&](lt::session&, lt::alert const* a) {
+		if (auto* at = lt::alert_cast<lt::add_torrent_alert>(a))
+		{
+			seed_handle = at->handle;
+			// request the corrupt piece first, so its hash job is queued
+			// (and thus resolves) ahead of the good piece's.
+			peer1->connect_to(ep("50.0.0.1", 6881), info_hash);
+			peer1->send_interested();
+			peer1->send_request(bad_piece, 0);
+		}
+		if (auto* hf = lt::alert_cast<lt::hash_failed_alert>(a))
+		{
+			if (hf->piece_index == bad_piece)
+			{
+				hash_failed_seen = true;
+				// force_recheck() should now be deferred, waiting for
+				// good_piece's on-demand job (still outstanding: it was
+				// only just requested, and test_disk serializes hash jobs
+				// FIFO). Connect a new peer offering every piece, including
+				// good_piece, right now. Connecting any earlier would just
+				// get torn down immediately by force_recheck()'s own
+				// disconnect_all() (which runs regardless of whether it
+				// ends up deferring); torrent::connect_peer() is also
+				// subject to the normal per-tick outgoing-connection
+				// schedule rather than connecting instantly, which is why
+				// the wait below is generous.
+				seed_handle.connect_peer(ep("50.0.0.2", 6881));
+			}
+		}
+		if (auto* sc = lt::alert_cast<lt::state_changed_alert>(a))
+		{
+			// this is when the *deferred* force_recheck() actually runs (the
+			// wait is over): the earlier, immediate checking_resume_data
+			// transition inside leave_seed_mode()/force_recheck() itself
+			// only happens once m_num_outstanding_hash_jobs has drained, so
+			// this can only fire once good_piece's own on-demand job has
+			// resolved (whether normally, or via an illegitimate download
+			// from peer3).
+			if (sc->state == lt::torrent_status::checking_files
+				|| sc->state == lt::torrent_status::checking_resume_data)
+				recheck_started = true;
+		}
+		if (auto* pf = lt::alert_cast<lt::piece_finished_alert>(a))
+		{
+			// piece_finished_alert legitimately fires for good_piece once
+			// the recheck (started above) gets to it, that's expected.
+			// It firing *before* the recheck starts can only mean it was
+			// (re-)downloaded from peer3 while force_recheck() was still
+			// supposed to be deferred.
+			if (pf->piece_index == good_piece && !recheck_started)
+				good_piece_finished_before_recheck = true;
+		}
+	});
+
+	// request the good piece shortly after the corrupt one, so both hash
+	// jobs are outstanding together, but strictly after piece 0's job so it
+	// resolves (and fails) first.
+	sim::timer t1(sim, lt::milliseconds(50), [&](boost::system::error_code const&) {
+		peer2->connect_to(ep("50.0.0.1", 6881), info_hash);
+		peer2->send_interested();
+		peer2->send_request(good_piece, 0);
+	});
+
+	sim::timer t2(sim, lt::seconds(90), [&](boost::system::error_code const&) {
+		zombie_seed = ses_seed->abort();
+		zombie_peer3 = ses_peer3->abort();
+		ses_seed.reset();
+		ses_peer3.reset();
+	});
+
+	sim.run();
+
+	TEST_CHECK(hash_failed_seen);
+	TEST_CHECK(recheck_started);
+	TEST_CHECK(!good_piece_finished_before_recheck);
 }

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5420,7 +5420,22 @@ namespace {
 		TORRENT_ASSERT(m_outstanding_piece_verification > 0);
 		--m_outstanding_piece_verification;
 
-		if (!t || t->is_aborted()) return;
+		if (!t)
+			return;
+
+		// must run even while aborting, to keep the outstanding-job count
+		// accurate; hash_job_completed() itself safely no-ops a pending
+		// force_recheck() in that case. A genuine disk error is still
+		// reported below even if a deferred recheck already ran.
+		if (t->hash_job_completed())
+		{
+			if (error)
+				t->handle_disk_error("hash", error, this);
+			return;
+		}
+
+		if (t->is_aborted())
+			return;
 
 		if (error)
 		{

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -585,6 +585,35 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		set_need_save_resume(torrent_handle::if_download_progress);
 	}
 
+	bool torrent::hash_job_completed()
+	{
+		TORRENT_ASSERT(m_num_outstanding_hash_jobs > 0);
+		if (m_num_outstanding_hash_jobs > 0)
+			--m_num_outstanding_hash_jobs;
+
+		if (m_abort || m_deleted)
+		{
+			m_pending_force_recheck = false;
+			return false;
+		}
+
+		if (m_num_outstanding_hash_jobs > 0)
+			return false;
+
+		// a force_recheck() was requested while this (or another) hash job
+		// was still outstanding; force_recheck_impl() discards all picker
+		// state and re-derives it from scratch, including this job's own
+		// outcome. clear_error_first is false: a disk error just reported
+		// by this job (or its caller) must survive, not be cleared here.
+		if (m_pending_force_recheck)
+		{
+			m_pending_force_recheck = false;
+			force_recheck_impl(false);
+			return true;
+		}
+		return false;
+	}
+
 	void torrent::start()
 	{
 		TORRENT_ASSERT(is_single_thread());
@@ -1468,6 +1497,12 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 			&& state() != torrent_status::checking_resume_data);
 		if (state() == torrent_status::checking_files
 			|| state() == torrent_status::checking_resume_data)
+			return;
+
+		// verify_piece() below guards against this too, but bail out here
+		// as well to skip the disk writes and picker mutation below for
+		// data that's about to be discarded by the pending recheck anyway.
+		if (m_pending_force_recheck)
 			return;
 
 		need_picker();
@@ -2371,6 +2406,19 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 				// --- UNFINISHED PIECES ---
 
+				// a truncated have_pieces bitfield (should_start_full_check)
+				// means this torrent was mid-check when the resume data was
+				// saved; downloading (the only source of unfinished pieces)
+				// is disabled during a check, and force_recheck() clears
+				// existing unfinished pieces first, so genuine resume data
+				// never has both. Discard it in that case, rather than
+				// dispatch a verify_piece() job for a piece start_checking()
+				// is about to check anyway; this is external input (a plain
+				// struct, possibly read from disk), so don't rely on that
+				// invariant holding, just enforce it.
+				if (should_start_full_check)
+					m_add_torrent_params->unfinished_pieces.clear();
+
 				int const num_blocks_per_piece = torrent_file().blocks_per_piece();
 
 				for (auto const& p : m_add_torrent_params->unfinished_pieces)
@@ -2388,7 +2436,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 					// being in seed mode and missing a piece is not compatible.
 					// Leave seed mode if that happens
-					if (m_seed_mode) leave_seed_mode(seed_mode_t::skip_checking);
+					if (m_seed_mode)
+						leave_seed_mode(seed_mode_t::skip_checking);
 
 					if (has_picker() && m_picker->have_piece(piece))
 					{
@@ -2427,7 +2476,8 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		{
 			stop_announcing();
 			set_state(torrent_status::checking_files);
-			if (should_check_files()) start_checking();
+			if (should_check_files())
+				start_checking();
 
 			// start the checking right away (potentially)
 			m_ses.trigger_auto_manage();
@@ -2448,7 +2498,9 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 	}
 	catch (...) { handle_exception(); }
 
-	void torrent::force_recheck()
+	void torrent::force_recheck() { force_recheck_impl(true); }
+
+	void torrent::force_recheck_impl(bool const clear_error_first)
 	{
 		INVARIANT_CHECK;
 
@@ -2460,14 +2512,51 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 			|| m_state == torrent_status::checking_resume_data)
 			return;
 
-		clear_error();
+		// clear_error_first is false only when resuming a deferred recheck
+		// (see hash_job_completed()): a disk error that job just reported
+		// must survive, not be wiped out here again.
+		if (clear_error_first)
+			clear_error();
 
+		// disconnect peers, leave seed mode, and mark files as not checked
+		// before the outstanding-jobs check below (even if we end up
+		// deferring, and even when resuming a deferred recheck): a peer
+		// could connect during the wait, and the picker reset further down
+		// requires none be attached.
+		//  - disconnect_all() stops new on-demand seed-mode checks
+		//    (verifying()) and new peer-driven downloads (verify_piece());
+		//  - m_files_checked = false is what actually gates block requests
+		//    (request_blocks.cpp): once m_verifying is cleared below, a job
+		//    it covers is no longer visible to verify_piece()'s own
+		//    is_hashing() guard, so this is the real protection against a
+		//    new peer completing that same piece while we wait. A busy seed
+		//    could otherwise keep m_num_outstanding_hash_jobs from ever
+		//    reaching zero.
+		// All but clear_error() is idempotent, so repeating this on
+		// resumption is just cheap no-ops.
 		disconnect_all(errors::stopping_torrent, operation_t::bittorrent);
 		stop_announcing();
 
 		// we're checking everything anyway, no point in assuming we are a seed
 		// now.
 		leave_seed_mode(seed_mode_t::skip_checking);
+
+		// block new block requests via are_files_checked() (see above) for
+		// the whole wait below, not just once checking actually starts.
+		m_files_checked = false;
+
+		// a hash job (verify_piece() or the seed-mode on-demand check,
+		// verifying()) may already have been in flight before
+		// disconnect_all()/leave_seed_mode() above could stop new ones.
+		// Resetting the picker now would lose track of it, and
+		// start_checking() would dispatch a redundant hash job for the same
+		// piece. Defer until it completes; hash_job_completed() calls
+		// force_recheck_impl() once none are left.
+		if (m_num_outstanding_hash_jobs > 0)
+		{
+			m_pending_force_recheck = true;
+			return;
+		}
 
 		// forget that we have any pieces
 		set_have_all(false);
@@ -2485,9 +2574,6 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 		// resizing the picker above may have changed is_finished(), which
 		// set_have_all() above didn't catch if m_have_all was already false
 		update_state_timers();
-
-		// assume that we don't have anything
-		m_files_checked = false;
 
 		update_gauge();
 		update_want_tick();
@@ -2598,6 +2684,13 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 					++m_num_checked_pieces;
 				}
 			}
+
+			// callers must not invoke start_checking() while any piece has a
+			// hash job outstanding (see m_num_outstanding_hash_jobs); we rely
+			// on that to not dispatch a second, concurrent async_hash() for
+			// the same piece, which disk_cache does not allow.
+			TORRENT_ASSERT(m_checking_piece >= m_torrent_file->end_piece() || !has_picker()
+				|| !m_picker->is_hashing(m_checking_piece));
 
 			if (m_checking_piece >= m_torrent_file->end_piece()) break;
 
@@ -2787,6 +2880,9 @@ aux::vector<download_priority_t, piece_index_t> file_to_piece_prio(
 
 			if (m_checking_piece >= m_torrent_file->end_piece())
 				return;
+
+			// see the matching assert (and comment) in start_checking()
+			TORRENT_ASSERT(!has_picker() || !m_picker->is_hashing(m_checking_piece));
 
 			auto flags = disk_interface::sequential_access | disk_interface::volatile_read;
 
@@ -4410,6 +4506,16 @@ namespace {
 		, sha1_hash const& piece_hash, storage_error const& error) try
 	{
 		TORRENT_ASSERT(is_single_thread());
+
+		if (hash_job_completed())
+		{
+			// this job's pass/fail no longer matters (a deferred
+			// force_recheck() will re-derive it), but a genuine disk error
+			// must still be reported, not silently dropped.
+			if (error)
+				handle_disk_error("piece_verified", error);
+			return;
+		}
 
 		if (m_abort) return;
 		if (m_deleted) return;
@@ -10327,7 +10433,8 @@ namespace {
 			m_ses.trigger_auto_manage();
 		}
 
-		if (should_check_files()) start_checking();
+		if (should_check_files())
+			start_checking();
 
 		state_updated();
 		update_want_peers();
@@ -11811,6 +11918,18 @@ namespace {
 	{
 		TORRENT_ASSERT(m_storage);
 		TORRENT_ASSERT(!m_picker->is_hashing(piece));
+
+		// a force_recheck() is deferred, waiting for outstanding hash jobs
+		// to drain before it can (re-)build the picker; dispatching a new
+		// one here would race it the same way. Not a caller precondition
+		// (this is purely internal state), so just ignore the call.
+		if (m_pending_force_recheck)
+			return;
+
+		// on_piece_verified() decrements this once the job completes, however
+		// it gets there (async_hash() callback or the disable_hash_checks
+		// short-circuit below).
+		++m_num_outstanding_hash_jobs;
 
 		// we just completed the piece, it should be flushed to disk
 		disk_job_flags_t flags{};

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -511,6 +511,31 @@ void wait_for_seeding(lt::session& ses, char const* name)
 	}
 }
 
+void wait_for_complete(lt::session& ses, lt::torrent_handle h, char const* name)
+{
+	int last_progress = 0;
+	time_point last_change = clock_type::now();
+	for (int i = 0; i < 2000; ++i)
+	{
+		print_alerts(ses, name);
+		torrent_status st = h.status();
+		std::printf("%d ms -  %f %%\n",
+			int(total_milliseconds(clock_type::now() - last_change)),
+			st.progress_ppm / 10000.0);
+		if (st.progress_ppm == 1000000)
+			return;
+		if (st.progress_ppm != last_progress)
+		{
+			last_progress = st.progress_ppm;
+			last_change = clock_type::now();
+		}
+		if (clock_type::now() - last_change > seconds(30))
+			break;
+		std::this_thread::sleep_for(100ms);
+	}
+	TEST_ERROR("torrent did not finish");
+}
+
 void print_ses_rate(lt::clock_type::time_point const start_time
 	, lt::torrent_status const* st1
 	, lt::torrent_status const* st2

--- a/test/setup_transfer.hpp
+++ b/test/setup_transfer.hpp
@@ -74,6 +74,10 @@ EXPORT void wait_for_downloading(lt::session& ses, char const* name);
 EXPORT void wait_for_seeding(lt::session& ses, char const* name);
 EXPORT void wait_for_disconnect(lt::session& ses, char const* name);
 
+// polls torrent_status::progress_ppm until the torrent reaches 100%, up to a
+// 200s absolute backstop; bails out early if progress stalls for 30s.
+EXPORT void wait_for_complete(lt::session& ses, lt::torrent_handle h, char const* name);
+
 EXPORT std::vector<char> generate_piece(lt::piece_index_t idx, int piece_size = 0x4000);
 EXPORT lt::file_storage make_file_storage(lt::span<const int> file_sizes
 	, int const piece_size, std::string base_name = "test_dir-");

--- a/test/test_recheck.cpp
+++ b/test/test_recheck.cpp
@@ -16,6 +16,8 @@ see LICENSE file.
 #include "libtorrent/time.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/disk_interface.hpp"
+#include "libtorrent/bitfield.hpp"
 #include <tuple>
 #include <functional>
 
@@ -30,35 +32,6 @@ see LICENSE file.
 
 using namespace lt;
 using namespace std::chrono_literals;
-
-namespace {
-
-void wait_for_complete(lt::session& ses, torrent_handle h)
-{
-	int last_progress = 0;
-	clock_type::time_point last_change = clock_type::now();
-	// bounded by a 200s absolute backstop; the short poll interval keeps a
-	// quick completion from waiting out a full second of granularity.
-	for (int i = 0; i < 2000; ++i)
-	{
-		print_alerts(ses, "ses1");
-		torrent_status st = h.status();
-		std::printf("%d ms -  %f %%\n"
-			, int(total_milliseconds(clock_type::now() - last_change))
-			, st.progress_ppm / 10000.0);
-		if (st.progress_ppm == 1000000) return;
-		if (st.progress_ppm != last_progress)
-		{
-			last_progress = st.progress_ppm;
-			last_change = clock_type::now();
-		}
-		if (clock_type::now() - last_change > seconds(30)) break;
-		std::this_thread::sleep_for(100ms);
-	}
-	TEST_ERROR("torrent did not finish");
-}
-
-} // anonymous namespace
 
 TORRENT_TEST_DISK_IO(recheck)
 {
@@ -92,11 +65,91 @@ TORRENT_TEST_DISK_IO(recheck)
 
 	torrent_status st1 = tor1.status();
 	TEST_CHECK(st1.progress_ppm <= 1000000);
-	wait_for_complete(ses1, tor1);
+	wait_for_complete(ses1, tor1, "ses1");
 
 	tor1.force_recheck();
 
 	st1 = tor1.status();
 	TEST_CHECK(st1.progress_ppm <= 1000000);
-	wait_for_complete(ses1, tor1);
+	wait_for_complete(ses1, tor1, "ses1");
+}
+
+// Regression test for on_resume_data_checked() with resume data that pairs a
+// truncated have_pieces bitfield (implying a previous full check was
+// interrupted, and start_checking() will pick up checking from where it left
+// off) with a non-empty unfinished_pieces entry at or past that point. That
+// combination can't come from torrent::write_resume_data(): downloading (the
+// only source of unfinished_pieces) is disabled for the whole duration of a
+// check, and force_recheck() clears any pre-existing unfinished pieces from
+// the picker before a check begins, so genuinely-produced resume data never
+// has both at once. But add_torrent_params is a plain public struct, and
+// resume data can come from disk, so this combination can still reach
+// on_resume_data_checked() (as constructed by this test). Processing the
+// unfinished_pieces entry in that case would dispatch a verify_piece() job
+// for a piece start_checking() is also about to check, deterministically
+// tripping disk_cache's "never two concurrent async_hash() requests for the
+// same piece" invariant.
+//
+// on_resume_data_checked() skips the unfinished_pieces loop entirely
+// whenever the have_pieces bitfield was truncated, rather than processing
+// entries that start_checking() is about to redo anyway.
+TORRENT_TEST_DISK_IO(recheck_unfinished_piece_vs_start_checking)
+{
+	error_code ec;
+	settings_pack sett = settings();
+	sett.set_str(settings_pack::listen_interfaces, test_listen_interface());
+	sett.set_bool(settings_pack::enable_upnp, false);
+	sett.set_bool(settings_pack::enable_natpmp, false);
+	sett.set_bool(settings_pack::enable_lsd, false);
+	sett.set_bool(settings_pack::enable_dht, false);
+	lt::session_params sp(sett);
+	sp.disk_io_constructor = disk_io;
+	lt::session ses1(sp);
+
+	int const piece_size = default_block_size;
+	int const num_pieces = 4;
+
+	error_code ec2;
+	create_directory("tmp1_recheck_unfinished", ec2);
+	if (ec2)
+		std::printf("create_directory: %s\n", ec2.message().c_str());
+
+	// write the full (correct) payload to disk up front, so the resume data
+	// below describes a torrent whose files are already complete on disk.
+	std::ofstream file("tmp1_recheck_unfinished/temporary");
+	add_torrent_params param = ::create_torrent(
+		&file, "temporary", piece_size, num_pieces, false, lt::create_torrent::v1_only);
+	file.close();
+
+	param.flags &= ~torrent_flags::paused;
+	param.flags &= ~torrent_flags::auto_managed;
+	param.save_path = "tmp1_recheck_unfinished";
+
+	// resume data claiming only piece 0 has been checked (a truncated
+	// have_pieces bitfield, as if a previous full recheck was interrupted
+	// right after piece 0). This makes on_resume_data_checked() resume
+	// checking from piece 1 onward via start_checking().
+	param.have_pieces.resize(1);
+	param.have_pieces.set_bit(piece_index_t(0));
+
+	// resume data *also* claims piece 1's only block is already written (but
+	// not yet hash-checked). Genuine resume data would never pair this with
+	// a truncated have_pieces bitfield (see the comment above), but nothing
+	// stops an add_torrent_params constructed this way, directly or from an
+	// external resume file, from reaching on_resume_data_checked().
+	bitfield const blocks(1, true);
+	param.unfinished_pieces[piece_index_t(1)] = blocks;
+
+	torrent_handle tor1 = ses1.add_torrent(param, ec);
+	if (ec)
+		std::printf("add_torrent: %s\n", ec.message().c_str());
+
+	wait_for_complete(ses1, tor1, "ses1");
+
+	// all pieces are legitimately correct on disk, so start_checking()
+	// covering pieces 1-3 (the unfinished_pieces entry for piece 1 is
+	// skipped, per the comment above) should bring this to 100% on its own.
+	std::vector<std::int64_t> const fp = tor1.file_progress();
+	TEST_EQUAL(int(fp.size()), 1);
+	TEST_EQUAL(fp[0], std::int64_t(piece_size) * num_pieces);
 }

--- a/test/test_slow_hash.cpp
+++ b/test/test_slow_hash.cpp
@@ -39,10 +39,13 @@ TORRENT_TEST(slow_hash_tests_skipped) {}
 #include "libtorrent/sha1_hash.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/alert_types.hpp"
+#include "settings.hpp"
 
 using lt::span;
 using namespace lt;
 using namespace lt::aux;
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -562,6 +565,113 @@ TORRENT_TEST(flush_storage_during_hashing_hybrid)
 	TORRENT_TEST(kick_hasher_keep_going_fills_hole_hybrid)
 	{
 		test_kick_hasher_keep_going_fills_hole(test_mode::v1 | test_mode::v2);
+	}
+
+	// Regression test for a race between torrent::force_recheck() and an
+	// in-flight per-piece hash-check job.
+	//
+	// verify_piece() dispatches an async hash job and marks the piece
+	// "hashing" in the piece_picker. force_recheck() must not reset the
+	// picker via piece_picker::resize() while that job is outstanding: doing
+	// so wipes the "hashing" bit, so start_checking() dispatches a second,
+	// independent hash job for the same piece.
+	//
+	// Whichever job completes first calls torrent::we_have() for the piece.
+	// A second call re-enters we_have() for a piece already "have"; the
+	// asserts guarding against that are non-fatal under
+	// TORRENT_PRODUCTION_ASSERTS, so file_progress::update()
+	// (src/file_progress.cpp) silently double-counts that piece's bytes, an
+	// invariant violation it documents. Depending on dispatch order, this can
+	// instead trip disk_cache::try_hash_piece()'s "no simultaneous
+	// async_hash() requests for the same piece" assert.
+	//
+	// force_recheck() defers via m_num_outstanding_hash_jobs /
+	// m_pending_force_recheck until outstanding verify_piece() jobs complete,
+	// rather than resetting the picker out from under them.
+	//
+	// Needs a slow-hash configuration to reliably reproduce: it keeps the
+	// original hash job running long enough for force_recheck() to act on
+	// the same piece before it completes.
+	TORRENT_TEST_DISK_IO(recheck_race_double_count)
+	{
+		error_code ec;
+		settings_pack sett = settings();
+		sett.set_str(settings_pack::listen_interfaces, test_listen_interface());
+		sett.set_bool(settings_pack::enable_upnp, false);
+		sett.set_bool(settings_pack::enable_natpmp, false);
+		sett.set_bool(settings_pack::enable_lsd, false);
+		sett.set_bool(settings_pack::enable_dht, false);
+		// serialize hashing onto a single thread, so the two jobs racing over
+		// piece 0 complete in dispatch order (deterministic) rather than leaving
+		// the outcome to thread scheduling.
+		sett.set_int(settings_pack::aio_threads, 1);
+		sett.set_int(settings_pack::hashing_threads, 1);
+		lt::session_params sp(sett);
+		sp.disk_io_constructor = disk_io;
+		lt::session ses1(sp);
+
+		int const piece_size = 16 * 1024;
+		int const num_pieces = 4;
+
+		error_code ec2;
+		create_directory("tmp1_recheck_race", ec2);
+		if (ec2)
+			std::printf("create_directory: %s\n", ec2.message().c_str());
+
+		// a v1-only torrent whose pieces are all bit-for-bit identical (see
+		// ::create_torrent()'s repeating 'A'..'Z' pattern), so any piece can be
+		// injected with the same buffer via add_piece(), without needing real
+		// peers or pre-written files.
+		add_torrent_params param = ::create_torrent(
+			nullptr, "recheck_race", piece_size, num_pieces, false, lt::create_torrent::v1_only);
+		param.flags &= ~torrent_flags::paused;
+		param.flags &= ~torrent_flags::auto_managed;
+		param.save_path = "tmp1_recheck_race";
+		torrent_handle tor1 = ses1.add_torrent(param, ec);
+		if (ec)
+			std::printf("add_torrent: %s\n", ec.message().c_str());
+
+		wait_for_downloading(ses1, "ses1");
+
+		std::vector<char> piece_buf(static_cast<std::size_t>(piece_size));
+		for (int i = 0; i < piece_size; ++i)
+			piece_buf[static_cast<std::size_t>(i)] = char((i % 26) + 'A');
+
+		// finish piece 0 (dispatches hash job #1, marks it "hashing"), then
+		// immediately force a recheck. Both calls post to the same network
+		// thread in order, so job #1 is still dispatched (and, in this
+		// slow-hash configuration, still running) when force_recheck() resets
+		// the picker and start_checking() dispatches job #2 for the same piece.
+		tor1.add_piece(piece_index_t(0), piece_buf.data());
+		tor1.force_recheck();
+
+		wait_for_alert(
+			ses1,
+			"ses1",
+			[](lt::alert const* al) {
+				auto const* sc = alert_cast<state_changed_alert>(al);
+				return sc && sc->state == torrent_status::checking_files;
+			},
+			30s);
+		wait_for_downloading(ses1, "ses1");
+
+		// finish the rest of the download normally
+		torrent_status const st = tor1.status();
+		for (piece_index_t p(0); p < piece_index_t(num_pieces); ++p)
+		{
+			if (st.pieces[p])
+				continue;
+			tor1.add_piece(p, piece_buf.data());
+		}
+
+		wait_for_complete(ses1, tor1, "ses1");
+
+		// a double-count here inflates piece 0's bytes in file_progress; once the
+		// download is complete, that surfaces as a reported file size larger
+		// than the file actually is.
+		std::vector<std::int64_t> const fp = tor1.file_progress();
+		TEST_EQUAL(int(fp.size()), 1);
+		TEST_EQUAL(fp[0], std::int64_t(piece_size) * num_pieces);
 	}
 
 #endif // TORRENT_SIMULATE_SLOW_HASH


### PR DESCRIPTION
specifically, when triggering a full recheck, we must make sure all other async_hash() jobs first complete