### PR TITLE
optimize pad-file names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.2.0 not released
 
+	* optimize padfile memory usage
 	* make DHT DoS protection based on bytes in addition to packets
 	* make smart-ban built-in, not a plugin
 	* improve support for mapped v4 addresses

--- a/bindings/python/src/file_storage.cpp
+++ b/bindings/python/src/file_storage.cpp
@@ -221,6 +221,12 @@ namespace {
 	{
 		return std::string(rf.file_name(fs, index));
 	}
+
+	std::string file_storage_file_name(file_storage const& fs, file_index_t index)
+	{
+		file_storage_check_index(fs, index);
+		return std::string(fs.file_name(index));
+	}
 }
 
 void bind_file_storage()
@@ -265,7 +271,7 @@ void bind_file_storage()
 #endif
 				.def("symlink", &wrap_file_check<std::string, &file_storage::symlink>)
 				.def("file_path", &file_storage_file_path, (arg("idx"), arg("save_path") = ""))
-				.def("file_name", &wrap_file_check<string_view, &file_storage::file_name>)
+				.def("file_name", &file_storage_file_name, arg("idx"))
 				.def("file_size", &wrap_file_check<std::int64_t, &file_storage::file_size>)
 				.def("root", &file_storage::root)
 				.def("file_offset", &wrap_file_check<std::int64_t, &file_storage::file_offset>)

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -16,6 +16,7 @@ see LICENSE file.
 
 #include <string>
 #include <vector>
+#include <variant>
 #include <unordered_set>
 #include <unordered_map>
 #include <map>
