### PR TITLE
remove the oldest deprecated API of file_storage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2.2.0 not released
 
+	* deprecate file_storage::add_file()
+	* remove deprecated file_entry type and the file_storage iterator API
 	* remove deprecated filehash field
 	* remove deprecated rename_file() on file_storage
 	* optimize padfile memory usage

--- a/bindings/python/libtorrent/__init__.pyi
+++ b/bindings/python/libtorrent/__init__.pyi
@@ -36,7 +36,6 @@ Instructions on adding new types, assuming the tooling told you something was mi
 """
 
 from collections.abc import Callable
-from collections.abc import Iterator
 import datetime
 from typing import Final
 from typing import Literal
@@ -1519,27 +1518,6 @@ class file_completed_alert(torrent_alert):
     @property
     def index(self) -> int: ...
 
-class file_entry(metaclass=_BoostBaseClass):
-    __instance_size__: int
-
-    filehash: sha1_hash
-    mtime: int
-    path: str
-    symlink_path: str
-
-    @property
-    def executable_attribute(self) -> bool: ...
-    @property
-    def hidden_attribute(self) -> bool: ...
-    @property
-    def offset(self) -> int: ...
-    @property
-    def pad_file(self) -> bool: ...
-    @property
-    def size(self) -> int: ...
-    @property
-    def symlink_attribute(self) -> bool: ...
-
 class file_error_alert(torrent_alert):
     def filename(self) -> str:
         """
@@ -1623,7 +1601,6 @@ class file_storage(metaclass=_BoostBaseClass):
             constructing a file_storage directly is deprecated, use create_torrent and create_file_entry instead
         """
 
-    @overload
     def add_file(
         self,
         path: str,
@@ -1634,17 +1611,6 @@ class file_storage(metaclass=_BoostBaseClass):
     ) -> None:
         """
         add_file( (file_storage)arg1, (str)path, (int)size [, (object)flags=0 [, (int)mtime=0 [, (str)linkpath='']]]) -> None :
-        """
-
-    @overload
-    def add_file(self, entry: file_entry) -> None:
-        """
-        add_file( (file_storage)arg1, (file_entry)entry) -> None :
-        """
-
-    def at(self, _index: int) -> file_entry:
-        """
-        at( (file_storage)arg1, (int)arg2) -> file_entry :
         """
 
     def file_absolute_path(self, arg2: int) -> bool:
@@ -1775,16 +1741,6 @@ class file_storage(metaclass=_BoostBaseClass):
     def v2(self) -> bool:
         """
         v2( (file_storage)arg1) -> bool :
-        """
-
-    def __iter__(self) -> Iterator[file_entry]:
-        """
-        __iter__( (object)arg1) -> object :
-        """
-
-    def __len__(self) -> int:
-        """
-        __len__( (file_storage)arg1) -> int :
         """
 
 class fingerprint(metaclass=_BoostBaseClass):
@@ -4927,11 +4883,6 @@ class torrent_info(metaclass=_BoostBaseClass):
     def creator(self) -> str:
         """
         creator( (torrent_info)arg1) -> str :
