### PR TITLE
fix UPnP hostname SSRF bypass

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -43,6 +43,7 @@ see LICENSE file.
 #include <cstdlib>
 #include <cstdio> // for snprintf
 #include <cstdarg>
+#include <algorithm>
 #include <functional>
 
 using namespace std::placeholders;
@@ -158,17 +159,31 @@ namespace {
 	address_v4 const ssdp_multicast_addr = make_address_v4("239.255.255.250");
 	int const ssdp_port = 1900;
 
-	// reject Location/control-URL hosts a real IGD would never use, to block
+	// reject Location/control-URL addresses a real IGD would never use, to block
 	// SSRF via forged SSDP replies or device descriptions. RFC1918 stays
-	// allowed since that is where real devices live. only IP literals are
-	// checked here, not DNS names.
+	// allowed since that is where real devices live.
+	bool invalid_upnp_address(address const& addr)
+	{
+		address const normalized = (addr.is_v6() && addr.to_v6().is_v4_mapped())
+			? address(make_address_v4(v4_mapped, addr.to_v6()))
+			: addr;
+		return normalized.is_unspecified() || normalized.is_loopback()
+			|| aux::is_link_local(normalized) || normalized.is_multicast();
+	}
+
 	bool invalid_upnp_host(std::string const& hostname)
 	{
 		error_code ec;
 		address const addr = make_address(hostname.c_str(), ec);
-		if (ec) return false;
-		return addr.is_unspecified() || addr.is_loopback() || aux::is_link_local(addr)
-			|| addr.is_multicast();
+		return !ec && invalid_upnp_address(addr);
+	}
+
+	void filter_upnp_endpoints(aux::http_connection&
+		, std::vector<tcp::endpoint>& endpoints)
+	{
+		auto const end = std::remove_if(endpoints.begin(), endpoints.end()
+			, [](tcp::endpoint const& ep) { return invalid_upnp_address(ep.address()); });
+		endpoints.erase(end, endpoints.end());
 	}
 }
 
@@ -453,7 +468,7 @@ void upnp::connect(rootdevice& d)
 			, std::bind(&upnp::on_upnp_xml, self(), _1, _2
 				, std::ref(d), _4), default_max_bottled_buffer_size
 			, http_connect_handler()
-			, http_filter_handler()
+			, filter_upnp_endpoints
 			, hostname_filter_handler()
 #if TORRENT_USE_SSL
 			, &m_ssl_ctx
@@ -887,7 +902,7 @@ void upnp::update_map(rootdevice& d, port_mapping_t const i)
 			, std::bind(&upnp::on_upnp_map_response, self(), _1, _2
 				, std::ref(d), i, _4), default_max_bottled_buffer_size
 			, std::bind(&upnp::create_port_mapping, self(), _1, std::ref(d), i)
-			, http_filter_handler()
+			, filter_upnp_endpoints
 			, hostname_filter_handler()
 #if TORRENT_USE_SSL
 			, &m_ssl_ctx
@@ -906,7 +921,7 @@ void upnp::update_map(rootdevice& d, port_mapping_t const i)
 			, std::bind(&upnp::on_upnp_unmap_response, self(), _1, _2
 				, std::ref(d), i, _4), default_max_bottled_buffer_size
 			, std::bind(&upnp::delete_port_mapping, self(), std::ref(d), i)
-			, http_filter_handler()
+			, filter_upnp_endpoints
 			, hostname_filter_handler()
 #if TORRENT_USE_SSL
 			, &m_ssl_ctx
@@ -1145,7 +1160,7 @@ void upnp::on_upnp_xml(error_code const& e
 		, std::bind(&upnp::on_upnp_get_ip_address_response, self(), _1, _2
 			, std::ref(d), _4), default_max_bottled_buffer_size
 		, std::bind(&upnp::get_ip_address, self(), std::ref(d))
-		, http_filter_handler()
+		, filter_upnp_endpoints
 		, hostname_filter_handler()
 #if TORRENT_USE_SSL
 		, &m_ssl_ctx


### PR DESCRIPTION
UPnP validates literal Location and control URL addresses but accepted
IPv4-mapped loopback addresses and DNS names resolving to forbidden
endpoints. A forged local SSDP response could cause a request to a
loopback or link-local service.

Normalize mapped addresses and filter forbidden resolved endpoints on all
UPnP HTTP connections, including description fetches, control requests,
and redirects.

Also, do you want all PRs against RC_2_1 or master?
