### PR TITLE
clamp prefix length in build_netmask to avoid out of bounds write

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -536,8 +536,13 @@ int _System __libsocket_sysctl(int* mib, u_int namelen, void *oldp, size_t *oldl
 
 	void build_netmask_impl(span<unsigned char> mask, int prefix_bits)
 	{
-		TORRENT_ASSERT(prefix_bits <= mask.size() * 8);
 		TORRENT_ASSERT(prefix_bits >= 0);
+		// a prefix length that doesn't fit the address would run the fill loop
+		// below past the end of mask. the netlink prefix fields feeding this are
+		// a single byte, so an out of range value can arrive from a malformed
+		// message. cap it to a full mask, the same way the Windows path already
+		// bounds the prefix length.
+		prefix_bits = std::min(prefix_bits, int(mask.size()) * 8);
 		int i = 0;
 		while (prefix_bits >= 8)
 		{

--- a/test/test_enum_net.cpp
+++ b/test/test_enum_net.cpp
@@ -103,6 +103,11 @@ TORRENT_TEST(build_netmask_v4)
 	TEST_CHECK(build_netmask(30, AF_INET) == make_address("255.255.255.252"));
 	TEST_CHECK(build_netmask(31, AF_INET) == make_address("255.255.255.254"));
 	TEST_CHECK(build_netmask(32, AF_INET) == make_address("255.255.255.255"));
+
+	// a prefix length that exceeds the address size is clamped to a full mask
+	// rather than writing past the end of the mask buffer
+	TEST_CHECK(build_netmask(33, AF_INET)  == make_address("255.255.255.255"));
+	TEST_CHECK(build_netmask(255, AF_INET) == make_address("255.255.255.255"));
 }
 
 TORRENT_TEST(build_netmask_v6)
@@ -130,6 +135,11 @@ TORRENT_TEST(build_netmask_v6)
 	TEST_CHECK(build_netmask(126, AF_INET6) == make_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc"));
 	TEST_CHECK(build_netmask(127, AF_INET6) == make_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"));
 	TEST_CHECK(build_netmask(128, AF_INET6) == make_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+
+	// a prefix length that exceeds the address size is clamped to a full mask
+	// rather than writing past the end of the mask buffer
+	TEST_CHECK(build_netmask(129, AF_INET6) == make_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+	TEST_CHECK(build_netmask(255, AF_INET6) == make_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
 }
 
 TORRENT_TEST(build_netmask_unknown)


### PR DESCRIPTION
build_netmask writes the prefix into a fixed 4 or 16 byte stack array, and the length is only guarded by a TORRENT_ASSERT that disappears in release builds, so a prefix longer than the address (for example an out of range ifa_prefixlen or rtm_dst_len byte from a malformed netlink message) runs the fill loop past the end of the array. The Windows path already caps the prefix length before building the mask, so I moved the same clamp into build_netmask_impl where every caller passes through it. Valid prefixes build the identical mask as before, and I added the out of range cases to the existing build_netmask tests.