### PR TITLE
optimize sanitize_append_path_element()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1087,6 +1087,7 @@ TEST_TORRENTS = \
   invalid_name.torrent \
   invalid_name2.torrent \
   invalid_name3.torrent \
+  invalid_name4.torrent \
   invalid_path_list.torrent \
   invalid_piece_len.torrent \
   invalid_pieces.torrent \

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -724,8 +724,12 @@ public:
 		bool m_v2 = false;
 
 		// TODO: can we remove set_name?
-		void update_path_index(aux::file_entry& e, std::string const& path
-			, bool set_name = true);
+		// path must be the directory portion only, never including the
+		// leaf; filename is the leaf, always passed in separately. The
+		// caller is responsible for splitting a full path with rsplit_path()
+		// first, when it doesn't already have path and filename apart.
+		void update_path_index(
+			aux::file_entry& e, string_view path, string_view filename, bool set_name = true);
 
 		// the list of files that this torrent consists of
 		aux::vector<aux::file_entry, file_index_t> m_files;

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -48,10 +48,15 @@ namespace libtorrent {
 
 namespace aux {
 
-	// internal, exposed for the unit test
-	TORRENT_EXTRA_EXPORT void sanitize_append_path_element(std::string& path
-		, string_view element, bool force_element = false);
-	TORRENT_EXTRA_EXPORT bool verify_encoding(std::string& target);
+// internal, exposed for the unit test
+// returns true if element was modified while being appended to path.
+// if leaf is true and element turns out to need no modification at all,
+// path is left untouched (nothing is appended, not even a separator)
+// instead of appending element verbatim; the caller is expected to use
+// element directly in that case.
+TORRENT_EXTRA_EXPORT bool sanitize_append_path_element(
+	std::string& path, string_view element, bool force_element = false, bool leaf = false);
+TORRENT_EXTRA_EXPORT bool verify_encoding(std::string& target);
 
 #if TORRENT_ABI_VERSION < 4
 	struct internal_drained_state

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -122,54 +122,65 @@ TORRENT_VERSION_NAMESPACE_4
 		return (m_piece_length + default_block_size - 1) / default_block_size;
 	}
 
-	// path is supposed to include the name of the torrent itself.
-	// or an absolute path, to move a file outside of the download directory
-	void file_storage::update_path_index(aux::file_entry& e
-		, std::string const& path, bool const set_name)
+	// path is the directory portion only, never including the leaf (which
+	// is passed in separately as filename), except when path is an absolute
+	// path, to move a file outside of the download directory - in that case
+	// filename is folded into it as a single name.
+	void file_storage::update_path_index(
+		aux::file_entry& e, string_view const path, string_view const filename, bool const set_name)
 	{
-		// TODO: at appears set_name is always true
+		if (path.empty())
+		{
+			if (set_name)
+				e.set_name(filename);
+			e.path_index = aux::file_entry::no_path;
+			return;
+		}
+
 		if (is_complete(path))
 		{
-			TORRENT_ASSERT(set_name);
-			e.set_name(path);
+			// an absolute directory is rare enough (and path_is_absolute
+			// stores the whole thing as a single name) that it's not worth
+			// avoiding the concatenation here. filename is empty when path
+			// is already the complete absolute path (the caller found no
+			// leaf to split off without losing the leading separator).
+			std::string full(path);
+			if (!filename.empty())
+			{
+				full += TORRENT_SEPARATOR;
+				full.append(filename.data(), filename.size());
+			}
+			e.set_name(full);
 			e.path_index = aux::file_entry::path_is_absolute;
 			return;
 		}
 
 		TORRENT_ASSERT(path[0] != '/');
 
-		// split the string into the leaf filename
-		// and the branch path
-		auto [branch_path, leaf] = rsplit_path(path);
-
-		if (branch_path.empty())
-		{
-			if (set_name) e.set_name(leaf);
-			e.path_index = aux::file_entry::no_path;
-			return;
-		}
-
 		// if the path *does* contain the name of the torrent (as we expect)
 		// strip it before adding it to m_paths
-		if (lsplit_path(branch_path).first == m_name)
+		if (lsplit_path(path).first == m_name)
 		{
-			branch_path = lsplit_path(branch_path).second;
+			string_view branch_path = lsplit_path(path).second;
 			// strip duplicate separators
-			while (!branch_path.empty() && (branch_path.front() == TORRENT_SEPARATOR
+			while (!branch_path.empty()
+				&& (branch_path.front() == TORRENT_SEPARATOR
 #if defined(TORRENT_WINDOWS) || defined(TORRENT_OS2)
-				|| branch_path.front() == '/'
+					|| branch_path.front() == '/'
 #endif
-				))
+					))
 				branch_path.remove_prefix(1);
 			e.no_root_dir = false;
+			e.path_index = get_or_add_path(branch_path);
 		}
 		else
 		{
 			e.no_root_dir = true;
+			e.path_index = get_or_add_path(path);
 		}
 
-		e.path_index = get_or_add_path(branch_path);
-		if (set_name) e.set_name(leaf);
+		if (set_name)
+			e.set_name(filename);
 	}
 
 	aux::path_index_t file_storage::get_or_add_path(string_view const path)
@@ -481,7 +492,18 @@ TORRENT_VERSION_NAMESPACE_4
 		, std::string const& new_filename)
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < end_file());
-		update_path_index(m_files[index], new_filename);
+		// splitting off the leaf with rsplit_path() loses the leading
+		// separator for a single-component absolute path (e.g. "/tmp"),
+		// so is_complete() must be checked before splitting
+		if (is_complete(new_filename))
+		{
+			update_path_index(m_files[index], new_filename, string_view());
+		}
+		else
+		{
+			auto const [branch_path, leaf] = rsplit_path(new_filename);
+			update_path_index(m_files[index], branch_path, leaf);
+		}
 	}
 #endif // TORRENT_ABI_VERSION
 
