### PR TITLE
optimize file_entry size. to make file_storage use less memory

### DIFF
--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -152,9 +152,10 @@ namespace aux {
 		// that's why it's private, to keep people away from it
 		char const* name = nullptr;
 	public:
-		// the SHA-256 root of the merkle tree for this file
-		// this is a pointer into the .torrent file
-		char const* root = nullptr;
+		// offset into file_storage::m_info_section where this file's SHA-256
+		// merkle tree root is stored, or file_storage::no_root_hash if this
+		// file has none
+		std::int32_t root_offset = -1;
 
 		// the index into file_storage::m_paths. To get
 		// the full path to this file, concatenate the path
@@ -205,7 +206,15 @@ public:
 	TORRENT_UNEXPORT
 #endif
 	// hidden
+	// constructs a file_storage whose v2 (BEP 52) merkle tree root
+	// hashes, passed to add_file()/add_file_borrow() as pointers, or to
+	// add_file_borrow() as offsets, are resolved relative to
+	// ``info_section``. ``info_section`` must out-live this file_storage
+	// object and any copy of it.
 	file_storage();
+
+	// internal
+	TORRENT_UNEXPORT explicit file_storage(char const* info_section);
 
 	// hidden
 	~file_storage();
@@ -236,6 +245,11 @@ public:
 	// blocks per piece, which is more restrictive, at a block size of 16
 	// kiB (0x4000).
 	static constexpr std::int32_t max_piece_size = ((1 << 15) - 1) * 0x4000;
+
+	// sentinel value for the ``root_hash_offset`` argument to
+	// add_file_borrow(), meaning the file has no v2 (BEP 52)
+	// merkle tree root hash
+	static constexpr std::int32_t no_root_hash = -1;
 
 	// returns true if the piece length has been initialized
 	// on the file_storage. This is typically taken as a proxy
@@ -289,13 +303,19 @@ public:
 		//
 		// ``root_hash`` is an optional pointer to a 32 byte SHA-256 hash, being
 		// the merkle tree root hash for this file. This is only used for v2
-		// torrents. If the ``root hash`` is specified for one file, it has to
-		// be specified for all, otherwise this function will fail.
-		// Note that the buffer ``root_hash`` points to must out-live the
-		// file_storage object, it will not be copied. This parameter is only
-		// used when *loading* torrents, that already have their file hashes
-		// computed. When creating torrents, the file hashes will be computed by
-		// the piece hashes.
+		// torrents. If the root hash is specified for one file, it has to
+		// be specified for all, otherwise this function will fail. The
+		// pointer must point into the buffer this file_storage was
+		// constructed with (see the ``file_storage(char const*)``
+		// constructor); it will not be copied. This parameter is only used
+		// when *loading* torrents, that already have their file hashes
+		// computed. When creating torrents, the file hashes will be
+		// computed by the piece hashes.
+		//
+		// ``add_file_borrow()`` additionally has an overload taking
+		// ``root_hash_offset``, the byte offset of the root hash within
+		// that same buffer, instead of a pointer. Use
+		// ``file_storage::no_root_hash`` when there is none.
 		//
 		// If more files than one are added, certain restrictions to their paths
 		// apply. In a multi-file file storage (torrent), all files must share
@@ -319,13 +339,23 @@ public:
 			string_view symlink_path = string_view(),
 			char const* root_hash = nullptr);
 #endif
+#if TORRENT_ABI_VERSION < 5
+		TORRENT_DEPRECATED
+		TORRENT_UNEXPORT void add_file_borrow(string_view filename,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags,
+			std::int64_t mtime,
+			string_view symlink_path,
+			char const* root_hash);
+#endif
 		TORRENT_UNEXPORT void add_file_borrow(string_view filename,
 			std::string const& path,
 			std::int64_t file_size,
 			file_flags_t file_flags = {},
 			std::int64_t mtime = 0,
 			string_view symlink_path = string_view(),
-			char const* root_hash = nullptr);
+			std::int32_t root_hash_offset = no_root_hash);
 		void add_file(std::string const& path, std::int64_t file_size
 			, file_flags_t file_flags = {}
 			, std::time_t mtime = 0, string_view symlink_path = string_view()
@@ -343,6 +373,17 @@ public:
 			string_view symlink_path = string_view(),
 			char const* root_hash = nullptr);
 #endif