@@ -100,6 +101,32 @@ namespace aux {
 	struct path_index_tag;
 	using path_index_t = aux::strong_typedef<std::uint32_t, path_index_tag>;
 
+	// a file's name. For ordinary files this is a view into a string
+	// owned elsewhere, exactly like a string_view. Pad files have no
+	// stored name; one is generated from the pad file's size each time
+	// this is asked for.
+	struct TORRENT_EXPORT file_name_view
+	{
+		file_name_view(string_view name)
+			: m_name(name)
+		{} // NOLINT
+		explicit file_name_view(std::uint64_t pad_size);
+
+		// converting to string_view or std::string is explicit since, for
+		// pad files, the returned string_view may refer to storage owned by
+		// this object; the caller must not outlive it when taking a view
+		explicit operator string_view() const
+		{
+			return std::visit([](auto const& n) { return string_view(n); }, m_name);
+		}
+		explicit operator std::string() const { return std::string(string_view(*this)); }
+		char const* data() const { return string_view(*this).data(); }
+		std::size_t size() const { return string_view(*this).size(); }
+
+	private:
+		std::variant<string_view, std::string> m_name;
+	};
+
 	// internal
 	struct file_entry
 	{
@@ -110,8 +137,10 @@ namespace aux {
 		file_entry& operator=(file_entry&& fe) & noexcept;
 		~file_entry();
 
+		// has no effect, and must not be called, for pad files: their
+		// name is synthesized from their size on demand, see filename()
 		void set_name(string_view n, bool borrow_string = false);
-		string_view filename() const;
+		file_name_view filename() const;
 
 		enum {
 			name_is_owned = (1 << 12) - 1,
@@ -140,6 +169,7 @@ namespace aux {
 		// (i.e. it should be freed in the destructor). If
 		// the len is not name_is_owned, the name pointer does not belong
 		// to this object, and it's not 0-terminated
+		// meaningless when pad_file is set, name is then unused (nullptr)
 		std::uint64_t name_len:12;
 		std::uint64_t pad_file:1;
 		std::uint64_t hidden_attribute:1;
@@ -149,7 +179,8 @@ namespace aux {
 		// make it available for logging
 	private:
 		// This string is not necessarily 0-terminated!
-		// that's why it's private, to keep people away from it
+		// that's why it's private, to keep people away from it.
+		// unused (nullptr) when pad_file is set, see filename()
 		char const* name = nullptr;
 	public:
 		// the SHA-256 root of the merkle tree for this file
@@ -561,7 +592,7 @@ public:
 		std::string symlink(file_index_t index) const;
 		std::time_t mtime(file_index_t index) const;
 		std::string file_path(file_index_t index, std::string const& save_path = "") const;
-		string_view file_name(file_index_t index) const;
+		aux::file_name_view file_name(file_index_t index) const;
 		std::int64_t file_size(file_index_t index) const;
 		bool pad_file_at(file_index_t index) const;
 		std::int64_t file_offset(file_index_t index) const;
@@ -644,9 +675,10 @@ public:
 
 #if TORRENT_ABI_VERSION <= 2
 		// low-level function. returns a pointer to the internal storage for
-		// the filename. This string may not be 0-terminated!
+		// the filename. This string may not be 0-terminated! Always nullptr
+		// for pad files, since they have no stored name.
 		// the ``file_name_len()`` function returns the length of the filename.
-		// prefer to use ``file_name()`` instead, which returns a ``string_view``.
+		// prefer to use ``file_name()`` instead.
 		TORRENT_DEPRECATED
 		char const* file_name_ptr(file_index_t index) const;
 		TORRENT_DEPRECATED
@@ -803,7 +835,7 @@ namespace aux {
 		// true if the recorded rename is an absolute path (in which
 		// case ``save_path`` is ignored).
 		std::string file_path(file_storage const& fs, file_index_t index, std::string const& save_path = "") const;
-		string_view file_name(file_storage const& fs, file_index_t index) const;
+		aux::file_name_view file_name(file_storage const& fs, file_index_t index) const;
 		bool file_absolute_path(file_storage const& fs, file_index_t index) const;
 
 		// records that the file at ``index`` in ``fs`` should be

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -182,6 +182,7 @@ struct peer_plugin;
 struct crypto_plugin;
 
 // include/libtorrent/file_storage.hpp
+struct file_name_view;
 struct file_slice;
 TORRENT_VERSION_NAMESPACE_4
 class file_storage;

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -25,8 +25,6 @@ see LICENSE file.
 #include <boost/crc.hpp>
 #include "libtorrent/aux_/disable_warnings_pop.hpp"
 
-#include <cstdio>
-#include <cinttypes>
 #include <cstring>
 #include <algorithm>
 #include <functional>
@@ -127,11 +125,10 @@ TORRENT_VERSION_NAMESPACE_4
 	void file_storage::update_path_index(aux::file_entry& e
 		, std::string const& path, bool const set_name)
 	{
-		// TODO: at appears set_name is always true
 		if (is_complete(path))
 		{
-			TORRENT_ASSERT(set_name);
-			e.set_name(path);
+			if (set_name)
+				e.set_name(path);
 			e.path_index = aux::file_entry::path_is_absolute;
 			return;
 		}
@@ -232,9 +229,8 @@ TORRENT_VERSION_NAMESPACE_4_END
 		return ret;
 	}
 
-	string_view renamed_files::file_name(
-		file_storage const& fs
-		, file_index_t const index) const
+	aux::file_name_view renamed_files::file_name(
+		file_storage const& fs, file_index_t const index) const
 	{
 		auto i = m_renamed_files.find(index);
 		if (i == m_renamed_files.end()) return fs.file_name(index);
@@ -255,6 +251,10 @@ TORRENT_VERSION_NAMESPACE_4_END
 	{
 		TORRENT_ASSERT(new_filename.size() > 0);
 		if (new_filename.size() == 0)
+			return;
+
+		// pad files are managed internally and cannot be renamed
+		if (fs.pad_file_at(index))
 			return;
 
 		if (is_complete(new_filename))
@@ -331,22 +331,27 @@ TORRENT_VERSION_NAMESPACE_4_END
 
 namespace aux {
 
-	file_entry::file_entry()
-		: offset(0)
-		, symlink_index(not_a_symlink)
-		, no_root_dir(false)
-		, size(0)
-		, name_len(name_is_owned)
-		, pad_file(false)
-		, hidden_attribute(false)
-		, executable_attribute(false)
-		, symlink_attribute(false)
-	{}
+file_name_view::file_name_view(std::uint64_t const pad_size)
+	: m_name(std::to_string(pad_size))
+{}
 
-	file_entry::~file_entry()
-	{
-		if (name_len == name_is_owned) delete[] name;
-	}
+file_entry::file_entry()
+	: offset(0)
+	, symlink_index(not_a_symlink)
+	, no_root_dir(false)
+	, size(0)
+	, name_len(name_is_owned)
+	, pad_file(false)
+	, hidden_attribute(false)
+	, executable_attribute(false)
+	, symlink_attribute(false)
+{}
+
+file_entry::~file_entry()
+{
+	if (name_len == name_is_owned)
+		delete[] name;
+}
 
 	file_entry::file_entry(file_entry const& fe)
 		: offset(fe.offset)
@@ -361,8 +366,11 @@ namespace aux {
 		, root(fe.root)
 		, path_index(fe.path_index)
 	{
-		bool const borrow = fe.name_len != name_is_owned;
-		set_name(fe.filename(), borrow);
+		if (!pad_file)
+		{
+			bool const borrow = fe.name_len != name_is_owned;
+			set_name(string_view(fe.filename()), borrow);
+		}
 	}
 
 	file_entry::file_entry(file_entry&& fe) noexcept
@@ -413,6 +421,9 @@ namespace aux {
 	// file_entry.
 	void file_entry::set_name(string_view n, bool const borrow_string)
 	{
+		// pad files don't store a name, it's synthesized from their size
+		TORRENT_ASSERT(!pad_file);
+
 		// free the current string, before assigning the new one
 		if (name_len == name_is_owned) delete[] name;
 		if (n.empty())
@@ -436,10 +447,13 @@ namespace aux {
 		}
 	}
 
-	string_view file_entry::filename() const
+	file_name_view file_entry::filename() const
 	{
-		if (name_len != name_is_owned) return {name, std::size_t(name_len)};
-		return name ? string_view(name) : string_view();
+		if (pad_file)
+			return file_name_view(size);
+		if (name_len != name_is_owned)
+			return {string_view(name, std::size_t(name_len))};
+		return {name ? string_view(name) : string_view()};
 	}
 
 } // aux namespace
@@ -481,6 +495,9 @@ TORRENT_VERSION_NAMESPACE_4
 		, std::string const& new_filename)
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < end_file());
+		// pad files are managed internally and cannot be renamed
+		if (m_files[index].pad_file)
+			return;
 		update_path_index(m_files[index], new_filename);
 	}
 #endif // TORRENT_ABI_VERSION
@@ -564,6 +581,10 @@ TORRENT_VERSION_NAMESPACE_4
 
 	int file_storage::file_name_len(file_index_t const index) const
 	{
+		// pad files have no stored name (file_name_ptr() returns nullptr for
+		// them), the name_is_owned sentinel would be misleading here
+		if (m_files[index].pad_file)
+			return 0;
 		if (m_files[index].name_len == aux::file_entry::name_is_owned)
 			return -1;
 		return m_files[index].name_len;
@@ -862,20 +883,24 @@ TORRENT_VERSION_NAMESPACE_4
 		m_files.emplace_back();
 		aux::file_entry& e = m_files.back();
 
+		bool const is_pad_file = bool(file_flags & file_storage::flag_pad_file);
+
 		// the last argument specified whether the function should also set
 		// the filename. If it does, it will copy the leaf filename from path.
 		// if filename is empty, we should copy it. If it isn't, we're borrowing
 		// it and we can save the copy by setting it after this call to
-		// update_path_index().
-		update_path_index(e, path, filename.empty());
+		// update_path_index(). pad files never store a name, whatever leaf
+		// name they were given (e.g. by a torrent's own padding convention)
+		// is discarded; it's synthesized from their size on demand instead.
+		update_path_index(e, path, filename.empty() && !is_pad_file);
 
 		// filename is allowed to be empty, in which case we just use path
-		if (!filename.empty())
+		if (!filename.empty() && !is_pad_file)
 			e.set_name(filename, true);
 
 		e.size = aux::numeric_cast<std::uint64_t>(file_size);
 		e.offset = aux::numeric_cast<std::uint64_t>(m_total_size);
-		e.pad_file = bool(file_flags & file_storage::flag_pad_file);
+		e.pad_file = is_pad_file;
 		e.hidden_attribute = bool(file_flags & file_storage::flag_hidden);
 		e.executable_attribute = bool(file_flags & file_storage::flag_executable);
 		e.symlink_attribute = bool(file_flags & file_storage::flag_symlink);
@@ -934,10 +959,6 @@ TORRENT_VERSION_NAMESPACE_4
 			TORRENT_ASSERT(m_total_size > 0);
 			pad.offset = static_cast<std::uint64_t>(m_total_size);
 			pad.path_index = get_or_add_path(".pad");
-			char name[30];
-			std::snprintf(name, sizeof(name), "%" PRIu64
-				, pad.size);
-			pad.set_name(name);
 			pad.pad_file = true;
 			m_total_size += pad_size;
 		}
@@ -1077,7 +1098,7 @@ namespace {
 
 		if (fe.path_index == aux::file_entry::path_is_absolute)
 		{
-			process_string_lowercase(crc, fe.filename());
+			process_string_lowercase(crc, string_view(fe.filename()));
 		}
 		else if (fe.path_index == aux::file_entry::no_path)
 		{
@@ -1087,7 +1108,7 @@ namespace {
 				TORRENT_ASSERT(save_path[save_path.size() - 1] != TORRENT_SEPARATOR);
 				crc.process_byte(TORRENT_SEPARATOR);
 			}
-			process_string_lowercase(crc, fe.filename());
+			process_string_lowercase(crc, string_view(fe.filename()));
 		}
 		else if (fe.no_root_dir)
 		{
@@ -1104,7 +1125,7 @@ namespace {
 				TORRENT_ASSERT(p[p.size() - 1] != TORRENT_SEPARATOR);
 				crc.process_byte(TORRENT_SEPARATOR);
 			}
-			process_string_lowercase(crc, fe.filename());
+			process_string_lowercase(crc, string_view(fe.filename()));
 		}
 		else
 		{
@@ -1127,7 +1148,7 @@ namespace {
 				TORRENT_ASSERT(p[p.size() - 1] != TORRENT_SEPARATOR);
 				crc.process_byte(TORRENT_SEPARATOR);
 			}
-			process_string_lowercase(crc, fe.filename());
+			process_string_lowercase(crc, string_view(fe.filename()));
 		}
 
 		return crc.checksum();
@@ -1137,38 +1158,39 @@ namespace {
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < end_file());
 		aux::file_entry const& fe = m_files[index];
+		aux::file_name_view const name = fe.filename();
 
 		std::string ret;
 
 		if (fe.path_index == aux::file_entry::path_is_absolute)
 		{
 			// TODO: do we still need this case?
-			ret = fe.filename();
+			ret = std::string(name);
 		}
 		else if (fe.path_index == aux::file_entry::no_path)
 		{
-			ret.reserve(save_path.size() + fe.filename().size() + 1);
+			ret.reserve(save_path.size() + name.size() + 1);
 			ret.assign(save_path);
-			append_path(ret, fe.filename());
+			append_path(ret, string_view(name));
 		}
 		else if (fe.no_root_dir)
 		{
 			std::string const& p = m_paths[fe.path_index];
 
-			ret.reserve(save_path.size() + p.size() + fe.filename().size() + 2);
+			ret.reserve(save_path.size() + p.size() + name.size() + 2);
 			ret.assign(save_path);
 			append_path(ret, p);
-			append_path(ret, fe.filename());
+			append_path(ret, string_view(name));
 		}
 		else
 		{
 			std::string const& p = m_paths[fe.path_index];
 
-			ret.reserve(save_path.size() + m_name.size() + p.size() + fe.filename().size() + 3);
+			ret.reserve(save_path.size() + m_name.size() + p.size() + name.size() + 3);
 			ret.assign(save_path);
 			append_path(ret, m_name);
 			append_path(ret, p);
-			append_path(ret, fe.filename());
+			append_path(ret, string_view(name));
 		}
 
 		// a single return statement, just to make NRVO more likely to kick in
@@ -1185,9 +1207,10 @@ namespace {
 		{
 			std::string ret;
 			std::string const& p = m_paths[fe.path_index];
-			ret.reserve(p.size() + fe.filename().size() + 2);
+			aux::file_name_view const name = fe.filename();
+			ret.reserve(p.size() + name.size() + 2);
 			append_path(ret, p);
-			append_path(ret, fe.filename());
+			append_path(ret, string_view(name));
 			return ret;
 		}
 		else
@@ -1196,7 +1219,7 @@ namespace {
 		}
 	}
 
-	string_view file_storage::file_name(file_index_t const index) const
+	aux::file_name_view file_storage::file_name(file_index_t const index) const
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < end_file());
 		aux::file_entry const& fe = m_files[index];
@@ -1409,11 +1432,13 @@ namespace {
 			auto const& rf = m_files[r];
 			if (lf.path_index != rf.path_index)
 			{
-				int const ret = path_compare(m_paths[lf.path_index], lf.filename()
-					, m_paths[rf.path_index], rf.filename());
+				int const ret = path_compare(m_paths[lf.path_index],
+					string_view(lf.filename()),
+					m_paths[rf.path_index],
+					string_view(rf.filename()));
 				if (ret != 0) return ret < 0;
 			}
-			return lf.filename() < rf.filename();
+			return string_view(lf.filename()) < string_view(rf.filename());
 		});
 
 		aux::vector<aux::file_entry, file_index_t> new_files;
@@ -1443,9 +1468,6 @@ namespace {
 				pad.offset = static_cast<std::uint64_t>(off);
 				off += pad_size;
 				pad.path_index = get_or_add_path(".pad");
-				char name[30];
-				std::snprintf(name, sizeof(name), "%" PRIu64, pad.size);
-				pad.set_name(name);
 				pad.pad_file = true;
 
 				if (!m_file_hashes.empty())

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1748,6 +1748,11 @@ TORRENT_VERSION_NAMESPACE_4
 	{
 		for (auto const i : m_files.file_range())
 		{
+			// pad files don't store a name, it's generated from their size
+			// on demand, none of the checks below apply to them
+			if (m_files.pad_file_at(i))
+				continue;
+
 			TORRENT_ASSERT(m_files.file_name(i).data() != nullptr);
 			if (!m_files.owns_name(i))
 			{
@@ -1758,7 +1763,7 @@ TORRENT_VERSION_NAMESPACE_4
 			else
 			{
 				// name must be a null terminated string
-				string_view const name = m_files.file_name(i);
+				aux::file_name_view const name = m_files.file_name(i);
 				TORRENT_ASSERT(name.data()[name.size()] == '\0');
 			}
 		}

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -306,9 +306,9 @@ TORRENT_TEST(v2_only)
 		lt::torrent_info info(buffer, lt::from_span);
 		TEST_CHECK(info.info_hashes().has_v2());
 		TEST_CHECK(!info.info_hashes().has_v1());
-		TEST_EQUAL(info.layout().file_name(0_file), "A");
+		TEST_EQUAL(std::string(info.layout().file_name(0_file)), "A");
 		TEST_CHECK(info.layout().pad_file_at(1_file));
-		TEST_EQUAL(info.layout().file_name(2_file), "B");
+		TEST_EQUAL(std::string(info.layout().file_name(2_file)), "B");
 		TEST_EQUAL(info.name(), "test");
 
 		lt::create_torrent t2(info);
@@ -322,9 +322,9 @@ TORRENT_TEST(v2_only)
 	std::shared_ptr<lt::torrent_info const> info = lt::load_torrent_buffer(buffer).ti;
 	TEST_CHECK(info->info_hashes().has_v2());
 	TEST_CHECK(!info->info_hashes().has_v1());
-	TEST_EQUAL(info->layout().file_name(0_file), "A");
+	TEST_EQUAL(std::string(info->layout().file_name(0_file)), "A");
 	TEST_CHECK(info->layout().pad_file_at(1_file));
-	TEST_EQUAL(info->layout().file_name(2_file), "B");
+	TEST_EQUAL(std::string(info->layout().file_name(2_file)), "B");
 	TEST_EQUAL(info->name(), "test");
 
 }
@@ -659,18 +659,18 @@ TORRENT_TEST(implicit_v2_only)
 		auto& info = *atp.ti;
 		TEST_CHECK(info.info_hashes().has_v2());
 		TEST_CHECK(!info.info_hashes().has_v1());
-		TEST_EQUAL(info.layout().file_name(0_file), "A");
+		TEST_EQUAL(std::string(info.layout().file_name(0_file)), "A");
 		TEST_EQUAL(info.layout().pad_file_at(1_file), true);
-		TEST_EQUAL(info.layout().file_name(2_file), "B");
+		TEST_EQUAL(std::string(info.layout().file_name(2_file)), "B");
 		TEST_EQUAL(info.name(), "test");
 	}
 
 	auto atp = lt::load_torrent_buffer(buffer);
 	TEST_CHECK(atp.ti->info_hashes().has_v2());
 	TEST_CHECK(!atp.ti->info_hashes().has_v1());
-	TEST_EQUAL(atp.ti->layout().file_name(0_file), "A");
+	TEST_EQUAL(std::string(atp.ti->layout().file_name(0_file)), "A");
 	TEST_EQUAL(atp.ti->layout().pad_file_at(1_file), true);
-	TEST_EQUAL(atp.ti->layout().file_name(2_file), "B");
+	TEST_EQUAL(std::string(atp.ti->layout().file_name(2_file)), "B");
 	TEST_EQUAL(atp.ti->name(), "test");
 }
 
@@ -694,18 +694,18 @@ TORRENT_TEST(implicit_v1_only)
 		auto& info = *atp.ti;
 		TEST_CHECK(!info.info_hashes().has_v2());
 		TEST_CHECK(info.info_hashes().has_v1());
-		TEST_EQUAL(info.layout().file_name(0_file), "A");
+		TEST_EQUAL(std::string(info.layout().file_name(0_file)), "A");
 		TEST_EQUAL(info.layout().pad_file_at(1_file), true);
-		TEST_EQUAL(info.layout().file_name(2_file), "B");
+		TEST_EQUAL(std::string(info.layout().file_name(2_file)), "B");
 		TEST_EQUAL(info.name(), "test");
 	}
 
 	auto info = lt::load_torrent_buffer(buffer).ti;
 	TEST_CHECK(!info->info_hashes().has_v2());
 	TEST_CHECK(info->info_hashes().has_v1());
-	TEST_EQUAL(info->layout().file_name(0_file), "A");
+	TEST_EQUAL(std::string(info->layout().file_name(0_file)), "A");
 	TEST_EQUAL(info->layout().pad_file_at(1_file), true);
-	TEST_EQUAL(info->layout().file_name(2_file), "B");
+	TEST_EQUAL(std::string(info->layout().file_name(2_file)), "B");
 	TEST_EQUAL(info->name(), "test");
 }
 
@@ -1167,21 +1167,21 @@ TORRENT_TEST(canonicalize_pad)
 	TEST_EQUAL(fs.num_files(), 6);
 
 	TEST_EQUAL(fs.file_size(0_file), 1);
-	TEST_EQUAL(fs.file_name(0_file), "1");
+	TEST_EQUAL(std::string(fs.file_name(0_file)), "1");
 	TEST_EQUAL(fs.pad_file_at(0_file), false);
 
 	TEST_EQUAL(fs.file_size(1_file), 0x4000 - 1);
 	TEST_EQUAL(fs.pad_file_at(1_file), true);
 
 	TEST_EQUAL(fs.file_size(2_file), 0x7000);
-	TEST_EQUAL(fs.file_name(2_file), "2");
+	TEST_EQUAL(std::string(fs.file_name(2_file)), "2");
 	TEST_EQUAL(fs.pad_file_at(2_file), false);
 
 	TEST_EQUAL(fs.file_size(3_file), 0x8000 - 0x7000);
 	TEST_EQUAL(fs.pad_file_at(3_file), true);
 
 	TEST_EQUAL(fs.file_size(4_file), 0x7001);
-	TEST_EQUAL(fs.file_name(4_file), "3");
+	TEST_EQUAL(std::string(fs.file_name(4_file)), "3");
 	TEST_EQUAL(fs.pad_file_at(4_file), false);
 	TEST_EQUAL(fs.size_on_disk(), 0x7000 + 1 + 0x7001);
 

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -31,10 +31,10 @@ void setup_test_storage(file_storage& st)
 	st.set_piece_length(0x4000);
 	st.set_num_pieces(aux::calc_num_pieces(st));
 
-	TEST_EQUAL(st.file_name(file_index_t{0}), "a");
-	TEST_EQUAL(st.file_name(file_index_t{1}), "b");
-	TEST_EQUAL(st.file_name(file_index_t{2}), "a");
-	TEST_EQUAL(st.file_name(file_index_t{3}), "b");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{0})), "a");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{1})), "b");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{2})), "a");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{3})), "b");
 	TEST_EQUAL(st.name(), "test");
 
 	TEST_EQUAL(st.file_path(file_index_t{0}), combine_path("test", "a"));