@@ -821,14 +843,18 @@ TORRENT_VERSION_NAMESPACE_4
 			return;
 		}
 
-		if (!has_parent_path(path))
+		// when filename is borrowed, path holds only the directory portion
+		// (never the leaf), so "no parent" just means an empty path; there's
+		// no leaf embedded in path to scan for with has_parent_path()
+		bool const has_parent = filename.empty() ? has_parent_path(path) : !path.empty();
+		if (!has_parent)
 		{
 			// you have already added at least one file with a
 			// path to the file (branch_path), which means that
 			// all the other files need to be in the same top
 			// directory as the first file.
 			TORRENT_ASSERT_PRECOND(m_files.empty());
-			m_name = path;
+			m_name = filename.empty() ? path : std::string(filename);
 		}
 		else
 		{
@@ -862,12 +888,29 @@ TORRENT_VERSION_NAMESPACE_4
 		m_files.emplace_back();
 		aux::file_entry& e = m_files.back();
 
-		// the last argument specified whether the function should also set
-		// the filename. If it does, it will copy the leaf filename from path.
-		// if filename is empty, we should copy it. If it isn't, we're borrowing
-		// it and we can save the copy by setting it after this call to
-		// update_path_index().
-		update_path_index(e, path, filename.empty());
+		// if filename is empty, path holds the full path (directory and
+		// leaf together), so it needs splitting here. if filename is
+		// non-empty, it's borrowed and path already holds only the
+		// directory portion, so no split is needed to find the leaf.
+		if (filename.empty())
+		{
+			// splitting off the leaf with rsplit_path() loses the leading
+			// separator for a single-component absolute path (e.g.
+			// "/bar"), so is_complete() must be checked before splitting
+			if (is_complete(path))
+			{
+				update_path_index(e, path, string_view());
+			}
+			else
+			{
+				auto const [branch_path, leaf] = rsplit_path(path);
+				update_path_index(e, branch_path, leaf);
+			}
+		}
+		else
+		{
+			update_path_index(e, path, filename, false);
+		}
 
 		// filename is allowed to be empty, in which case we just use path
 		if (!filename.empty())

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -156,28 +156,46 @@ namespace aux {
 	// meaning in v2 torrents (it means the previous path element was the
 	// filename). Also, If we're adding the torrent name as the first path
 	// element, in a multi-file torrent, we must have a directory name.
-	void sanitize_append_path_element(std::string& path, string_view element, bool const force_element)
+	// returns true if element was modified while being appended to path.
+	// if leaf is true and element turns out to need no modification, path
+	// is left completely untouched (not even the separator is added)
+	// instead of appending element verbatim.
+	bool sanitize_append_path_element(
+		std::string& path, string_view element, bool const force_element, bool const leaf)
 	{
-		if (element.size() == 1 && element[0] == '.' && !force_element) return;
+		if (element.size() == 1 && element[0] == '.' && !force_element)
+			return true;
 
 #ifdef TORRENT_WINDOWS
 #define TORRENT_SEPARATOR '\\'
 #else
 #define TORRENT_SEPARATOR '/'
 #endif
-		path.reserve(path.size() + element.size() + 2);
-		int added_separator = 0;
-		if (!path.empty())
-		{
-			path += TORRENT_SEPARATOR;
-			added_separator = 1;
-		}
+		int const added_separator = path.empty() ? 0 : 1;
+
+		// nothing has been written to path for this element yet. Every write
+		// below goes through commit(), so as long as it's never called, a
+		// leaf element leaves path exactly as it was on entry.
+		bool committed = false;
+		auto commit = [&] {
+			if (committed)
+				return;
+			committed = true;
+			path.reserve(path.size() + element.size() + 2);
+			if (added_separator)
+				path += TORRENT_SEPARATOR;
+		};
+		if (!leaf)
+			commit();
 
 		if (element.empty())
 		{
+			commit();
 			path += "_";
-			return;
+			return true;
 		}
+
+		bool modified = false;
 
 #if !TORRENT_USE_UNC_PATHS && defined TORRENT_WINDOWS
 #pragma message ("building for windows without UNC paths is deprecated")
@@ -207,6 +225,7 @@ namespace aux {
 		{
 			pe = "_" + pe;
 			element = string_view();
+			modified = true;
 		}
 #endif
 #ifdef TORRENT_WINDOWS
@@ -221,6 +240,13 @@ namespace aux {
 		char num_dots = 0;
 		bool found_extension = false;
 
+		// [run_start, i) is a span of element that has passed validation and
+		// is pending a single bulk copy into path, rather than being copied
+		// character by character. It's flushed whenever a character needs to
+		// be dropped or substituted, and once at the end of the loop. This
+		// makes the common case, where element needs no sanitization at all,
+		// a single append() call (or, for a leaf, no call at all).
+		std::size_t run_start = 0;
 		int seq_len = 0;
 		for (std::size_t i = 0; i < element.size(); i += std::size_t(seq_len))
 		{
@@ -229,27 +255,30 @@ namespace aux {
 
 			if (code_point >= 0 && filter_path_character(code_point))
 			{
+				commit();
+				path.append(element.data() + run_start, i - run_start);
+				run_start = i + std::size_t(seq_len);
+				modified = true;
 				continue;
 			}
 
 			if (code_point < 0 || !valid_path_character(code_point))
 			{
 				// invalid utf8 sequence, replace with "_"
+				commit();
+				path.append(element.data() + run_start, i - run_start);
 				path += '_';
+				run_start = i + std::size_t(seq_len);
 				++added;
+				modified = true;
 #ifdef TORRENT_WINDOWS
 				++unicode_chars;
 #endif
 				continue;
 			}
 
-			// validation passed, add it to the output string
-			for (std::size_t k = i; k < i + std::size_t(seq_len); ++k)
-			{
-				TORRENT_ASSERT(element[k] != 0);
-				path.push_back(element[k]);
-			}
-
+			// validation passed, it stays part of the pending run and is
+			// copied to path in bulk once the run ends
 			if (code_point == '.') ++num_dots;
 
 			added += seq_len;
@@ -267,6 +296,10 @@ namespace aux {
 			if (added >= 240 && !found_extension)
 #endif
 			{
+				commit();
+				path.append(element.data() + run_start, i + std::size_t(seq_len) - run_start);
+				modified = true;
+
 				int dot = -1;
 				for (int j = int(element.size()) - 1;
 					j > std::max(int(element.size()) - 10, int(i)); --j)
@@ -276,52 +309,113 @@ namespace aux {
 					break;
 				}
 				// there is no extension
-				if (dot == -1) break;
+				if (dot == -1)
+				{
+					run_start = element.size();
+					break;
+				}
 				found_extension = true;
 				TORRENT_ASSERT(dot > 0);
 				i = std::size_t(dot - seq_len);
+				run_start = std::size_t(dot);
 			}
 		}
+		// flush whatever's left of the pending run. If nothing has been
+		// committed at this point, element hasn't needed any modification so
+		// far (added == element.size()), so this is the only remaining
+		// unconditional write to avoid.
+		if (committed)
+			path.append(element.data() + run_start, element.size() - run_start);
 
 		if (added == num_dots && added <= 2)
 		{
+			// the surviving content is 0-2 dots, which isn't a valid path
+			// component on any OS (it means "self" or "parent directory").
+			// This is always treated as a modification, whether or not any
+			// individual character was flagged above.
 			if (force_element)
 			{
 				// revert the invalid filename and replace it with an underscore
-				path.erase(path.end() - added, path.end());
+				if (committed)
+					path.erase(path.end() - added, path.end());
+				else
+					commit();
 				path += "_";
 			}
-			else
+			else if (committed)
 			{
-				// revert everything
+				// revert everything, including the separator
 				path.erase(path.end() - added - added_separator, path.end());
 			}
-			return;
+			// else: nothing was ever written; path is already in the
+			// reverted state
+			return true;
 		}
 
 #ifdef TORRENT_WINDOWS
-		// remove trailing spaces and dots. These aren't allowed in filenames on windows
-		for (int i = int(path.size()) - 1; i >= 0; --i)
+		if (committed)
 		{
-			if (path[i] != ' ' && path[i] != '.') break;
-			path.resize(i);
-			--added;
-			TORRENT_ASSERT(added >= 0);
+			// remove trailing spaces and dots. These aren't allowed in filenames on windows
+			for (int i = int(path.size()) - 1; i >= 0; --i)
+			{
+				if (path[i] != ' ' && path[i] != '.')
+					break;
+				path.resize(i);
+				--added;
+				modified = true;
+				TORRENT_ASSERT(added >= 0);
+			}
+		}
+		else
+		{
+			// nothing has been written to path yet, so element is still
+			// exactly the pending content (added == element.size()). Mirror
+			// the trim above by scanning element directly, so we can still
+			// avoid touching path if nothing actually needs trimming.
+			std::size_t keep = element.size();
+			while (keep > 0 && (element[keep - 1] == ' ' || element[keep - 1] == '.'))
+			{
+				--keep;
+				--added;
+				TORRENT_ASSERT(added >= 0);
+			}
+			if (keep != element.size())
+			{
+				modified = true;
+				if (added > 0)
+				{
+					commit();
+					path.append(element.data(), keep);
+				}
+			}
 		}
 
 		if (force_element && added == 0)
 		{
+			commit();
 			path += "_";
+			modified = true;
 		}
 		else if (added == 0 && added_separator)
 		{
-			// remove the separator added at the beginning
-			path.erase(path.end() - 1);
-			return;
+			if (committed)
+			{
+				// remove the separator added at the beginning
+				path.erase(path.end() - 1);
+			}
+			return true;
 		}
 #endif
 
-		if (path.empty()) path = "_";
+		if (!committed)
+			return modified;
+
+		if (path.empty())
+		{
+			path = "_";
+			modified = true;
+		}
+		return modified;
 	}
 }
 
@@ -506,6 +600,7 @@ namespace {
 
 		std::string path = root_dir;
 		string_view filename;
+		bool modified = false;
 
 		if (top_level)
 		{
@@ -525,8 +620,22 @@ namespace {
 			while (!filename.empty() && filename.front() == TORRENT_SEPARATOR)
 				filename.remove_prefix(1);
 
-			aux::sanitize_append_path_element(path, p.string_value());
-			if (path.empty())
+			// a name consisting entirely of separators strips down to nothing
+			if (filename.empty())
+			{
+				ec = errors::torrent_missing_name;
+				return false;
+			}
+
+			// leave path empty (rather than just holding filename) when
+			// filename doesn't need sanitizing, so it can be borrowed
+			// directly by add_file_borrow() below instead of being copied
+			// into path and re-split back out. When unmodified, filename is
+			// already known to be valid and non-empty (checked above), so
+			// only a modified-and-reverted result can leave path empty and
+			// mean an actually missing name.
+			modified = aux::sanitize_append_path_element(path, filename, false, true);
+			if (modified && path.empty())
 			{
 				ec = errors::torrent_missing_name;
 				return false;
@@ -558,8 +667,16 @@ namespace {
 							, static_cast<std::size_t>(e.string_length()) };
 						while (!filename.empty() && filename.front() == TORRENT_SEPARATOR)
 							filename.remove_prefix(1);
+						// leave path as just the directory when filename
+						// doesn't need sanitizing, so it can be borrowed
+						// directly by add_file_borrow() below instead of
+						// being copied into path and re-split back out
+						modified = aux::sanitize_append_path_element(path, filename, true, true);
 					}
-					aux::sanitize_append_path_element(path, e.string_value(), true);
+					else
+					{
+						aux::sanitize_append_path_element(path, e.string_value(), true);
+					}
 					++idx;
 				}
 			}
@@ -578,8 +695,11 @@ namespace {
 			}
 		}
 
-		// bitcomet pad file
-		if (path.find("_____padding_file_") != std::string::npos)
+		// bitcomet pad file. filename may or may not be folded into path
+		// (it's left separate, and path left as just the directory, when
+		// filename didn't need sanitizing), so both need checking.
+		if (filename.find("_____padding_file_") != string_view::npos
+			|| path.find("_____padding_file_") != std::string::npos)
 			file_flags |= file_storage::flag_pad_file;
 
 #if TORRENT_ABI_VERSION < 4
@@ -626,10 +746,9 @@ namespace {
 			// directory we haven't parsed yet
 		}
 
-		if (filename.size() > path.length()
-			|| path.substr(path.size() - filename.size()) != filename)
+		if (modified)
 		{
-			// if the filename was sanitized and differ, clear it to just use path
+			// if the filename was sanitized, clear it to just use path
 			filename = {};
 		}
 
@@ -697,14 +816,18 @@ namespace {
 			bool const single_file = leaf_node && !is_multi_file && frame.tree.dict_size() == 1;
 
 			std::string path = single_file ? std::string() : frame.path;
-			aux::sanitize_append_path_element(path, filename, true);
+			// only leaf (file) entries can skip the append when unmodified:
+			// non-leaf entries are directory names that must always end up
+			// in path, since it's pushed onto the stack for children to
+			// build on top of
+			bool const modified =
+				aux::sanitize_append_path_element(path, filename, true, leaf_node);
 
 			if (leaf_node)
 			{
-				if (filename.size() > path.length()
-					|| path.substr(path.size() - filename.size()) != filename)
+				if (modified)
 				{
-					// if the filename was sanitized and differ, clear it to just use path
+					// if the filename was sanitized, clear it to just use path
 					filename = {};
 				}
 

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -166,6 +166,66 @@ TORRENT_TEST(rename_file2)
 }
 #endif
 
+#if TORRENT_ABI_VERSION < 4
+TORRENT_TEST(rename_file_absolute_single_component)
+{
+	// a single path-component absolute path (no intermediate directory,
+	// e.g. "/tmp" rather than "/tmp/a") must still be recognized as
+	// absolute, not collapsed into an ordinary relative filename
+	file_storage st;
+	setup_test_storage(st);
+
+#ifdef TORRENT_WINDOWS
+	st.rename_file(file_index_t{0}, "c:\\tmp");
+	TEST_EQUAL(st.file_path(file_index_t{0}, "."), "c:\\tmp");
+#else
+	st.rename_file(file_index_t{0}, "/tmp");
+	TEST_EQUAL(st.file_path(file_index_t{0}, "."), "/tmp");
+#endif
+	TEST_CHECK(st.file_absolute_path(file_index_t{0}));
+}
+#endif
+
+TORRENT_TEST(add_file_absolute_single_component)
+{
+	// same case as rename_file_absolute_single_component, but reached
+	// through add_file(), which hits update_path_index() via a
+	// different call site (add_file_borrow_impl)
+	file_storage fs;
+#ifdef TORRENT_WINDOWS
+	fs.add_file("c:\\bar", 10);
+	TEST_EQUAL(fs.file_path(file_index_t{0}, "."), "c:\\bar");
+#else
+	fs.add_file("/bar", 10);
+	TEST_EQUAL(fs.file_path(file_index_t{0}, "."), "/bar");
+#endif
+	TEST_CHECK(fs.file_absolute_path(file_index_t{0}));
+}
+
+TORRENT_TEST(add_file_no_directory_not_absolute)
+{
+	// a plain filename with no directory component (the common case)
+	// must not be mistaken for a collapsed single-component absolute path
+	file_storage fs;
+	fs.add_file("bar", 10);
+	TEST_CHECK(!fs.file_absolute_path(file_index_t{0}));
+	TEST_EQUAL(fs.file_path(file_index_t{0}, "save_path"), combine_path("save_path", "bar"));
+}
+
+TORRENT_TEST(add_file_borrow_single_file_torrent)
+{
+	// mirrors how torrent_info parses a single-file torrent's "name"
+	// field: the filename is borrowed directly (non-empty) with an
+	// empty directory path. This goes through a different branch of
+	// add_file_borrow_impl than add_file_no_directory_not_absolute
+	// (the filename is never split out of path here), but must still
+	// not be treated as absolute.
+	file_storage fs;
+	fs.add_file_borrow("bar", "", 10);
+	TEST_CHECK(!fs.file_absolute_path(file_index_t{0}));
+	TEST_EQUAL(fs.file_path(file_index_t{0}, "save_path"), combine_path("save_path", "bar"));
+}
+
 TORRENT_TEST(pointer_offset)
 {
 	// test applying pointer offset
@@ -177,12 +237,18 @@ TORRENT_TEST(pointer_offset)
 #endif
 	char const roothash[] = "01234567890123456789012345678912-----";
 
-	st.add_file_borrow({filename, 5}, combine_path("test-torrent-1", "test1")
-		, 10, file_flags_t{}
+	// filename is borrowed and non-empty, so path must hold only the
+	// directory portion, not the leaf ("test1") - it's never both
+	st.add_file_borrow({filename, 5},
+		"test-torrent-1",
+		10,
+		file_flags_t{},
 #if TORRENT_ABI_VERSION < 4
-		, filehash
+		filehash,
 #endif
-		, 0, {}, roothash);
+		0,
+		{},
+		roothash);
 
 	// test filename_ptr and filename_len
 #if TORRENT_ABI_VERSION <= 2

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -427,50 +427,50 @@ struct test_failing_torrent_t
 	error_code error; // the expected error
 };
 
-test_failing_torrent_t test_error_torrents[] =
-{
-	{ "missing_piece_len.torrent", errors::torrent_missing_piece_length },
-	{ "invalid_piece_len.torrent", errors::torrent_missing_piece_length },
-	{ "negative_piece_len.torrent", errors::torrent_missing_piece_length },
-	{ "no_name.torrent", errors::torrent_missing_name },
-	{ "bad_name.torrent", errors::torrent_missing_name },
-	{ "invalid_name.torrent", errors::torrent_missing_name },
-	{ "invalid_info.torrent", errors::torrent_missing_info },
-	{ "string.torrent", errors::torrent_is_no_dict },
-	{ "negative_size.torrent", errors::torrent_invalid_length },
-	{ "negative_file_size.torrent", errors::torrent_invalid_length },
-	{ "invalid_path_list.torrent", errors::torrent_invalid_name},
-	{ "missing_path_list.torrent", errors::torrent_missing_name },
-	{ "invalid_pieces.torrent", errors::torrent_missing_pieces },
-	{ "unaligned_pieces.torrent", errors::torrent_invalid_hashes },
-	{ "invalid_file_size.torrent", errors::torrent_invalid_length },
-	{ "invalid_symlink.torrent", errors::torrent_invalid_name },
-	{ "many_pieces.torrent", errors::too_many_pieces_in_torrent },
-	{ "no_files.torrent", errors::no_files_in_torrent},
-	{ "zero.torrent", errors::torrent_invalid_length},
-	{ "zero2.torrent", errors::torrent_invalid_length},
-	{ "v2_mismatching_metadata.torrent", errors::torrent_inconsistent_files},
-	{ "v2_no_power2_piece.torrent", errors::torrent_missing_piece_length},
-	{ "v2_invalid_file.torrent", errors::torrent_file_parse_failed},
-	{ "v2_deep_recursion.torrent", bdecode_errors::depth_exceeded},
-	{ "v2_non_multiple_piece_layer.torrent", errors::torrent_invalid_piece_layer},
-	{ "v2_piece_layer_invalid_file_hash.torrent", errors::torrent_invalid_piece_layer},
-	{ "v2_invalid_piece_layer.torrent", errors::torrent_invalid_piece_layer},
-	{ "v2_invalid_piece_layer_root.torrent", errors::torrent_invalid_piece_layer},
-	{ "v2_unknown_piece_layer_entry.torrent", errors::torrent_invalid_piece_layer},
-	{ "v2_invalid_piece_layer_size.torrent", errors::torrent_invalid_piece_layer},
-	{ "v2_bad_file_alignment.torrent", errors::torrent_inconsistent_files},
-	{ "v2_unordered_files.torrent", errors::invalid_bencoding},
-	{ "v2_overlong_integer.torrent", errors::invalid_bencoding},
-	{ "v2_missing_file_root_invalid_symlink.torrent", errors::torrent_missing_pieces_root},
-	{ "v2_large_file.torrent", errors::torrent_invalid_length},
-	{ "v2_large_offset.torrent", errors::too_many_pieces_in_torrent},
-	{ "v2_piece_size.torrent", errors::torrent_missing_piece_length},
-	{ "v2_invalid_pad_file.torrent", errors::torrent_invalid_pad_file},
-	{ "v2_zero_root.torrent", errors::torrent_missing_pieces_root},
-	{ "v2_zero_root_small.torrent", errors::torrent_missing_pieces_root},
-	{ "v2_empty_filename.torrent", errors::torrent_file_parse_failed},
-	{ "duplicate_files2.torrent", errors::too_many_duplicate_filenames},
+test_failing_torrent_t test_error_torrents[] = {
+	{"missing_piece_len.torrent", errors::torrent_missing_piece_length},
+	{"invalid_piece_len.torrent", errors::torrent_missing_piece_length},
+	{"negative_piece_len.torrent", errors::torrent_missing_piece_length},
+	{"no_name.torrent", errors::torrent_missing_name},
+	{"bad_name.torrent", errors::torrent_missing_name},
+	{"invalid_name.torrent", errors::torrent_missing_name},
+	{"invalid_info.torrent", errors::torrent_missing_info},
+	{"string.torrent", errors::torrent_is_no_dict},
+	{"negative_size.torrent", errors::torrent_invalid_length},
+	{"negative_file_size.torrent", errors::torrent_invalid_length},
+	{"invalid_path_list.torrent", errors::torrent_invalid_name},
+	{"invalid_name4.torrent", errors::torrent_missing_name},
+	{"missing_path_list.torrent", errors::torrent_missing_name},
+	{"invalid_pieces.torrent", errors::torrent_missing_pieces},
+	{"unaligned_pieces.torrent", errors::torrent_invalid_hashes},
+	{"invalid_file_size.torrent", errors::torrent_invalid_length},
+	{"invalid_symlink.torrent", errors::torrent_invalid_name},
+	{"many_pieces.torrent", errors::too_many_pieces_in_torrent},
+	{"no_files.torrent", errors::no_files_in_torrent},
+	{"zero.torrent", errors::torrent_invalid_length},
+	{"zero2.torrent", errors::torrent_invalid_length},
+	{"v2_mismatching_metadata.torrent", errors::torrent_inconsistent_files},
+	{"v2_no_power2_piece.torrent", errors::torrent_missing_piece_length},
+	{"v2_invalid_file.torrent", errors::torrent_file_parse_failed},
+	{"v2_deep_recursion.torrent", bdecode_errors::depth_exceeded},
+	{"v2_non_multiple_piece_layer.torrent", errors::torrent_invalid_piece_layer},
+	{"v2_piece_layer_invalid_file_hash.torrent", errors::torrent_invalid_piece_layer},
+	{"v2_invalid_piece_layer.torrent", errors::torrent_invalid_piece_layer},
+	{"v2_invalid_piece_layer_root.torrent", errors::torrent_invalid_piece_layer},
+	{"v2_unknown_piece_layer_entry.torrent", errors::torrent_invalid_piece_layer},
+	{"v2_invalid_piece_layer_size.torrent", errors::torrent_invalid_piece_layer},
+	{"v2_bad_file_alignment.torrent", errors::torrent_inconsistent_files},
+	{"v2_unordered_files.torrent", errors::invalid_bencoding},
+	{"v2_overlong_integer.torrent", errors::invalid_bencoding},
+	{"v2_missing_file_root_invalid_symlink.torrent", errors::torrent_missing_pieces_root},
+	{"v2_large_file.torrent", errors::torrent_invalid_length},
+	{"v2_large_offset.torrent", errors::too_many_pieces_in_torrent},
+	{"v2_piece_size.torrent", errors::torrent_missing_piece_length},
+	{"v2_invalid_pad_file.torrent", errors::torrent_invalid_pad_file},
+	{"v2_zero_root.torrent", errors::torrent_missing_pieces_root},
+	{"v2_zero_root_small.torrent", errors::torrent_missing_pieces_root},
+	{"v2_empty_filename.torrent", errors::torrent_file_parse_failed},
+	{"duplicate_files2.torrent", errors::too_many_duplicate_filenames},
 };
 
 } // anonymous namespace
@@ -652,18 +652,28 @@ TORRENT_TEST(sanitize_path_truncate)
 	using lt::aux::sanitize_append_path_element;
 
 	std::string path;
-	sanitize_append_path_element(path,
+	// no extension in the truncation window: the "no extension" branch
+	bool const modified1 = sanitize_append_path_element(path,
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_");
-	sanitize_append_path_element(path,
+	TEST_EQUAL(modified1, true);
+	TEST_EQUAL(path,
+		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_");
+	// extension found in the truncation window: the extension-preserving branch
+	bool const modified2 = sanitize_append_path_element(path,
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcde.test");
+	TEST_EQUAL(modified2, true);
 	TEST_EQUAL(path,
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
@@ -683,12 +693,17 @@ TORRENT_TEST(sanitize_path_truncate_utf)
 
 	std::string path;
 	// msvc doesn't like unicode string literals, so we encode it as UTF-8 explicitly
-	sanitize_append_path_element(path,
+	bool const modified = sanitize_append_path_element(path,
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
-		"abcdefghi_abcdefghi_abcdefghi_abcdefghi" "\xE2" "\x80" "\x94" "abcde.jpg");
+		"abcdefghi_abcdefghi_abcdefghi_abcdefghi"
+		"\xE2"
+		"\x80"
+		"\x94"
+		"abcde.jpg");
+	TEST_EQUAL(modified, true);
 	TEST_EQUAL(path,
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
 		"abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
@@ -702,7 +717,13 @@ TORRENT_TEST(sanitize_path_trailing_dots)
 	std::string path;
 	using lt::aux::sanitize_append_path_element;
 	sanitize_append_path_element(path, "a");
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "abc...");
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "a" SEPARATOR "abc");
+#else
+	TEST_EQUAL(path, "a" SEPARATOR "abc...");
+#endif
 	sanitize_append_path_element(path, "c");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "a" SEPARATOR "abc" SEPARATOR "c");
@@ -711,11 +732,13 @@ TORRENT_TEST(sanitize_path_trailing_dots)
 #endif
 
 	path.clear();
-	sanitize_append_path_element(path, "abc...");
+	bool const modified = sanitize_append_path_element(path, "abc...");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "abc");
+	TEST_EQUAL(modified, true);
 #else
 	TEST_EQUAL(path, "abc...");
+	TEST_EQUAL(modified, false);
 #endif
 
 	path.clear();
@@ -741,7 +764,13 @@ TORRENT_TEST(sanitize_path_trailing_spaces)
 	using lt::aux::sanitize_append_path_element;
 	std::string path;
 	sanitize_append_path_element(path, "a");
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "abc   ");
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "a" SEPARATOR "abc");
+#else
+	TEST_EQUAL(path, "a" SEPARATOR "abc   ");
+#endif
 	sanitize_append_path_element(path, "c");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "a" SEPARATOR "abc" SEPARATOR "c");
@@ -750,11 +779,13 @@ TORRENT_TEST(sanitize_path_trailing_spaces)
 #endif
 
 	path.clear();
-	sanitize_append_path_element(path, "abc   ");
+	bool const modified = sanitize_append_path_element(path, "abc   ");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "abc");
+	TEST_EQUAL(modified, true);
 #else
 	TEST_EQUAL(path, "abc   ");
+	TEST_EQUAL(modified, false);
 #endif
 
 	path.clear();
@@ -775,7 +806,9 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "/a/");
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "b");
+	TEST_EQUAL(path, "a" SEPARATOR "b");
 	sanitize_append_path_element(path, "c");
 	TEST_EQUAL(path, "a" SEPARATOR "b" SEPARATOR "c");
 
@@ -785,18 +818,26 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "a");
+	TEST_EQUAL(path, "a");
+	// ".." is reverted entirely, including the separator that precedes it
 	sanitize_append_path_element(path, "..");
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "c");
 	TEST_EQUAL(path, "a" SEPARATOR "c");
 
 	path.clear();
 	sanitize_append_path_element(path, "a");
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "..");
 	TEST_EQUAL(path, "a");
 
 	path.clear();
