### PR TITLE
File storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ DOCS_PAGES = \
   docs/upgrade_to_1.2-ref.html    \
   docs/upgrade_to_2.0-ref.html    \
   docs/upgrade_to_2.1-ref.html    \
+  docs/upgrade_to_2.2-ref.html    \
   docs/security-audit.html        \
   docs/reference.html             \
   docs/reference-Core.html        \

--- a/bindings/python/src/create_torrent.cpp
+++ b/bindings/python/src/create_torrent.cpp
@@ -134,19 +134,14 @@ void bind_create_torrent()
 		.add_property("symlink", &lt::create_file_entry::symlink);
 
 	{
-		scope s = class_<create_torrent>("create_torrent", no_init)
+		scope s = class_<create_torrent, boost::noncopyable>("create_torrent", no_init)
 					  .def(init<std::vector<lt::create_file_entry>, int, create_flags_t>(
-						  (arg("files"), arg("piece_size") = 0, arg("flags") = 0)
-					  ))
+						  (arg("files"), arg("piece_size") = 0, arg("flags") = 0)))
 #if TORRENT_ABI_VERSION < 4
-					  .def(
-						  "__init__",
-						  make_constructor(
-							  &file_storage_constructor,
+					  .def("__init__",
+						  make_constructor(&file_storage_constructor,
 							  default_call_policies(),
-							  (arg("storage"), arg("piece_size") = 0, arg("flags") = 0)
-						  )
-					  )
+							  (arg("storage"), arg("piece_size") = 0, arg("flags") = 0)))
 					  .def("__init__", make_constructor(&torrent_info_constructor))
 #endif
 

--- a/bindings/python/src/file_storage.cpp
+++ b/bindings/python/src/file_storage.cpp
@@ -218,35 +218,29 @@ void bind_file_storage()
 {
 	{
 		scope s =
-			class_<file_storage>("file_storage")
+			class_<file_storage>("file_storage", no_init)
 				.def("is_valid", &file_storage::is_valid)
-				.def(
-					"add_file",
+				.def("add_file",
 					add_file0,
 					(arg("path"),
-					 arg("size"),
-					 arg("flags") = 0,
-					 arg("mtime") = 0,
-					 arg("linkpath") = "")
-				)
-				.def(
-					"add_file",
+						arg("size"),
+						arg("flags") = 0,
+						arg("mtime") = 0,
+						arg("linkpath") = ""))
+				.def("add_file",
 					add_file1,
 					(arg("path"),
-					 arg("size"),
-					 arg("flags") = 0,
-					 arg("mtime") = 0,
-					 arg("linkpath") = "")
-				)
-				.def(
-					"add_file",
+						arg("size"),
+						arg("flags") = 0,
+						arg("mtime") = 0,
+						arg("linkpath") = ""))
+				.def("add_file",
 					add_file2,
 					(arg("path"),
-					 arg("size"),
-					 arg("flags") = 0,
-					 arg("mtime") = 0,
-					 arg("linkpath") = "")
-				)
+						arg("size"),
+						arg("flags") = 0,
+						arg("mtime") = 0,
+						arg("linkpath") = ""))
 				.def("num_files", &file_storage::num_files)
 #if TORRENT_ABI_VERSION == 1
 				.def("at", depr(file_storage_at))
@@ -266,11 +260,15 @@ void bind_file_storage()
 				.def("file_flags", &wrap_file_check<file_flags_t, &file_storage::file_flags>)
 
 				.def("file_index_for_root", &file_storage::file_index_for_root)
-				.def("piece_index_at_file", &wrap_file_check<piece_index_t, &file_storage::piece_index_at_file>)
-				.def("file_index_at_piece", &wrap_piece_check<file_index_t, &file_storage::file_index_at_piece>)
-				.def("last_file_index_at_piece", &wrap_piece_check<file_index_t, &file_storage::last_file_index_at_piece>)
+				.def("piece_index_at_file",
+					&wrap_file_check<piece_index_t, &file_storage::piece_index_at_file>)
+				.def("file_index_at_piece",
+					&wrap_piece_check<file_index_t, &file_storage::file_index_at_piece>)
+				.def("last_file_index_at_piece",
+					&wrap_piece_check<file_index_t, &file_storage::last_file_index_at_piece>)
 				.def("file_index_at_offset", &file_storage::file_index_at_offset)
-				.def("file_absolute_path", &wrap_file_check<bool, &file_storage::file_absolute_path>)
+				.def(
+					"file_absolute_path", &wrap_file_check<bool, &file_storage::file_absolute_path>)
 
 				.def("v2", &file_storage::v2)
 

