### PR TITLE
Update build condition for tests in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,7 +1082,7 @@ if (build_examples)
 endif()
 
 # === build tests ===
-if(build_tests)
+if(build_tests OR build_examples OR build_tools)
 	enable_testing()
 	# this will make some internal functions available in the DLL interface
 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_EXPORT_EXTRA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1071,6 +1071,11 @@ if (MSVC)
 	)
 endif()
 
+# Tests, examples and tools use some internal functions.
+if(build_tests OR build_examples OR build_tools)
+    target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_EXPORT_EXTRA)
+endif()
+
 # === build tools ===
 if (build_tools)
 	add_subdirectory(tools)
@@ -1082,11 +1087,9 @@ if (build_examples)
 endif()
 
 # === build tests ===
-if(build_tests OR build_examples OR build_tools)
-	enable_testing()
-	# this will make some internal functions available in the DLL interface
-	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_EXPORT_EXTRA)
-	add_subdirectory(test)
+if(build_tests)
+    enable_testing()
+    add_subdirectory(test)
 endif()
 
 feature_summary(DEFAULT_DESCRIPTION WHAT ALL)


### PR DESCRIPTION
TORRENT_EXPORT_EXTRA is currently enabled only as part of the build_tests block.

Some examples and tools also call internal APIs marked with TORRENT_EXTRA_EXPORT. With BUILD_SHARED_LIBS=ON and either build_examples=ON or build_tools=ON, but build_tests=OFF, those functions are therefore not exported from torrent-rasterbar.

This causes linker errors on Windows shared builds. For example, connection_tester references several merkle_* functions marked with TORRENT_EXTRA_EXPORT, but they are missing from the DLL import library.

Enable TORRENT_EXPORT_EXTRA whenever tests, examples, or tools are built, while keeping add_subdirectory(test) conditional on build_tests.

Found while updating the vcpkg libtorrent port to 2.1.1: microsoft/vcpkg#53354