@@ -124,6 +124,26 @@ TORRENT_TEST(rename_file)
 	TEST_EQUAL(st.file_path(file_index_t{0}, "."), combine_path(".", combine_path("test__"
 		, "a")));
 }
+
+TORRENT_TEST(rename_pad_file)
+{
+	// pad files cannot be renamed, their name is always synthesized from
+	// their size
+	file_storage st;
+	st.set_piece_length(0x4000);
+	st.add_file(combine_path("test", "a"), 10000);
+	st.add_file(
+		combine_path("test", combine_path(".pad", "6384")), 6384, file_storage::flag_pad_file);
+
+	std::string const pad_path = combine_path("test", combine_path(".pad", "6384"));
+	TEST_EQUAL(st.file_path(file_index_t{1}, ""), pad_path);
+
+	st.rename_file(file_index_t{1}, combine_path("test", "renamed"));
+
+	// the rename had no effect
+	TEST_EQUAL(st.file_path(file_index_t{1}, ""), pad_path);
+	TEST_EQUAL(std::string(st.file_name(file_index_t{1})), "6384");
+}
 #endif
 
 TORRENT_TEST(set_name)
@@ -189,7 +209,7 @@ TORRENT_TEST(pointer_offset)
 	TEST_EQUAL(st.file_name_ptr(file_index_t{0}), filename);
 	TEST_EQUAL(st.file_name_len(file_index_t{0}), 5);
 #endif
