### PR TITLE
extend CI to build 32bit builds on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
            filter: tree:0
            submodules: recursive
 
+      - name: patch libdatachannel (windows 32/64-bit builds)
+        run: git apply ../patch-libdatachannel-32bit-builds.patch
+        working-directory: deps/libdatachannel
+
       - name: update package lists
         continue-on-error: true
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -191,6 +191,10 @@ jobs:
            fetch-depth: 1
            filter: tree:0
 
+      - name: patch libdatachannel (windows 32/64-bit builds)
+        run: git apply ../patch-libdatachannel-32bit-builds.patch
+        working-directory: deps/libdatachannel
+
       - name: install boost
         run: |
           git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.91.0 https://github.com/boostorg/boost.git

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -179,6 +179,44 @@ jobs:
           cd tools
           b2 --hash ${{ matrix.config }} msvc-version-macro=on address-model=64 warnings=all warnings-as-errors=on
 
+   build-32bit:
+      name: Build (32-bit)
+      runs-on: windows-2022
+
+      steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+           submodules: recursive
+           fetch-depth: 1
+           filter: tree:0
+
+      - name: install boost
+        run: |
+          git clone --depth=1 --recurse-submodules -j10 --branch=boost-1.91.0 https://github.com/boostorg/boost.git
+          cd boost
+          bootstrap.bat
+
+      - name: boost headers
+        run: |
+          cd boost
+          .\b2 headers
+
+      - name: install openssl:x86-windows-static
+        uses: ./.github/actions/win_install_openssl
+        with:
+          architecture: x86
+          linking: static
+
+      - name: setup msbuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: build library
+        run: |
+          set BOOST_ROOT=%CD%\boost
+          set PATH=%BOOST_ROOT%;%PATH%
+          b2 --hash msvc-version-macro=on address-model=32 warnings=all warnings-as-errors=on openssl-include="C:/Program Files/OpenSSL/include" openssl-lib="C:/Program Files/OpenSSL/lib"
+
    mingw:
       name: MingW
       runs-on: windows-latest

--- a/deps/patch-libdatachannel-32bit-builds.patch
+++ b/deps/patch-libdatachannel-32bit-builds.patch
@@ -1,8 +1,8 @@
 diff --git a/Jamfile b/Jamfile
-index 9c740467..bba7864c 100644
+index 9c74046..cb44ae4 100644
 --- a/Jamfile
 +++ b/Jamfile
-@@ -110,7 +110,14 @@ rule make_libusrsctp_msvc ( targets * : sources * : properties * )
+@@ -110,7 +110,19 @@ rule make_libusrsctp_msvc ( targets * : sources * : properties * )
  {
  	local VARIANT = [ feature.get-values <variant> : $(properties) ] ;
  	VARIANT on $(targets) = $(VARIANT) ;
@@ -14,20 +14,28 @@ index 9c740467..bba7864c 100644
 +	{ ARCH = Win32 ; }
 +	ARCH on $(targets) = $(ARCH) ;
 +
++	local CONFIG = Release ;
++	if $(VARIANT) = debug
++	{ CONFIG = Debug ; }
++	CONFIG on $(targets) = $(CONFIG) ;
++
 +	BUILD_DIR on $(targets) = "build-$(ARCH)-$(VARIANT)" ;
  }
  actions make_libusrsctp_msvc
  {
-@@ -118,7 +125,7 @@ actions make_libusrsctp_msvc
+@@ -118,8 +130,8 @@ actions make_libusrsctp_msvc
      cd $(CWD)/deps/usrsctp
      mkdir $(BUILD_DIR)
      cd $(BUILD_DIR)
 -    cmake -G "Visual Studio 17 2022" -Dsctp_werror=0 -Dsctp_build_shared_lib=0 -Dsctp_build_programs=0 -Dsctp_inet=0 -Dsctp_inet6=0 ..
+-    msbuild usrsctplib.sln /property:Configuration=$(VARIANT)
 +    cmake -G "Visual Studio 17 2022" -A $(ARCH) -Dsctp_werror=0 -Dsctp_build_shared_lib=0 -Dsctp_build_programs=0 -Dsctp_inet=0 -Dsctp_inet6=0 ..
-     msbuild usrsctplib.sln /property:Configuration=$(VARIANT)
++    msbuild usrsctplib.sln /property:Configuration=$(VARIANT) /property:Platform=$(ARCH)
      cd %OLDD%
-     cp $(CWD)/deps/usrsctp/$(BUILD_DIR)/usrsctplib/Release/usrsctp.lib $(<)
-@@ -165,14 +172,21 @@ rule make_libjuice_msvc ( targets * : sources * : properties * )
+-    cp $(CWD)/deps/usrsctp/$(BUILD_DIR)/usrsctplib/Release/usrsctp.lib $(<)
++    cp $(CWD)/deps/usrsctp/$(BUILD_DIR)/usrsctplib/$(CONFIG)/usrsctp.lib $(<)
+ }
+@@ -165,14 +177,26 @@ rule make_libjuice_msvc ( targets * : sources * : properties * )
  {
  	local VARIANT = [ feature.get-values <variant> : $(properties) ] ;
  	VARIANT on $(targets) = $(VARIANT) ;
@@ -37,6 +45,11 @@ index 9c740467..bba7864c 100644
 +	if $(ADDRESS_MODEL) = 32
 +	{ ARCH = Win32 ; }
 +	ARCH on $(targets) = $(ARCH) ;
++
++	local CONFIG = Release ;
++	if $(VARIANT) = debug
++	{ CONFIG = Debug ; }
++	CONFIG on $(targets) = $(CONFIG) ;
 +
  	if <gnutls>on in $(properties)
  	{
@@ -51,12 +64,15 @@ index 9c740467..bba7864c 100644
  		CMAKEOPTS on $(targets) = "-DUSE_NETTLE=0" ;
  	}
  }
-@@ -182,7 +196,7 @@ actions make_libjuice_msvc
+@@ -182,8 +206,8 @@ actions make_libjuice_msvc
      cd $(CWD)/deps/libjuice
      mkdir $(BUILD_DIR)
      cd $(BUILD_DIR)
 -    cmake -G "Visual Studio 17 2022" $(CMAKEOPTS) ..
+-    msbuild libjuice.sln /property:Configuration=$(VARIANT)
 +    cmake -G "Visual Studio 17 2022" -A $(ARCH) $(CMAKEOPTS) ..
-     msbuild libjuice.sln /property:Configuration=$(VARIANT)
++    msbuild libjuice.sln /property:Configuration=$(VARIANT) /property:Platform=$(ARCH)
      cd %OLDD%
-     cp $(CWD)/deps/libjuice/$(BUILD_DIR)/Release/juice-static.lib $(<)
+-    cp $(CWD)/deps/libjuice/$(BUILD_DIR)/Release/juice-static.lib $(<)
++    cp $(CWD)/deps/libjuice/$(BUILD_DIR)/$(CONFIG)/juice-static.lib $(<)
+ }


### PR DESCRIPTION
This extends the patch of `libdatachannel/Jamfile` to also take debug/release into account in the bridge to cmake.

It also patches the vendored version of libdatachannel when building the tarball.