### PR TITLE
optimize visit_set() a bit more, to still perform well in dense sets

### DIFF
--- a/include/libtorrent/bitfield.hpp
+++ b/include/libtorrent/bitfield.hpp
@@ -329,18 +329,55 @@ namespace libtorrent {
 		template <typename Fun>
 		void visit_set(Fun&& fun) const
 		{
-			for (int word = 0; word < this->num_words(); ++word)
+			int const words = num_words();
+			for (int word = 0; word < words; ++word)
 			{
-				std::uint32_t bits = aux::network_to_host(this->buf()[word]);
-				while (bits != 0)
+				std::uint32_t const raw = buf()[word];
+
+				// 0 and 0xffffffff are fixed points of network_to_host(), so these
+				// two common cases skip the byte-swap and the popcount() below
+				if (raw == 0)
+					continue;
+
+				// trailing padding bits are always clear, so a set word is fully in range
+				if (raw == 0xffffffff)
 				{
-					int const bit = std::countl_zero(bits);
-					int const index = word * 32 + bit;
-					if (index >= this->size())
-						return;
-					if (!fun(IndexType(index)))
-						return;
-					bits ^= 0x80000000 >> bit;
+					int const base = word * 32;
+					for (int bit = 0; bit < 32; ++bit)
+					{
+						if (!fun(IndexType(base + bit)))
+							return;
+					}
+					continue;
+				}
+
+				std::uint32_t bits = aux::network_to_host(raw);
+
+				// threshold from a microbenchmark: below it, countl_zero() per set
+				// bit beats testing all 32 positions
+				if (std::popcount(bits) <= 7)
+				{
+					while (bits != 0)
+					{
+						int const bit = std::countl_zero(bits);
+						int const index = word * 32 + bit;
+						if (index >= size())
+							return;
+						if (!fun(IndexType(index)))
+							return;
+						bits ^= 0x80000000 >> bit;
+					}
+				}
+				else
+				{
+					for (int bit = 0; bit < 32; ++bit)
+					{
+						int const index = word * 32 + bit;
+						if (index >= size())
+							return;
+						if ((bits & (0x80000000 >> bit)) && !fun(IndexType(index)))
+							return;
+					}
 				}
 			}
 		}

--- a/test/test_bitfield.cpp
+++ b/test/test_bitfield.cpp
@@ -473,3 +473,60 @@ TORRENT_TEST(visit_set_early_exit)
 	std::vector<int> const expected = {0, 31, 32};
 	TEST_CHECK(visited == expected);
 }
+
+TORRENT_TEST(visit_set_all_clear_word)
+{
+	// the middle word is entirely clear, the others have a few bits set
+	typed_bitfield<int> bits(96, false);
+	bits.set_bit(0);
+	bits.set_bit(31);
+	bits.set_bit(64);
+	bits.set_bit(95);
+
+	std::vector<int> visited;
+	bits.visit_set([&visited](int const index) {
+		visited.push_back(index);
+		return true;
+	});
+
+	std::vector<int> const expected = {0, 31, 64, 95};
+	TEST_CHECK(visited == expected);
+}
+
+TORRENT_TEST(visit_set_all_set_word)
+{
+	// the middle word is entirely set, the others have a single bit set
+	typed_bitfield<int> bits(96, false);
+	bits.set_bit(0);
+	for (int i = 32; i < 64; ++i)
+		bits.set_bit(i);
+	bits.set_bit(95);
+
+	std::vector<int> visited;
+	bits.visit_set([&visited](int const index) {
+		visited.push_back(index);
+		return true;
+	});
+
+	std::vector<int> expected = {0};
+	for (int i = 32; i < 64; ++i)
+		expected.push_back(i);
+	expected.push_back(95);
+	TEST_CHECK(visited == expected);
+}
+
+TORRENT_TEST(visit_set_all_set_word_early_exit)
+{
+	// a single, fully set word that is also the last word (size is an exact
+	// multiple of 32, so there are no trailing padding bits to worry about)
+	typed_bitfield<int> const bits(32, true);
+
+	std::vector<int> visited;
+	bits.visit_set([&visited](int const index) {
+		visited.push_back(index);
+		return index != 10;
+	});
+
+	std::vector<int> const expected = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+	TEST_CHECK(visited == expected);
+}


### PR DESCRIPTION
the recent optimization caused a regression in dense bitfields. the cost of calling `countl_zero()` for every bit was expensive. This determines whether to use a plain loop (checking every bit) or whether the word is sparse enough to use `countl_zero()`.

It also adds special cases for all bits and no bits being set.

The main case this addresses is `piece picker: add/remove near-seed` and the sparse bitfields are instead slightly worse off now.

| benchmark | before | after | speed-up |
|---|---|---|---|
| piece picker: add/remove near-seed | 524352.88 | 185740.79 | 2.823 |
| piece picker: add/remove seed | 25.62 | 26.84 | 0.955 |
| piece picker: break one seed | 129186.61 | 129606.94 | 0.997 |
| piece picker: get availability | 15111.44 | 16814.89 | 0.899 |
| piece picker: mark as downloading, high index | 90.72 | 99.92 | 0.908 |
| piece picker: mark as downloading, low index | 2526.79 | 2633.87 | 0.959 |
| piece picker: pick pieces, after dirty | 1455857.09 | 1804179.87 | 0.807 |
| piece picker: pick pieces, clean | 47.44 | 48.22 | 0.984 |
| piece picker: pick pieces, dense peer | 52.88 | 49.55 | 1.067 |
| piece picker: pick pieces, sparse peer | 762717.46 | 764562.69 | 0.998 |
| piece picker: piece priorities | 19047.97 | 21167.21 | 0.900 |
| piece picker: refcount bitfield, 1 bit set | 5178.35 | 6355.31 | 0.815 |
| piece picker: refcount bitfield, 10 bits set | 5440.24 | 6349.18 | 0.857 |
| piece picker: refcount bitfield, 200 bits set | 7355.91 | 8858.76 | 0.830 |
| piece picker: refcount bitfield, 49 bits set | 6374.18 | 7249.63 | 0.879 |
| piece picker: refcount bitfield, 50 bits set | 6702.38 | 7729.32 | 0.867 |
| piece picker: refcount bitfield, 5000 bits set | 28138.86 | 43018.72 | 0.654 |

<img width="1739" height="600" alt="latency_comparison" src="https://github.com/user-attachments/assets/a1265581-c6ef-402d-9eab-8f9fb239f280" />
