### PR TITLE
avoid unnecessary string copies in function parameters

### DIFF
--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -1618,7 +1618,7 @@ void write_handler(torrent_info const& ti,
 	disk.submit_jobs();
 }
 
-void generate_data(std::string const path, torrent_info const& ti)
+void generate_data(std::string const& path, torrent_info const& ti)
 {
 	io_context ios;
 	counters stats_counters;

--- a/examples/custom_storage.cpp
+++ b/examples/custom_storage.cpp
@@ -216,7 +216,7 @@ struct temp_disk_io final : lt::disk_interface
 
 	void async_rename_file(lt::storage_index_t
 		, lt::file_index_t const idx
-		, std::string const name
+		, std::string const& name
 		, std::function<void(std::string const&, lt::file_index_t, lt::storage_error const&)> handler) override
 	{
 		post(m_ioc, [=]{ handler(name, idx, lt::storage_error()); });

--- a/include/libtorrent/aux_/tracker_manager.hpp
+++ b/include/libtorrent/aux_/tracker_manager.hpp
@@ -291,7 +291,7 @@ using tracker_request_flags_t = flags::bitfield_flag<std::uint8_t, struct tracke
 
 	protected:
 
-		void fail_impl(error_code const& ec, operation_t op, std::string msg = std::string()
+		void fail_impl(error_code const& ec, operation_t op, std::string const& msg = std::string()
 			, seconds32 interval = seconds32(0), seconds32 min_interval = seconds32(0));
 
 		tracker_request m_req;

--- a/include/libtorrent/disk_interface.hpp
+++ b/include/libtorrent/disk_interface.hpp
@@ -302,7 +302,7 @@ namespace file_open_mode {
 		// potentially outstanding operations against the file (such as read,
 		// write, move, etc.).
 		virtual void async_rename_file(storage_index_t storage
-			, file_index_t index, std::string name
+			, file_index_t index, std::string const& name
 			, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) = 0;
 
 		// This function is called when some file(s) on disk have been requested

--- a/simulation/disk_io.cpp
+++ b/simulation/disk_io.cpp
@@ -615,7 +615,7 @@ struct test_disk_io final : lt::disk_interface
 
 	void async_rename_file(lt::storage_index_t
 		, lt::file_index_t const idx
-		, std::string const name
+		, std::string const& name
 		, std::function<void(std::string const&, lt::file_index_t, lt::storage_error const&)> handler) override
 	{
 		TORRENT_ASSERT(m_files);

--- a/src/disabled_disk_io.cpp
+++ b/src/disabled_disk_io.cpp
@@ -119,7 +119,7 @@ struct TORRENT_EXTRA_EXPORT disabled_disk_io final
 	}
 
 	void async_rename_file(storage_index_t
-		, file_index_t index, std::string name
+		, file_index_t index, std::string const& name
 		, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) override
 	{
 		post(m_ios, [h = std::move(handler), index, n = std::move(name)] () mutable

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -541,7 +541,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 		return permissions;
 	}
 
-	int open_file(std::string const filename, open_mode_t const mode)
+	int open_file(std::string const& filename, open_mode_t const mode)
 	{
 		int ret = ::open(filename.c_str(), file_flags(mode), file_perms(mode));
 

--- a/src/mmap_disk_io.cpp
+++ b/src/mmap_disk_io.cpp
@@ -117,7 +117,7 @@ struct TORRENT_EXTRA_EXPORT mmap_disk_io final
 		, add_torrent_params const* resume_data
 		, aux::vector<std::string, file_index_t> links
 		, std::function<void(status_t, storage_error const&)> handler) override;
-	void async_rename_file(storage_index_t storage, file_index_t index, std::string name
+	void async_rename_file(storage_index_t storage, file_index_t index, std::string const& name
 		, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) override;
 	void async_stop_torrent(storage_index_t storage
 		, std::function<void()> handler) override;
@@ -797,7 +797,7 @@ TORRENT_EXPORT std::unique_ptr<disk_interface> mmap_disk_io_constructor(
 	}
 
 	void mmap_disk_io::async_rename_file(storage_index_t const storage
-		, file_index_t const index, std::string name
+		, file_index_t const index, std::string const& name
 		, std::function<void(std::string const&, file_index_t, storage_error const&)> handler)
 	{
 		aux::mmap_disk_job* j = m_job_pool.allocate_job<aux::job::rename_file>(

--- a/src/posix_disk_io.cpp
+++ b/src/posix_disk_io.cpp
@@ -315,7 +315,7 @@ namespace {
 
 		void async_rename_file(storage_index_t const storage
 			, file_index_t const idx
-			, std::string name
+			, std::string const& name
 			, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) override
 		{
 			posix_storage* st = m_torrents[storage].get();

--- a/src/pread_disk_io.cpp
+++ b/src/pread_disk_io.cpp
@@ -139,7 +139,7 @@ struct TORRENT_EXTRA_EXPORT pread_disk_io final
 		, add_torrent_params const* resume_data
 		, aux::vector<std::string, file_index_t> links
 		, std::function<void(status_t, storage_error const&)> handler) override;
-	void async_rename_file(storage_index_t storage, file_index_t index, std::string name
+	void async_rename_file(storage_index_t storage, file_index_t index, std::string const& name
 		, std::function<void(std::string const&, file_index_t, storage_error const&)> handler) override;
 	void async_stop_torrent(storage_index_t storage
 		, std::function<void()> handler) override;
@@ -1052,7 +1052,7 @@ void pread_disk_io::async_check_files(storage_index_t const storage
 }
 
 void pread_disk_io::async_rename_file(storage_index_t const storage
-	, file_index_t const index, std::string name
+	, file_index_t const index, std::string const& name
 	, std::function<void(std::string const&, file_index_t, storage_error const&)> handler)
 {
 	aux::pread_disk_job* j = m_job_pool.allocate_job<aux::job::rename_file>(

--- a/src/tracker_manager.cpp
+++ b/src/tracker_manager.cpp
@@ -148,7 +148,7 @@ namespace libtorrent::aux {
 	}
 
 	void tracker_connection::fail_impl(error_code const& ec, operation_t const op
-		, std::string const msg, seconds32 const interval, seconds32 const min_interval)
+		, std::string const& msg, seconds32 const interval, seconds32 const min_interval)
 	{
 		// fail() only posts this call, so m_req is not necessarily still
 		// pending by the time it runs: the connection's own logic may have


### PR DESCRIPTION
Change std::string parameters to std::string const& in a few functions where the string is only read.