+#if TORRENT_ABI_VERSION < 5
+		TORRENT_DEPRECATED
+		TORRENT_UNEXPORT void add_file_borrow(error_code& ec,
+			string_view filename,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags,
+			std::int64_t mtime,
+			string_view symlink_path,
+			char const* root_hash);
+#endif
 		// internal
 		// these overloads report failures through the ``ec`` reference
 		// rather than throwing. ``add_file_borrow()`` does not copy the
@@ -357,7 +398,7 @@ public:
 			file_flags_t file_flags = {},
 			std::int64_t mtime = 0,
 			string_view symlink_path = string_view(),
-			char const* root_hash = nullptr);
+			std::int32_t root_hash_offset = no_root_hash);
 		void add_file(error_code& ec, std::string const& path, std::int64_t file_size
 			, file_flags_t file_flags = {}
 			, std::time_t mtime = 0, string_view symlink_path = string_view()
@@ -531,8 +572,9 @@ public:
 		// ``root()`` returns the SHA-256 merkle tree root of the specified file,
 		// in case this is a v2 torrent. Otherwise returns zeros.
 		// ``root_ptr()`` returns a pointer to the SHA-256 merkle tree root hash
-		// for the specified file. The pointer points into storage referred to
-		// when the file was added, it is not owned by this object. Torrents
+		// for the specified file. The pointer points into the buffer this
+		// file_storage was constructed with (see the ``file_storage(char
+		// const*)`` constructor), it is not owned by this object. Torrents
 		// that are not v2 torrents return nullptr.
 		//
 		// The ``mtime()`` is the modification time is the posix
@@ -698,14 +740,21 @@ public:
 		void canonicalize_impl(bool backwards_compatible);
 #endif
 
-		void add_file_borrow_impl(error_code& ec, string_view filename
-			, std::string const& path, std::int64_t const file_size
-			, file_flags_t const file_flags
+		void add_file_borrow_impl(error_code& ec,
+			string_view filename,
+			std::string const& path,
+			std::int64_t const file_size,
+			file_flags_t const file_flags,
 #if TORRENT_ABI_VERSION < 4
-			, char const* filehash
+			char const* filehash,
 #endif
-			, std::int64_t const mtime, string_view const symlink_path
-			, char const* root_hash);
+			std::int64_t const mtime,
+			string_view const symlink_path,
+			std::int32_t const root_hash_offset);
+
+		// converts a pointer into m_info_section into an offset relative to
+		// m_info_section, or no_root_hash if root_hash is nullptr
+		std::int32_t root_hash_to_offset(char const* root_hash) const;
 
 		std::string internal_file_path(file_index_t index) const;
 		file_index_t last_file() const noexcept;
@@ -770,6 +819,12 @@ public:
 
 		// the sum of all non-pad file sizes
 		std::int64_t m_size_on_disk = 0;
+
+		// the buffer that aux::file_entry::root_offset values are relative
+		// to. Borrowed, not owned by this object. This is the same pointer as
+		// torrent_info::m_info_section, when this file_storage was populated
+		// while parsing a .torrent file.
+		char const* m_info_section = nullptr;
 };
 
 TORRENT_VERSION_NAMESPACE_4_END

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -56,6 +56,9 @@ namespace {
 TORRENT_VERSION_NAMESPACE_4
 
 	file_storage::file_storage() = default;
+	file_storage::file_storage(char const* const info_section)
+		: m_info_section(info_section)
+	{}
 	file_storage::~file_storage() = default;
 
 	// even though this copy constructor and the move special member
@@ -358,7 +361,7 @@ namespace aux {
 		, hidden_attribute(fe.hidden_attribute)
 		, executable_attribute(fe.executable_attribute)
 		, symlink_attribute(fe.symlink_attribute)
-		, root(fe.root)
+		, root_offset(fe.root_offset)
 		, path_index(fe.path_index)
 	{
 		bool const borrow = fe.name_len != name_is_owned;
@@ -376,7 +379,7 @@ namespace aux {
 		, executable_attribute(fe.executable_attribute)
 		, symlink_attribute(fe.symlink_attribute)
 		, name(fe.name)
-		, root(fe.root)
+		, root_offset(fe.root_offset)
 		, path_index(fe.path_index)
 	{
 		fe.name_len = 0;
@@ -399,7 +402,7 @@ namespace aux {
 		if (name_len == name_is_owned) delete[] name;
 
 		name = fe.name;
-		root = fe.root;
+		root_offset = fe.root_offset;
 		name_len = fe.name_len;
 
 		fe.name_len = 0;
@@ -707,12 +710,19 @@ TORRENT_VERSION_NAMESPACE_4
 		, file_flags_t const file_flags, std::time_t const mtime, string_view const symlink_path
 		, char const* root_hash)
 	{
+		std::int32_t const root_hash_offset = root_hash_to_offset(root_hash);
 		error_code ec;
-		add_file_borrow_impl(ec, {}, path, file_size, file_flags
+		add_file_borrow_impl(ec,
+			{},
+			path,
+			file_size,
+			file_flags,
 #if TORRENT_ABI_VERSION < 4
-			, nullptr
+			nullptr,
 #endif
-			, mtime, symlink_path, root_hash);
+			mtime,
+			symlink_path,
+			root_hash_offset);
 		if (ec) aux::throw_ex<system_error>(ec);
 	}
 
@@ -723,27 +733,51 @@ TORRENT_VERSION_NAMESPACE_4
 		, std::int64_t const mtime, string_view const symlink_path
 		, char const* root_hash)
 	{
+		std::int32_t const root_hash_offset = root_hash_to_offset(root_hash);
 		error_code ec;
-		add_file_borrow_impl(ec, filename, path, file_size
-			, file_flags
-			, filehash
-			, mtime
-			, symlink_path, root_hash);
+		add_file_borrow_impl(ec,
+			filename,
+			path,
+			file_size,
+			file_flags,
+			filehash,
+			mtime,
+			symlink_path,
+			root_hash_offset);
 		if (ec) aux::throw_ex<system_error>(ec);
 	}
 #endif
+#if TORRENT_ABI_VERSION < 5
 	void file_storage::add_file_borrow(string_view filename
 		, std::string const& path, std::int64_t const file_size
 		, file_flags_t const file_flags, std::int64_t const mtime
 		, string_view const symlink_path, char const* root_hash)
 	{
-		error_code ec;
-		add_file_borrow_impl(ec, filename, path, file_size
-			, file_flags
-#if TORRENT_ABI_VERSION < 4
-			, nullptr
+		std::int32_t const root_hash_offset = root_hash_to_offset(root_hash);
+		add_file_borrow(
+			filename, path, file_size, file_flags, mtime, symlink_path, root_hash_offset);
+	}
 #endif
-			, mtime, symlink_path, root_hash);
+	void file_storage::add_file_borrow(string_view filename,
+		std::string const& path,
+		std::int64_t const file_size,
+		file_flags_t const file_flags,
+		std::int64_t const mtime,
+		string_view const symlink_path,
+		std::int32_t const root_hash_offset)
+	{
+		error_code ec;
+		add_file_borrow_impl(ec,
+			filename,
+			path,
+			file_size,
+			file_flags,
+#if TORRENT_ABI_VERSION < 4
+			nullptr,
+#endif
+			mtime,
+			symlink_path,
+			root_hash_offset);
 		if (ec) aux::throw_ex<system_error>(ec);
 	}
 #endif // BOOST_NO_EXCEPTIONS
@@ -752,11 +786,18 @@ TORRENT_VERSION_NAMESPACE_4
 		, std::int64_t const file_size, file_flags_t const file_flags, std::time_t const mtime
 		, string_view symlink_path, char const* root_hash)
 	{
-		add_file_borrow_impl(ec, {}, path, file_size, file_flags
+		std::int32_t const root_hash_offset = root_hash_to_offset(root_hash);
+		add_file_borrow_impl(ec,
+			{},
+			path,
+			file_size,
+			file_flags,
 #if TORRENT_ABI_VERSION < 4
-			, nullptr
+			nullptr,
 #endif
-			, mtime, symlink_path, root_hash);
+			mtime,
+			symlink_path,
+			root_hash_offset);
 	}
 
 #if TORRENT_ABI_VERSION < 4
@@ -766,31 +807,69 @@ TORRENT_VERSION_NAMESPACE_4
 		, std::int64_t const mtime, string_view const symlink_path
 		, char const* root_hash)
 	{
-		add_file_borrow_impl(ec, filename, path, file_size, file_flags
-			, filehash, mtime, symlink_path, root_hash);
+		std::int32_t const root_hash_offset = root_hash_to_offset(root_hash);
+		add_file_borrow_impl(ec,
+			filename,
+			path,
+			file_size,
+			file_flags,
+			filehash,
+			mtime,
+			symlink_path,
+			root_hash_offset);
 	}
 #endif
-
+#if TORRENT_ABI_VERSION < 5
 	void file_storage::add_file_borrow(error_code& ec, string_view filename
 		, std::string const& path, std::int64_t const file_size
 		, file_flags_t const file_flags, std::int64_t const mtime
 		, string_view const symlink_path, char const* root_hash)
 	{
-		add_file_borrow_impl(ec, filename, path, file_size, file_flags
-#if TORRENT_ABI_VERSION < 4
-			, nullptr
+		std::int32_t const root_hash_offset = root_hash_to_offset(root_hash);
+		add_file_borrow(
+			ec, filename, path, file_size, file_flags, mtime, symlink_path, root_hash_offset);
+	}
 #endif
-			, mtime, symlink_path, root_hash);
+
+	void file_storage::add_file_borrow(error_code& ec,
+		string_view filename,
+		std::string const& path,
+		std::int64_t const file_size,
+		file_flags_t const file_flags,
+		std::int64_t const mtime,
+		string_view const symlink_path,
+		std::int32_t const root_hash_offset)
+	{
+		add_file_borrow_impl(ec,
+			filename,
+			path,
+			file_size,
+			file_flags,
+#if TORRENT_ABI_VERSION < 4
+			nullptr,
+#endif
+			mtime,
+			symlink_path,
+			root_hash_offset);
 	}
 
-	void file_storage::add_file_borrow_impl(error_code& ec, string_view filename
-		, std::string const& path, std::int64_t const file_size
-		, file_flags_t const file_flags
+	std::int32_t file_storage::root_hash_to_offset(char const* root_hash) const
+	{
+		return root_hash ? aux::numeric_cast<std::int32_t>(root_hash - m_info_section)
+						 : no_root_hash;
+	}
+
+	void file_storage::add_file_borrow_impl(error_code& ec,
+		string_view filename,
+		std::string const& path,
+		std::int64_t const file_size,
+		file_flags_t const file_flags,
 #if TORRENT_ABI_VERSION < 4
-		, char const* filehash
+		char const* filehash,
 #endif
-		, std::int64_t const mtime, string_view const symlink_path
-		, char const* root_hash)
+		std::int64_t const mtime,
+		string_view const symlink_path,
+		std::int32_t const root_hash_offset)
 	{
 		TORRENT_ASSERT_PRECOND(file_size >= 0);
 		TORRENT_ASSERT_PRECOND(!is_complete(filename));
@@ -840,7 +919,7 @@ TORRENT_VERSION_NAMESPACE_4
 		// don't have a root hash and can be either v1 or v2
 		if (symlink_path.empty() && file_size > 0)
 		{
-			bool const v2 = (root_hash != nullptr);
+			bool const v2 = (root_hash_offset != no_root_hash);
 			// This condition is true of all files we've added so far have been
 			// symlinks. i.e. this is the first "real" file we're adding.
 			// or if m_total_size == 0, all files we've added so far have been
@@ -879,7 +958,8 @@ TORRENT_VERSION_NAMESPACE_4
 		e.hidden_attribute = bool(file_flags & file_storage::flag_hidden);
 		e.executable_attribute = bool(file_flags & file_storage::flag_executable);
 		e.symlink_attribute = bool(file_flags & file_storage::flag_symlink);
-		e.root = root_hash;
+		TORRENT_ASSERT(root_hash_offset == no_root_hash || m_info_section != nullptr);
+		e.root_offset = root_hash_offset;
 
 #if TORRENT_ABI_VERSION < 4
 		if (filehash)
@@ -982,14 +1062,21 @@ TORRENT_VERSION_NAMESPACE_4
 	sha256_hash file_storage::root(file_index_t const index) const
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t{} && index < end_file());
-		if (m_files[index].root == nullptr) return {};
-		return sha256_hash(m_files[index].root);
+		char const* const p = root_ptr(index);
+		if (p == nullptr)
+			return {};
+		return sha256_hash(p);
 	}
 
 	char const* file_storage::root_ptr(file_index_t const index) const
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t{} && index < end_file());
-		return m_files[index].root;
+		std::int32_t const off = m_files[index].root_offset;
+		if (off == no_root_hash)
+			return nullptr;
+		TORRENT_ASSERT(off >= 0);
+		TORRENT_ASSERT(m_info_section != nullptr);
+		return m_info_section + off;
 	}
 
 	std::string file_storage::symlink(file_index_t const index) const