-	TEST_EQUAL(st.file_name(file_index_t{0}), string_view(filename, 5));
+	TEST_EQUAL(std::string(st.file_name(file_index_t{0})), string_view(filename, 5));
 #if TORRENT_ABI_VERSION < 4
 	TEST_EQUAL(st.hash(file_index_t{0}), sha1_hash(filehash));
 #endif
@@ -210,7 +230,7 @@ TORRENT_TEST(invalid_path1)
 	st.add_file_borrow({}, "+///(", 10);
 #endif
 
-	TEST_EQUAL(st.file_name(file_index_t{0}), "(");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{0})), "(");
 	TEST_EQUAL(st.file_path(file_index_t{0}, ""), combine_path("+", "("));
 }
 
@@ -224,7 +244,7 @@ TORRENT_TEST(invalid_path2)
 	st.add_file_borrow({}, "+///+//(", 10);
 #endif
 
-	TEST_EQUAL(st.file_name(file_index_t{0}), "(");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{0})), "(");
 	TEST_EQUAL(st.file_path(file_index_t{0}, ""), combine_path("+", combine_path("+", "(")));
 }
 
@@ -288,21 +308,21 @@ TORRENT_TEST(canonicalize_pad)
 	TEST_EQUAL(fs.num_files(), 6);
 
 	TEST_EQUAL(fs.file_size(0_file), 1);