+	// "/.." leaves nothing once "/" is filtered and ".." is reverted
 	sanitize_append_path_element(path, "/..");
+	TEST_EQUAL(path, "");
+	// a lone "." is dropped without touching path
 	sanitize_append_path_element(path, ".");
+	TEST_EQUAL(path, "");
 	sanitize_append_path_element(path, "c");
 	TEST_EQUAL(path, "c");
 
@@ -810,6 +851,11 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "c:");
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "c_");
+#else
+	TEST_EQUAL(path, "c:");
+#endif
 	sanitize_append_path_element(path, "b");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "c_" SEPARATOR "b");
@@ -819,7 +865,18 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "c:");
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "c_");
+#else
+	TEST_EQUAL(path, "c:");
+#endif
+	// a lone "." is dropped without touching path
 	sanitize_append_path_element(path, ".");
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "c_");
+#else
+	TEST_EQUAL(path, "c:");
+#endif
 	sanitize_append_path_element(path, "c");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "c_" SEPARATOR "c");
@@ -829,7 +886,9 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "\\c");
+	TEST_EQUAL(path, "c");
 	sanitize_append_path_element(path, ".");
+	TEST_EQUAL(path, "c");
 	sanitize_append_path_element(path, "c");
 	TEST_EQUAL(path, "c" SEPARATOR "c");
 
