### PR TITLE
Fix short writes in copy file fallbacks

### DIFF
--- a/include/libtorrent/aux_/file.hpp
+++ b/include/libtorrent/aux_/file.hpp
@@ -61,10 +61,8 @@ namespace libtorrent::aux {
 	const handle_type invalid_handle = -1;
 #endif
 
-	int pwrite_all(handle_type handle
-		, span<char const> buf
-		, std::int64_t file_offset
-		, error_code& ec);
+	TORRENT_EXTRA_EXPORT int pwrite_all(
+		handle_type handle, span<char const> buf, std::int64_t file_offset, error_code& ec);
 
 	int pwritev_all(handle_type handle
 		, span<span<char const> const> bufs

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -108,24 +108,17 @@ void copy_range(HANDLE const in_handle, HANDLE const out_handle
 		}
 
 		len -= num_read;
-		int buf_offset = 0;
-		while (num_read > 0)
+		error_code write_error;
+		int const num_written =
+			pwrite_all(out_handle, span<char const>(buffer, num_read), in_offset, write_error);
+		if (write_error)
 		{
-			OVERLAPPED out_ol{};
-			out_ol.Offset = in_offset & 0xffffffff;
-			out_ol.OffsetHigh = in_offset >> 32;
-			DWORD num_written = 0;
-			if (WriteFile(out_handle, buffer + buf_offset, DWORD(num_read - buf_offset)
-				, &num_written, &out_ol) == 0)
-			{
-				se.operation = operation_t::file_write;
-				se.ec.assign(::GetLastError(), system_category());
-				return;
-			}
-			buf_offset += num_written;
-			num_read -= num_written;
-			in_offset += num_written;
+			se.operation = operation_t::file_write;
+			se.ec = write_error;
+			return;
 		}
+		TORRENT_ASSERT(num_written == int(num_read));
+		in_offset += num_written;
 	}
 	return;
 }
@@ -261,8 +254,8 @@ ssize_t copy_range_fallback(int const fd_in, int const fd_out, off_t in_offset
 		len -= num_read;
 
 		error_code write_error;
-		int const num_written = pwrite_all(fd_out
-			, span<char const>(buffer, num_read), in_offset, write_error);
+		int const num_written =
+			pwrite_all(fd_out, span<char const>(buffer, num_read), in_offset, write_error);
 		if (write_error)
 		{
 			se.operation = operation_t::file_write;

--- a/src/copy_file.cpp
+++ b/src/copy_file.cpp
@@ -10,6 +10,7 @@ see LICENSE file.
 #include "libtorrent/config.hpp"
 
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/aux_/file.hpp"
 #include "libtorrent/aux_/path.hpp"
 #include "libtorrent/aux_/storage_utils.hpp"
 
@@ -258,22 +259,19 @@ ssize_t copy_range_fallback(int const fd_in, int const fd_out, off_t in_offset
 			return -1;
 		}
 		len -= num_read;
-		int buf_offset = 0;
-		while (num_read > 0)
+
+		error_code write_error;
+		int const num_written = pwrite_all(fd_out
+			, span<char const>(buffer, num_read), in_offset, write_error);
+		if (write_error)
 		{
-			auto const ret = ::pwrite(fd_out, buffer + buf_offset
-				, std::size_t(num_read - buf_offset), in_offset);
-			if (ret <= 0)
-			{
-				se.operation = operation_t::file_write;
-				se.ec.assign(errno, system_category());
-				return -1;
-			}
-			buf_offset += ret;
-			num_read -= ret;
-			in_offset += ret;
-			total_copied += ret;
+			se.operation = operation_t::file_write;
+			se.ec = write_error;
+			return -1;
 		}
+		TORRENT_ASSERT(num_written == num_read);
+		in_offset += num_written;
+		total_copied += num_written;
 	}
 	return total_copied;
 }
@@ -434,4 +432,3 @@ void copy_file(std::string const& inf, std::string const& newf, storage_error& s
 
 }
 }
-

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -78,11 +78,7 @@ TORRENT_TEST(pwrite_all_short_write)
 		return;
 	}
 