--- a/bindings/python/tests/create_torrent_test.py
+++ b/bindings/python/tests/create_torrent_test.py
@@ -68,75 +68,90 @@ class EnumTest(unittest.TestCase):
             self.assertIsInstance(lt.create_torrent_flags_t.merkle, int)
 
 
+def _build_layout(
+    files: List[tuple],
+    flags: int = lt.create_torrent.v1_only,
+    piece_size: int = 0,
+) -> "lt.torrent_info":
+    entries = []
+    for item in files:
+        path, size = item[0], item[1]
+        symlink = item[2] if len(item) > 2 else ""
+        item_flags = int(lt.file_flags_t.flag_symlink) if symlink else 0
+        entries.append(
+            lt.create_file_entry(path, size, flags=item_flags, symlink=symlink)
+        )
+    ct = lt.create_torrent(entries, piece_size, flags=flags)
+    for i in range(ct.num_pieces()):
+        ct.set_hash(i, lib.get_random_bytes(20))
+    entry = ct.generate()
+    return lt.torrent_info(entry)
+
+
 class FileStorageTest(unittest.TestCase):
     def test_is_valid(self) -> None:
-        fs = lt.file_storage()
-        self.assertFalse(fs.is_valid())
-
-    def test_add_file(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "file.txt"), 1024)
-        self.assertEqual(fs.file_path(0), os.path.join("path", "file.txt"))
-        self.assertEqual(fs.file_size(0), 1024)
-
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "file.txt"), 1024, flags=0)
-        self.assertEqual(fs.file_flags(0), 0)
-
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "file.txt"), 1024, mtime=10000)
-        # TODO: can we test mtime?
-
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "file.txt"), 1024, linkpath="other.txt")
-        self.assertEqual(fs.symlink(0), os.path.join("path", "other.txt"))
-
-    def test_add_file_bytes(self) -> None:
-        fs = lt.file_storage()
-        with self.assertWarns(DeprecationWarning):
-            fs.add_file(os.path.join(b"path", b"file.txt"), 1024)  # type: ignore
-        self.assertEqual(fs.file_path(0), os.path.join("path", "file.txt"))
-
-        fs = lt.file_storage()
-        with self.assertWarns(DeprecationWarning):
-            fs.add_file(
-                os.path.join("path", "file.txt"),
-                1024,
-                linkpath=b"other.txt",
-            )
-        self.assertEqual(fs.symlink(0), os.path.join("path", "other.txt"))
+        ti = _build_layout([("file.txt", 1024)])
+        self.assertTrue(ti.layout().is_valid())
 
     def test_num_files(self) -> None:
-        fs = lt.file_storage()
-        self.assertEqual(fs.num_files(), 0)
-        fs.add_file("file.txt", 1024)
-        self.assertEqual(fs.num_files(), 1)
+        ti = _build_layout([("file.txt", 1024)])
+        self.assertEqual(ti.layout().num_files(), 1)
+
+    def test_add_file(self) -> None:
+        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+        fs = ti.layout()
+        fs.add_file(os.path.join("path", "file2.txt"), 512)
+        self.assertEqual(fs.num_files(), 2)
+        self.assertEqual(fs.file_path(1), os.path.join("path", "file2.txt"))
+        self.assertEqual(fs.file_size(1), 512)
+
+        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+        fs = ti.layout()
+        fs.add_file(os.path.join("path", "file2.txt"), 512, linkpath="file1.txt")
+        self.assertEqual(fs.symlink(1), os.path.join("path", "file1.txt"))
+
+    def test_add_file_bytes(self) -> None:
+        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+        fs = ti.layout()
+        with self.assertWarns(DeprecationWarning):
+            fs.add_file(os.path.join(b"path", b"file2.txt"), 512)  # type: ignore
+        self.assertEqual(fs.file_path(1), os.path.join("path", "file2.txt"))
+
+        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+        fs = ti.layout()
+        with self.assertWarns(DeprecationWarning):
+            fs.add_file(
+                os.path.join("path", "file2.txt"),
+                512,
+                linkpath=b"file1.txt",
+            )
+        self.assertEqual(fs.symlink(1), os.path.join("path", "file1.txt"))
 
     def test_add_file_entry(self) -> None:
         if lt.api_version < 2:
-            fs = lt.file_storage()
-            # It's not clear this path has ever been useful, as the entry size can't
-            # be modified
+            ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+            fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
                 fe = lt.file_entry()