@@ -839,21 +898,25 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "\b");
+	TEST_EQUAL(path, "_");
 	sanitize_append_path_element(path, "filename");
 	TEST_EQUAL(path, "_" SEPARATOR "filename");
 
 	path.clear();
 	sanitize_append_path_element(path, "filename");
+	TEST_EQUAL(path, "filename");
 	sanitize_append_path_element(path, "\b");
 	TEST_EQUAL(path, "filename" SEPARATOR "_");
 
 	path.clear();
 	sanitize_append_path_element(path, "abc");
+	TEST_EQUAL(path, "abc");
 	sanitize_append_path_element(path, "");
 	TEST_EQUAL(path, "abc" SEPARATOR "_");
 
 	path.clear();
 	sanitize_append_path_element(path, "abc");
+	TEST_EQUAL(path, "abc");
 	sanitize_append_path_element(path, "   ");
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "abc");
@@ -863,6 +926,7 @@ TORRENT_TEST(sanitize_path)
 
 	path.clear();
 	sanitize_append_path_element(path, "");
+	TEST_EQUAL(path, "_");
 	sanitize_append_path_element(path, "abc");
 	TEST_EQUAL(path, "_" SEPARATOR "abc");
 
@@ -1057,7 +1121,9 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "/a/", true);
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "b", true);
+	TEST_EQUAL(path, "a" SEPARATOR "b");
 	sanitize_append_path_element(path, "c", true);
 	TEST_EQUAL(path, "a" SEPARATOR "b" SEPARATOR "c");
 
