### PR TITLE
fix file priority updates being lost when issued in quick succession

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2.1.2 not released
 
 	* deprecate internal functions of file_storage
+	* fix file priority updates being lost when issued in quick succession
 	* optimize loading torrents
 	* fix mis-attribution of tracker source when loading a torrent file
 	* fix race between async_hash() and force_recheck()

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -6063,6 +6063,19 @@ namespace {
 
 		m_deferred_file_priorities.clear();
 
+		// if there's already an outstanding file priority update, we have to
+		// defer this one, just like set_file_priority() does. Two concurrent
+		// async_set_file_priority() jobs may have their completion handlers
+		// delivered out of order, in which case the stale one would overwrite
+		// this update and it would be silently lost. on_file_priority() applies
+		// the deferred priorities once the outstanding update completes.
+		if (m_outstanding_file_priority)
+		{
+			for (file_index_t const i : new_priority.range())
+				m_deferred_file_priorities[i] = new_priority[i];
+			return;
+		}
+
 		// storage may be NULL during shutdown
 		if (m_storage)
 		{

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -781,3 +781,60 @@ TORRENT_TEST(file_priority_stress_test)
 	}
 	std::cout << '\n';
 }
+
+// regression test for whole-torrent priority updates being lost when issued
+// while a previous update is still outstanding. Each call supersedes the
+// previous one, so the last one must take effect.
+TORRENT_TEST_DISK_IO(prioritize_files_multiple_calls)
+{
+	add_torrent_params atp = generate_torrent();
+	int const num_files = atp.ti->num_files();
+
+	lt::aux::vector<lt::download_priority_t, lt::file_index_t> local_prios(
+		static_cast<std::size_t>(num_files), lt::default_priority);
+
+	atp.save_path = ".";
+	atp.file_priorities = local_prios;
+
+	lt::session_params sp(settings());
+	sp.disk_io_constructor = disk_io;
+	lt::session ses(sp);
+	torrent_handle h = ses.add_torrent(atp);
+
+	std::mt19937 rng(0x82daf973);
+
+	for (int round = 0; round < 40; ++round)
+	{
+		// a burst of whole-torrent updates, issued without waiting for any of
+		// them to complete. The last one is the one that must take effect
+		for (int i = 0; i < 32; ++i)
+		{
+			for (auto& p : local_prios)
+				p = rand_prio(rng);
+			h.prioritize_files(
+				std::vector<lt::download_priority_t>(local_prios.begin(), local_prios.end()));
+		}
+
+		// the last update is deferred until the in-flight one completes, so
+		// converging takes two disk round-trips. Allow plenty of time for it
+		auto tp = h.get_file_priorities();
+		for (int i = 0; i < 20 && tp != local_prios; ++i)
+		{
+			std::this_thread::sleep_for(lt::milliseconds(500));
+			tp = h.get_file_priorities();
+		}
+
+		if (tp != local_prios)
+		{
+			std::cout << "round " << round << "\ntorrent file prios:\n";
+			for (auto const p : tp)
+				std::cout << " " << p;
+			std::cout << "\nexpected file prios:\n";
+			for (auto const p : local_prios)
+				std::cout << " " << p;
+			std::cout << '\n';
+			TEST_CHECK(tp == local_prios);
+			return;
+		}
+	}
+}


### PR DESCRIPTION
prioritize_files() issues an async_set_file_priority() disk job without checking m_outstanding_file_priority, so a second call made while a previous update is still in flight starts a second concurrent job.

When a fence job completes, add_completed_jobs_impl() unblocks and re-queues the next fence job before the completed one's handler has been posted, so the two handlers can be delivered out of order. on_file_priority() applies whatever it receives, so the stale update overwrites the newer one and that update is silently lost -- no error is reported and the picker never learns about the newly wanted files.

set_file_priority() already guards against this by deferring the update via m_deferred_file_priorities; only the whole-torrent path was missing it. Do the same there.

This is visible in clients that re-send the full priority vector on every user interaction: de-selecting a file and then selecting another one can leave the torrent with the priorities from the first call, so the newly selected files never start downloading until the torrent is paused and resumed.