### PR TITLE
fix signed overflow computing bitfield sizes in read_resume_data

### DIFF
--- a/.github/abi-suppressions.txt
+++ b/.github/abi-suppressions.txt
@@ -24,6 +24,14 @@
 # torrent_status, strong_typedef, ...), which name_not_regexp excludes so a
 # real change to one of those still fails the check.
 #
+# name_not_regexp anchors on the specialization subject (^std::(hash|
+# numeric_limits)<libtorrent) rather than just matching "libtorrent"
+# anywhere. A bare "libtorrent" also un-suppresses std container internals
+# that merely take a libtorrent type as a template argument (e.g.
+# std::vector<libtorrent::bitfield>::_M_realloc_insert), which are libstdc++
+# implementation details, not our ABI, and would otherwise fail the check
+# when instantiations come and go.
+#
 # Variable (data-symbol) changes are deliberately NOT suppressed here: a
 # variable's size/layout is baked directly into every caller, so a spurious
 # diff there is rare and a real one is serious. If a specific guard-variable
@@ -31,7 +39,7 @@
 # [suppress_variable] for that exact symbol instead of broadening this.
 [suppress_type]
   name_regexp = ^(std|boost)::
-  name_not_regexp = libtorrent
+  name_not_regexp = ^std::(hash|numeric_limits)<libtorrent
 [suppress_function]
   name_regexp = ^(std|boost)::
-  name_not_regexp = libtorrent
+  name_not_regexp = ^std::(hash|numeric_limits)<libtorrent

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -50,17 +50,16 @@ namespace {
 	// by 8 is undefined and yields a negative size). a resume file large enough
 	// to hit either was not written by libtorrent, so it's corrupt at best and
 	// an attack at worst. fail the whole parse rather than silently truncate.
-	bitfield bitfield_from_resume(string_view const str
-		, std::int64_t const bit_limit, error_code& ec)
+	bitfield bitfield_from_resume(
+		string_view const str, std::int64_t const bit_limit, error_code& ec)
 	{
-		std::int64_t const cap = std::min(bit_limit
-			, std::int64_t(std::numeric_limits<int>::max()));
+		std::int64_t const cap = std::min(bit_limit, std::int64_t(std::numeric_limits<int>::max()));
 		if (std::int64_t(str.size()) > cap / CHAR_BIT)
 		{
 			ec = errors::too_many_pieces_in_torrent;
 			return {};
 		}
-		return bitfield(str.data(), int(str.size()) * CHAR_BIT);
+		return {str.data(), int(str.size()) * CHAR_BIT};
 	}
 
 } // anonyous namespace
@@ -201,7 +200,8 @@ namespace {
 					{
 						ret.verified_leaf_hashes.push_back(
 							bitfield_from_resume(str, std::int64_t(piece_limit) * 2, ec));
-						if (ec) return ret;
+						if (ec)
+							return ret;
 					}
 				}
 				else
@@ -225,7 +225,8 @@ namespace {
 					{
 						ret.merkle_tree_mask.push_back(
 							bitfield_from_resume(str, std::int64_t(piece_limit) * 2, ec));
-						if (ec) return ret;
+						if (ec)
+							return ret;
 					}
 				}
 				else
@@ -408,14 +409,16 @@ namespace {
 			else if (file_version == 2)
 			{
 				ret.have_pieces = bitfield_from_resume(pieces.string_value(), piece_limit, ec);
-				if (ec) return ret;
+				if (ec)
+					return ret;
 			}
 		}
 
 		if (bdecode_node const verified = rd.dict_find_string("verified"))
 		{
 			ret.verified_pieces = bitfield_from_resume(verified.string_value(), piece_limit, ec);
-			if (ec) return ret;
+			if (ec)
+				return ret;
 		}
 
 		if (bdecode_node const piece_priority = rd.dict_find_string("piece_priority"))
@@ -478,7 +481,8 @@ namespace {
 				// bounded only by what fits in the int bit-count.
 				ret.unfinished_pieces[piece] = bitfield_from_resume(
 					bitmask.string_value(), std::numeric_limits<int>::max(), ec);
-				if (ec) return ret;
+				if (ec)
+					return ret;
 			}
 		}
 

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -44,15 +44,22 @@ namespace {
 		}
 	}
 
-	// resume-data bitfields are stored as byte strings where each byte holds 8
-	// bits. bdecode accepts strings up to ~512 MiB, so multiplying such a
-	// length by 8 overflows the signed int bit-count bitfield expects, which is
-	// undefined and yields a negative size. a string too large to represent
-	// yields an empty bitfield.
-	bitfield bitfield_from_resume(string_view const str)
+	// resume-data bitfields are stored as byte strings, 8 bits per byte. reject
+	// a string whose bit count would exceed bit_limit, or overflow the signed
+	// int bit-count that bitfield uses (multiplying a ~512 MiB bdecode string
+	// by 8 is undefined and yields a negative size). a resume file large enough
+	// to hit either was not written by libtorrent, so it's corrupt at best and
+	// an attack at worst. fail the whole parse rather than silently truncate.
+	bitfield bitfield_from_resume(string_view const str
+		, std::int64_t const bit_limit, error_code& ec)
 	{
-		if (str.size() > std::size_t(std::numeric_limits<int>::max() / CHAR_BIT))
+		std::int64_t const cap = std::min(bit_limit
+			, std::int64_t(std::numeric_limits<int>::max()));
+		if (std::int64_t(str.size()) > cap / CHAR_BIT)
+		{
+			ec = errors::too_many_pieces_in_torrent;
 			return {};
+		}
 		return bitfield(str.data(), int(str.size()) * CHAR_BIT);
 	}
 