@@ -1067,18 +1133,26 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "a", true);
+	TEST_EQUAL(path, "a");
+	// with force_element, ".." is reverted and replaced with "_"
 	sanitize_append_path_element(path, "..", true);
+	TEST_EQUAL(path, "a" SEPARATOR "_");
 	sanitize_append_path_element(path, "c", true);
 	TEST_EQUAL(path, "a" SEPARATOR "_" SEPARATOR "c");
 
 	path.clear();
 	sanitize_append_path_element(path, "a", true);
+	TEST_EQUAL(path, "a");
 	sanitize_append_path_element(path, "..", true);
 	TEST_EQUAL(path, "a" SEPARATOR "_");
 
 	path.clear();
+	// "/.." leaves nothing once "/" is filtered, ".." is replaced with "_"
 	sanitize_append_path_element(path, "/..", true);
+	TEST_EQUAL(path, "_");
+	// with force_element, a lone "." is also reverted and replaced with "_"
 	sanitize_append_path_element(path, ".", true);
+	TEST_EQUAL(path, "_" SEPARATOR "_");
 	sanitize_append_path_element(path, "c", true);
 	TEST_EQUAL(path, "_" SEPARATOR "_" SEPARATOR "c");
 
@@ -1092,6 +1166,11 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "c:", true);
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "c_");
+#else
+	TEST_EQUAL(path, "c:");
+#endif
 	sanitize_append_path_element(path, "b", true);
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "c_" SEPARATOR "b");
@@ -1101,7 +1180,17 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "c:", true);
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "c_");
+#else
+	TEST_EQUAL(path, "c:");
+#endif
 	sanitize_append_path_element(path, ".", true);