-            fe.path = "file.txt"
+            fe.path = os.path.join("path", "file2.txt")
             with self.assertWarns(DeprecationWarning):
                 fs.add_file(fe)
 
     def test_at_invalid(self) -> None:
         if lt.api_version < 2:
-            fs = lt.file_storage()
+            ti = _build_layout([("test.txt", 1024)])
+            fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
                 with self.assertRaises(IndexError):
-                    fs.at(0)
+                    fs.at(1)
             with self.assertWarns(DeprecationWarning):
                 with self.assertRaises(IndexError):
                     fs.at(-1)
 
     def test_at(self) -> None:
         if lt.api_version < 2:
-            fs = lt.file_storage()
-            fs.add_file(os.path.join("path", "test.txt"), 1024)
+            ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])
+            fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
                 fe = fs.at(0)
             self.assertEqual(fe.path, os.path.join("path", "test.txt"))
@@ -145,158 +160,138 @@ class FileStorageTest(unittest.TestCase):
 
     def test_iter(self) -> None:
         if lt.api_version < 2:
-            fs = lt.file_storage()
-            fs.add_file("test.txt", 1024)
+            ti = _build_layout([("test.txt", 1024)])
+            fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
                 self.assertEqual([fe.path for fe in fs], ["test.txt"])
 
     def test_len(self) -> None:
         if lt.api_version < 2:
-            fs = lt.file_storage()
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(len(fs), 0)
-            fs.add_file("test.txt", 1024)
+            ti = _build_layout([("test.txt", 1024)])
+            fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
                 self.assertEqual(len(fs), 1)
 
     def test_symlink(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test.txt"), 1024)
-        self.assertEqual(fs.symlink(0), "")
+        ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])
+        self.assertEqual(ti.layout().symlink(0), "")
 
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test.txt"), 0, linkpath="other.txt")
-        self.assertEqual(fs.symlink(0), os.path.join("path", "other.txt"))
+        ti = _build_layout(
+            [
+                (os.path.join("path", "real.txt"), 1024),
+                (os.path.join("path", "test.txt"), 0, "real.txt"),
+            ],
+            flags=lt.create_torrent.v1_only | lt.create_torrent.symlinks,
+        )
+        self.assertEqual(ti.layout().symlink(1), os.path.join("path", "real.txt"))
 
     def test_symlink_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.symlink(0)
+            fs.symlink(1)
         with self.assertRaises(IndexError):
             fs.symlink(-1)
 
     def test_file_path(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test.txt"), 1024)
+        ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])
+        fs = ti.layout()
         self.assertEqual(fs.file_path(0), os.path.join("path", "test.txt"))
         self.assertEqual(
             fs.file_path(0, save_path="base"), os.path.join("base", "path", "test.txt")
         )
 
     def test_file_path_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.file_path(0)
+            fs.file_path(1)
         with self.assertRaises(IndexError):
             fs.file_path(-1)
 
     def test_file_name(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test.txt"), 1024)
-        self.assertEqual(fs.file_name(0), "test.txt")
+        ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])
+        self.assertEqual(ti.layout().file_name(0), "test.txt")
 
     def test_file_name_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.file_name(0)
