### PR TITLE
reject existing destinations in pread storage renames

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.1.2 not released
 
+	* prevent pread disk I/O from overwriting files when renaming
 	* fix file priority updates being lost when issued in quick succession
 	* deprecate internal functions of file_storage
 	* optimize loading torrents
@@ -2352,4 +2353,3 @@ Initial release 0.9
 	* supports compact=1
 	* selective downloading
 	* ip filter
-

--- a/src/pread_storage.cpp
+++ b/src/pread_storage.cpp
@@ -325,6 +325,16 @@ namespace libtorrent::aux {
 			else new_path = combine_path(m_save_path, new_filename);
 			std::string new_dir = parent_path(new_path);
 
+			error_code best_effort;
+			if (exists(new_path, best_effort))
+			{
+				// We don't want to overwrite an existing file
+				ec.ec = error_code(boost::system::errc::file_exists, generic_category());
+				ec.file(index);
+				ec.operation = operation_t::file_rename;
+				return;
+			}
+
 			// create any missing directories that the new filename
 			// lands in
 			create_directories(new_dir, ec.ec);

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -546,6 +546,51 @@ void test_rename(std::string const& test_path)
 	TEST_EQUAL(s->names().file_path(0_file), "new_filename");
 }
 
+template <typename StorageType>
+void test_rename_to_existing(std::string const& test_path)
+{
+	delete_dirs("temp_storage");
+
+	std::vector<char> buf;
+	typename file_pool_type<StorageType>::type fp;
+	aux::session_settings set;
+	auto [s, info] = setup_torrent<StorageType>(fp, buf, test_path, set);
+	file_storage const& fs = info->layout();
+
+	std::string const original_filename = fs.file_path(0_file);
+	std::string const source_path = fs.file_path(0_file, test_path);
+	std::string const new_filename = combine_path("temp_storage", "existing.tmp");
+	std::string const destination_path = combine_path(test_path, new_filename);
+	std::string const source_content = "source content";
+	std::string const destination_content = "destination content";
+
+	error_code ec;
+	create_directories(parent_path(source_path), ec);
+	TEST_CHECK(!ec);
+	std::ofstream(source_path, std::ios::binary)
+		.write(source_content.data(), static_cast<std::streamsize>(source_content.size()));
+	std::ofstream(destination_path, std::ios::binary)
+		.write(
+			destination_content.data(), static_cast<std::streamsize>(destination_content.size()));
+
+	storage_error se;
+	s->rename_file(0_file, new_filename, se);
+
+	TEST_CHECK(se.ec == boost::system::errc::file_exists);
+	TEST_CHECK(se.operation == operation_t::file_rename);
+	TEST_EQUAL(static_cast<int>(se.file()), 0);
+	TEST_EQUAL(s->names().file_path(0_file), original_filename);
+
+	std::vector<char> content;
+	TEST_EQUAL(load_file(source_path, content, ec), 0);
+	TEST_CHECK(!ec);
+	TEST_EQUAL(std::string(content.begin(), content.end()), source_content);
+
+	TEST_EQUAL(load_file(destination_path, content, ec), 0);
+	TEST_CHECK(!ec);
+	TEST_EQUAL(std::string(content.begin(), content.end()), destination_content);
+}
+
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 namespace {
 std::int64_t file_size_on_disk(std::string const& path)
@@ -941,9 +986,23 @@ TORRENT_TEST(remove_posix_disk_io)
 	test_remove<posix_storage>(current_working_directory());
 }
 
-TORRENT_TEST(rename_pread_disk_io)
+TORRENT_TEST(rename_pread_disk_io) { test_rename<pread_storage>(current_working_directory()); }
+
+#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
+TORRENT_TEST(rename_to_existing_mmap_disk_io)
 {
-	test_rename<pread_storage>(current_working_directory());
+	test_rename_to_existing<mmap_storage>(current_working_directory());
+}
+#endif
+
+TORRENT_TEST(rename_to_existing_posix_disk_io)
+{
+	test_rename_to_existing<posix_storage>(current_working_directory());
+}
+
+TORRENT_TEST(rename_to_existing_pread_disk_io)
+{
+	test_rename_to_existing<pread_storage>(current_working_directory());
 }
 
 TORRENT_TEST(remove_pread_disk_io)

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -546,18 +546,31 @@ void test_rename(std::string const& test_path)
 	TEST_EQUAL(s->names().file_path(0_file), "new_filename");
 }
 