+#ifdef TORRENT_WINDOWS
+	TEST_EQUAL(path, "c_" SEPARATOR "_");
+#else
+	TEST_EQUAL(path, "c:" SEPARATOR "_");
+#endif
 	sanitize_append_path_element(path, "c", true);
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "c_" SEPARATOR "_" SEPARATOR "c");
@@ -1111,7 +1200,9 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "\\c", true);
+	TEST_EQUAL(path, "c");
 	sanitize_append_path_element(path, ".", true);
+	TEST_EQUAL(path, "c" SEPARATOR "_");
 	sanitize_append_path_element(path, "c", true);
 	TEST_EQUAL(path, "c" SEPARATOR "_" SEPARATOR "c");
 
@@ -1121,21 +1212,25 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "\b", true);
+	TEST_EQUAL(path, "_");
 	sanitize_append_path_element(path, "filename", true);
 	TEST_EQUAL(path, "_" SEPARATOR "filename");
 
 	path.clear();
 	sanitize_append_path_element(path, "filename", true);
+	TEST_EQUAL(path, "filename");
 	sanitize_append_path_element(path, "\b", true);
 	TEST_EQUAL(path, "filename" SEPARATOR "_");
 
 	path.clear();
 	sanitize_append_path_element(path, "abc", true);
+	TEST_EQUAL(path, "abc");
 	sanitize_append_path_element(path, "", true);
 	TEST_EQUAL(path, "abc" SEPARATOR "_");
 
 	path.clear();
 	sanitize_append_path_element(path, "abc", true);