-	struct sigaction ignore_action
-	{};
-	ignore_action.sa_handler = SIG_IGN;
-	sigemptyset(&ignore_action.sa_mask);
-	if (::sigaction(SIGXFSZ, &ignore_action, nullptr) != 0)
+	if (::signal(SIGXFSZ, SIG_IGN) == SIG_ERR)
 	{
 		TEST_ERROR("could not ignore SIGXFSZ");
 		return;

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -31,7 +31,7 @@ see LICENSE file.
 #include <iostream>
 
 #ifndef TORRENT_WINDOWS
-#include <signal.h>
+#include <csignal>
 #include <sys/resource.h>
 #endif
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -20,12 +20,20 @@ see LICENSE file.
 #include "libtorrent/aux_/numeric_cast.hpp"
 #include "libtorrent/aux_/storage_utils.hpp"
 #include "libtorrent/aux_/file_pool_impl.hpp"
+#include "libtorrent/aux_/scope_end.hpp"
 #include "test.hpp"
 #include "test_utils.hpp"
+#include <algorithm>
+#include <cerrno>
 #include <vector>
 #include <set>
 #include <thread>
 #include <iostream>
+
+#ifndef TORRENT_WINDOWS
+#include <signal.h>
+#include <sys/resource.h>
+#endif
 
 using namespace lt;
 
@@ -42,6 +50,71 @@ void touch_file(std::string const& filename, int size)
 }
 
 } // anonymous namespace
+
+#ifndef TORRENT_WINDOWS
+TORRENT_TEST(pwrite_all_short_write)
+{
+	struct rlimit original_limit;
+	if (::getrlimit(RLIMIT_FSIZE, &original_limit) != 0)
+	{
+		TEST_ERROR("getrlimit failed");
+		return;
+	}
+
+	constexpr rlim_t preferred_limit = 10'000;
+	rlim_t const file_size_limit = original_limit.rlim_max == RLIM_INFINITY
+		? preferred_limit
+		: std::min(preferred_limit, original_limit.rlim_max);
+	if (file_size_limit == 0)
+	{
+		TEST_ERROR("hard file-size limit is zero");
+		return;
+	}
+
+	struct sigaction original_action;
+	if (::sigaction(SIGXFSZ, nullptr, &original_action) != 0)
+	{
+		TEST_ERROR("could not read SIGXFSZ action");
+		return;
+	}
+
+	struct sigaction ignore_action
+	{};
+	ignore_action.sa_handler = SIG_IGN;
+	sigemptyset(&ignore_action.sa_mask);
+	if (::sigaction(SIGXFSZ, &ignore_action, nullptr) != 0)
+	{
+		TEST_ERROR("could not ignore SIGXFSZ");
+		return;
+	}
+	auto const restore_action = aux::scope_end([original_action] {
+		if (::sigaction(SIGXFSZ, &original_action, nullptr) != 0)
+			TEST_ERROR("could not restore SIGXFSZ action");
+	});
+
+	struct rlimit short_write_limit = original_limit;
+	short_write_limit.rlim_cur = file_size_limit;
+	if (::setrlimit(RLIMIT_FSIZE, &short_write_limit) != 0)
+	{
+		TEST_ERROR("could not set file-size limit");
+		return;
+	}
+	auto const restore_limit = aux::scope_end([original_limit] {
+		if (::setrlimit(RLIMIT_FSIZE, &original_limit) != 0)
+			TEST_ERROR("could not restore file-size limit");
+	});
+
+	std::vector<char> buffer(std::size_t(file_size_limit) + 1024);
+	aux::file_handle file(
+		"pwrite-all-short-write", 0, aux::open_mode::write | aux::open_mode::truncate);
+	error_code ec;
+	int const written = aux::pwrite_all(file.fd(), buffer, 0, ec);
+
+	TEST_EQUAL(written, int(file_size_limit));
+	TEST_CHECK(ec == error_code(EFBIG, system_category()));
+	TEST_EQUAL(file.get_size(), std::int64_t(file_size_limit));
+}
+#endif
 
 TORRENT_TEST(create_directory)
 {
@@ -700,4 +773,3 @@ TORRENT_TEST(to_file_open_mode)
 	TEST_CHECK(aux::to_file_open_mode(aux::open_mode::write | aux::open_mode::no_atime, false) == (file_open_mode::read_write | file_open_mode::no_atime));
 	TEST_CHECK(aux::to_file_open_mode(aux::open_mode::write, true) == (file_open_mode::read_write | file_open_mode::mmapped));
 }
-


### PR DESCRIPTION
The copy file fallback loops advanced the buffer offset while also shrinking the byte count. A short write could therefore skip data or underflow the next write size.

Use the existing pwrite_all helper for both POSIX and Windows fallback paths and preserve file_write error reporting. Add a kernel-backed regression test covering partial positional writes and the resulting file size.

Tests: pre-commit, clang-format 18, CMake build and test suite, installed-header check, and B2 test_file/test_copy_file with WebTorrent enabled and disabled.