-	TEST_EQUAL(fs.file_name(0_file), "1");
+	TEST_EQUAL(std::string(fs.file_name(0_file)), "1");
 	TEST_EQUAL(fs.pad_file_at(0_file), false);
 
 	TEST_EQUAL(fs.file_size(1_file), 0x4000 - 1);
 	TEST_EQUAL(fs.pad_file_at(1_file), true);
 
 	TEST_EQUAL(fs.file_size(2_file), 0x7000);
-	TEST_EQUAL(fs.file_name(2_file), "2");
+	TEST_EQUAL(std::string(fs.file_name(2_file)), "2");
 	TEST_EQUAL(fs.pad_file_at(2_file), false);
 
 	TEST_EQUAL(fs.file_size(3_file), 0x8000 - 0x7000);
 	TEST_EQUAL(fs.pad_file_at(3_file), true);
 
 	TEST_EQUAL(fs.file_size(4_file), 0x7001);
-	TEST_EQUAL(fs.file_name(4_file), "3");
+	TEST_EQUAL(std::string(fs.file_name(4_file)), "3");
 	TEST_EQUAL(fs.pad_file_at(4_file), false);
 
 	TEST_EQUAL(fs.file_size(5_file), 0x8000 - 0x7001);
@@ -1286,10 +1306,10 @@ TORRENT_TEST(test_renamed_files)
 	TEST_EQUAL(rf.file_path(fs, 3_file, "/root"), "/root/test/2/2");
 #endif
 
