### PR TITLE
fix pread pre-allocation after priority changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.1.2 not released
 
+	* fix pre-allocation after enabling files with pread disk I/O
 	* fix race between stop torrent and hasher threads in pread_storage
 	* prevent pread disk I/O from overwriting files when renaming
 	* fix file priority updates being lost when issued in quick succession

--- a/src/pread_storage.cpp
+++ b/src/pread_storage.cpp
@@ -30,6 +30,7 @@ see LICENSE file.
 #include "libtorrent/aux_/stat_cache.hpp"
 #include "libtorrent/aux_/readwrite.hpp"
 #include "libtorrent/hex.hpp" // to_hex
+#include "libtorrent/aux_/scope_end.hpp"
 
 #include <sys/types.h>
 
@@ -123,15 +124,23 @@ namespace libtorrent::aux {
 
 			download_priority_t const old_prio = m_file_priority[i];
 			download_priority_t new_prio = prio[i];
+
+			m_file_priority[i] = new_prio;
+
+			// in case there's an error, we make sure m_file_priority is only
+			// updated for the successful files. By leaving failed files as
+			// priority 0, we allow re-trying them.
+			auto restore_prio = aux::scope_end([&] {
+				m_file_priority[i] = old_prio;
+				prio = m_file_priority;
+			});
+
 			if (old_prio == dont_download && new_prio != dont_download)
 			{
 				// move stuff out of the part file
 				auto f = open_file(sett, i, open_mode::write, ec);
 				if (ec)
-				{
-					prio = m_file_priority;
 					return;
-				}
 				TORRENT_ASSERT(f);
 
 				if (m_part_file && use_partfile(i))
@@ -153,7 +162,6 @@ namespace libtorrent::aux {
 						{
 							ec.file(i);
 							ec.operation = operation_t::partfile_write;
-							prio = m_file_priority;
 							return;
 						}
 					}
@@ -178,13 +186,12 @@ namespace libtorrent::aux {
 				{
 					ec.file(i);
 					ec.operation = operation_t::file_stat;
-					prio = m_file_priority;
 					return;
 				}
 				use_partfile(i, !file_exists);
 			}
 			ec.ec.clear();
-			m_file_priority[i] = new_prio;
+			restore_prio.disarm();
 
 			if (m_file_priority[i] == dont_download && use_partfile(i))
 			{

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -985,7 +985,9 @@ TORRENT_TEST_DISK_IO(check_files_allocate) { test_check_files_all_threads(zero_p
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(test_pre_allocate_mmap) { test_pre_allocate<mmap_storage>(); }
 #endif
+#ifndef TORRENT_WINDOWS
 TORRENT_TEST(test_pre_allocate_pread) { test_pre_allocate<pread_storage>(); }
+#endif
 
 // posix_storage is meant to only use the most portable API for disk I/O, and so
 // doesn't support pre-allocating files

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -982,6 +982,7 @@ TORRENT_TEST_DISK_IO(check_files_allocate) { test_check_files_all_threads(zero_p
 
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(test_pre_allocate_mmap) { test_pre_allocate<mmap_storage>(); }
+TORRENT_TEST(test_pre_allocate_pread) { test_pre_allocate<pread_storage>(); }
 #endif
 
 // posix_storage is meant to only use the most portable API for disk I/O, and so

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -48,6 +48,10 @@ see LICENSE file.
 #include <fstream>
 #include <iostream>
 
+#ifndef TORRENT_WINDOWS
+#include <sys/stat.h>
+#endif
+
 using namespace std::placeholders;
 using namespace lt;
 
@@ -620,7 +624,6 @@ void test_rename_to_existing(
 	disk_io->abort(true);
 }
 
-#if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 namespace {
 std::int64_t file_size_on_disk(std::string const& path)
 {
@@ -753,7 +756,6 @@ void test_pre_allocate()
 		}
 	}
 }
-#endif // TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 
 using lt::operator""_bit;
 using check_files_flag_t = lt::flags::bitfield_flag<std::uint64_t, struct check_files_flag_type_tag>;
@@ -982,8 +984,8 @@ TORRENT_TEST_DISK_IO(check_files_allocate) { test_check_files_all_threads(zero_p
 
 #if TORRENT_HAVE_MMAP || TORRENT_HAVE_MAP_VIEW_OF_FILE
 TORRENT_TEST(test_pre_allocate_mmap) { test_pre_allocate<mmap_storage>(); }
-TORRENT_TEST(test_pre_allocate_pread) { test_pre_allocate<pread_storage>(); }
 #endif
+TORRENT_TEST(test_pre_allocate_pread) { test_pre_allocate<pread_storage>(); }
 
 // posix_storage is meant to only use the most portable API for disk I/O, and so
 // doesn't support pre-allocating files


### PR DESCRIPTION
Update pread storage priorities before opening newly enabled files so storage_mode_allocate is honored, restoring them on failure.
Reuse the existing pre-allocation test for pread storage, including mmap-disabled builds.