@@ -1366,6 +1453,7 @@ namespace {
 		swap(ti.m_name, m_name);
 		swap(ti.m_total_size, m_total_size);
 		swap(ti.m_size_on_disk, m_size_on_disk);
+		swap(ti.m_info_section, m_info_section);
 		swap(ti.m_num_pieces, m_num_pieces);
 		swap(ti.m_piece_length, m_piece_length);
 		swap(ti.m_v2, m_v2);

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -365,16 +365,13 @@ namespace {
 		return ret + p.list_size();
 	}
 
-	bool extract_single_file2(
-		bdecode_node const& dict,
+	bool extract_single_file2(bdecode_node const& dict,
 		file_storage& files,
 		std::string const& path,
 		string_view const name,
 		std::ptrdiff_t const info_offset,
-		char const* info_buffer,
 		int const max_directory_depth,
-		error_code& ec
-	)
+		error_code& ec)
 	{
 		if (dict.type() != bdecode_node::dict_t)
 		{
@@ -408,7 +405,7 @@ namespace {
 
 		auto const mtime = static_cast<std::time_t>(dict.dict_find_int_value("mtime", 0));
 
-		char const* pieces_root = nullptr;
+		std::int32_t pieces_root_offset = file_storage::no_root_hash;
 
 		std::string symlink_path;
 		if (file_flags & file_storage::flag_symlink)
@@ -449,16 +446,19 @@ namespace {
 				ec = errors::torrent_missing_pieces_root;
 				return false;
 			}
-			pieces_root = info_buffer + (root.string_offset() - info_offset);
-			if (sha256_hash(pieces_root).is_all_zeros())
+			if (sha256_hash(root.string_value().data()).is_all_zeros())
 			{
 				ec = errors::torrent_missing_pieces_root;
 				return false;
 			}
+			std::ptrdiff_t const off = root.string_offset() - info_offset;
+			TORRENT_ASSERT(off >= 0);
+			TORRENT_ASSERT(off < std::numeric_limits<std::int32_t>::max());
+			pieces_root_offset = static_cast<std::int32_t>(off);
 		}
 
-		files.add_file_borrow(ec, name, path, file_size, file_flags
-			, mtime, symlink_path, pieces_root);
+		files.add_file_borrow(
+			ec, name, path, file_size, file_flags, mtime, symlink_path, pieces_root_offset);
 		return !ec;
 	}
 
@@ -708,16 +708,13 @@ namespace {
 					filename = {};
 				}
 
-				if (!extract_single_file2(
-						e.second.dict_at(0).second,
+				if (!extract_single_file2(e.second.dict_at(0).second,
 						target,
 						path,
 						filename,
 						info_offset,
-						info_buffer,
 						max_directory_depth,
-						ec
-					))
+						ec))
 				{
 					return false;
 				}
@@ -1216,7 +1213,7 @@ TORRENT_VERSION_NAMESPACE_4
 			return;
 		}
 
-		file_storage files;
+		file_storage files(m_info_section.get());
 		files.set_piece_length(static_cast<int>(piece_length));
 
 		// extract file name (or the directory name if it's a multi file libtorrent)

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -21,6 +21,29 @@ using namespace lt;
 
 namespace {
 
+// builds one buffer holding the concatenated bytes of each 32-byte SHA-256
+// hash literal in ``hashes``, and returns it together with each hash's
+// offset within the buffer. Used by tests exercising file_storage's v2
+// root-hash offsets, which must all resolve against a single shared buffer.
+std::pair<std::vector<char>, std::vector<std::int32_t>> build_root_hashes(
+	std::initializer_list<char const*> hashes)
+{
+	std::vector<char> buf;
+	std::vector<std::int32_t> offsets;
+	for (char const* h : hashes)
+	{
+		offsets.push_back(std::int32_t(buf.size()));
+		buf.insert(buf.end(), h, h + sha256_hash::size());
+	}
+	return {std::move(buf), std::move(offsets)};
+}
+
+// a single reusable root hash, for tests that only care that some v2 root
+// hash is present (to trigger v2 file layout rules), not its actual value
+char const dummy_root_hash[] = "01234567890123456789012345678901";
+
+file_storage make_v2_storage() { return file_storage(dummy_root_hash); }
+
 void setup_test_storage(file_storage& st)
 {
 	st.add_file(combine_path("test", "a"), 10000);
@@ -169,20 +192,29 @@ TORRENT_TEST(rename_file2)
 TORRENT_TEST(pointer_offset)
 {
 	// test applying pointer offset
-	file_storage st;
-	st.set_piece_length(16 * 1024);
 	char const filename[] = "test1fooba";
 #if TORRENT_ABI_VERSION < 4
 	char const filehash[] = "01234567890123456789-----";
 #endif
 	char const roothash[] = "01234567890123456789012345678912-----";
 
-	st.add_file_borrow({filename, 5}, combine_path("test-torrent-1", "test1")
-		, 10, file_flags_t{}
+	file_storage st{roothash};
+	st.set_piece_length(16 * 1024);
+
+	st.add_file_borrow({filename, 5},
+		combine_path("test-torrent-1", "test1"),
+		10,
+		file_flags_t{},
 #if TORRENT_ABI_VERSION < 4
-		, filehash
+		filehash,
 #endif
-		, 0, {}, roothash);
+		0,
+		{},
+#if TORRENT_ABI_VERSION < 4
+		roothash);
+#else
+		0);
+#endif
 
 	// test filename_ptr and filename_len
 #if TORRENT_ABI_VERSION <= 2
@@ -962,24 +994,24 @@ TORRENT_TEST(large_filename)
 
 TORRENT_TEST(piece_size2)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
 	// passing in a root hash (the last argument) makes it follow v2 rules, to
 	// add pad files
-	fs.add_file("test/0", 0x5000, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/0", 0x5000, {}, 0, {}, dummy_root_hash);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 1);
 	TEST_EQUAL(fs.piece_size2(0_piece), 0x5000);
 
-	fs.add_file("test/1", 0x2000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/2", 0x8000, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/1", 0x2000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/2", 0x8000, {}, 0, {}, dummy_root_hash);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 3);
 	TEST_EQUAL(fs.piece_size2(2_piece), 0x8000);
 
-	fs.add_file("test/3", 8, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/3", 8, {}, 0, {}, dummy_root_hash);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 4);
@@ -988,7 +1020,7 @@ TORRENT_TEST(piece_size2)
 	TEST_EQUAL(fs.piece_size2(2_piece), 0x8000);
 	TEST_EQUAL(fs.piece_size2(3_piece), 8);
 
-	fs.add_file("test/4", 0x8001, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/4", 0x8001, {}, 0, {}, dummy_root_hash);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 6);
@@ -1004,14 +1036,14 @@ TORRENT_TEST(piece_size2)
 #if TORRENT_ABI_VERSION < 4
 TORRENT_TEST(file_num_blocks)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x5000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/1", 0x2000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/2", 0x8000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/3", 0x8001, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/4", 1, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/5", 0, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/0", 0x5000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/1", 0x2000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/2", 0x8000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/3", 0x8001, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/4", 1, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/5", 0, {}, 0, {}, dummy_root_hash);
 
 	fs.canonicalize();
 
@@ -1036,14 +1068,14 @@ TORRENT_TEST(file_num_blocks)
 
 TORRENT_TEST(file_num_pieces)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x5000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/1", 0x2000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/2", 0x8000, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/3", 0x8001, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/4", 1, {}, 0, {}, "01234567890123456789012345678901");
-	fs.add_file("test/5", 0, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/0", 0x5000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/1", 0x2000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/2", 0x8000, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/3", 0x8001, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/4", 1, {}, 0, {}, dummy_root_hash);
+	fs.add_file("test/5", 0, {}, 0, {}, dummy_root_hash);
 
 	fs.canonicalize();
 
@@ -1070,18 +1102,18 @@ TORRENT_TEST(file_num_pieces)
 namespace {
 int first_piece_node(int piece_size, int file_size)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(piece_size);
-	fs.add_file("test/0", file_size, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/0", file_size, {}, 0, {}, dummy_root_hash);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs.file_first_piece_node(file_index_t{0});
 }
 
 int first_block_node(int file_size)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x10000);
-	fs.add_file("test/0", file_size, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/0", file_size, {}, 0, {}, dummy_root_hash);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs.file_first_block_node(file_index_t{0});
 }
@@ -1136,23 +1168,23 @@ TORRENT_TEST(file_first_block_node)
 
 TORRENT_TEST(mismatching_file_hash1)
 {
-	file_storage st;
+	file_storage st = make_v2_storage();
 	st.set_piece_length(0x4000);
 
 	error_code ec;
 	st.add_file(ec, combine_path("test", "a"), 10000);
 	TEST_CHECK(!ec);
-	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, "abababababababababababababababab");
+	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, dummy_root_hash);
 	TEST_CHECK(ec);
 }
 
 TORRENT_TEST(mismatching_file_hash2)
 {
-	file_storage st;
+	file_storage st = make_v2_storage();
 	st.set_piece_length(0x4000);
 
 	error_code ec;
-	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, "abababababababababababababababab");
+	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, dummy_root_hash);
 	TEST_CHECK(!ec);
 	st.add_file(ec, combine_path("test", "a"), 10000);
 	TEST_CHECK(ec);
@@ -1160,21 +1192,21 @@ TORRENT_TEST(mismatching_file_hash2)
 
 TORRENT_TEST(v2_detection_1)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
 	// passing in a root hash (the last argument) makes it follow v2 rules, to
 	// add pad files
 	fs.add_file("test/0", 0x5000, {}, 0, "symlink-test-1");
 	fs.add_file("test/1", 0x5000, {}, 0, "symlink-test-2");
 
-	fs.add_file("test/2", 0x2000, {}, 0, {}, "01234567890123456789012345678901");
+	fs.add_file("test/2", 0x2000, {}, 0, {}, dummy_root_hash);
 	// it's an error to add a v1 file to a v2 torrent
 	TEST_THROW(fs.add_file("test/3", 0x2000));
 }
 
 TORRENT_TEST(v2_detection_2)
 {
-	file_storage fs;
+	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
 	// passing in a root hash (the last argument) makes it follow v2 rules, to
 	// add pad files
@@ -1184,7 +1216,7 @@ TORRENT_TEST(v2_detection_2)
 	fs.add_file("test/2", 0x2000);
 
 	// it's an error to add a v1 file to a v2 torrent
-	TEST_THROW(fs.add_file("test/3", 0x2000, {}, 0, {}, "01234567890123456789012345678901"));
+	TEST_THROW(fs.add_file("test/3", 0x2000, {}, 0, {}, dummy_root_hash));
 }
 
 TORRENT_TEST(blocks_in_piece2)
@@ -1197,9 +1229,9 @@ TORRENT_TEST(blocks_in_piece2)
 
 	for (auto t : piece_sizes)
 	{
-		file_storage fs;
+		file_storage fs = make_v2_storage();
 		fs.set_piece_length(0x8000);
-		fs.add_file("test/0", t.first, {}, 0, {}, "01234567890123456789012345678901");
+		fs.add_file("test/0", t.first, {}, 0, {}, dummy_root_hash);
 		fs.set_num_pieces(aux::calc_num_pieces(fs));
 		TEST_EQUAL(fs.blocks_in_piece2(0_piece), t.second);
 	}
@@ -1207,12 +1239,18 @@ TORRENT_TEST(blocks_in_piece2)
 
 TORRENT_TEST(file_index_for_root)
 {
-	file_storage fs;
+	auto [buf, off] = build_root_hashes({
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+		"33333333333333333333333333333333",
+		"44444444444444444444444444444444",
+	});
+	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x8000, {}, 0, {}, "11111111111111111111111111111111");
-	fs.add_file("test/1", 0x8000, {}, 0, {}, "22222222222222222222222222222222");
-	fs.add_file("test/2", 0x8000, {}, 0, {}, "33333333333333333333333333333333");
-	fs.add_file("test/3", 0x8000, {}, 0, {}, "44444444444444444444444444444444");
+	fs.add_file("test/0", 0x8000, {}, 0, {}, buf.data() + off[0]);
+	fs.add_file("test/1", 0x8000, {}, 0, {}, buf.data() + off[1]);
+	fs.add_file("test/2", 0x8000, {}, 0, {}, buf.data() + off[2]);
+	fs.add_file("test/3", 0x8000, {}, 0, {}, buf.data() + off[3]);
 
 	TEST_EQUAL(fs.file_index_for_root(sha256_hash("11111111111111111111111111111111")), file_index_t{0});
 	TEST_EQUAL(fs.file_index_for_root(sha256_hash("22222222222222222222222222222222")), file_index_t{1});
@@ -1223,21 +1261,27 @@ TORRENT_TEST(file_index_for_root)
 
 TORRENT_TEST(size_on_disk)
 {
-	file_storage fs;
+	auto [buf, off] = build_root_hashes({
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+		"33333333333333333333333333333333",
+		"44444444444444444444444444444444",
+	});
+	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
 
 	std::int64_t size_on_disk = 0;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/0", 100, {}, 0, {}, "11111111111111111111111111111111");
+	fs.add_file("test/0", 100, {}, 0, {}, buf.data() + off[0]);
 	size_on_disk += 100;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/1", 800, {}, 0, {}, "22222222222222222222222222222222");
+	fs.add_file("test/1", 800, {}, 0, {}, buf.data() + off[1]);
 	size_on_disk += 800;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/2", 333, {}, 0, {}, "33333333333333333333333333333333");
+	fs.add_file("test/2", 333, {}, 0, {}, buf.data() + off[2]);
 	size_on_disk += 333;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/3", 1337, {}, 0, {}, "44444444444444444444444444444444");
+	fs.add_file("test/3", 1337, {}, 0, {}, buf.data() + off[3]);
 	size_on_disk += 1337;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
 	TEST_CHECK(fs.size_on_disk() < fs.total_size());
@@ -1245,19 +1289,24 @@ TORRENT_TEST(size_on_disk)
 
 TORRENT_TEST(size_on_disk_explicit_pads)
 {
-	file_storage fs;
+	auto [buf, off] = build_root_hashes({
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+		"33333333333333333333333333333333",
+	});
+	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
 
 	std::int64_t size_on_disk = 0;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/0", 100, {}, 0, {}, "11111111111111111111111111111111");
+	fs.add_file("test/0", 100, {}, 0, {}, buf.data() + off[0]);
 	size_on_disk += 100;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
 
 	// when adding a pad file, size_on_disk does not increment
-	fs.add_file("test/pad/0", 80, file_storage::flag_pad_file, 0, {}, "22222222222222222222222222222222");
+	fs.add_file("test/pad/0", 80, file_storage::flag_pad_file, 0, {}, buf.data() + off[1]);
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/2", 333, {}, 0, {}, "33333333333333333333333333333333");
+	fs.add_file("test/2", 333, {}, 0, {}, buf.data() + off[2]);
 	size_on_disk += 333;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
 	TEST_CHECK(fs.size_on_disk() < fs.total_size());
@@ -1265,12 +1314,18 @@ TORRENT_TEST(size_on_disk_explicit_pads)
 
 TORRENT_TEST(test_renamed_files)
 {
-	file_storage fs;
+	auto [buf, off] = build_root_hashes({
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+		"33333333333333333333333333333333",
+		"44444444444444444444444444444444",
+	});
+	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x8000, {}, 0, {}, "11111111111111111111111111111111");
-	fs.add_file("test/1", 0x8000, {}, 0, {}, "22222222222222222222222222222222");
-	fs.add_file("test/2/1", 0x8000, {}, 0, {}, "33333333333333333333333333333333");
-	fs.add_file("test/2/2", 0x8000, {}, 0, {}, "44444444444444444444444444444444");
+	fs.add_file("test/0", 0x8000, {}, 0, {}, buf.data() + off[0]);
+	fs.add_file("test/1", 0x8000, {}, 0, {}, buf.data() + off[1]);
+	fs.add_file("test/2/1", 0x8000, {}, 0, {}, buf.data() + off[2]);
+	fs.add_file("test/2/2", 0x8000, {}, 0, {}, buf.data() + off[3]);
 
 	renamed_files rf;
 
@@ -1324,12 +1379,18 @@ TORRENT_TEST(test_renamed_files)
 
 TORRENT_TEST(renamed_files_round_trip)
 {
-	file_storage fs;
+	auto [buf, off] = build_root_hashes({
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+		"33333333333333333333333333333333",
+		"44444444444444444444444444444444",
+	});
+	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x8000, {}, 0, {}, "11111111111111111111111111111111");
-	fs.add_file("test/1", 0x8000, {}, 0, {}, "22222222222222222222222222222222");
-	fs.add_file("test/2/1", 0x8000, {}, 0, {}, "33333333333333333333333333333333");
-	fs.add_file("test/2/2", 0x8000, {}, 0, {}, "44444444444444444444444444444444");
+	fs.add_file("test/0", 0x8000, {}, 0, {}, buf.data() + off[0]);
+	fs.add_file("test/1", 0x8000, {}, 0, {}, buf.data() + off[1]);
+	fs.add_file("test/2/1", 0x8000, {}, 0, {}, buf.data() + off[2]);
+	fs.add_file("test/2/2", 0x8000, {}, 0, {}, buf.data() + off[3]);
 
 	renamed_files rf;
 


### PR DESCRIPTION
the file root (the v2 merkle tree root hash for files) always live in the info-section of the torrent. The pointer to the hash we store today can just as well be expressed as an offset into the info section. This saves 8 bytes per file.