-	TEST_EQUAL(rf.file_name(fs, 0_file), "0");
-	TEST_EQUAL(rf.file_name(fs, 1_file), "1");
-	TEST_EQUAL(rf.file_name(fs, 2_file), "1");
-	TEST_EQUAL(rf.file_name(fs, 3_file), "2");
+	TEST_EQUAL(std::string(rf.file_name(fs, 0_file)), "0");
+	TEST_EQUAL(std::string(rf.file_name(fs, 1_file)), "1");
+	TEST_EQUAL(std::string(rf.file_name(fs, 2_file)), "1");
+	TEST_EQUAL(std::string(rf.file_name(fs, 3_file)), "2");
 
 	// no root path
 	rf.rename_file(fs, 0_file, "foobar");
@@ -1298,7 +1318,7 @@ TORRENT_TEST(test_renamed_files)
 #else
 	TEST_EQUAL(rf.file_path(fs, 0_file, "/root"), "/root/foobar");
 #endif
-	TEST_EQUAL(rf.file_name(fs, 0_file), "foobar");
+	TEST_EQUAL(std::string(rf.file_name(fs, 0_file)), "foobar");
 
 	// full path
 #ifdef TORRENT_WINDOWS
@@ -1308,7 +1328,7 @@ TORRENT_TEST(test_renamed_files)
 	rf.rename_file(fs, 1_file, "test/bar");
 	TEST_EQUAL(rf.file_path(fs, 1_file, "/root"), "/root/test/bar");
 #endif