+            fs.file_name(1)
         with self.assertRaises(IndexError):
             fs.file_name(-1)
 
     def test_file_size(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file("test.txt", 1024)
-        self.assertEqual(fs.file_size(0), 1024)
+        ti = _build_layout([("test.txt", 1024)])
+        self.assertEqual(ti.layout().file_size(0), 1024)
 
     def test_file_size_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.file_size(0)
+            fs.file_size(1)
         with self.assertRaises(IndexError):
             fs.file_size(-1)
 
     def test_file_offset(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test1.txt"), 1024)
-        fs.add_file(os.path.join("path", "test2.txt"), 1024)
+        ti = _build_layout(
+            [
+                (os.path.join("path", "test1.txt"), 1024),
+                (os.path.join("path", "test2.txt"), 1024),
+            ]
+        )
+        fs = ti.layout()
         self.assertEqual(fs.file_offset(0), 0)
         self.assertEqual(fs.file_offset(1), 1024)
 
     def test_file_offset_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.file_offset(0)
+            fs.file_offset(1)
         with self.assertRaises(IndexError):
             fs.file_offset(-1)
 
     def test_file_flags(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file("test.txt", 1024)
-        self.assertEqual(fs.file_flags(0), 0)
+        ti = _build_layout([("test.txt", 1024)])
+        self.assertEqual(ti.layout().file_flags(0), 0)
 
     def test_file_flags_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.file_flags(0)
+            fs.file_flags(1)
         with self.assertRaises(IndexError):
             fs.file_flags(-1)
 
     def test_total_size(self) -> None:
-        fs = lt.file_storage()
-        self.assertEqual(fs.total_size(), 0)
-        fs.add_file("test.txt", 1024)
-        self.assertEqual(fs.total_size(), 1024)
+        ti = _build_layout([("test.txt", 1024)])
+        self.assertEqual(ti.layout().total_size(), 1024)
 
     def test_piece_length(self) -> None:
-        fs = lt.file_storage()
-        fs.set_piece_length(16384)
-        self.assertEqual(fs.piece_length(), 16384)
+        ti = _build_layout([("test.txt", 1024)], piece_size=16384)
+        self.assertEqual(ti.layout().piece_length(), 16384)
 
     def test_piece_size(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file("test.txt", 1024)
-        fs.set_piece_length(16384)
-        fs.set_num_pieces(1)
+        ti = _build_layout([("test.txt", 1024)], piece_size=16384)
+        fs = ti.layout()
         self.assertEqual(fs.piece_size(0), 1024)
         with self.assertRaises(IndexError):
             fs.piece_size(1)
 
     def test_name(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test.txt"), 1024)
-        self.assertEqual(fs.name(), "path")
-        fs.set_name("other")
-        self.assertEqual(fs.file_path(0), os.path.join("other", "test.txt"))
-
-        with self.assertWarns(DeprecationWarning):
-            fs.set_name(b"bytes")  # type: ignore
-        self.assertEqual(fs.file_path(0), os.path.join("bytes", "test.txt"))
-
-    def test_rename_file(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test.txt"), 1024)
-        fs.rename_file(0, os.path.join("path", "other.txt"))
-        self.assertEqual(fs.file_path(0), os.path.join("path", "other.txt"))
-
-        with self.assertWarns(DeprecationWarning):
-            fs.rename_file(0, os.path.join(b"path", b"bytes.txt"))  # type: ignore
-        self.assertEqual(fs.file_path(0), os.path.join("path", "bytes.txt"))
-
-    def test_rename_file_invalid(self) -> None:
-        fs = lt.file_storage()
-        with self.assertRaises(IndexError):
-            fs.rename_file(0, os.path.join("path", "test.txt"))
-        with self.assertRaises(IndexError):
-            fs.rename_file(-1, os.path.join("path", "test.txt"))
+        ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])
+        self.assertEqual(ti.layout().name(), "path")
 
     def test_hash(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file("test.txt", 1024)
-        self.assertIsInstance(fs.hash(0), lt.sha1_hash)
+        ti = _build_layout([("test.txt", 1024)])
+        self.assertIsInstance(ti.layout().hash(0), lt.sha1_hash)
 
     def test_hash_invalid(self) -> None:
-        fs = lt.file_storage()
+        ti = _build_layout([("test.txt", 1024)])
+        fs = ti.layout()
         with self.assertRaises(IndexError):
-            fs.hash(0)
+            fs.hash(1)
 
 
 class CreateTorrentTest(unittest.TestCase):
@@ -327,8 +322,7 @@ class CreateTorrentTest(unittest.TestCase):
         lt.create_torrent(fs, flags=lt.create_torrent_flags_t.v2_only)
 
     def test_args_deprecated(self) -> None:
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "test1.txt"), 1024)
+        fs = _build_layout([(os.path.join("path", "test1.txt"), 1024)]).layout()
 
         with self.assertWarns(DeprecationWarning):
             lt.create_torrent(fs)
@@ -603,7 +597,7 @@ class ListTest(unittest.TestCase):
 
 class AddFilesTest(unittest.TestCase):
     def test_args_no_pred(self) -> None:
-        fs = lt.file_storage()
+        fs = _build_layout([("existing.txt", 1024)]).layout()
         with tempfile.TemporaryDirectory() as path:
             with self.assertWarns(DeprecationWarning):
                 lt.add_files(fs, path)
@@ -626,12 +620,12 @@ class AddFilesTest(unittest.TestCase):
                     fp.write(lib.get_random_bytes(1024))
             calls = [unittest.mock.call(file_path) for file_path in file_paths]
 
-            fs = lt.file_storage()
+            fs = _build_layout([("existing.txt", 1024)]).layout()
             pred = unittest.mock.Mock(return_value=True)
             with self.assertWarns(DeprecationWarning):
                 lt.add_files(fs, path, pred)
             pred.assert_has_calls(calls, any_order=True)
-            self.assertEqual(fs.num_files(), 2)
+            self.assertEqual(fs.num_files(), 3)
 
     def test_args_pred_kwargs(self) -> None:
         with tempfile.TemporaryDirectory() as path:
@@ -642,7 +636,7 @@ class AddFilesTest(unittest.TestCase):
                     fp.write(lib.get_random_bytes(1024))
             calls = [unittest.mock.call(file_path) for file_path in file_paths]
 
-            fs = lt.file_storage()
+            fs = _build_layout([("existing.txt", 1024)]).layout()
             pred = unittest.mock.Mock(return_value=True)
             with self.assertWarns(DeprecationWarning):
                 lt.add_files(
@@ -652,7 +646,7 @@ class AddFilesTest(unittest.TestCase):
                     flags=lt.create_torrent_flags_t.v2_only,
                 )
             pred.assert_has_calls(calls, any_order=True)
-            self.assertEqual(fs.num_files(), 2)
+            self.assertEqual(fs.num_files(), 3)
 
     # We don't bother testing how file_storage sanitizes paths; we assume
     # this is exercised in C++ tests. We just test that various path forms

--- a/bindings/python/tests/torrent_info_test.py
+++ b/bindings/python/tests/torrent_info_test.py
@@ -543,7 +543,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.ti.files().file_path(0)
 
-    def test_files_and_remap(self) -> None:
+    def test_files(self) -> None:
         ti = lt.torrent_info(
             TorrentFileDict(
                 {
@@ -559,20 +559,6 @@ class FieldTest(unittest.TestCase):
 
         self.assertEqual(ti.name(), "test.txt")
         self.assertEqual(ti.layout().file_path(0), "test.txt")
-        self.assertEqual(ti.orig_files().file_path(0), "test.txt")
-
-        fs = lt.file_storage()
-        fs.add_file(os.path.join("path", "remapped1.txt"), 512)
-        fs.add_file(os.path.join("path", "remapped2.txt"), 512)
-
-        ti.remap_files(fs)
-
-        self.assertEqual(ti.name(), "path")
-        self.assertEqual(ti.files().num_files(), 2)
-        self.assertEqual(ti.files().file_path(0), os.path.join("path", "remapped1.txt"))
-        self.assertEqual(ti.files().file_path(1), os.path.join("path", "remapped2.txt"))
-
-        self.assertEqual(ti.orig_files().num_files(), 1)
         self.assertEqual(ti.orig_files().file_path(0), "test.txt")
 
     def test_map(self) -> None:

--- a/docs/gen_reference_doc.py
+++ b/docs/gen_reference_doc.py
@@ -50,6 +50,7 @@ preprocess_rst = \
         'upgrade_to_1.2.rst': 'upgrade_to_1.2-ref.rst',
         'upgrade_to_2.0.rst': 'upgrade_to_2.0-ref.rst',
         'upgrade_to_2.1.rst': 'upgrade_to_2.1-ref.rst',
+        'upgrade_to_2.2.rst': 'upgrade_to_2.2-ref.rst',
         'settings.rst': 'settings-ref.rst'
     }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Documentation
 
 * reference_
 * `blog`_
+* `upgrade to 2.2`_
 * `upgrade to 2.1`_
 * `upgrade to 2.0`_
 * `upgrade to 1.2`_
@@ -76,6 +77,7 @@ Bindings
 .. _examples: examples.html
 .. _overview: manual-ref.html
 .. _reference: reference.html
+.. _`upgrade to 2.2`: upgrade_to_2.2-ref.html
 .. _`upgrade to 2.1`: upgrade_to_2.1-ref.html
 .. _`upgrade to 2.0`: upgrade_to_2.0-ref.html
 .. _`upgrade to 1.2`: upgrade_to_1.2-ref.html

--- a/docs/makefile
+++ b/docs/makefile
@@ -21,6 +21,7 @@ REFERENCE_TARGETS = \
 	upgrade_to_1.2-ref \
 	upgrade_to_2.0-ref \
 	upgrade_to_2.1-ref \
+	upgrade_to_2.2-ref \
 	reference \
 	reference-Core \
 	reference-DHT \
@@ -166,6 +167,7 @@ spell-check:plain_text_out.txt $(MANUAL_TARGETS:=.html) manual.rst settings.rst 
 	python3 filter-rst.py upgrade_to_1.2.rst >upgrade-1_2-plain.txt
 	python3 filter-rst.py upgrade_to_2.0.rst >upgrade-2_0-plain.txt
 	python3 filter-rst.py upgrade_to_2.1.rst >upgrade-2_1-plain.txt
+	python3 filter-rst.py upgrade_to_2.2.rst >upgrade-2_2-plain.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l plain_text_out.txt >hunspell-report.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l manual-plain.txt >>hunspell-report.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l tutorial-plain.txt >>hunspell-report.txt
@@ -173,6 +175,7 @@ spell-check:plain_text_out.txt $(MANUAL_TARGETS:=.html) manual.rst settings.rst 
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l upgrade-1_2-plain.txt >>hunspell-report.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l upgrade-2_0-plain.txt >>hunspell-report.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l upgrade-2_1-plain.txt >>hunspell-report.txt
+	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -l upgrade-2_2-plain.txt >>hunspell-report.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/settings.dic -l settings-plain.txt >>hunspell-report.txt
 	hunspell -i UTF-8 -d hunspell/en_US -p hunspell/libtorrent.dic -H -l $(MANUAL_TARGETS:=.html) >>hunspell-report.txt
 	@if [ -s hunspell-report.txt ]; then echo 'spellcheck failed, fix words or add to dictionary:'; cat hunspell-report.txt; false; fi;

--- a/docs/upgrade_to_2.2.rst
+++ b/docs/upgrade_to_2.2.rst
@@ -33,3 +33,36 @@ built into the ``torrent`` object directly, controlled by the
 ``settings_pack::enable_smart_ban`` setting (enabled by default).
 ``create_smart_ban_plugin()`` is deprecated, constructs nothing and always
 returns a null pointer.
+
+file_storage isn't constructible
+================================
+
+``file_storage`` is not a class clients are meant to build up from
+scratch. It is part of the ``torrent_info`` object, and is normally
+only accessed as a reference through it (e.g. via
+``torrent_info::layout()``). A ``file_storage`` object must never
+outlive the ``torrent_info`` it came from.
+
+To build a file list when creating a new torrent, use ``create_torrent``
+and ``create_file_entry`` instead, see `Creating torrents`_ in the 2.1
+upgrade guide.
+
+``file_storage``'s default constructor and the ``add_file_borrow()``
+overloads are no longer exported from the shared library, and have
+been removed from the python bindings. They were never meant to be
+part of the public interface, only used internally by ``torrent_info``
+while parsing a .torrent file. Statically linked C++ code can
+technically still call them, but this should not be relied on.
+
+``file_storage``'s copy and move constructors/assignment and
+``add_file()`` remain exported and are available from python, so an
+existing ``file_storage`` (obtained by reference from
+``torrent_info::layout()`` or ``torrent_info::files()``) can still be
+copied and appended to. The deprecated ``create_torrent(file_storage)``
+python constructor remains available for this reason. The python
+bindings for ``torrent_info::remap_files()`` (still available and
+deprecated in C++) and the free function ``add_files()`` have been
+removed, since neither had a way to obtain a suitable ``file_storage``
+argument from python.
+
+.. _`Creating torrents`: upgrade_to_2.1-ref.html#creating-torrents

--- a/docs/upgrade_to_2.2.rst
+++ b/docs/upgrade_to_2.2.rst
@@ -1,0 +1,35 @@
+===========================
+Upgrading to libtorrent 2.2
+===========================
+
+:Author: Arvid Norberg, arvid@libtorrent.org
+
+.. contents:: Table of contents
+  :depth: 2
+  :backlinks: none
+
+This document summarizes the changes affecting library clients in libtorrent
+2.2.
+
+C++17 no longer supported
+=========================
+
+libtorrent 2.2 requires at least C++-20. To build with boost build, specify the
+C++ version using the ``cxxstd=20`` build feature (20 is the default).
+
+predictive pieces feature removed
+=================================
+
+The predictive pieces feature has been removed. ``settings_pack::predictive_piece_announce``
+is deprecated and no longer has any effect. The ``predictive-pieces`` build
+feature and the ``TORRENT_DISABLE_PREDICTIVE_PIECES`` macro have also been
+removed.
+
+smart_ban is now built-in
+=========================
+
+The ``smart_ban`` plugin is no longer an extension. Its functionality is now
+built into the ``torrent`` object directly, controlled by the
+``settings_pack::enable_smart_ban`` setting (enabled by default).
+``create_smart_ban_plugin()`` is deprecated, constructs nothing and always
+returns a null pointer.

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -195,50 +195,50 @@ namespace aux {
 
 TORRENT_VERSION_NAMESPACE_4
 
-	// The ``file_storage`` class represents a file list and the piece
-	// size. Everything necessary to interpret a regular bittorrent storage
-	// file structure.
-	class TORRENT_EXPORT file_storage
-	{
-	public:
-		// hidden
-		file_storage();
-		// hidden
-		~file_storage();
-		file_storage(file_storage const&);
-		file_storage& operator=(file_storage const&) &;
-		file_storage(file_storage&&) noexcept;
-		file_storage& operator=(file_storage&&) &;
+// The ``file_storage`` class represents a file list and the piece
+// size. Everything necessary to interpret a regular bittorrent storage
+// file structure. A file storage is tied to the torrent_info object that
+// created it, which it should never outlive.
+class TORRENT_EXPORT file_storage
+{
+public:
+	// hidden
+	TORRENT_UNEXPORT file_storage();
+	// hidden
+	~file_storage();
+	file_storage(file_storage const&);
+	file_storage& operator=(file_storage const&) &;
+	file_storage(file_storage&&) noexcept;
+	file_storage& operator=(file_storage&&) &;
 
-		// internal limitations restrict file sizes to not be larger than this
-		// We use int to index into file merkle trees, so a file may not contain more
-		// than INT_MAX entries. That means INT_MAX / 2 blocks (leafs) in each
-		// tree.
-		static constexpr std::int64_t max_file_size = (std::min)(
-			(std::int64_t(1) << 48) - 1
-			, std::int64_t((std::numeric_limits<int>::max)() / 2) * default_block_size);
-		static constexpr std::int64_t max_file_offset = (std::int64_t(1) << 48) - 1;
+	// internal limitations restrict file sizes to not be larger than this
+	// We use int to index into file merkle trees, so a file may not contain more
+	// than INT_MAX entries. That means INT_MAX / 2 blocks (leafs) in each
+	// tree.
+	static constexpr std::int64_t max_file_size = (std::min)((std::int64_t(1) << 48) - 1,
+		std::int64_t((std::numeric_limits<int>::max)() / 2) * default_block_size);
+	static constexpr std::int64_t max_file_offset = (std::int64_t(1) << 48) - 1;
 
-		// we use a signed 32 bit integer for piece indices internally, but
-		// frequently need headroom for intermediate calculations, so we limit
-		// the number of pieces 1 bit below the maximum
-		static constexpr std::int32_t max_num_pieces = (std::int32_t(1) << 30) - 1;
+	// we use a signed 32 bit integer for piece indices internally, but
+	// frequently need headroom for intermediate calculations, so we limit
+	// the number of pieces 1 bit below the maximum
+	static constexpr std::int32_t max_num_pieces = (std::int32_t(1) << 30) - 1;
 
-		// limit the piece length at (2 ^ 30) to get a bit of headroom. We
-		// commonly compute the number of blocks per pieces by adding
-		// block_size - 1 before dividing by block_size. That would overflow with
-		// a piece size of 2 ^ 31. This limit is still an unreasonably large
-		// piece size anyway.
-		// The piece picker (currently) has a limit of no more than (2^15)-1
-		// blocks per piece, which is more restrictive, at a block size of 16
-		// kiB (0x4000).
-		static constexpr std::int32_t max_piece_size = ((1 << 15) - 1) * 0x4000;
+	// limit the piece length at (2 ^ 30) to get a bit of headroom. We
+	// commonly compute the number of blocks per pieces by adding
+	// block_size - 1 before dividing by block_size. That would overflow with
+	// a piece size of 2 ^ 31. This limit is still an unreasonably large
+	// piece size anyway.
+	// The piece picker (currently) has a limit of no more than (2^15)-1
+	// blocks per piece, which is more restrictive, at a block size of 16
+	// kiB (0x4000).
+	static constexpr std::int32_t max_piece_size = ((1 << 15) - 1) * 0x4000;
 
-		// returns true if the piece length has been initialized
-		// on the file_storage. This is typically taken as a proxy
-		// of whether the file_storage as a whole is initialized or
-		// not.
-		bool is_valid() const { return m_piece_length > 0; }
+	// returns true if the piece length has been initialized
+	// on the file_storage. This is typically taken as a proxy
+	// of whether the file_storage as a whole is initialized or
+	// not.
+	bool is_valid() const { return m_piece_length > 0; }
 
 #if TORRENT_ABI_VERSION == 1
 		using flags_t = file_flags_t;
@@ -253,6 +253,7 @@ TORRENT_VERSION_NAMESPACE_4
 		// of files to be added is known up-front.
 		void reserve(int num_files);
 
+		// internal
 		// Adds a file to the file storage. The ``add_file_borrow`` version
 		// expects that ``filename`` is the file name (without a path) of
 		// the file that's being added.
@@ -306,17 +307,22 @@ TORRENT_VERSION_NAMESPACE_4
 #ifndef BOOST_NO_EXCEPTIONS
 #if TORRENT_ABI_VERSION < 4
 		TORRENT_DEPRECATED
-		void add_file_borrow(string_view filename
-			, std::string const& path, std::int64_t file_size
-			, file_flags_t file_flags, char const* filehash
-			, std::int64_t mtime = 0, string_view symlink_path = string_view()
-			, char const* root_hash = nullptr);
+		TORRENT_UNEXPORT void add_file_borrow(string_view filename,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags,
+			char const* filehash,
+			std::int64_t mtime = 0,
+			string_view symlink_path = string_view(),
+			char const* root_hash = nullptr);
 #endif
-		void add_file_borrow(string_view filename
-			, std::string const& path, std::int64_t file_size
-			, file_flags_t file_flags = {}, std::int64_t mtime = 0
-			, string_view symlink_path = string_view()
-			, char const* root_hash = nullptr);
+		TORRENT_UNEXPORT void add_file_borrow(string_view filename,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags = {},
+			std::int64_t mtime = 0,
+			string_view symlink_path = string_view(),
+			char const* root_hash = nullptr);
 		void add_file(std::string const& path, std::int64_t file_size
 			, file_flags_t file_flags = {}
 			, std::time_t mtime = 0, string_view symlink_path = string_view()
@@ -324,23 +330,31 @@ TORRENT_VERSION_NAMESPACE_4
 #endif // BOOST_NO_EXCEPTIONS
 #if TORRENT_ABI_VERSION < 4
 		TORRENT_DEPRECATED
-		void add_file_borrow(error_code& ec, string_view filename
-			, std::string const& path, std::int64_t file_size
-			, file_flags_t file_flags, char const* filehash
-			, std::int64_t mtime = 0, string_view symlink_path = string_view()
-			, char const* root_hash = nullptr);
+		TORRENT_UNEXPORT void add_file_borrow(error_code& ec,
+			string_view filename,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags,
+			char const* filehash,
+			std::int64_t mtime = 0,
+			string_view symlink_path = string_view(),
+			char const* root_hash = nullptr);
 #endif
+		// internal
 		// these overloads report failures through the ``ec`` reference
 		// rather than throwing. ``add_file_borrow()`` does not copy the
 		// ``filename`` string; it is borrowed by reference and the caller
 		// must keep it alive for the lifetime of this ``file_storage``
 		// object. This is useful when constructing the file list from a
 		// memory-mapped .torrent file.
-		void add_file_borrow(error_code& ec, string_view filename
-			, std::string const& path, std::int64_t file_size
-			, file_flags_t file_flags = {}, std::int64_t mtime = 0
-			, string_view symlink_path = string_view()
-			, char const* root_hash = nullptr);
+		TORRENT_UNEXPORT void add_file_borrow(error_code& ec,
+			string_view filename,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags = {},
+			std::int64_t mtime = 0,
+			string_view symlink_path = string_view(),
+			char const* root_hash = nullptr);
 		void add_file(error_code& ec, std::string const& path, std::int64_t file_size
 			, file_flags_t file_flags = {}
 			, std::time_t mtime = 0, string_view symlink_path = string_view()
@@ -360,10 +374,14 @@ TORRENT_VERSION_NAMESPACE_4
 #include "libtorrent/aux_/disable_deprecation_warnings_push.hpp"
 
 		TORRENT_DEPRECATED
-		void add_file_borrow(char const* filename, int filename_len
-			, std::string const& path, std::int64_t file_size
-			, file_flags_t file_flags = {}, char const* filehash = nullptr
-			, std::int64_t mtime = 0, string_view symlink_path = string_view());
+		TORRENT_UNEXPORT void add_file_borrow(char const* filename,
+			int filename_len,
+			std::string const& path,
+			std::int64_t file_size,
+			file_flags_t file_flags = {},
+			char const* filehash = nullptr,
+			std::int64_t mtime = 0,
+			string_view symlink_path = string_view());
 		TORRENT_DEPRECATED
 		void add_file(file_entry const& fe, char const* filehash = nullptr);
 
@@ -749,7 +767,7 @@ TORRENT_VERSION_NAMESPACE_4
 
 		// the sum of all non-pad file sizes
 		std::int64_t m_size_on_disk = 0;
-	};
+};
 
 TORRENT_VERSION_NAMESPACE_4_END
 


### PR DESCRIPTION
* start upgrade_to_2.2 document
* tighten up restrictions to `file_storage` further. It's not meant to be used to create torrents anymore, and `remap_files()` is dropped from python bindings.