@@ -192,7 +199,9 @@ namespace {
 					}
 					else
 					{
-						ret.verified_leaf_hashes.push_back(bitfield_from_resume(str));
+						ret.verified_leaf_hashes.push_back(
+							bitfield_from_resume(str, std::int64_t(piece_limit) * 2, ec));
+						if (ec) return ret;
 					}
 				}
 				else
@@ -214,7 +223,9 @@ namespace {
 					}
 					else
 					{
-						ret.merkle_tree_mask.push_back(bitfield_from_resume(str));
+						ret.merkle_tree_mask.push_back(
+							bitfield_from_resume(str, std::int64_t(piece_limit) * 2, ec));
+						if (ec) return ret;
 					}
 				}
 				else
@@ -396,13 +407,15 @@ namespace {
 			}
 			else if (file_version == 2)
 			{
-				ret.have_pieces = bitfield_from_resume(pieces.string_value());
+				ret.have_pieces = bitfield_from_resume(pieces.string_value(), piece_limit, ec);
+				if (ec) return ret;
 			}
 		}
 
 		if (bdecode_node const verified = rd.dict_find_string("verified"))
 		{
-			ret.verified_pieces = bitfield_from_resume(verified.string_value());
+			ret.verified_pieces = bitfield_from_resume(verified.string_value(), piece_limit, ec);
+			if (ec) return ret;
 		}
 
 		if (bdecode_node const piece_priority = rd.dict_find_string("piece_priority"))
@@ -461,7 +474,11 @@ namespace {
 
 				bdecode_node const bitmask = e.dict_find_string("bitmask");
 				if (!bitmask || bitmask.string_length() == 0) continue;
-				ret.unfinished_pieces[piece] = bitfield_from_resume(bitmask.string_value());
+				// each bit is a block within this piece, not a piece, so it's
+				// bounded only by what fits in the int bit-count.
+				ret.unfinished_pieces[piece] = bitfield_from_resume(
+					bitmask.string_value(), std::numeric_limits<int>::max(), ec);
+				if (ec) return ret;
 			}
 		}
 

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -13,6 +13,8 @@ see LICENSE file.
 
 #include <cstdint>
 #include <algorithm>
+#include <limits>
+#include <climits> // for CHAR_BIT
 
 #include "libtorrent/bdecode.hpp"
 #include "libtorrent/read_resume_data.hpp"
@@ -40,6 +42,18 @@ namespace {
 		{
 			current_flags |= flag;
 		}
+	}
+
+	// resume-data bitfields are stored as byte strings where each byte holds 8
+	// bits. bdecode accepts strings up to ~512 MiB, so multiplying such a
+	// length by 8 overflows the signed int bit-count bitfield expects, which is
+	// undefined and yields a negative size. a string too large to represent
+	// yields an empty bitfield.
+	bitfield bitfield_from_resume(string_view const str)
+	{
+		if (str.size() > std::size_t(std::numeric_limits<int>::max() / CHAR_BIT))
+			return {};
+		return bitfield(str.data(), int(str.size()) * CHAR_BIT);
 	}
 
 } // anonyous namespace
@@ -178,7 +192,7 @@ namespace {
 					}
 					else
 					{
-						ret.verified_leaf_hashes.emplace_back(str.data(), int(str.size()) * 8);
+						ret.verified_leaf_hashes.push_back(bitfield_from_resume(str));
 					}
 				}
 				else
@@ -200,7 +214,7 @@ namespace {
 					}
 					else
 					{
-						ret.merkle_tree_mask.emplace_back(str.data(), int(str.size()) * 8);
+						ret.merkle_tree_mask.push_back(bitfield_from_resume(str));
 					}
 				}
 				else
@@ -382,15 +396,13 @@ namespace {
 			}
 			else if (file_version == 2)
 			{
-				string_view const str = pieces.string_value();
-				ret.have_pieces.assign(str.data(), int(str.size()) * 8);
+				ret.have_pieces = bitfield_from_resume(pieces.string_value());
 			}
 		}
 
 		if (bdecode_node const verified = rd.dict_find_string("verified"))
 		{
-			string_view const str = verified.string_value();
-			ret.verified_pieces.assign(str.data(), int(str.size()) * 8);
+			ret.verified_pieces = bitfield_from_resume(verified.string_value());
 		}
 
 		if (bdecode_node const piece_priority = rd.dict_find_string("piece_priority"))