-        """
-
-    def file_at(self, _index: int) -> file_entry:
-        """
-        file_at( (torrent_info)arg1, (int)arg2) -> file_entry :
         """
 
     def files(self) -> file_storage:

--- a/bindings/python/src/file_storage.cpp
+++ b/bindings/python/src/file_storage.cpp
@@ -38,62 +38,6 @@ namespace {
 		}
 	}
 
-#if TORRENT_ABI_VERSION == 1
-	void add_file_deprecated(file_storage& ct, file_entry const& fe)
-	{
-		python_deprecated("this overload of add_file() is deprecated");
-		ct.add_file(fe);
-	}
-
-	struct FileIter
-	{
-		using value_type = lt::file_entry;
-		using reference = lt::file_entry;
-		using pointer = lt::file_entry*;
-		using difference_type = int;
-		using iterator_category = std::forward_iterator_tag;
-
-		FileIter(file_storage const& fs, file_index_t i)
-			: m_fs(&fs)
-			, m_i(i)
-		{}
-		FileIter(FileIter const&) = default;
-		FileIter()
-			: m_fs(nullptr)
-			, m_i(0)
-		{}
-		lt::file_entry operator*() const { return m_fs->at(m_i); }
-
-		FileIter operator++()
-		{
-			m_i++;
-			return *this;
-		}
-		FileIter operator++(int) { return FileIter(*m_fs, m_i++); }
-
-		bool operator==(FileIter const& rhs) const { return m_fs == rhs.m_fs && m_i == rhs.m_i; }
-
-		int operator-(FileIter const& rhs) const
-		{
-			assert(rhs.m_fs == m_fs);
-			return m_i - rhs.m_i;
-		}
-
-		FileIter& operator=(FileIter const&) = default;
-
-		file_storage const* m_fs;
-		file_index_t m_i;
-	};
-
-	FileIter begin_files(file_storage const& self)
-	{
-		python_deprecated("__iter__ is deprecated");
-		return FileIter(self, file_index_t(0));
-	}
-
-	FileIter end_files(file_storage const& self) { return FileIter(self, self.end_file()); }
-#endif // TORRENT_ABI_VERSION
-
 #if TORRENT_ABI_VERSION < 5
 	std::shared_ptr<file_storage> file_storage_constructor()
 	{
@@ -123,6 +67,7 @@ namespace {
 	}
 #endif
 
+#if TORRENT_ABI_VERSION < 5
 	void add_file0(
 		file_storage& fs,
 		string_view const file,
@@ -132,6 +77,7 @@ namespace {
 		string_view const link
 	)
 	{
+		python_deprecated("add_file is deprecated");
 		fs.add_file(std::string(file), size, flags, md, std::string(link));
 	}
 
@@ -160,6 +106,7 @@ namespace {
 		python_deprecated("add_file with bytes is deprecated");
 		fs.add_file(std::string(file), size, flags, md, link.arr);
 	}
+#endif
 
 	struct dummy_file_flags
 	{};
@@ -170,14 +117,6 @@ namespace {
 		file_storage_check_index(fs, index);
 		return fs.file_path(index, base);
 	}
-
-#if TORRENT_ABI_VERSION == 1
-	file_entry file_storage_at(file_storage const& fs, file_index_t index)
-	{
-		file_storage_check_index(fs, index);
-		return fs.at(index);
-	}
-#endif
 
 	void set_name0(file_storage& fs, string_view const name) { fs.set_name(std::string(name)); }
 
@@ -223,6 +162,7 @@ void bind_file_storage()
 				.def("__init__", make_constructor(&file_storage_constructor))
 #endif
 				.def("is_valid", &file_storage::is_valid)
+#if TORRENT_ABI_VERSION < 5
 				.def("add_file",
 					add_file0,
 					(arg("path"),
@@ -244,13 +184,8 @@ void bind_file_storage()
 						arg("flags") = 0,
 						arg("mtime") = 0,
 						arg("linkpath") = ""))
+#endif
 				.def("num_files", &file_storage::num_files)
-#if TORRENT_ABI_VERSION == 1
-				.def("at", depr(file_storage_at))
-				.def("add_file", add_file_deprecated, arg("entry"))
-				.def("__iter__", boost::python::range(&begin_files, &end_files))
-				.def("__len__", depr(&file_storage::num_files))
-#endif // TORRENT_ABI_VERSION
 #if TORRENT_ABI_VERSION < 4
 				.def("hash", &wrap_file_check<sha1_hash, &file_storage::hash>)
 #endif

--- a/bindings/python/src/torrent_info.cpp
+++ b/bindings/python/src/torrent_info.cpp
@@ -273,36 +273,6 @@ namespace {
 		python_deprecated("send_stats is deprecated");
 		return ae.send_stats;
 	}
-	std::int64_t get_size(file_entry const& fe)
-	{
-		python_deprecated("file_entry is deprecated");
-		return fe.size;
-	}
-	std::int64_t get_offset(file_entry const& fe)
-	{
-		python_deprecated("file_entry is deprecated");
-		return fe.offset;
-	}
-	bool get_pad_file(file_entry const& fe)
-	{
-		python_deprecated("file_entry is deprecated");
-		return fe.pad_file;
-	}
-	bool get_executable_attribute(file_entry const& fe)
-	{
-		python_deprecated("file_entry is deprecated");
-		return fe.executable_attribute;
-	}
-	bool get_hidden_attribute(file_entry const& fe)
-	{
-		python_deprecated("file_entry is deprecated");
-		return fe.hidden_attribute;
-	}
-	bool get_symlink_attribute(file_entry const& fe)
-	{
-		python_deprecated("file_entry is deprecated");
-		return fe.symlink_attribute;
-	}
 #endif
 
 } // namespace unnamed
@@ -395,14 +365,6 @@ std::shared_ptr<torrent_info> bencoded_constructor1(dict d, dict limits)
 }
 #endif
 
-#if TORRENT_ABI_VERSION == 1
-std::shared_ptr<file_entry> file_entry_constructor()
-{
-	python_deprecated("file_entry is deprecated");
-	return std::make_shared<file_entry>();
-}
-#endif
-
 using by_value = return_value_policy<return_by_value>;
 void bind_torrent_info()
 {
@@ -449,25 +411,19 @@ void bind_torrent_info()
 		.def("__init__", make_constructor(&sha256_constructor0))
 
 #if TORRENT_ABI_VERSION < 4
-		.def(
-			"add_tracker",
+		.def("add_tracker",
 			(add_tracker1)&torrent_info::add_tracker,
-			(arg("url"), arg("tier") = 0, arg("source") = announce_entry::source_client)
-		)
-		.def(
-			"add_url_seed",
+			(arg("url"), arg("tier") = 0, arg("source") = announce_entry::source_client))
+		.def("add_url_seed",
 			&torrent_info::add_url_seed,
 			(arg("url"),
-			 arg("extern_auth") = std::string{},
-			 arg("extra_headers") = web_seed_entry::headers_t{})
-		)
-		.def(
-			"add_http_seed",
+				arg("extern_auth") = std::string{},
+				arg("extra_headers") = web_seed_entry::headers_t{}))
+		.def("add_http_seed",
 			depr(&torrent_info::add_http_seed),
 			(arg("url"),
-			 arg("extern_auth") = std::string{},
-			 arg("extra_headers") = web_seed_entry::headers_t{})
-		)
+				arg("extern_auth") = std::string{},
+				arg("extra_headers") = web_seed_entry::headers_t{}))
 		.def("web_seeds", get_web_seeds)
 		.def("set_web_seeds", set_web_seeds)
 #endif
@@ -502,10 +458,6 @@ void bind_torrent_info()
 		.def("orig_files", depr(&torrent_info::orig_files), return_internal_reference<>())
 #endif
 
-#if TORRENT_ABI_VERSION == 1
-		.def("file_at", depr(&torrent_info::file_at))
-#endif // TORRENT_ABI_VERSION
-
 		.def("is_valid", &torrent_info::is_valid)
 		.def("priv", &torrent_info::priv)
 		.def("is_i2p", &torrent_info::is_i2p)
@@ -525,21 +477,6 @@ void bind_torrent_info()
 		.def("info_section", &get_info_section)
 		.def("map_block", map_block)
 		.def("map_file", &torrent_info::map_file);
-
-#if TORRENT_ABI_VERSION == 1
-	class_<file_entry>("file_entry", no_init)
-		.def("__init__", make_constructor(&file_entry_constructor))
-		.def_readwrite("path", &file_entry::path)
-		.def_readwrite("symlink_path", &file_entry::symlink_path)
-		.def_readwrite("filehash", &file_entry::filehash)
-		.def_readwrite("mtime", &file_entry::mtime)
-		.add_property("pad_file", &get_pad_file)
-		.add_property("executable_attribute", &get_executable_attribute)
-		.add_property("hidden_attribute", &get_hidden_attribute)
-		.add_property("symlink_attribute", &get_symlink_attribute)
-		.add_property("offset", &get_offset)
-		.add_property("size", &get_size);
-#endif
 
 	class_<announce_entry>("announce_entry", init<std::string const&>())
 		.def_readwrite("url", &announce_entry::url)

--- a/bindings/python/tests/create_torrent_test.py
+++ b/bindings/python/tests/create_torrent_test.py
@@ -98,79 +98,36 @@ class FileStorageTest(unittest.TestCase):
         self.assertEqual(ti.layout().num_files(), 1)
 
     def test_add_file(self) -> None:
-        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
-        fs = ti.layout()
-        fs.add_file(os.path.join("path", "file2.txt"), 512)
-        self.assertEqual(fs.num_files(), 2)
-        self.assertEqual(fs.file_path(1), os.path.join("path", "file2.txt"))
-        self.assertEqual(fs.file_size(1), 512)
+        if lt.api_version < 5:
+            ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+            fs = ti.layout()
+            fs.add_file(os.path.join("path", "file2.txt"), 512)
+            self.assertEqual(fs.num_files(), 2)
+            self.assertEqual(fs.file_path(1), os.path.join("path", "file2.txt"))
+            self.assertEqual(fs.file_size(1), 512)
 
-        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
-        fs = ti.layout()
-        fs.add_file(os.path.join("path", "file2.txt"), 512, linkpath="file1.txt")
-        self.assertEqual(fs.symlink(1), os.path.join("path", "file1.txt"))
+            ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
+            fs = ti.layout()
+            fs.add_file(os.path.join("path", "file2.txt"), 512, linkpath="file1.txt")
+            self.assertEqual(fs.symlink(1), os.path.join("path", "file1.txt"))
 
     def test_add_file_bytes(self) -> None:
-        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
-        fs = ti.layout()
-        with self.assertWarns(DeprecationWarning):
-            fs.add_file(os.path.join(b"path", b"file2.txt"), 512)  # type: ignore
-        self.assertEqual(fs.file_path(1), os.path.join("path", "file2.txt"))
-
-        ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
-        fs = ti.layout()
-        with self.assertWarns(DeprecationWarning):
-            fs.add_file(
-                os.path.join("path", "file2.txt"),
-                512,
-                linkpath=b"file1.txt",
-            )
-        self.assertEqual(fs.symlink(1), os.path.join("path", "file1.txt"))
-
-    def test_add_file_entry(self) -> None:
-        if lt.api_version < 2:
+        if lt.api_version < 5:
             ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
             fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
-                fe = lt.file_entry()
-            fe.path = os.path.join("path", "file2.txt")
-            with self.assertWarns(DeprecationWarning):
-                fs.add_file(fe)
+                fs.add_file(os.path.join(b"path", b"file2.txt"), 512)  # type: ignore
+            self.assertEqual(fs.file_path(1), os.path.join("path", "file2.txt"))
 
-    def test_at_invalid(self) -> None:
-        if lt.api_version < 2:
-            ti = _build_layout([("test.txt", 1024)])
+            ti = _build_layout([(os.path.join("path", "file1.txt"), 1024)])
             fs = ti.layout()
             with self.assertWarns(DeprecationWarning):
-                with self.assertRaises(IndexError):
-                    fs.at(1)
-            with self.assertWarns(DeprecationWarning):
-                with self.assertRaises(IndexError):
-                    fs.at(-1)
-
-    def test_at(self) -> None:
-        if lt.api_version < 2:
-            ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])
-            fs = ti.layout()
-            with self.assertWarns(DeprecationWarning):
-                fe = fs.at(0)
-            self.assertEqual(fe.path, os.path.join("path", "test.txt"))
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(fe.size, 1024)
-
-    def test_iter(self) -> None:
-        if lt.api_version < 2:
-            ti = _build_layout([("test.txt", 1024)])
-            fs = ti.layout()
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual([fe.path for fe in fs], ["test.txt"])
-
-    def test_len(self) -> None:
-        if lt.api_version < 2:
-            ti = _build_layout([("test.txt", 1024)])
-            fs = ti.layout()
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(len(fs), 1)
+                fs.add_file(
+                    os.path.join("path", "file2.txt"),
+                    512,
+                    linkpath=b"file1.txt",
+                )
+            self.assertEqual(fs.symlink(1), os.path.join("path", "file1.txt"))
 
     def test_symlink(self) -> None:
         ti = _build_layout([(os.path.join("path", "test.txt"), 1024)])

--- a/bindings/python/tests/torrent_info_test.py
+++ b/bindings/python/tests/torrent_info_test.py
@@ -20,40 +20,6 @@ else:
     _Entry, TorrentFileDict, load_torrent_limits = dict, dict, dict
 
 
-class FileEntryTest(unittest.TestCase):
-    def test_attributes(self) -> None:
-        if lt.api_version < 2:
-            with self.assertWarns(DeprecationWarning):
-                fe = lt.file_entry()
-
-            fe.path = os.path.join("path", "file.txt")
-            path = fe.path
-            self.assertEqual(path, os.path.join("path", "file.txt"))
-
-            fe.symlink_path = os.path.join("path", "other.txt")
-            self.assertEqual(fe.symlink_path, os.path.join("path", "other.txt"))
-
-            fe.filehash = lt.sha1_hash(b"a" * 20)
-            self.assertEqual(fe.filehash, lt.sha1_hash(b"a" * 20))
-
-            fe.mtime = 123456
-            self.assertEqual(fe.mtime, 123456)
-
-            with self.assertWarns(DeprecationWarning):
-                self.assertFalse(fe.pad_file)
-            with self.assertWarns(DeprecationWarning):
-                self.assertFalse(fe.executable_attribute)
-            with self.assertWarns(DeprecationWarning):
-                self.assertFalse(fe.hidden_attribute)
-            with self.assertWarns(DeprecationWarning):
-                self.assertFalse(fe.symlink_attribute)
-
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(fe.offset, 0)
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(fe.size, 0)
-
-
 class InfoHashTest(unittest.TestCase):
     def test_sha1(self) -> None:
         sha1 = lt.sha1_hash(lib.get_random_bytes(20))
@@ -573,9 +539,3 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(file_slice.file_index, 0)
         self.assertEqual(file_slice.offset, 100)
         self.assertEqual(file_slice.size, 200)
-
-    def test_file_at(self) -> None:
-        if lt.api_version < 2:
-            with self.assertWarns(DeprecationWarning):
-                fe = self.ti.file_at(0)
-            self.assertEqual(fe.path, self.ti.layout().file_path(0))

--- a/fuzzers/src/file_storage_add_file.cpp
+++ b/fuzzers/src/file_storage_add_file.cpp
@@ -14,7 +14,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 	lt::file_storage fs;
 	// we expect this call to fail sometimes
 	try {
-		fs.add_file({reinterpret_cast<char const*>(data), size}, 1);
+		fs.add_file_borrow({}, {reinterpret_cast<char const*>(data), size}, 1);
 	}
 	catch (...) {}
 	return 0;

--- a/fuzzers/src/hash_picker.cpp
+++ b/fuzzers/src/hash_picker.cpp
@@ -52,7 +52,7 @@ extern "C" int LLVMFuzzerInitialize(int*, char***)
 	int const num_pieces = 4 * 512;
 
 	g_fs.set_piece_length(piece_size);
-	g_fs.add_file("test/tmp1", std::int64_t(num_pieces) * piece_size);
+	g_fs.add_file_borrow({}, "test/tmp1", std::int64_t(num_pieces) * piece_size);
 
 	char const root[32] = {};
 	g_trees.emplace_back(

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -37,64 +37,6 @@ see LICENSE file.
 
 namespace libtorrent {
 
-#if TORRENT_ABI_VERSION == 1
-	// information about a file in a file_storage
-	struct TORRENT_DEPRECATED_EXPORT file_entry
-	{
-#include "libtorrent/aux_/disable_deprecation_warnings_push.hpp"
-		// hidden
-		file_entry();
-		// hidden
-		~file_entry();
-		file_entry(file_entry const&) = default;
-		file_entry& operator=(file_entry const&) & = default;
-		file_entry(file_entry&&) noexcept = default;
-		file_entry& operator=(file_entry&&) & = default;
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
-		// the full path of this file. The paths are unicode strings
-		// encoded in UTF-8.
-		std::string path;
-
-		// the path which this is a symlink to, or empty if this is
-		// not a symlink. This field is only used if the ``symlink_attribute`` is set.
-		std::string symlink_path;
-
-		// the offset of this file inside the torrent
-		std::int64_t offset;
-
-		// the size of the file (in bytes) and ``offset`` is the byte offset
-		// of the file within the torrent. i.e. the sum of all the sizes of the files
-		// before it in the list.
-		std::int64_t size;
-
-		// the modification time of this file specified in posix time.
-		std::time_t mtime;
-
-		// always a default constructed hash.
-		sha1_hash filehash;
-
-		// set to true for files that are not part of the data of the torrent.
-		// They are just there to make sure the next file is aligned to a particular byte offset
-		// or piece boundary. These files should typically be hidden from an end user. They are
-		// not written to disk.
-		bool pad_file:1;
-
-		// true if the file was marked as hidden (on windows).
-		bool hidden_attribute:1;
-
-		// true if the file was marked as executable (posix)
-		bool executable_attribute:1;
-
-		// true if the file was a symlink. If this is the case
-		// the ``symlink_index`` refers to a string which specifies the original location
-		// where the data for this file was found.
-		bool symlink_attribute:1;
-	};
-
-#endif // TORRENT_ABI_VERSION
-
 namespace aux {
 	struct path_index_tag;
 	using path_index_t = aux::strong_typedef<std::uint32_t, path_index_tag>;
@@ -358,10 +300,13 @@ public:
 		//
 		// The overloads that take an `error_code` reference will report failures
 		// via that variable, otherwise `system_error` is thrown.
+#if TORRENT_ABI_VERSION < 5
+		TORRENT_DEPRECATED
 		void add_file(std::string const& path, std::int64_t file_size
 			, file_flags_t file_flags = {}
 			, std::time_t mtime = 0, string_view symlink_path = string_view()
 			, char const* root_hash = nullptr);
+#endif
 #endif // BOOST_NO_EXCEPTIONS
 
 		// internal
@@ -380,57 +325,18 @@ public:
 
 		// this overload reports failures through the ``ec`` reference rather
 		// than throwing.
+#if TORRENT_ABI_VERSION < 5
+		TORRENT_DEPRECATED
 		void add_file(error_code& ec, std::string const& path, std::int64_t file_size
 			, file_flags_t file_flags = {}
 			, std::time_t mtime = 0, string_view symlink_path = string_view()
 			, char const* root_hash = nullptr);
+#endif
 
 #if TORRENT_ABI_VERSION < 4
 		// internal
 		TORRENT_UNEXPORT void rename_file_impl(file_index_t index, std::string const& new_filename);
 #endif
-
-#if TORRENT_ABI_VERSION == 1
-#include "libtorrent/aux_/disable_deprecation_warnings_push.hpp"
-
-		TORRENT_DEPRECATED
-		void add_file(file_entry const& fe, char const* filehash = nullptr);
-
-		// all functions depending on aux::file_entry
-		// were deprecated in 1.0. Use the variants that take an
-		// index instead
-		using iterator = std::vector<aux::file_entry>::const_iterator;
-		using reverse_iterator = std::vector<aux::file_entry>::const_reverse_iterator;
-
-		TORRENT_DEPRECATED
-		iterator file_at_offset(std::int64_t offset) const;
-		TORRENT_DEPRECATED
-		iterator begin() const { return m_files.begin(); }
-		TORRENT_DEPRECATED
-		iterator end() const { return m_files.end(); }
-		TORRENT_DEPRECATED
-		reverse_iterator rbegin() const { return m_files.rbegin(); }
-		TORRENT_DEPRECATED
-		reverse_iterator rend() const { return m_files.rend(); }
-		TORRENT_DEPRECATED
-		aux::file_entry const& internal_at(int const index) const;
-		TORRENT_DEPRECATED
-		file_entry at(iterator i) const;
-
-		// returns a file_entry with information about the file
-		// at ``index``. Index must be in the range [0, ``num_files()`` ).
-		TORRENT_DEPRECATED
-		file_entry at(int index) const;
-
-		iterator begin_deprecated() const { return m_files.begin(); }
-		iterator end_deprecated() const { return m_files.end(); }
-		reverse_iterator rbegin_deprecated() const { return m_files.rbegin(); }
-		reverse_iterator rend_deprecated() const { return m_files.rend(); }
-		iterator file_at_offset_deprecated(std::int64_t offset) const;
-		file_entry at_deprecated(int index) const;
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-#endif // TORRENT_ABI_VERSION
 
 		// returns a list of file_slice objects representing the portions of
 		// files the specified piece index, byte offset and size range overlaps.

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -291,9 +291,6 @@ struct anonymous_mode_alert;
 struct mmap_cache_alert;
 TORRENT_VERSION_NAMESPACE_4_END
 
-// include/libtorrent/file_storage.hpp
-struct file_entry;
-
 // include/libtorrent/fingerprint.hpp
 struct fingerprint;
 

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -419,42 +419,6 @@ TORRENT_VERSION_NAMESPACE_4
 		bool v1() const;
 		bool v2() const;
 
-#if TORRENT_ABI_VERSION == 1
-		// deprecated in 1.0. Use the variants that take an index instead
-		// internal_file_entry is no longer exposed in the API
-		using file_iterator = file_storage::iterator;
-		using reverse_file_iterator = file_storage::reverse_iterator;
-
-		// This class will need some explanation. First of all, to get a list of
-		// all files in the torrent, you can use ``begin_files()``,
-		// ``end_files()``, ``rbegin_files()`` and ``rend_files()``. These will
-		// give you standard vector iterators with the type
-		// ``internal_file_entry``, which is an internal type.
-		//
-		// You can resolve it into the public representation of a file
-		// (``file_entry``) using the ``file_storage::at`` function, which takes
-		// an index and an iterator.
-		TORRENT_DEPRECATED
-		file_iterator begin_files() const { return files_impl().begin_deprecated(); }
-		TORRENT_DEPRECATED
-		file_iterator end_files() const { return files_impl().end_deprecated(); }
-		reverse_file_iterator rbegin_files() const { return files_impl().rbegin_deprecated(); }
-		TORRENT_DEPRECATED
-		reverse_file_iterator rend_files() const { return files_impl().rend_deprecated(); }
-
-		TORRENT_DEPRECATED
-		file_iterator file_at_offset(std::int64_t offset) const
-		{ return files_impl().file_at_offset_deprecated(offset); }
-
-#include "libtorrent/aux_/disable_deprecation_warnings_push.hpp"
-
-		TORRENT_DEPRECATED
-		file_entry file_at(int index) const { return files_impl().at_deprecated(index); }
-
-#include "libtorrent/aux_/disable_warnings_pop.hpp"
-
-#endif // TORRENT_ABI_VERSION
-
 		// If you need index-access to files you can use the ``num_files()`` along
 		// with the ``file_path()``, ``file_size()``-family of functions to access
 		// files using indices.

--- a/simulation/test_file_pool.cpp
+++ b/simulation/test_file_pool.cpp
@@ -83,7 +83,7 @@ TORRENT_TEST(file_pool_size)
 			{
 				char filename[50];
 				snprintf(filename, sizeof(filename), "root/file-%d", i);
-				fs.add_file(filename, 0x400);
+				fs.add_file_borrow({}, filename, 0x400);
 			}
 			atp.ti = std::make_shared<torrent_info>(*atp.ti);
 			atp.ti->remap_files(fs);

--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -199,11 +199,11 @@ namespace {
 				// target as well (e.g. to reject symlinks pointing at files
 				// the predicate excluded earlier)
 				if (!pred(combine_path(torrent_root, sym_path))) return;
-				fs.add_file(l, 0, file_flags, std::time_t(s.mtime), sym_path);
+				fs.add_file_borrow({}, l, 0, file_flags, std::time_t(s.mtime), sym_path);
 			}
 			else
 			{
-				fs.add_file(l, s.file_size, file_flags, std::time_t(s.mtime));
+				fs.add_file_borrow({}, l, s.file_size, file_flags, std::time_t(s.mtime));
 			}
 		}
 	}
@@ -420,7 +420,7 @@ namespace {
 		file_storage ret;
 		ret.set_piece_length(piece_size);
 		for (auto const& f : files)
-			ret.add_file(f.filename, f.size, f.flags);
+			ret.add_file_borrow({}, f.filename, f.size, f.flags);
 		ret.set_num_pieces(aux::calc_num_pieces(ret));
 		return ret;
 	}

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -322,16 +322,6 @@ TORRENT_VERSION_NAMESPACE_4_END
 		}
 	}
 
-#if TORRENT_ABI_VERSION == 1
-	file_entry::file_entry(): offset(0), size(0)
-		, mtime(0), pad_file(false), hidden_attribute(false)
-		, executable_attribute(false)
-		, symlink_attribute(false)
-	{}
-
-	file_entry::~file_entry() = default;
-#endif // TORRENT_ABI_VERSION
-
 namespace aux {
 
 file_name_view::file_name_view(std::uint64_t const pad_size)
@@ -463,21 +453,6 @@ file_entry::~file_entry()
 
 TORRENT_VERSION_NAMESPACE_4
 
-#if TORRENT_ABI_VERSION == 1
-
-	void file_storage::add_file(file_entry const& fe, char const* filehash)
-	{
-		TORRENT_UNUSED(filehash);
-		file_flags_t flags = {};
-		if (fe.pad_file) flags |= file_storage::flag_pad_file;
-		if (fe.hidden_attribute) flags |= file_storage::flag_hidden;
-		if (fe.executable_attribute) flags |= file_storage::flag_executable;
-		if (fe.symlink_attribute) flags |= file_storage::flag_symlink;
-
-		add_file_borrow({}, fe.path, fe.size, flags, fe.mtime, fe.symlink_path);
-	}
-#endif // TORRENT_ABI_VERSION
-
 #if TORRENT_ABI_VERSION < 4
 	void file_storage::rename_file_impl(file_index_t const index
 		, std::string const& new_filename)
@@ -489,29 +464,6 @@ TORRENT_VERSION_NAMESPACE_4
 		update_path_index(m_files[index], new_filename);
 	}
 #endif // TORRENT_ABI_VERSION
-
-#if TORRENT_ABI_VERSION == 1
-	file_storage::iterator file_storage::file_at_offset_deprecated(std::int64_t offset) const
-	{
-		// find the file iterator and file offset
-		aux::file_entry target;
-		TORRENT_ASSERT(offset <= max_file_offset);
-		target.offset = aux::numeric_cast<std::uint64_t>(offset);
-		TORRENT_ASSERT(!compare_file_offset(target, m_files.front()));
-
-		auto file_iter = std::upper_bound(
-			begin_deprecated(), end_deprecated(), target, compare_file_offset);
-
-		TORRENT_ASSERT(file_iter != begin_deprecated());
-		--file_iter;
-		return file_iter;
-	}
-
-	file_storage::iterator file_storage::file_at_offset(std::int64_t offset) const
-	{
-		return file_at_offset_deprecated(offset);
-	}
-#endif
 
 	file_index_t file_storage::file_index_at_offset(std::int64_t const offset) const
 	{
@@ -628,39 +580,6 @@ TORRENT_VERSION_NAMESPACE_4
 		return ret;
 	}
 
-#if TORRENT_ABI_VERSION == 1
-	file_entry file_storage::at(int index) const
-	{
-		return at_deprecated(index);
-	}
-
-	aux::file_entry const& file_storage::internal_at(int const index) const
-	{
-		TORRENT_ASSERT(index >= 0);
-		TORRENT_ASSERT(index < int(m_files.size()));
-		return m_files[file_index_t(index)];
-	}
-
-	file_entry file_storage::at_deprecated(int index) const
-	{
-		TORRENT_ASSERT_PRECOND(index >= 0 && index < int(m_files.size()));
-		file_entry ret;
-		aux::file_entry const& ife = m_files[index];
-		ret.path = file_path(index);
-		ret.offset = ife.offset;
-		ret.size = ife.size;
-		ret.mtime = mtime(index);
-		ret.pad_file = ife.pad_file;
-		ret.hidden_attribute = ife.hidden_attribute;
-		ret.executable_attribute = ife.executable_attribute;
-		ret.symlink_attribute = ife.symlink_attribute;
-		if (ife.symlink_index != aux::file_entry::not_a_symlink)
-			ret.symlink_path = symlink(index);
-		ret.filehash = hash(index);
-		return ret;
-	}
-#endif // TORRENT_ABI_VERSION
-
 	int file_storage::num_files() const noexcept
 	{ return int(m_files.size()); }
 
@@ -712,6 +631,7 @@ TORRENT_VERSION_NAMESPACE_4
 	}
 
 #ifndef BOOST_NO_EXCEPTIONS
+#if TORRENT_ABI_VERSION < 5
 	void file_storage::add_file(std::string const& path, std::int64_t const file_size
 		, file_flags_t const file_flags, std::time_t const mtime, string_view const symlink_path
 		, char const* root_hash)
@@ -722,6 +642,7 @@ TORRENT_VERSION_NAMESPACE_4
 			ec, {}, path, file_size, file_flags, mtime, symlink_path, root_hash_offset);
 		if (ec) aux::throw_ex<system_error>(ec);
 	}
+#endif
 
 	void file_storage::add_file_borrow(string_view filename,
 		std::string const& path,
@@ -738,6 +659,7 @@ TORRENT_VERSION_NAMESPACE_4
 	}
 #endif // BOOST_NO_EXCEPTIONS
 
+#if TORRENT_ABI_VERSION < 5
 	void file_storage::add_file(error_code& ec, std::string const& path
 		, std::int64_t const file_size, file_flags_t const file_flags, std::time_t const mtime
 		, string_view symlink_path, char const* root_hash)
@@ -746,6 +668,7 @@ TORRENT_VERSION_NAMESPACE_4
 		add_file_borrow_impl(
 			ec, {}, path, file_size, file_flags, mtime, symlink_path, root_hash_offset);
 	}
+#endif
 
 	void file_storage::add_file_borrow(error_code& ec,
 		string_view filename,
@@ -1328,13 +1251,7 @@ namespace {
 		return fe.pad_file;
 	}
 
-	std::int64_t file_storage::file_offset(aux::file_entry const& fe) const
-	{
-		return fe.offset;
-	}
-
-	file_entry file_storage::at(file_storage::iterator i) const
-	{ return at_deprecated(int(i - m_files.begin())); }
+	std::int64_t file_storage::file_offset(aux::file_entry const& fe) const { return fe.offset; }
 #endif // TORRENT_ABI_VERSION
 
 	void file_storage::swap(file_storage& ti) noexcept

--- a/test/setup_transfer.cpp
+++ b/test/setup_transfer.cpp
@@ -820,7 +820,7 @@ lt::file_storage make_file_storage(span<const int> const file_sizes
 			, int(i) / 5);
 		std::string full_path = combine_path(dirname, filename);
 
-		fs.add_file(full_path, file_sizes[i]);
+		fs.add_file_borrow({}, full_path, file_sizes[i]);
 	}
 
 	fs.set_piece_length(piece_size);

--- a/test/test_apply_pad.cpp
+++ b/test/test_apply_pad.cpp
@@ -58,7 +58,8 @@ lt::file_storage make_fs(std::vector<file_ent> const files, int const piece_size
 	{
 		char filename[200];
 		std::snprintf(filename, sizeof(filename), "t/test%d", int(i++));
-		fs.add_file(filename, e.size, e.pad ? file_storage::flag_pad_file : file_flags_t{});
+		fs.add_file_borrow(
+			{}, filename, e.size, e.pad ? file_storage::flag_pad_file : file_flags_t{});
 	}
 
 	fs.set_piece_length(piece_size);

--- a/test/test_create_torrent.cpp
+++ b/test/test_create_torrent.cpp
@@ -92,7 +92,7 @@ TORRENT_TEST(auto_piece_size)
 #if TORRENT_ABI_VERSION < 4
 		{
 			lt::file_storage fs;
-			fs.add_file("a", t.first);
+			fs.add_file_borrow({}, "a", t.first);
 			lt::create_torrent ct(fs, 0);
 			TEST_CHECK(ct.piece_length() == static_cast<int>(t.second));
 		}
@@ -116,7 +116,7 @@ int test_piece_size(int const piece_size, lt::create_flags_t const f = {})
 #if TORRENT_ABI_VERSION < 4
 	{
 		lt::file_storage fs;
-		fs.add_file("a", 100 * MiB);
+		fs.add_file_borrow({}, "a", 100 * MiB);
 		lt::create_torrent ct2(fs, piece_size, f);
 		TEST_EQUAL(ct2.piece_length(), ct.piece_length());
 	}

--- a/test/test_disk_io.cpp
+++ b/test/test_disk_io.cpp
@@ -95,7 +95,7 @@ static void disk_io_test_suite_impl(lt::disk_io_constructor_type disk_io,
 	{
 		int const file_size = piece_size * 2 + i * 11;
 		total_size += file_size;
-		fs.add_file("test-torrent/file-" + std::to_string(i), file_size, {});
+		fs.add_file_borrow({}, "test-torrent/file-" + std::to_string(i), file_size, {});
 	}
 	fs.set_num_pieces(int((total_size + piece_size - 1) / piece_size));
 
@@ -336,7 +336,7 @@ static void hash2_before_flush_impl(
 	lt::file_storage fs;
 	fs.set_piece_length(piece_size);
 	int const file_size = piece_size * 3 + 17;
-	fs.add_file("hash2_before_flush_torrent/file-0", file_size, {});
+	fs.add_file_borrow({}, "hash2_before_flush_torrent/file-0", file_size, {});
 	fs.set_num_pieces(int((file_size + piece_size - 1) / piece_size));
 
 	lt::storage_holder storage = add_test_torrent(*disk_thread,
@@ -500,7 +500,7 @@ static void unaligned_cross_block_read_impl(
 	fs.set_piece_length(piece_size);
 	// one extra, never-written piece to raise a no-op storage fence on.
 	int const file_size = piece_size * (num_test_pieces + 1);
-	fs.add_file("unaligned_read_torrent/file-0", file_size, {});
+	fs.add_file_borrow({}, "unaligned_read_torrent/file-0", file_size, {});
 	fs.set_num_pieces(int((file_size + piece_size - 1) / piece_size));
 
 	lt::storage_holder storage =
@@ -711,7 +711,7 @@ static void clear_during_flush_impl(
 	lt::file_storage fs;
 	fs.set_piece_length(piece_size);
 	int const file_size = piece_size * 4;
-	fs.add_file("clear_during_flush_torrent/file-0", file_size, {});
+	fs.add_file_borrow({}, "clear_during_flush_torrent/file-0", file_size, {});
 	fs.set_num_pieces(int((file_size + piece_size - 1) / piece_size));
 
 	lt::aux::vector<lt::download_priority_t, lt::file_index_t> priorities;

--- a/test/test_file_progress.cpp
+++ b/test/test_file_progress.cpp
@@ -22,13 +22,13 @@ TORRENT_TEST(init)
 	const int piece_size = 256;
 
 	file_storage fs;
-	fs.add_file("torrent/1", 0);
-	fs.add_file("torrent/2", 10);
-	fs.add_file("torrent/3", 20);
-	fs.add_file("torrent/4", 30);
-	fs.add_file("torrent/5", 40);
-	fs.add_file("torrent/6", 100000);
-	fs.add_file("torrent/7", 30);
+	fs.add_file_borrow({}, "torrent/1", 0);
+	fs.add_file_borrow({}, "torrent/2", 10);
+	fs.add_file_borrow({}, "torrent/3", 20);
+	fs.add_file_borrow({}, "torrent/4", 30);
+	fs.add_file_borrow({}, "torrent/5", 40);
+	fs.add_file_borrow({}, "torrent/6", 100000);
+	fs.add_file_borrow({}, "torrent/7", 30);
 	fs.set_piece_length(piece_size);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 
@@ -59,8 +59,8 @@ TORRENT_TEST(init2)
 	const int piece_size = 256;
 
 	file_storage fs;
-	fs.add_file("torrent/1", 100000);
-	fs.add_file("torrent/2", 10);
+	fs.add_file_borrow({}, "torrent/1", 100000);
+	fs.add_file_borrow({}, "torrent/2", 10);
 	fs.set_piece_length(piece_size);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 
@@ -89,9 +89,9 @@ TORRENT_TEST(update_simple_sequential)
 	int const piece_size = 256;
 
 	file_storage fs;
-	fs.add_file("torrent/1", 100000);
-	fs.add_file("torrent/2", 100);
-	fs.add_file("torrent/3", 45000);
+	fs.add_file_borrow({}, "torrent/1", 100000);
+	fs.add_file_borrow({}, "torrent/2", 100);
+	fs.add_file_borrow({}, "torrent/3", 45000);
 	fs.set_piece_length(piece_size);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 
@@ -123,9 +123,9 @@ TORRENT_TEST(pad_file_completion_callback)
 	int const piece_size = 256;
 
 	file_storage fs;
-	fs.add_file("torrent/1", 100000);
-	fs.add_file("torrent/2", 100, file_storage::flag_pad_file);
-	fs.add_file("torrent/3", 45000);
+	fs.add_file_borrow({}, "torrent/1", 100000);
+	fs.add_file_borrow({}, "torrent/2", 100, file_storage::flag_pad_file);
+	fs.add_file_borrow({}, "torrent/3", 45000);
 	fs.set_piece_length(piece_size);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -46,10 +46,10 @@ file_storage make_v2_storage() { return file_storage(dummy_root_hash); }
 
 void setup_test_storage(file_storage& st)
 {
-	st.add_file(combine_path("test", "a"), 10000);
-	st.add_file(combine_path("test", "b"), 20000);
-	st.add_file(combine_path("test", combine_path("c", "a")), 30000);
-	st.add_file(combine_path("test", combine_path("c", "b")), 40000);
+	st.add_file_borrow({}, combine_path("test", "a"), 10000);
+	st.add_file_borrow({}, combine_path("test", "b"), 20000);
+	st.add_file_borrow({}, combine_path("test", combine_path("c", "a")), 30000);
+	st.add_file_borrow({}, combine_path("test", combine_path("c", "b")), 40000);
 
 	st.set_piece_length(0x4000);
 	st.set_num_pieces(aux::calc_num_pieces(st));
@@ -94,19 +94,19 @@ TORRENT_TEST(coalesce_path)
 {
 	file_storage st;
 	st.set_piece_length(0x4000);
-	st.add_file(combine_path("test", "a"), 10000);
+	st.add_file_borrow({}, combine_path("test", "a"), 10000);
 	TEST_EQUAL(st.paths().size(), 1);
 	TEST_EQUAL(st.paths()[0_path], "");
-	st.add_file(combine_path("test", "b"), 20000);
+	st.add_file_borrow({}, combine_path("test", "b"), 20000);
 	TEST_EQUAL(st.paths().size(), 1);
 	TEST_EQUAL(st.paths()[0_path], "");
-	st.add_file(combine_path("test", combine_path("c", "a")), 30000);
+	st.add_file_borrow({}, combine_path("test", combine_path("c", "a")), 30000);
 	TEST_EQUAL(st.paths().size(), 2);
 	TEST_EQUAL(st.paths()[0_path], "");
 	TEST_EQUAL(st.paths()[1_path], "c");
 
 	// make sure that two files with the same path shares the path entry
-	st.add_file(combine_path("test", combine_path("c", "b")), 40000);
+	st.add_file_borrow({}, combine_path("test", combine_path("c", "b")), 40000);
 	TEST_EQUAL(st.paths().size(), 2);
 	TEST_EQUAL(st.paths()[0_path], "");
 	TEST_EQUAL(st.paths()[1_path], "c");
@@ -153,9 +153,9 @@ TORRENT_TEST(rename_pad_file)
 	// their size
 	file_storage st;
 	st.set_piece_length(0x4000);
-	st.add_file(combine_path("test", "a"), 10000);
-	st.add_file(
-		combine_path("test", combine_path(".pad", "6384")), 6384, file_storage::flag_pad_file);
+	st.add_file_borrow({}, combine_path("test", "a"), 10000);
+	st.add_file_borrow(
+		{}, combine_path("test", combine_path(".pad", "6384")), 6384, file_storage::flag_pad_file);
 
 	std::string const pad_path = combine_path("test", combine_path(".pad", "6384"));
 	TEST_EQUAL(st.file_path(file_index_t{1}, ""), pad_path);
@@ -186,7 +186,7 @@ TORRENT_TEST(rename_file2)
 {
 	// test rename_file
 	file_storage st;
-	st.add_file("a", 10000);
+	st.add_file_borrow({}, "a", 10000);
 	TEST_EQUAL(st.file_path(file_index_t{0}, ""), "a");
 
 	st.rename_file_impl(file_index_t{0}, combine_path("test", combine_path("c", "d")));
@@ -269,13 +269,13 @@ TORRENT_TEST(map_file)
 	// test map_file
 	file_storage fs;
 	fs.set_piece_length(512);
-	fs.add_file(combine_path("temp_storage", "test1.tmp"), 17);
-	fs.add_file(combine_path("temp_storage", "test2.tmp"), 612);
-	fs.add_file(combine_path("temp_storage", "test3.tmp"), 0);
-	fs.add_file(combine_path("temp_storage", "test4.tmp"), 0);
-	fs.add_file(combine_path("temp_storage", "test5.tmp"), 3253);
+	fs.add_file_borrow({}, combine_path("temp_storage", "test1.tmp"), 17);
+	fs.add_file_borrow({}, combine_path("temp_storage", "test2.tmp"), 612);
+	fs.add_file_borrow({}, combine_path("temp_storage", "test3.tmp"), 0);
+	fs.add_file_borrow({}, combine_path("temp_storage", "test4.tmp"), 0);
+	fs.add_file_borrow({}, combine_path("temp_storage", "test5.tmp"), 3253);
 	// size: 3882
-	fs.add_file(combine_path("temp_storage", "test6.tmp"), 841);
+	fs.add_file_borrow({}, combine_path("temp_storage", "test6.tmp"), 841);
 	// size: 4723
 
 	peer_request rq = fs.map_file(file_index_t{0}, 0, 10);
@@ -298,8 +298,8 @@ TORRENT_TEST(file_path_hash)
 	// whose name collides with
 	file_storage fs;
 	fs.set_piece_length(512);
-	fs.add_file(combine_path("temp_storage", "Foo"), 17);
-	fs.add_file(combine_path("temp_storage", "foo"), 612);
+	fs.add_file_borrow({}, combine_path("temp_storage", "Foo"), 17);
+	fs.add_file_borrow({}, combine_path("temp_storage", "foo"), 612);
 
 	std::printf("path: %s\n", fs.file_path(0_file).c_str());
 	std::printf("file: %s\n", fs.file_path(1_file).c_str());
@@ -314,9 +314,9 @@ TORRENT_TEST(canonicalize_pad)
 {
 	file_storage fs;
 	fs.set_piece_length(0x4000);
-	fs.add_file(combine_path("s", "2"), 0x7000);
-	fs.add_file(combine_path("s", "1"), 1);
-	fs.add_file(combine_path("s", "3"), 0x7001);
+	fs.add_file_borrow({}, combine_path("s", "2"), 0x7000);
+	fs.add_file_borrow({}, combine_path("s", "1"), 1);
+	fs.add_file_borrow({}, combine_path("s", "3"), 0x7001);
 	TEST_EQUAL(fs.size_on_disk(), 0x7000 + 1 + 0x7001);
 
 	fs.canonicalize();
@@ -352,10 +352,10 @@ TORRENT_TEST(canonicalize_path)
 {
 	file_storage fs;
 	fs.set_piece_length(0x4000);
-	fs.add_file(combine_path("b", combine_path("2", "a")), 0x4000);
-	fs.add_file(combine_path("b", combine_path("1", "a")), 0x4000);
-	fs.add_file(combine_path("b", combine_path("3", "a")), 0x4000);
-	fs.add_file(combine_path("b", "11"), 0x4000);
+	fs.add_file_borrow({}, combine_path("b", combine_path("2", "a")), 0x4000);
+	fs.add_file_borrow({}, combine_path("b", combine_path("1", "a")), 0x4000);
+	fs.add_file_borrow({}, combine_path("b", combine_path("3", "a")), 0x4000);
+	fs.add_file_borrow({}, combine_path("b", "11"), 0x4000);
 
 	fs.canonicalize();
 
@@ -373,9 +373,9 @@ TORRENT_TEST(piece_range_exclusive)
 	int const piece_size = 16;
 	file_storage fs;
 	fs.set_piece_length(piece_size);
-	fs.add_file(combine_path("temp_storage", "0"), piece_size);
-	fs.add_file(combine_path("temp_storage", "1"), piece_size * 4 + 1);
-	fs.add_file(combine_path("temp_storage", "2"), piece_size * 4 - 1);
+	fs.add_file_borrow({}, combine_path("temp_storage", "0"), piece_size);
+	fs.add_file_borrow({}, combine_path("temp_storage", "1"), piece_size * 4 + 1);
+	fs.add_file_borrow({}, combine_path("temp_storage", "2"), piece_size * 4 - 1);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	//        +---+---+---+---+---+---+---+---+---+
 	// pieces | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
@@ -396,9 +396,9 @@ TORRENT_TEST(piece_range_inclusive)
 	int const piece_size = 16;
 	file_storage fs;
 	fs.set_piece_length(piece_size);
-	fs.add_file(combine_path("temp_storage", "0"), piece_size);
-	fs.add_file(combine_path("temp_storage", "1"), piece_size * 4 + 1);
-	fs.add_file(combine_path("temp_storage", "2"), piece_size * 4 - 1);
+	fs.add_file_borrow({}, combine_path("temp_storage", "0"), piece_size);
+	fs.add_file_borrow({}, combine_path("temp_storage", "1"), piece_size * 4 + 1);
+	fs.add_file_borrow({}, combine_path("temp_storage", "2"), piece_size * 4 - 1);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	//        +---+---+---+---+---+---+---+---+---+
 	// pieces | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
@@ -419,8 +419,8 @@ TORRENT_TEST(piece_range)
 	int const piece_size = 0x4000;
 	file_storage fs;
 	fs.set_piece_length(piece_size);
-	fs.add_file(combine_path("temp_storage", "0"), piece_size * 3);
-	fs.add_file(combine_path("temp_storage", "1"), piece_size * 3 + 0x30);
+	fs.add_file_borrow({}, combine_path("temp_storage", "0"), piece_size * 3);
+	fs.add_file_borrow({}, combine_path("temp_storage", "1"), piece_size * 3 + 0x30);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	//        +---+---+---+---+---+---+---+
 	// pieces | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
@@ -443,7 +443,7 @@ TORRENT_TEST(piece_size_last_piece)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("0", 100);
+	fs.add_file_borrow({}, "0", 100);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.piece_size(0_piece), 100);
 }
@@ -452,7 +452,7 @@ TORRENT_TEST(piece_size_middle_piece)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("0", 2000);
+	fs.add_file_borrow({}, "0", 2000);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.piece_size(0_piece), 1024);
 	TEST_EQUAL(fs.piece_size(1_piece), 2000 - 1024);
@@ -462,11 +462,11 @@ TORRENT_TEST(file_index_at_offset)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("test/0", 1);
-	fs.add_file("test/1", 2);
-	fs.add_file("test/2", 3);
-	fs.add_file("test/3", 4);
-	fs.add_file("test/4", 5);
+	fs.add_file_borrow({}, "test/0", 1);
+	fs.add_file_borrow({}, "test/1", 2);
+	fs.add_file_borrow({}, "test/2", 3);
+	fs.add_file_borrow({}, "test/3", 4);
+	fs.add_file_borrow({}, "test/4", 5);
 	std::int64_t offset = 0;
 	for (int f : {0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4})
 	{
@@ -478,11 +478,11 @@ TORRENT_TEST(map_block_start)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("test/0", 1);
-	fs.add_file("test/1", 2);
-	fs.add_file("test/2", 3);
-	fs.add_file("test/3", 4);
-	fs.add_file("test/4", 5);
+	fs.add_file_borrow({}, "test/0", 1);
+	fs.add_file_borrow({}, "test/1", 2);
+	fs.add_file_borrow({}, "test/2", 3);
+	fs.add_file_borrow({}, "test/3", 4);
+	fs.add_file_borrow({}, "test/4", 5);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	int len = 0;
 	for (int f : {0, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5})
@@ -506,11 +506,11 @@ TORRENT_TEST(map_block_mid)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("test/0", 1);
-	fs.add_file("test/1", 2);
-	fs.add_file("test/2", 3);
-	fs.add_file("test/3", 4);
-	fs.add_file("test/4", 5);
+	fs.add_file_borrow({}, "test/0", 1);
+	fs.add_file_borrow({}, "test/1", 2);
+	fs.add_file_borrow({}, "test/2", 3);
+	fs.add_file_borrow({}, "test/3", 4);
+	fs.add_file_borrow({}, "test/4", 5);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	int offset = 0;
 	for (int f : {0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4})
@@ -538,34 +538,35 @@ TORRENT_TEST(sanitize_symlinks)
 
 	// invalid
 #if defined(TORRENT_WINDOWS) || defined(TORRENT_OS2)
-	fs.add_file("test/0", 0, file_storage::flag_symlink, 0, "C:\\invalid\\target\\path");
+	fs.add_file_borrow({}, "test/0", 0, file_storage::flag_symlink, 0, "C:\\invalid\\target\\path");
 #else
-	fs.add_file("test/0", 0, file_storage::flag_symlink, 0, "/invalid/target/path");
+	fs.add_file_borrow({}, "test/0", 0, file_storage::flag_symlink, 0, "/invalid/target/path");
 #endif
 
 	// there is no file with this name, so this is invalid
-	fs.add_file("test/1", 0, file_storage::flag_symlink, 0, "ZZ");
+	fs.add_file_borrow({}, "test/1", 0, file_storage::flag_symlink, 0, "ZZ");
 
 	// there is no file with this name, so this is invalid
-	fs.add_file("test/2", 0, file_storage::flag_symlink, 0, "B" SEP "B" SEP "ZZ");
+	fs.add_file_borrow({}, "test/2", 0, file_storage::flag_symlink, 0, "B" SEP "B" SEP "ZZ");
 
 	// this should be OK
-	fs.add_file("test/3", 0, file_storage::flag_symlink, 0, "0");
+	fs.add_file_borrow({}, "test/3", 0, file_storage::flag_symlink, 0, "0");
 
 	// this should be OK
-	fs.add_file("test/4", 0, file_storage::flag_symlink, 0, "A");
+	fs.add_file_borrow({}, "test/4", 0, file_storage::flag_symlink, 0, "A");
 
 	// this is advanced, but OK
-	fs.add_file("test/5", 0, file_storage::flag_symlink, 0, "4" SEP "B");
+	fs.add_file_borrow({}, "test/5", 0, file_storage::flag_symlink, 0, "4" SEP "B");
 
 	// this is advanced, but OK
-	fs.add_file("test/6", 0, file_storage::flag_symlink, 0, "5" SEP "C");
+	fs.add_file_borrow({}, "test/6", 0, file_storage::flag_symlink, 0, "5" SEP "C");
 
 	// this is not OK
-	fs.add_file("test/7", 0, file_storage::flag_symlink, 0, "4" SEP "B" SEP "C" SEP "ZZ");
+	fs.add_file_borrow(
+		{}, "test/7", 0, file_storage::flag_symlink, 0, "4" SEP "B" SEP "C" SEP "ZZ");
 
 	// this is the only actual content
-	fs.add_file("test/A" SEP "B" SEP "C", 10000);
+	fs.add_file_borrow({}, "test/A" SEP "B" SEP "C", 10000);
 	fs.set_num_pieces(int((fs.total_size() + 1023) / 1024));
 
 	fs.sanitize_symlinks();
@@ -589,7 +590,7 @@ TORRENT_TEST(sanitize_symlinks_single_file)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("test", 1);
+	fs.add_file_borrow({}, "test", 1);
 	fs.set_num_pieces(int((fs.total_size() + 1023) / 1024));
 
 	fs.sanitize_symlinks();
@@ -602,18 +603,18 @@ TORRENT_TEST(sanitize_symlinks_cascade)
 	file_storage fs;
 	fs.set_piece_length(1024);
 
-	fs.add_file("test/0", 0, file_storage::flag_symlink, 0, "1" SEP "ZZ");
-	fs.add_file("test/1", 0, file_storage::flag_symlink, 0, "2");
-	fs.add_file("test/2", 0, file_storage::flag_symlink, 0, "3");
-	fs.add_file("test/3", 0, file_storage::flag_symlink, 0, "4");
-	fs.add_file("test/4", 0, file_storage::flag_symlink, 0, "5");
-	fs.add_file("test/5", 0, file_storage::flag_symlink, 0, "6");
-	fs.add_file("test/6", 0, file_storage::flag_symlink, 0, "7");
-	fs.add_file("test/7", 0, file_storage::flag_symlink, 0, "A");
-	fs.add_file("test/no-exist", 0, file_storage::flag_symlink, 0, "1" SEP "ZZZ");
+	fs.add_file_borrow({}, "test/0", 0, file_storage::flag_symlink, 0, "1" SEP "ZZ");
+	fs.add_file_borrow({}, "test/1", 0, file_storage::flag_symlink, 0, "2");
+	fs.add_file_borrow({}, "test/2", 0, file_storage::flag_symlink, 0, "3");
+	fs.add_file_borrow({}, "test/3", 0, file_storage::flag_symlink, 0, "4");
+	fs.add_file_borrow({}, "test/4", 0, file_storage::flag_symlink, 0, "5");
+	fs.add_file_borrow({}, "test/5", 0, file_storage::flag_symlink, 0, "6");
+	fs.add_file_borrow({}, "test/6", 0, file_storage::flag_symlink, 0, "7");
+	fs.add_file_borrow({}, "test/7", 0, file_storage::flag_symlink, 0, "A");
+	fs.add_file_borrow({}, "test/no-exist", 0, file_storage::flag_symlink, 0, "1" SEP "ZZZ");
 
 	// this is the only actual content
-	fs.add_file("test/A" SEP "ZZ", 10000);
+	fs.add_file_borrow({}, "test/A" SEP "ZZ", 10000);
 	fs.set_num_pieces(int((fs.total_size() + 1023) / 1024));
 
 	fs.sanitize_symlinks();
@@ -634,15 +635,15 @@ TORRENT_TEST(sanitize_symlinks_circular)
 	file_storage fs;
 	fs.set_piece_length(1024);
 
-	fs.add_file("test/0", 0, file_storage::flag_symlink, 0, "1");
-	fs.add_file("test/1", 0, file_storage::flag_symlink, 0, "0");
+	fs.add_file_borrow({}, "test/0", 0, file_storage::flag_symlink, 0, "1");
+	fs.add_file_borrow({}, "test/1", 0, file_storage::flag_symlink, 0, "0");
 
 	// when this is resolved, we end up in an infinite loop. Make sure we can
 	// handle that
-	fs.add_file("test/2", 0, file_storage::flag_symlink, 0, "0/ZZ");
+	fs.add_file_borrow({}, "test/2", 0, file_storage::flag_symlink, 0, "0/ZZ");
 
 	// this is the only actual content
-	fs.add_file("test/A" SEP "ZZ", 10000);
+	fs.add_file_borrow({}, "test/A" SEP "ZZ", 10000);
 	fs.set_num_pieces(int((fs.total_size() + 1023) / 1024));
 
 	fs.sanitize_symlinks();
@@ -665,13 +666,13 @@ TORRENT_TEST(sanitize_symlinks_lexicographic)
 	fs.set_piece_length(1024);
 
 #if defined(TORRENT_WINDOWS) || defined(TORRENT_OS2)
-	fs.add_file("test\\A.bar\\leaf", 100);
-	fs.add_file("test\\A\\B\\leaf", 100);
-	fs.add_file("test\\sym", 0, file_storage::flag_symlink, 0, "A");
+	fs.add_file_borrow({}, "test\\A.bar\\leaf", 100);
+	fs.add_file_borrow({}, "test\\A\\B\\leaf", 100);
+	fs.add_file_borrow({}, "test\\sym", 0, file_storage::flag_symlink, 0, "A");
 #else
-	fs.add_file("test/A.bar/leaf", 100);
-	fs.add_file("test/A/B/leaf", 100);
-	fs.add_file("test/sym", 0, file_storage::flag_symlink, 0, "A");
+	fs.add_file_borrow({}, "test/A.bar/leaf", 100);
+	fs.add_file_borrow({}, "test/A/B/leaf", 100);
+	fs.add_file_borrow({}, "test/sym", 0, file_storage::flag_symlink, 0, "A");
 #endif
 
 	fs.set_num_pieces(int((fs.total_size() + 1023) / 1024));
@@ -685,10 +686,10 @@ TORRENT_TEST(query_symlinks)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("test/0", 0, file_storage::flag_symlink, 0, "0");
-	fs.add_file("test/1", 0, file_storage::flag_symlink, 0, "1");
-	fs.add_file("test/2", 0, file_storage::flag_symlink, 0, "2");
-	fs.add_file("test/3", 0, file_storage::flag_symlink, 0, "3");
+	fs.add_file_borrow({}, "test/0", 0, file_storage::flag_symlink, 0, "0");
+	fs.add_file_borrow({}, "test/1", 0, file_storage::flag_symlink, 0, "1");
+	fs.add_file_borrow({}, "test/2", 0, file_storage::flag_symlink, 0, "2");
+	fs.add_file_borrow({}, "test/3", 0, file_storage::flag_symlink, 0, "3");
 
 	auto const& ret1 = fs.symlink(file_index_t{0});
 	auto const& ret2 = fs.symlink(file_index_t{1});
@@ -707,10 +708,10 @@ TORRENT_TEST(query_symlinks2)
 {
 	file_storage fs;
 	fs.set_piece_length(1024);
-	fs.add_file("test/0", 10);
-	fs.add_file("test/1", 10);
-	fs.add_file("test/2", 10);
-	fs.add_file("test/3", 10);
+	fs.add_file_borrow({}, "test/0", 10);
+	fs.add_file_borrow({}, "test/1", 10);
+	fs.add_file_borrow({}, "test/2", 10);
+	fs.add_file_borrow({}, "test/3", 10);
 
 	TEST_CHECK(fs.symlink(file_index_t{0}).empty());
 	TEST_CHECK(fs.symlink(file_index_t{1}).empty());
@@ -722,13 +723,13 @@ TORRENT_TEST(files_compatible)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2);
 
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
 }
@@ -737,12 +738,12 @@ TORRENT_TEST(files_compatible_num_files)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 3);
+	fs2.add_file_borrow({}, "test/0", 3);
 
 	TEST_CHECK(!lt::aux::files_compatible(fs1, fs2));
 }
@@ -751,13 +752,13 @@ TORRENT_TEST(files_compatible_size)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 2);
-	fs1.add_file("test/1", 1);
+	fs1.add_file_borrow({}, "test/0", 2);
+	fs1.add_file_borrow({}, "test/1", 1);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2);
 
 	TEST_CHECK(!lt::aux::files_compatible(fs1, fs2));
 }
@@ -766,13 +767,13 @@ TORRENT_TEST(files_compatible_name)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/1", 1);
-	fs1.add_file("test/0", 2);
+	fs1.add_file_borrow({}, "test/1", 1);
+	fs1.add_file_borrow({}, "test/0", 2);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2);
 
 	TEST_CHECK(!lt::aux::files_compatible(fs1, fs2));
 }
@@ -781,13 +782,13 @@ TORRENT_TEST(files_compatible_hidden)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2, file_storage::flag_hidden);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2, file_storage::flag_hidden);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2);
 
 	// hidden attribute does not affect compatibility
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
@@ -797,13 +798,13 @@ TORRENT_TEST(files_compatible_pad)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2, file_storage::flag_pad_file);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2, file_storage::flag_pad_file);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2);
 
 	// pad attribute does affect compatibility
 	TEST_CHECK(!lt::aux::files_compatible(fs1, fs2));
@@ -813,17 +814,17 @@ TORRENT_TEST(files_compatible_empty_file_order)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 0);
-	fs1.add_file("test/2", 0);
-	fs1.add_file("test/3", 0);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 0);
+	fs1.add_file_borrow({}, "test/2", 0);
+	fs1.add_file_borrow({}, "test/3", 0);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/3", 0);
-	fs2.add_file("test/2", 0);
-	fs2.add_file("test/1", 0);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/3", 0);
+	fs2.add_file_borrow({}, "test/2", 0);
+	fs2.add_file_borrow({}, "test/1", 0);
 
 	// order of empty files does not affect compatibility
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
@@ -833,13 +834,13 @@ TORRENT_TEST(files_compatible_mtime)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1, {}, 1234);
-	fs1.add_file("test/1", 2, {}, 1235);
+	fs1.add_file_borrow({}, "test/0", 1, {}, 1234);
+	fs1.add_file_borrow({}, "test/1", 2, {}, 1235);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1, {}, 1234);
-	fs2.add_file("test/1", 2, {}, 1234);
+	fs2.add_file_borrow({}, "test/0", 1, {}, 1234);
+	fs2.add_file_borrow({}, "test/1", 2, {}, 1234);
 
 	// mtime does not affect compatibility
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
@@ -849,13 +850,13 @@ TORRENT_TEST(files_compatible_piece_size)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x8000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2);
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2);
 
 	TEST_CHECK(!lt::aux::files_compatible(fs1, fs2));
 }
@@ -864,13 +865,13 @@ TORRENT_TEST(files_compatible_different_symlink)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2, file_storage::flag_symlink, 0, "test/0");
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2, file_storage::flag_symlink, 0, "test/0");
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2, file_storage::flag_symlink, 0, "test/1");
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2, file_storage::flag_symlink, 0, "test/1");
 
 	TEST_CHECK(!lt::aux::files_compatible(fs1, fs2));
 }
@@ -879,13 +880,13 @@ TORRENT_TEST(files_compatible_same_symlink)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2, file_storage::flag_symlink, 0, "test/0");
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2, file_storage::flag_symlink, 0, "test/0");
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 2, file_storage::flag_symlink, 0, "test/0");
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 2, file_storage::flag_symlink, 0, "test/0");
 
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
 }
@@ -894,18 +895,18 @@ TORRENT_TEST(remove_tail_padding_not_last)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2, file_storage::flag_pad_file);
-	fs1.add_file("test/2", 0);
-	fs1.add_file("test/3", 0);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2, file_storage::flag_pad_file);
+	fs1.add_file_borrow({}, "test/2", 0);
+	fs1.add_file_borrow({}, "test/3", 0);
 
 	fs1.remove_tail_padding();
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/2", 0);
-	fs2.add_file("test/3", 0);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/2", 0);
+	fs2.add_file_borrow({}, "test/3", 0);
 
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
 }
@@ -914,14 +915,14 @@ TORRENT_TEST(remove_tail_padding_last)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 2, file_storage::flag_pad_file);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 2, file_storage::flag_pad_file);
 
 	fs1.remove_tail_padding();
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
+	fs2.add_file_borrow({}, "test/0", 1);
 
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
 }
@@ -930,19 +931,19 @@ TORRENT_TEST(remove_tail_padding_no_op)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	fs1.add_file("test/0", 1);
-	fs1.add_file("test/1", 0);
-	fs1.add_file("test/2", 0);
-	fs1.add_file("test/3", 0);
+	fs1.add_file_borrow({}, "test/0", 1);
+	fs1.add_file_borrow({}, "test/1", 0);
+	fs1.add_file_borrow({}, "test/2", 0);
+	fs1.add_file_borrow({}, "test/3", 0);
 
 	fs1.remove_tail_padding();
 
 	file_storage fs2;
 	fs2.set_piece_length(0x4000);
-	fs2.add_file("test/0", 1);
-	fs2.add_file("test/1", 0);
-	fs2.add_file("test/2", 0);
-	fs2.add_file("test/3", 0);
+	fs2.add_file_borrow({}, "test/0", 1);
+	fs2.add_file_borrow({}, "test/1", 0);
+	fs2.add_file_borrow({}, "test/2", 0);
+	fs2.add_file_borrow({}, "test/3", 0);
 
 	TEST_CHECK(lt::aux::files_compatible(fs1, fs2));
 }
@@ -954,14 +955,14 @@ TORRENT_TEST(large_files)
 {
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
-	TEST_THROW(fs1.add_file("test/0", int_max / 2 * lt::default_block_size + 1));
+	TEST_THROW(fs1.add_file_borrow({}, "test/0", int_max / 2 * lt::default_block_size + 1));
 
 	error_code ec;
-	fs1.add_file(ec, "test/0", int_max * lt::default_block_size + 1);
+	fs1.add_file_borrow(ec, {}, "test/0", int_max * lt::default_block_size + 1);
 	TEST_EQUAL(ec, make_error_code(boost::system::errc::file_too_large));
 
 	// should not throw
-	TEST_NOTHROW(fs1.add_file("test/0", int_max / 2 * lt::default_block_size));
+	TEST_NOTHROW(fs1.add_file_borrow({}, "test/0", int_max / 2 * lt::default_block_size));
 }
 
 TORRENT_TEST(large_offset)
@@ -969,17 +970,18 @@ TORRENT_TEST(large_offset)
 	file_storage fs1;
 	fs1.set_piece_length(0x4000);
 	for (int i = 0; i < 16; ++i)
-		fs1.add_file(("test/" + std::to_string(i)).c_str(), int_max / 2 * lt::default_block_size);
+		fs1.add_file_borrow(
+			{}, ("test/" + std::to_string(i)).c_str(), int_max / 2 * lt::default_block_size);
 
 	// this exceeds the 2^48-1 limit
-	TEST_THROW(fs1.add_file("test/16", 262144));
+	TEST_THROW(fs1.add_file_borrow({}, "test/16", 262144));
 
 	error_code ec;
-	fs1.add_file(ec, "test/8", 262144);
+	fs1.add_file_borrow(ec, {}, "test/8", 262144);
 	TEST_EQUAL(ec, make_error_code(errors::torrent_invalid_length));
 
 	// this should be OK, but just
-	fs1.add_file("test/8", 262143);
+	fs1.add_file_borrow({}, "test/8", 262143);
 }
 
 TORRENT_TEST(large_filename)
@@ -1002,20 +1004,20 @@ TORRENT_TEST(piece_size2)
 	fs.set_piece_length(0x8000);
 	// passing in a root hash (the last argument) makes it follow v2 rules, to
 	// add pad files
-	fs.add_file("test/0", 0x5000, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/0", 0x5000, {}, 0, {}, 0);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 1);
 	TEST_EQUAL(fs.piece_size2(0_piece), 0x5000);
 
-	fs.add_file("test/1", 0x2000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/2", 0x8000, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/1", 0x2000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/2", 0x8000, {}, 0, {}, 0);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 3);
 	TEST_EQUAL(fs.piece_size2(2_piece), 0x8000);
 
-	fs.add_file("test/3", 8, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/3", 8, {}, 0, {}, 0);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 4);
@@ -1024,7 +1026,7 @@ TORRENT_TEST(piece_size2)
 	TEST_EQUAL(fs.piece_size2(2_piece), 0x8000);
 	TEST_EQUAL(fs.piece_size2(3_piece), 8);
 
-	fs.add_file("test/4", 0x8001, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/4", 0x8001, {}, 0, {}, 0);
 
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	TEST_EQUAL(fs.num_pieces(), 6);
@@ -1042,12 +1044,12 @@ TORRENT_TEST(file_num_blocks)
 {
 	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x5000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/1", 0x2000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/2", 0x8000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/3", 0x8001, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/4", 1, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/5", 0, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/0", 0x5000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/1", 0x2000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/2", 0x8000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/3", 0x8001, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/4", 1, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/5", 0, {}, 0, {}, 0);
 
 	fs.canonicalize();
 
@@ -1074,12 +1076,12 @@ TORRENT_TEST(file_num_pieces)
 {
 	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x5000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/1", 0x2000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/2", 0x8000, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/3", 0x8001, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/4", 1, {}, 0, {}, dummy_root_hash);
-	fs.add_file("test/5", 0, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/0", 0x5000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/1", 0x2000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/2", 0x8000, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/3", 0x8001, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/4", 1, {}, 0, {}, 0);
+	fs.add_file_borrow({}, "test/5", 0, {}, 0, {}, 0);
 
 	fs.canonicalize();
 
@@ -1108,7 +1110,7 @@ int first_piece_node(int piece_size, int file_size)
 {
 	file_storage fs = make_v2_storage();
 	fs.set_piece_length(piece_size);
-	fs.add_file("test/0", file_size, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/0", file_size, {}, 0, {}, 0);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs.file_first_piece_node(file_index_t{0});
 }
@@ -1117,7 +1119,7 @@ int first_block_node(int file_size)
 {
 	file_storage fs = make_v2_storage();
 	fs.set_piece_length(0x10000);
-	fs.add_file("test/0", file_size, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/0", file_size, {}, 0, {}, 0);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs.file_first_block_node(file_index_t{0});
 }
@@ -1176,9 +1178,9 @@ TORRENT_TEST(mismatching_file_hash1)
 	st.set_piece_length(0x4000);
 
 	error_code ec;
-	st.add_file(ec, combine_path("test", "a"), 10000);
+	st.add_file_borrow(ec, {}, combine_path("test", "a"), 10000);
 	TEST_CHECK(!ec);
-	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, dummy_root_hash);
+	st.add_file_borrow(ec, {}, combine_path("test", "B"), 10000, {}, 0, {}, 0);
 	TEST_CHECK(ec);
 }
 
@@ -1188,9 +1190,9 @@ TORRENT_TEST(mismatching_file_hash2)
 	st.set_piece_length(0x4000);
 
 	error_code ec;
-	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, dummy_root_hash);
+	st.add_file_borrow(ec, {}, combine_path("test", "B"), 10000, {}, 0, {}, 0);
 	TEST_CHECK(!ec);
-	st.add_file(ec, combine_path("test", "a"), 10000);
+	st.add_file_borrow(ec, {}, combine_path("test", "a"), 10000);
 	TEST_CHECK(ec);
 }
 
@@ -1200,12 +1202,12 @@ TORRENT_TEST(v2_detection_1)
 	fs.set_piece_length(0x8000);
 	// passing in a root hash (the last argument) makes it follow v2 rules, to
 	// add pad files
-	fs.add_file("test/0", 0x5000, {}, 0, "symlink-test-1");
-	fs.add_file("test/1", 0x5000, {}, 0, "symlink-test-2");
+	fs.add_file_borrow({}, "test/0", 0x5000, {}, 0, "symlink-test-1");
+	fs.add_file_borrow({}, "test/1", 0x5000, {}, 0, "symlink-test-2");
 
-	fs.add_file("test/2", 0x2000, {}, 0, {}, dummy_root_hash);
+	fs.add_file_borrow({}, "test/2", 0x2000, {}, 0, {}, 0);
 	// it's an error to add a v1 file to a v2 torrent
-	TEST_THROW(fs.add_file("test/3", 0x2000));
+	TEST_THROW(fs.add_file_borrow({}, "test/3", 0x2000));
 }
 
 TORRENT_TEST(v2_detection_2)
@@ -1214,13 +1216,13 @@ TORRENT_TEST(v2_detection_2)
 	fs.set_piece_length(0x8000);
 	// passing in a root hash (the last argument) makes it follow v2 rules, to
 	// add pad files
-	fs.add_file("test/0", 0x5000, {}, 0, "symlink-test-1");
-	fs.add_file("test/1", 0x5000, {}, 0, "symlink-test-2");
+	fs.add_file_borrow({}, "test/0", 0x5000, {}, 0, "symlink-test-1");
+	fs.add_file_borrow({}, "test/1", 0x5000, {}, 0, "symlink-test-2");
 
-	fs.add_file("test/2", 0x2000);
+	fs.add_file_borrow({}, "test/2", 0x2000);
 
 	// it's an error to add a v1 file to a v2 torrent
-	TEST_THROW(fs.add_file("test/3", 0x2000, {}, 0, {}, dummy_root_hash));
+	TEST_THROW(fs.add_file_borrow({}, "test/3", 0x2000, {}, 0, {}, 0));
 }
 
 TORRENT_TEST(blocks_in_piece2)
@@ -1235,7 +1237,7 @@ TORRENT_TEST(blocks_in_piece2)
 	{
 		file_storage fs = make_v2_storage();
 		fs.set_piece_length(0x8000);
-		fs.add_file("test/0", t.first, {}, 0, {}, dummy_root_hash);
+		fs.add_file_borrow({}, "test/0", t.first, {}, 0, {}, 0);
 		fs.set_num_pieces(aux::calc_num_pieces(fs));
 		TEST_EQUAL(fs.blocks_in_piece2(0_piece), t.second);
 	}
@@ -1251,10 +1253,10 @@ TORRENT_TEST(file_index_for_root)
 	});
 	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x8000, {}, 0, {}, buf.data() + off[0]);
-	fs.add_file("test/1", 0x8000, {}, 0, {}, buf.data() + off[1]);
-	fs.add_file("test/2", 0x8000, {}, 0, {}, buf.data() + off[2]);
-	fs.add_file("test/3", 0x8000, {}, 0, {}, buf.data() + off[3]);
+	fs.add_file_borrow({}, "test/0", 0x8000, {}, 0, {}, off[0]);
+	fs.add_file_borrow({}, "test/1", 0x8000, {}, 0, {}, off[1]);
+	fs.add_file_borrow({}, "test/2", 0x8000, {}, 0, {}, off[2]);
+	fs.add_file_borrow({}, "test/3", 0x8000, {}, 0, {}, off[3]);
 
 	TEST_EQUAL(fs.file_index_for_root(sha256_hash("11111111111111111111111111111111")), file_index_t{0});
 	TEST_EQUAL(fs.file_index_for_root(sha256_hash("22222222222222222222222222222222")), file_index_t{1});
@@ -1276,16 +1278,16 @@ TORRENT_TEST(size_on_disk)
 
 	std::int64_t size_on_disk = 0;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/0", 100, {}, 0, {}, buf.data() + off[0]);
+	fs.add_file_borrow({}, "test/0", 100, {}, 0, {}, off[0]);
 	size_on_disk += 100;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/1", 800, {}, 0, {}, buf.data() + off[1]);
+	fs.add_file_borrow({}, "test/1", 800, {}, 0, {}, off[1]);
 	size_on_disk += 800;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/2", 333, {}, 0, {}, buf.data() + off[2]);
+	fs.add_file_borrow({}, "test/2", 333, {}, 0, {}, off[2]);
 	size_on_disk += 333;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/3", 1337, {}, 0, {}, buf.data() + off[3]);
+	fs.add_file_borrow({}, "test/3", 1337, {}, 0, {}, off[3]);
 	size_on_disk += 1337;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
 	TEST_CHECK(fs.size_on_disk() < fs.total_size());
@@ -1303,14 +1305,14 @@ TORRENT_TEST(size_on_disk_explicit_pads)
 
 	std::int64_t size_on_disk = 0;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/0", 100, {}, 0, {}, buf.data() + off[0]);
+	fs.add_file_borrow({}, "test/0", 100, {}, 0, {}, off[0]);
 	size_on_disk += 100;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
 
 	// when adding a pad file, size_on_disk does not increment
-	fs.add_file("test/pad/0", 80, file_storage::flag_pad_file, 0, {}, buf.data() + off[1]);
+	fs.add_file_borrow({}, "test/pad/0", 80, file_storage::flag_pad_file, 0, {}, off[1]);
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
-	fs.add_file("test/2", 333, {}, 0, {}, buf.data() + off[2]);
+	fs.add_file_borrow({}, "test/2", 333, {}, 0, {}, off[2]);
 	size_on_disk += 333;
 	TEST_EQUAL(fs.size_on_disk(), size_on_disk);
 	TEST_CHECK(fs.size_on_disk() < fs.total_size());
@@ -1326,10 +1328,10 @@ TORRENT_TEST(test_renamed_files)
 	});
 	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x8000, {}, 0, {}, buf.data() + off[0]);
-	fs.add_file("test/1", 0x8000, {}, 0, {}, buf.data() + off[1]);
-	fs.add_file("test/2/1", 0x8000, {}, 0, {}, buf.data() + off[2]);
-	fs.add_file("test/2/2", 0x8000, {}, 0, {}, buf.data() + off[3]);
+	fs.add_file_borrow({}, "test/0", 0x8000, {}, 0, {}, off[0]);
+	fs.add_file_borrow({}, "test/1", 0x8000, {}, 0, {}, off[1]);
+	fs.add_file_borrow({}, "test/2/1", 0x8000, {}, 0, {}, off[2]);
+	fs.add_file_borrow({}, "test/2/2", 0x8000, {}, 0, {}, off[3]);
 
 	renamed_files rf;
 
@@ -1391,10 +1393,10 @@ TORRENT_TEST(renamed_files_round_trip)
 	});
 	file_storage fs{buf.data()};
 	fs.set_piece_length(0x8000);
-	fs.add_file("test/0", 0x8000, {}, 0, {}, buf.data() + off[0]);
-	fs.add_file("test/1", 0x8000, {}, 0, {}, buf.data() + off[1]);
-	fs.add_file("test/2/1", 0x8000, {}, 0, {}, buf.data() + off[2]);
-	fs.add_file("test/2/2", 0x8000, {}, 0, {}, buf.data() + off[3]);
+	fs.add_file_borrow({}, "test/0", 0x8000, {}, 0, {}, off[0]);
+	fs.add_file_borrow({}, "test/1", 0x8000, {}, 0, {}, off[1]);
+	fs.add_file_borrow({}, "test/2/1", 0x8000, {}, 0, {}, off[2]);
+	fs.add_file_borrow({}, "test/2/2", 0x8000, {}, 0, {}, off[3]);
 
 	renamed_files rf;
 

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -71,8 +71,8 @@ TORRENT_TEST(pick_piece_layer)
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
-	fs.add_file("test/tmp2", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp2", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 
@@ -157,7 +157,7 @@ TORRENT_TEST(hash_picker_empty_trees)
 {
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 
@@ -173,7 +173,7 @@ TORRENT_TEST(reject_piece_request)
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
@@ -197,7 +197,7 @@ TORRENT_TEST(reject_block_hash_request)
 	fs.set_piece_length(16 * default_block_size);
 
 	// 100 pieces means m_piece_hash_requested only has a single 512-piece bucket
-	fs.add_file("test/tmp1", 100 * 16 * default_block_size);
+	fs.add_file_borrow({}, "test/tmp1", 100 * 16 * default_block_size);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
@@ -224,7 +224,7 @@ TORRENT_TEST(add_leaf_hashes)
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
@@ -271,7 +271,7 @@ TORRENT_TEST(add_piece_hashes)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 1024 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 1024 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 1024);
@@ -302,7 +302,7 @@ TORRENT_TEST(add_piece_hashes_marks_request_complete)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
@@ -339,7 +339,7 @@ TORRENT_TEST(add_piece_hashes_padded)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 1029 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 1029 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 1029);
@@ -369,7 +369,7 @@ TORRENT_TEST(add_piece_hashes_unpadded)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 1029 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 1029 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 1029);
@@ -398,7 +398,7 @@ TORRENT_TEST(add_bad_hashes)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
@@ -426,7 +426,7 @@ TORRENT_TEST(bad_block_hash)
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	auto const full_tree = build_tree(4 * 512);
 
@@ -459,7 +459,7 @@ TORRENT_TEST(set_block_hash)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto const full_tree = build_tree(4 * 512);
@@ -487,7 +487,7 @@ TORRENT_TEST(set_block_hash_fail)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto full_tree = build_tree(4 * 512);
@@ -527,7 +527,7 @@ TORRENT_TEST(set_block_hash_pass)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	auto full_tree = build_tree(4 * 512);
@@ -563,7 +563,7 @@ TORRENT_TEST(pass_piece)
 	file_storage fs;
 	fs.set_piece_length(4 * 16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	auto const full_tree = build_tree(4 * 512);
 
@@ -600,7 +600,7 @@ TORRENT_TEST(only_pick_have_pieces)
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
 
-	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 4 * 512 * 16 * 1024);
 
 	aux::vector<aux::merkle_tree, file_index_t> trees;
 	sha256_hash root = from_hex("0000000000000000000000000000000000000000000000000000000000000001");
@@ -633,7 +633,7 @@ TORRENT_TEST(validate_hash_request)
 {
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
-	fs.add_file("test/tmp1", 2048 * 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 2048 * 16 * 1024);
 
 	// the merkle tree for this file has 2048 blocks
 	int const num_leaves = merkle_num_leafs(2048);
@@ -704,8 +704,8 @@ TORRENT_TEST(validate_hash_request_pad_file)
 {
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
-	fs.add_file("test/tmp1", 2048 * 16 * 1024);
-	fs.add_file(".pad/16384", 16 * 1024, file_storage::flag_pad_file);
+	fs.add_file_borrow({}, "test/tmp1", 2048 * 16 * 1024);
+	fs.add_file_borrow({}, ".pad/16384", 16 * 1024, file_storage::flag_pad_file);
 
 	// sanity: requests for the regular file are still accepted
 	TEST_CHECK(validate_hash_request(aux::hash_request(file_index_t{0}, 0, 0, 1, 0), fs));
@@ -720,8 +720,8 @@ TORRENT_TEST(validate_hash_request_empty_file)
 {
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
-	fs.add_file("test/tmp1", 2048 * 16 * 1024);
-	fs.add_file("test/empty", 0);
+	fs.add_file_borrow({}, "test/tmp1", 2048 * 16 * 1024);
+	fs.add_file_borrow({}, "test/empty", 0);
 
 	// sanity: requests for the regular file are still accepted
 	TEST_CHECK(validate_hash_request(aux::hash_request(file_index_t{0}, 0, 0, 1, 0), fs));
@@ -739,7 +739,7 @@ TORRENT_TEST(validate_hash_request_single_block_file)
 	// base=0, index=0, count=1 — must be rejected.
 	file_storage fs;
 	fs.set_piece_length(16 * 1024);
-	fs.add_file("test/tmp1", 16 * 1024);
+	fs.add_file_borrow({}, "test/tmp1", 16 * 1024);
 
 	TEST_EQUAL(merkle_num_leafs(fs.file_num_blocks(file_index_t{0})), 1);
 	TEST_EQUAL(merkle_num_layers(merkle_num_leafs(fs.file_num_blocks(file_index_t{0}))), 0);

--- a/test/test_part_file.cpp
+++ b/test/test_part_file.cpp
@@ -32,7 +32,7 @@ namespace {
 	void truncate_part_file(std::string const& filename, std::int64_t const size)
 	{
 		file_storage fs;
-		fs.add_file(libtorrent::filename(filename), size);
+		fs.add_file_borrow({}, libtorrent::filename(filename), size);
 		storage_error se;
 		truncate_files(fs, parent_path(filename), se);
 		TEST_CHECK(!se);

--- a/test/test_readwrite.cpp
+++ b/test/test_readwrite.cpp
@@ -144,7 +144,7 @@ file_storage make_fs(std::vector<std::int64_t> const& file_sizes, int const piec
 	file_storage fs;
 	int i = 0;
 	for (std::int64_t const sz : file_sizes)
-		fs.add_file(combine_path("t", "f" + std::to_string(i++)), sz);
+		fs.add_file_borrow({}, combine_path("t", "f" + std::to_string(i++)), sz);
 	fs.set_piece_length(piece_length);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs;

--- a/test/test_slow_hash.cpp
+++ b/test/test_slow_hash.cpp
@@ -84,7 +84,7 @@ void hash_job_retry_test(lt::disk_io_constructor_type disk_io
 	int const piece_size = 2 * lt::default_block_size;
 	lt::file_storage fs;
 	fs.set_piece_length(piece_size);
-	fs.add_file("test-retry/file-0", piece_size, {});
+	fs.add_file_borrow({}, "test-retry/file-0", piece_size, {});
 	fs.set_num_pieces(1);
 
 	// Step 1: pre-create the file so the retried hash job can read block 1.

--- a/test/test_stat_cache.cpp
+++ b/test/test_stat_cache.cpp
@@ -26,7 +26,7 @@ TORRENT_TEST(stat_cache)
 	{
 		char buf[50];
 		std::snprintf(buf, sizeof(buf), "test_torrent/test-%d", i);
-		fs.add_file(buf, (i + 1) * 10);
+		fs.add_file_borrow({}, buf, (i + 1) * 10);
 	}
 	renamed_files rf;
 	filenames fn(fs, rf);

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -1076,9 +1076,9 @@ TORRENT_TEST(fastresume_spanning_piece_missing_file)
 	delete_dirs(save_path);
 
 	file_storage fs;
-	fs.add_file(combine_path("test", "first"), resume_piece_size / 2);
-	fs.add_file(combine_path("test", "missing"), resume_piece_size / 2);
-	fs.add_file(combine_path("test", "unchecked"), resume_piece_size);
+	fs.add_file_borrow({}, combine_path("test", "first"), resume_piece_size / 2);
+	fs.add_file_borrow({}, combine_path("test", "missing"), resume_piece_size / 2);
+	fs.add_file_borrow({}, combine_path("test", "unchecked"), resume_piece_size);
 	fs.set_piece_length(resume_piece_size);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 
@@ -1447,10 +1447,10 @@ namespace {
 file_storage make_fs()
 {
 	file_storage fs;
-	fs.add_file(combine_path("readwrite", "1"), 3);
-	fs.add_file(combine_path("readwrite", "2"), 9);
-	fs.add_file(combine_path("readwrite", "3"), 81);
-	fs.add_file(combine_path("readwrite", "4"), 6561);
+	fs.add_file_borrow({}, combine_path("readwrite", "1"), 3);
+	fs.add_file_borrow({}, combine_path("readwrite", "2"), 9);
+	fs.add_file_borrow({}, combine_path("readwrite", "3"), 81);
+	fs.add_file_borrow({}, combine_path("readwrite", "4"), 6561);
 	fs.set_piece_length(0x1000);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs;
@@ -1635,11 +1635,11 @@ TORRENT_TEST(readwrite_error)
 TORRENT_TEST(readwrite_zero_size_files)
 {
 	file_storage fs;
-	fs.add_file(combine_path("readwrite", "1"), 3);
-	fs.add_file(combine_path("readwrite", "2"), 0);
-	fs.add_file(combine_path("readwrite", "3"), 81);
-	fs.add_file(combine_path("readwrite", "4"), 0);
-	fs.add_file(combine_path("readwrite", "5"), 6561);
+	fs.add_file_borrow({}, combine_path("readwrite", "1"), 3);
+	fs.add_file_borrow({}, combine_path("readwrite", "2"), 0);
+	fs.add_file_borrow({}, combine_path("readwrite", "3"), 81);
+	fs.add_file_borrow({}, combine_path("readwrite", "4"), 0);
+	fs.add_file_borrow({}, combine_path("readwrite", "5"), 6561);
 	fs.set_piece_length(0x1000);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	test_read_fileop fop(10000000);
@@ -1814,10 +1814,13 @@ TORRENT_TEST(move_pread_storage_reset)
 TORRENT_TEST(storage_paths_string_pooling)
 {
 	file_storage file_storage;
-	file_storage.add_file(combine_path("test_storage", "root.txt"), 0x4000);
-	file_storage.add_file(combine_path("test_storage", combine_path("sub", "test1.txt")), 0x4000);
-	file_storage.add_file(combine_path("test_storage", combine_path("sub", "test2.txt")), 0x4000);
-	file_storage.add_file(combine_path("test_storage", combine_path("sub", "test3.txt")), 0x4000);
+	file_storage.add_file_borrow({}, combine_path("test_storage", "root.txt"), 0x4000);
+	file_storage.add_file_borrow(
+		{}, combine_path("test_storage", combine_path("sub", "test1.txt")), 0x4000);
+	file_storage.add_file_borrow(
+		{}, combine_path("test_storage", combine_path("sub", "test2.txt")), 0x4000);
+	file_storage.add_file_borrow(
+		{}, combine_path("test_storage", combine_path("sub", "test3.txt")), 0x4000);
 
 	// "sub" paths should point to same string item, so paths.size() must not grow
 	TEST_CHECK(file_storage.paths().size() <= 2);
@@ -1902,7 +1905,7 @@ void test_unaligned_read(lt::disk_io_constructor_type constructor, Fun fun)
 		= constructor(ioc, pack, cnt);
 
 	lt::file_storage fs;
-	fs.add_file("test", lt::default_block_size * 2);
+	fs.add_file_borrow({}, "test", lt::default_block_size * 2);
 	fs.set_num_pieces(1);
 	fs.set_piece_length(lt::default_block_size * 2);
 

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -855,7 +855,7 @@ file_storage test_fs()
 {
 	file_storage fs;
 	fs.set_piece_length(piece_size);
-	fs.add_file("temp", 99999999999);
+	fs.add_file_borrow({}, "temp", 99999999999);
 	fs.set_num_pieces(aux::calc_num_pieces(fs));
 	return fs;
 }

--- a/test/test_truncate.cpp
+++ b/test/test_truncate.cpp
@@ -44,9 +44,9 @@ TORRENT_TEST(truncate_small_files)
 	using lt::combine_path;
 
 	lt::file_storage fs;
-	fs.add_file(combine_path("test", "a"), 100);
-	fs.add_file(combine_path("test", "b"), 900);
-	fs.add_file(combine_path("test", "c"), 10);
+	fs.add_file_borrow({}, combine_path("test", "a"), 100);
+	fs.add_file_borrow({}, combine_path("test", "b"), 900);
+	fs.add_file_borrow({}, combine_path("test", "c"), 10);
 
 	create_file(combine_path("test", "a"), 99);
 	create_file(combine_path("test", "b"), 899);
@@ -66,9 +66,9 @@ TORRENT_TEST(truncate_large_files)
 	using lt::combine_path;
 
 	lt::file_storage fs;
-	fs.add_file(combine_path("test", "a"), 100);
-	fs.add_file(combine_path("test", "b"), 900);
-	fs.add_file(combine_path("test", "c"), 10);
+	fs.add_file_borrow({}, combine_path("test", "a"), 100);
+	fs.add_file_borrow({}, combine_path("test", "b"), 900);
+	fs.add_file_borrow({}, combine_path("test", "c"), 10);
 
 	create_file(combine_path("test", "a"), 101);
 	create_file(combine_path("test", "b"), 901);

--- a/tools/disk_io_stress_test.cpp
+++ b/tools/disk_io_stress_test.cpp
@@ -111,7 +111,7 @@ int run_test(test_case const& t)
 	{
 		for (int i = 0; i < t.num_files; ++i)
 		{
-			fs.add_file("test/" + std::to_string(i), file_size);
+			fs.add_file_borrow({}, "test/" + std::to_string(i), file_size);
 			file_size *= 2;
 		}
 		std::int64_t const total_size = fs.total_size();


### PR DESCRIPTION
deprecate `add_file()` from `file_storage`, it's no longer meant to be used for generating torrents.