-template <typename StorageType>
-void test_rename_to_existing(std::string const& test_path)
+void test_rename_to_existing(
+	std::string const& test_path, lt::disk_io_constructor_type const& disk_constructor)
 {
 	delete_dirs("temp_storage");
 
 	std::vector<char> buf;
-	typename file_pool_type<StorageType>::type fp;
-	aux::session_settings set;
-	auto [s, info] = setup_torrent<StorageType>(fp, buf, test_path, set);
+	auto info = setup_torrent_info(buf);
 	file_storage const& fs = info->layout();
+	boost::asio::io_context ios;
+	aux::session_settings settings;
+	counters cnt;
+	auto disk_io = disk_constructor(ios, settings, cnt);
+	aux::vector<download_priority_t, file_index_t> priorities;
+	renamed_files renamed;
+	storage_params params{fs,
+		renamed,
+		test_path,
+		{},
+		storage_mode_allocate,
+		priorities,
+		sha1_hash{},
+		info->v1(),
+		info->v2()};
+	auto const storage = disk_io->new_torrent(std::move(params), {});
 
-	std::string const original_filename = fs.file_path(0_file);
 	std::string const source_path = fs.file_path(0_file, test_path);
 	std::string const new_filename = combine_path("temp_storage", "existing.tmp");
 	std::string const destination_path = combine_path(test_path, new_filename);
@@ -574,12 +587,26 @@ void test_rename_to_existing(std::string const& test_path)
 			destination_content.data(), static_cast<std::streamsize>(destination_content.size()));
 
 	storage_error se;
-	s->rename_file(0_file, new_filename, se);
+	bool done = false;
+	std::string renamed_to;
+	file_index_t renamed_index{-1};
+	disk_io->async_rename_file(storage,
+		0_file,
+		new_filename,
+		[&](std::string const& name, file_index_t const index, storage_error const& error) {
+			renamed_to = name;
+			renamed_index = index;
+			se = error;
+			done = true;
+		});
+	disk_io->submit_jobs();
+	run_until(ios, done);
 
 	TEST_CHECK(se.ec == boost::system::errc::file_exists);
 	TEST_CHECK(se.operation == operation_t::file_rename);
 	TEST_EQUAL(static_cast<int>(se.file()), 0);
-	TEST_EQUAL(s->names().file_path(0_file), original_filename);
+	TEST_EQUAL(renamed_to, new_filename);
+	TEST_EQUAL(renamed_index, 0_file);
 
 	std::vector<char> content;
 	TEST_EQUAL(load_file(source_path, content, ec), 0);
@@ -589,6 +616,8 @@ void test_rename_to_existing(std::string const& test_path)
 	TEST_EQUAL(load_file(destination_path, content, ec), 0);
 	TEST_CHECK(!ec);
 	TEST_EQUAL(std::string(content.begin(), content.end()), destination_content);
+
+	disk_io->abort(true);
 }
 
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
@@ -988,21 +1017,9 @@ TORRENT_TEST(remove_posix_disk_io)
 
 TORRENT_TEST(rename_pread_disk_io) { test_rename<pread_storage>(current_working_directory()); }
 
-#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
-TORRENT_TEST(rename_to_existing_mmap_disk_io)
+TORRENT_TEST_DISK_IO(rename_to_existing)
 {
-	test_rename_to_existing<mmap_storage>(current_working_directory());
-}
-#endif
-
-TORRENT_TEST(rename_to_existing_posix_disk_io)
-{
-	test_rename_to_existing<posix_storage>(current_working_directory());
-}
-
-TORRENT_TEST(rename_to_existing_pread_disk_io)
-{
-	test_rename_to_existing<pread_storage>(current_working_directory());
+	test_rename_to_existing(current_working_directory(), disk_io);
 }
 
 TORRENT_TEST(remove_pread_disk_io)


### PR DESCRIPTION
Match mmap and posix storage behavior by rejecting pread renames when the destination already exists.
Add regression coverage that verifies the error contract and preserves both files.