@@ -449,8 +461,7 @@ namespace {
 
 				bdecode_node const bitmask = e.dict_find_string("bitmask");
 				if (!bitmask || bitmask.string_length() == 0) continue;
-				ret.unfinished_pieces[piece].assign(
-					bitmask.string_ptr(), bitmask.string_length() * CHAR_BIT);
+				ret.unfinished_pieces[piece] = bitfield_from_resume(bitmask.string_value());
 			}
 		}
 

--- a/test/test_read_resume.cpp
+++ b/test/test_read_resume.cpp
@@ -534,6 +534,94 @@ TORRENT_TEST(deprecated_trees_fields)
 		{true, true, true, false, false, true, false, true, false, true, true, true, true}));
 }
 
+TORRENT_TEST(verified_pieces_too_large)
+{
+	entry rd;
+	rd["file-format"] = "libtorrent resume file";
+	rd["file-version"] = 1;
+	rd["info-hash"] = "                    ";
+	// each byte holds 8 bits, so this is 8 * 32 = 256 bits, well over the
+	// 64-piece limit passed in below.
+	rd["verified"] = std::string(32, '\xff');
+
+	load_torrent_limits cfg;
+	cfg.max_pieces = 64;
+
+	error_code ec;
+	read_resume_data(bencode(rd), ec, cfg);
+	TEST_EQUAL(ec, error_code(errors::too_many_pieces_in_torrent));
+	// the non-ec overload should turn that into an exception
+	TEST_THROW(read_resume_data(bencode(rd), cfg));
+}
+
+TORRENT_TEST(have_pieces_too_large)
+{
+	entry rd;
+	rd["file-format"] = "libtorrent resume file";
+	rd["file-version"] = 2;
+	rd["info-hash2"] = "01234567890123456789012345678901";
+	rd["pieces"] = std::string(32, '\xff');
+
+	load_torrent_limits cfg;
+	cfg.max_pieces = 64;
+
+	error_code ec;
+	read_resume_data(bencode(rd), ec, cfg);
+	TEST_EQUAL(ec, error_code(errors::too_many_pieces_in_torrent));
+}
+
+TORRENT_TEST(merkle_tree_bitfield_too_large)
+{
+	auto const make = [](int const mask_bytes) {
+		entry rd;
+		rd["file-format"] = "libtorrent resume file";
+		rd["file-version"] = 2;
+		rd["info-hash2"] = "01234567890123456789012345678901";
+		auto& tree = rd["trees"].list();
+		tree.emplace_back(entry::dictionary_t);
+		auto& file = tree.back().dict();
+		file["hashes"] = std::string();
+		file["mask"] = std::string(std::size_t(mask_bytes), '\xff');
+		return bencode(rd);
+	};
+
+	// 64-piece limit means a 64-bit piece limit and a doubled 128-bit (16 byte)
+	// merkle-tree limit.
+	load_torrent_limits cfg;
+	cfg.max_pieces = 64;
+
+	// 12 bytes = 96 bits: past the 64-bit piece limit but within the doubled
+	// merkle limit, so it's accepted.
+	error_code ec;
+	read_resume_data(make(12), ec, cfg);
+	TEST_EQUAL(ec, error_code());
+
+	// 20 bytes = 160 bits: past the doubled merkle limit, so it's rejected.
+	read_resume_data(make(20), ec, cfg);
+	TEST_EQUAL(ec, error_code(errors::too_many_pieces_in_torrent));
+}
+
+// the unfinished bitmask counts blocks in a piece, not pieces, so it's bounded
+// only by what fits the int bit-count. a >= 256 MiB string would make
+// (size * 8) overflow a signed int, which must be rejected rather than trigger
+// undefined behavior. the buffer is built in memory, not saved to disk.
+TORRENT_TEST(unfinished_bitmask_overflow)
+{
+	entry rd;
+	rd["file-format"] = "libtorrent resume file";
+	rd["file-version"] = 1;
+	rd["info-hash"] = "                    ";
+	auto& unfinished = rd["unfinished"].list();
+	unfinished.emplace_back(entry::dictionary_t);
+	auto& piece = unfinished.back().dict();
+	piece["piece"] = 0;
+	piece["bitmask"] = std::string(std::size_t(1) << 28, '\xff');
+
+	error_code ec;
+	read_resume_data(bencode(rd), ec);
+	TEST_EQUAL(ec, error_code(errors::too_many_pieces_in_torrent));
+}
+
 TORRENT_TEST(read_resume_banned_peers)
 {
 	add_torrent_params atp;


### PR DESCRIPTION
read_resume_data builds several bitfields from resume byte strings with int(str.size()) * 8, but bdecode accepts strings up to ~512 MiB and nothing here caps these fields, so a pieces, verified, merkle verified/mask, or unfinished bitmask string of 256 MiB or more overflows the signed bit count and hands bitfield::assign a negative size. That trips the bits >= 0 assert in a debug build and drives a negative-length resize (null write or wild allocation) in release. Add a small helper that treats a byte string too large to fit an int bit count as an empty bitfield, applied to all five sites.