### PR TITLE
optimize some merkle tree functions

### DIFF
--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -111,6 +111,13 @@ namespace libtorrent {
 	bool merkle_validate_node(sha256_hash const& left, sha256_hash const& right
 		, sha256_hash const& parent);
 
+	// same as merkle_validate_node() above, but reuses the caller's hasher256
+	// context (calling reset() on it) instead of constructing a new one. Useful
+	// when validating many nodes in a loop.
+	TORRENT_EXTRA_EXPORT
+	bool merkle_validate_node(
+		hasher256& h, sha256_hash const& left, sha256_hash const& right, sha256_hash const& parent);
+
 	// validates hashes from src and copies the valid ones to dst given root as
 	// the expected root of the tree (i.e. index 0)
 	// src and dst must be the same size. dst is expected to be initialized

--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -109,13 +109,16 @@ namespace libtorrent {
 		TORRENT_ASSERT(level_start >= 0);
 		TORRENT_ASSERT(num_leafs >= 1);
 
+		// reused across all node hashes, to avoid re-allocating a crypto
+		// context (e.g. EVP_MD_CTX) per hash
+		hasher256 h;
 		int level_size = num_leafs;
 		while (level_size > 1)
 		{
 			int parent = merkle_get_parent(level_start);
 			for (int i = level_start; i < level_start + level_size; i += 2, ++parent)
 			{
-				hasher256 h;
+				h.reset();
 				h.update(tree[i]);
 				h.update(tree[i + 1]);
 				tree[parent] = h.final();
@@ -139,6 +142,7 @@ namespace libtorrent {
 		int const num_leafs = (num_nodes + 1) / 2;
 		int level_size = num_leafs;
 		int level_start = merkle_first_leaf(num_leafs);
+		hasher256 h;
 		while (level_size > 1)
 		{
 			level_start = merkle_get_parent(level_start);
@@ -150,7 +154,7 @@ namespace libtorrent {
 				bool const zeros_left = tree[child].is_all_zeros();
 				bool const zeros_right = tree[child + 1].is_all_zeros();
 				if (zeros_left || zeros_right) continue;
-				hasher256 h;
+				h.reset();
 				h.update(tree[child]);
 				h.update(tree[child + 1]);
 				tree[i] = h.final();
@@ -224,29 +228,28 @@ namespace libtorrent {
 
 		if (num_leafs == 1) return leaves[0];
 
+		hasher256 h;
 		while (num_leafs > 1)
 		{
 			int i = 0;
 			for (; i < int(leaves.size()) / 2; ++i)
 			{
-				scratch_space[std::size_t(i)] = hasher256()
-					.update(leaves[i * 2])
-					.update(leaves[i * 2 + 1])
-					.final();
+				h.reset();
+				scratch_space[std::size_t(i)] =
+					h.update(leaves[i * 2]).update(leaves[i * 2 + 1]).final();
 			}
 			if (leaves.size() & 1)
 			{
 				// if we have an odd number of leaves, compute the boundary hash
 				// here, that spans both a payload-hash and a pad hash
-				scratch_space[std::size_t(i)] = hasher256()
-					.update(leaves[i * 2])
-					.update(pad)
-					.final();
+				h.reset();
+				scratch_space[std::size_t(i)] = h.update(leaves[i * 2]).update(pad).final();
 				++i;
 			}
 			// we don't have to copy any pad hashes into memory, they are implied
 			// just keep track of the current layer's pad hash
-			pad = hasher256().update(pad).update(pad).final();
+			h.reset();
+			pad = h.update(pad).update(pad).final();
 
 			// step one level up
 			leaves = span<sha256_hash const>(scratch_space.data(), i);
@@ -279,9 +282,10 @@ namespace libtorrent {
 	{
 		TORRENT_ASSERT(blocks >= pieces);
 		sha256_hash ret{};
+		hasher256 h;
 		while (pieces < blocks)
 		{
-			hasher256 h;
+			h.reset();
 			h.update(ret);
 			h.update(ret);
 			ret = h.final();
@@ -320,6 +324,7 @@ namespace libtorrent {
 		// which is well under 32 for any tree this library can build.
 		std::uint32_t wrote_sibling = 0;
 		int iter = 0;
+		hasher256 h;
 
 		for (auto const& proof : uncle_hashes)
 		{
@@ -341,7 +346,10 @@ namespace libtorrent {
 			// in place and walk on
 
 			int const left = std::min(proof_idx, cursor);
-			auto const hash = hasher256().update(target_tree[left]).update(target_tree[left + 1]).final();
+			h.reset();
+			h.update(target_tree[left]);
+			h.update(target_tree[left + 1]);
+			auto const hash = h.final();
 			// success: the computed pair-hash matches a known parent,
 			// anchoring the chain from `node` up to a trusted node in
 			// the tree
@@ -384,6 +392,13 @@ namespace libtorrent {
 		, sha256_hash const& parent)
 	{
 		hasher256 h;
+		return merkle_validate_node(h, left, right, parent);
+	}
+
+	bool merkle_validate_node(
+		hasher256& h, sha256_hash const& left, sha256_hash const& right, sha256_hash const& parent)
+	{
+		h.reset();
 		h.update(left);
 		h.update(right);
 		return (h.final() == parent);
@@ -399,12 +414,13 @@ namespace libtorrent {
 		if (src[0] != root) return;
 		dst[0] = src[0];
 		int const leaf_layer_start = int(src.size() - num_leafs);
+		hasher256 h;
 		for (int i = 0; i < leaf_layer_start; ++i)
 		{
 			if (dst[i].is_all_zeros()) continue;
 			int const left_child = merkle_get_first_child(i);
 			int const right_child = left_child + 1;
-			if (merkle_validate_node(src[left_child], src[right_child], dst[i]))
+			if (merkle_validate_node(h, src[left_child], src[right_child], dst[i]))
 			{
 				dst[left_child] = src[left_child];
 				dst[right_child] = src[right_child];
@@ -432,9 +448,10 @@ namespace libtorrent {
 		int idx = merkle_first_leaf(num_leafs);
 		TORRENT_ASSERT(idx >= 1);
 
+		hasher256 h;
 		while (idx < end)
 		{
-			if (!merkle_validate_node(tree[idx], tree[idx + 1], tree[merkle_get_parent(idx)]))
+			if (!merkle_validate_node(h, tree[idx], tree[idx + 1], tree[merkle_get_parent(idx)]))
 				return false;
 			idx += 2;
 		}

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -893,6 +893,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 		int offset = 0;
 		int const blocks_to_read = std::max(blocks_in_piece, blocks_in_piece2);
 		time_point const start_time = clock_type::now();
+		hasher256 h2;
 		for (int i = 0; i < blocks_to_read; ++i)
 		{
 			bool const v2_block = i < blocks_in_piece2;
@@ -905,7 +906,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 			bool const have_precomputed_v2 =
 				v2_block && i < int(pc.size()) && !pc[i].is_all_zeros();
 
-			hasher256 h2;
+			h2.reset();
 
 			if (have_precomputed_v2 && !v1)
 			{

--- a/src/posix_disk_io.cpp
+++ b/src/posix_disk_io.cpp
@@ -151,6 +151,7 @@ namespace {
 				return;
 			}
 			hasher ph;
+			hasher256 h2;
 
 			posix_storage* st = m_torrents[storage].get();
 
@@ -177,7 +178,10 @@ namespace {
 				if (v1)
 					ph.update(b.first(std::min(ret, len)));
 				if (v2_block)
-					block_hashes[i] = hasher256(b.first(std::min(ret, len2))).final();
+				{
+					h2.reset();
+					block_hashes[i] = h2.update(b.first(std::min(ret, len2))).final();
+				}
 			}
 
 			sha1_hash const hash = v1 ? ph.final() : sha1_hash();

--- a/src/pread_disk_io.cpp
+++ b/src/pread_disk_io.cpp
@@ -1203,6 +1203,7 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 
 		int offset = start * default_block_size;
 		int blocks_read_from_disk = 0;
+		hasher256 ph2;
 		for (int i = start; i < blocks_to_read; ++i)
 		{
 			bool const v2_block = i < blocks_in_piece2;
@@ -1219,7 +1220,7 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 				continue;
 			}
 
-			hasher256 ph2;
+			ph2.reset();
 			char const* buf = (i < int(blocks.size())) ? blocks[i] : nullptr;
 			if (buf == nullptr)
 			{
@@ -1315,13 +1316,14 @@ status_t pread_disk_io::do_job(aux::job::hash& a, aux::pread_disk_job* j)
 
 			if (v2)
 			{
+				hasher256 h2;
 				int offset = 0;
 				for (int i = 0; i < blocks_in_piece2; ++i)
 				{
 					std::ptrdiff_t const len2 = std::min(default_block_size, piece_size2 - offset);
 					if (a.block_hashes[i].is_all_zeros())
 					{
-						hasher256 h2;
+						h2.reset();
 						h2.update({buf.get() + offset, len2});
 						a.block_hashes[i] = h2.final();
 					}

--- a/tools/bencher.cpp
+++ b/tools/bencher.cpp
@@ -467,9 +467,12 @@ namespace merkle_bench {
 	std::vector<sha256_hash> make_leaves()
 	{
 		std::vector<sha256_hash> leaves(static_cast<std::size_t>(num_leafs));
+		lt::hasher256 h;
 		for (int i = 0; i < num_leafs; ++i)
-			leaves[std::size_t(i)] =
-				lt::hasher256().update(reinterpret_cast<char const*>(&i), sizeof(i)).final();
+		{
+			h.reset();
+			leaves[std::size_t(i)] = h.update(reinterpret_cast<char const*>(&i), sizeof(i)).final();
+		}
 		return leaves;
 	}
 


### PR DESCRIPTION
by reusing the SHA-256 context rather then re-allocating it