+	TEST_EQUAL(path, "abc");
 	sanitize_append_path_element(path, "   ", true);
 #ifdef TORRENT_WINDOWS
 	TEST_EQUAL(path, "abc" SEPARATOR "_");
@@ -1145,6 +1240,7 @@ TORRENT_TEST(sanitize_path_force)
 
 	path.clear();
 	sanitize_append_path_element(path, "", true);
+	TEST_EQUAL(path, "_");
 	sanitize_append_path_element(path, "abc", true);
 	TEST_EQUAL(path, "_" SEPARATOR "abc");
 
@@ -1258,6 +1354,144 @@ TORRENT_TEST(sanitize_path_colon)
 #else
 	TEST_EQUAL(path, "foo:bar");
 #endif
+}
+
+// sanitize_append_path_element() returns whether element was modified while
+// being appended to path. torrent_info.cpp relies on this to decide whether
+// a file's name can be borrowed as a string_view into the original buffer
+// (unmodified) or must be copied out of the constructed path (modified).
+TORRENT_TEST(sanitize_path_modified_flag)
+{
+	using lt::aux::sanitize_append_path_element;
+
+	// the common case: a clean element requires no sanitization
+	std::string path;
+	TEST_EQUAL(sanitize_append_path_element(path, "abc"), false);
+	TEST_EQUAL(sanitize_append_path_element(path, "def"), false);
+	TEST_EQUAL(path, "abc" SEPARATOR "def");
+
+	// same, with force_element = true, the mode used for per-file path
+	// components when loading a torrent
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "abc", true), false);
+	TEST_EQUAL(sanitize_append_path_element(path, "def", true), false);
+	TEST_EQUAL(path, "abc" SEPARATOR "def");
+
+	// a valid multi-byte utf-8 sequence is not a modification
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "filename\xc2\xa1"), false);
+
+	// dots that aren't the entire element are not a modification
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "a...b"), false);
+
+	// dropping a filtered character (path separator) is a modification
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "/a/"), true);
+
+	// substituting an invalid utf-8 sequence is a modification
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "filename\xc2"), true);
+
+	// an empty element is a modification (replaced with "_")
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, ""), true);
+
+	// a dot-only element is always a modification: dropped entirely when
+	// not forced, replaced with "_" when forced
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "..", false), true);
+	TEST_EQUAL(path, "");
+
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "..", true), true);
+	TEST_EQUAL(path, "_");
+
+	// a single "." with force_element = false is dropped without touching
+	// path at all, which still counts as a modification
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path, "."), true);
+	TEST_EQUAL(path, "");
+}
+
+// with append_only_if_modified = true, path is left completely untouched
+// (not even the separator is added) whenever the element needs no
+// modification. torrent_info.cpp relies on this to avoid copying a
+// filename into path only to immediately discard it in favor of a
+// borrowed string_view.
+TORRENT_TEST(sanitize_path_append_only_if_modified)
+{
+	using lt::aux::sanitize_append_path_element;
+
+	// unmodified, empty path to start with: path stays empty, not even "_"
+	std::string path;
+	TEST_EQUAL(sanitize_append_path_element(path, "abc", false, true), false);
+	TEST_EQUAL(path, "");
+
+	// unmodified, non-empty path to start with: path stays exactly as it
+	// was, no separator added either
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "abc", false, true), false);
+	TEST_EQUAL(path, "dir");
+
+	// same, with force_element = true (the mode used for the leaf/filename
+	// component when loading a torrent)
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "abc", true, true), false);
+	TEST_EQUAL(path, "dir");
+
+	// a valid multi-byte utf-8 sequence is unmodified: path stays untouched
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "filename\xc2\xa1", true, true), false);
+	TEST_EQUAL(path, "dir");
+
+	// dots that aren't the entire element are unmodified: path untouched
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "a...b", true, true), false);
+	TEST_EQUAL(path, "dir");
+
+	// a filtered character forces a real commit: path gets the separator
+	// and the sanitized content, exactly as without the flag
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "/a/", true, true), true);
+	TEST_EQUAL(path, "dir" SEPARATOR "a");
+
+	// an invalid utf-8 sequence also forces a commit
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "filename\xc2", true, true), true);
+	TEST_EQUAL(path, "dir" SEPARATOR "filename_");
+
+	// an empty element always commits (path can never end up empty when
+	// the caller needs a placeholder), regardless of the flag
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "", true, true), true);
+	TEST_EQUAL(path, "dir" SEPARATOR "_");
+
+	// dot-only element, force_element = true: always a modification,
+	// substituted with "_" without ever writing the raw dots
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "..", true, true), true);
+	TEST_EQUAL(path, "dir" SEPARATOR "_");
+
+	// dot-only element, force_element = false: always a modification,
+	// but reverted to nothing; path stays completely untouched
+	path = "dir";
+	TEST_EQUAL(sanitize_append_path_element(path, "..", false, true), true);
+	TEST_EQUAL(path, "dir");
+
+	// truncation past 240 characters is always a modification, even
+	// though every individual character was valid on its own
+	path.clear();
+	TEST_EQUAL(sanitize_append_path_element(path,
+				   "abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+				   "abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+				   "abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+				   "abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_"
+				   "abcdefghi_abcdefghi_abcdefghi_abcdefghi_abcdefghi_",
+				   true,
+				   true),
+		true);
+	TEST_CHECK(!path.empty());
 }
 
 TORRENT_TEST(verify_encoding)

--- a/test/test_torrents/invalid_name4.torrent
+++ b/test/test_torrents/invalid_name4.torrent
@@ -1,0 +1,1 @@
+d4:infod6:lengthi1e4:name1:/12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaaee


### PR DESCRIPTION
Optimize the common path in `sanitize_append_path_element()` where there's no sanitization needed. Rather than allocating a new string up-front and build it from scratch, only build a new string if we need to sanitize any characters.

speeds up loading torrents, e.g. on startup.