-	TEST_EQUAL(rf.file_name(fs, 1_file), "bar");
+	TEST_EQUAL(std::string(rf.file_name(fs, 1_file)), "bar");
 
 	// absolute path
 #ifdef TORRENT_WINDOWS
@@ -1318,7 +1338,7 @@ TORRENT_TEST(test_renamed_files)
 	rf.rename_file(fs, 2_file, "/foobar/foo");
 	TEST_EQUAL(rf.file_path(fs, 2_file, "/root"), "/foobar/foo");
 #endif
-	TEST_EQUAL(rf.file_name(fs, 2_file), "foo");
+	TEST_EQUAL(std::string(rf.file_name(fs, 2_file)), "foo");
 }
 
 
@@ -1374,10 +1394,10 @@ TORRENT_TEST(renamed_files_round_trip)
 	TEST_EQUAL(rf2.file_path(fs, 2_file, save_path), path2);
 	TEST_EQUAL(rf2.file_path(fs, 3_file, save_path), path3);
 
-	TEST_EQUAL(rf2.file_name(fs, 0_file), rf.file_name(fs, 0_file));
-	TEST_EQUAL(rf2.file_name(fs, 1_file), rf.file_name(fs, 1_file));
-	TEST_EQUAL(rf2.file_name(fs, 2_file), rf.file_name(fs, 2_file));
-	TEST_EQUAL(rf2.file_name(fs, 3_file), rf.file_name(fs, 3_file));
+	TEST_EQUAL(std::string(rf2.file_name(fs, 0_file)), std::string(rf.file_name(fs, 0_file)));
+	TEST_EQUAL(std::string(rf2.file_name(fs, 1_file)), std::string(rf.file_name(fs, 1_file)));
+	TEST_EQUAL(std::string(rf2.file_name(fs, 2_file)), std::string(rf.file_name(fs, 2_file)));
+	TEST_EQUAL(std::string(rf2.file_name(fs, 3_file)), std::string(rf.file_name(fs, 3_file)));
 
 	TEST_EQUAL(rf2.file_absolute_path(fs, 0_file), rf.file_absolute_path(fs, 0_file));
 	TEST_EQUAL(rf2.file_absolute_path(fs, 1_file), rf.file_absolute_path(fs, 1_file));

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -1652,36 +1652,42 @@ namespace {
 			{"test/filler-2", 0x4000, {}, "test/filler-2"},
 		},
 		{
-			// pad files are allowed to collide, as long as they have the same size
-			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/1234"},
+			// pad files are allowed to collide, as long as they have the same
+			// size. their name is always synthesized from their size, so the
+			// literal name given here ("1234") is irrelevant
+			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/16384"},
 			{"test/filler-1", 0x4000, {}, "test/filler-1"},
-			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/1234"},
+			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/16384"},
 			{"test/filler-2", 0x4000, {}, "test/filler-2"},
 		},
 		{
 			// pad files of different sizes are NOT allowed to collide
-			{"test/.pad/1234", 0x8000, file_storage::flag_pad_file, "test/.pad/1234"},
+			{"test/.pad/1234", 0x8000, file_storage::flag_pad_file, "test/.pad/32768"},
 			{"test/filler-1", 0x4000, {}, "test/filler-1"},
-			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/1234.1"},
+			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/16384"},
 			{"test/filler-2", 0x4000, {}, "test/filler-2"},
 		},
 		{
-			// pad files are NOT allowed to collide with normal files
-			{"test/.pad/1234", 0x4000, {}, "test/.pad/1234"},
+			// pad files are NOT allowed to collide with normal files. the
+			// pad file's synthesized name is "16384" (its size), so the
+			// normal file is given that name to collide with it
+			{"test/.pad/16384", 0x4000, {}, "test/.pad/16384"},
 			{"test/filler-1", 0x4000, {}, "test/filler-1"},
-			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/1234.1"},
+			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/16384.1"},
 			{"test/filler-2", 0x4000, {}, "test/filler-2"},
 		},
 		{
 			// normal files are NOT allowed to collide with pad files
-			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/1234"},
+			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/16384"},
 			{"test/filler-1", 0x4000, {}, "test/filler-1"},
-			{"test/.pad/1234", 0x4000, {}, "test/.pad/1234.1"},
+			{"test/.pad/16384", 0x4000, {}, "test/.pad/16384.1"},
 			{"test/filler-2", 0x4000, {}, "test/filler-2"},
 		},
 		{
-			// pad files are NOT allowed to collide with directories
-			{"test/.pad/1234", 0x4000, file_storage::flag_pad_file, "test/.pad/1234.1"},
+			// pad files are NOT allowed to collide with directories. the pad
+			// file's size (1234 bytes) makes its synthesized name ("1234")
+			// collide with the directory implied by the next entry
+			{"test/.pad/1234", 1234, file_storage::flag_pad_file, "test/.pad/1234.1"},
 			{"test/filler-1", 0x4000, {}, "test/filler-1"},
 			{"test/.pad/1234/filler-2", 0x4000, {}, "test/.pad/1234/filler-2"},
 		},
@@ -1860,10 +1866,11 @@ TORRENT_TEST(copy)
 		combine_path(parent_path(current_working_directory())
 		, combine_path("test_torrents", "sample.torrent"))).ti;
 
-	aux::vector<char const*, file_index_t> expected_files =
-	{
+	// the padding file's name in the .torrent is "0", but pad files never
+	// store a name, it's always synthesized from their size
+	aux::vector<char const*, file_index_t> expected_files = {
 		"sample/text_file2.txt",
-		"sample/.____padding_file/0",
+		"sample/.____padding_file/16359",
 		"sample/text_file.txt",
 	};
 


### PR DESCRIPTION
by generating them lazily, instead of at load time. saves time and memory