### PR TITLE
more UPnP SSRF

### DIFF
--- a/.claude/rules/protocol-encryption.md
+++ b/.claude/rules/protocol-encryption.md
@@ -93,6 +93,16 @@ spec). `key = 2^random % prime`.
 - `get_secret()` -- shared secret S
 - `get_hash_xor_mask()` -- `hash('req3', S)` for SKEY obfuscation
 
+The local secret exponent is generated with `aux::random_bytes()` (a
+non-cryptographic PRNG), not `aux::crypto_random_bytes()`. This is
+deliberate, not an oversight: MSE is DPI obfuscation, unauthenticated and
+trivially defeated by an active man-in-the-middle, and RC4 is not a secure
+cipher by modern standards -- so a stronger PRNG here would not change what
+MSE actually protects against. Do not report this as a vulnerability without
+also proposing hardening the rest of the handshake (authentication, a modern
+cipher); a PRNG swap alone would not meaningfully change the security
+posture.
+
 ### RC4 Key Derivation
 
 For outgoing connections (client):

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2.2.0 not released
 
+	* reject invalid controlURL from UPnP router
 	* deprecate file_storage::file_absolute_path()
 	* avoid copying file path strings out of the info-section
 	* drop backwards compatibility for resolving symlinks relative to their own directory

--- a/Makefile
+++ b/Makefile
@@ -1181,13 +1181,13 @@ MUTABLE_TEST_TORRENTS = \
   test3_pad_files.torrent
 
 TEST_EXTRA = Jamfile \
-  Jamfile                    \
   CMakeLists.txt             \
   $(addprefix test_torrents/,${TEST_TORRENTS}) \
   $(addprefix mutable_test_torrents/,${MUTABLE_TEST_TORRENTS}) \
   root1.xml                          \
   root2.xml                          \
   root3.xml                          \
+  root_bad_control_url.xml           \
   ssl/regenerate_test_certificate.sh \
   ssl/dhparams.pem                   \
   ssl/invalid_peer_certificate.pem   \
@@ -1207,10 +1207,7 @@ TEST_EXTRA = Jamfile \
   web_server.py \
   websocket_server.py \
   socks.py \
-  http_proxy.py \
-  root1.xml \
-  root2.xml \
-  root3.xml
+  http_proxy.py
 
 dist: FORCE
 	(cd docs; make)

--- a/include/libtorrent/aux_/parse_url.hpp
+++ b/include/libtorrent/aux_/parse_url.hpp
@@ -15,6 +15,7 @@ see LICENSE file.
 
 #include <tuple>
 #include <string>
+#include <initializer_list>
 
 #include "libtorrent/string_view.hpp"
 #include "libtorrent/error_code.hpp"
@@ -40,6 +41,13 @@ namespace libtorrent::aux {
 	// arguments are "info_hash", "port", "key", "event", "uploaded",
 	// "downloaded", "left" or "corrupt".
 	TORRENT_EXTRA_EXPORT bool has_tracker_query_string(string_view query_string);
+
+	// returns true if url contains no control characters or space (which
+	// would allow HTTP header/CRLF injection), starts with one of
+	// allowed_schemes (each including the trailing "://", e.g. "http://"),
+	// and parses successfully via parse_url_components()
+	TORRENT_EXTRA_EXPORT bool is_valid_url(
+		string_view url, std::initializer_list<string_view> allowed_schemes);
 
 	// returns true if the url is a valid tracker url (http, https, udp, ws, wss)
 	TORRENT_EXTRA_EXPORT bool is_valid_tracker_url(string_view url);

--- a/include/libtorrent/aux_/pe_crypto.hpp
+++ b/include/libtorrent/aux_/pe_crypto.hpp
@@ -57,6 +57,17 @@ namespace libtorrent::aux {
 	};
 
 	// TODO: 3 dh_key_exchange should probably move into its own file
+
+	// Diffie-Hellman key exchange for BitTorrent Message Stream Encryption
+	// (MSE/PE, see BEP unofficial spec). MSE is deep-packet-inspection
+	// obfuscation, not a confidentiality guarantee against a targeted
+	// adversary: it has no authentication, so it is trivially defeated by an
+	// active man-in-the-middle, and RC4 is not a secure cipher by modern
+	// standards. Accordingly the local secret exponent is deliberately
+	// generated with aux::random_bytes() (a fast, non-cryptographic PRNG)
+	// rather than aux::crypto_random_bytes(): a stronger PRNG would not
+	// change what MSE actually protects against, and there is no plan to
+	// harden this into a real cryptographic channel.
 	class TORRENT_EXTRA_EXPORT dh_key_exchange
 	{
 	public:

--- a/include/libtorrent/settings_pack.hpp
+++ b/include/libtorrent/settings_pack.hpp
@@ -999,6 +999,14 @@ namespace aux {
 			// tracker request to loopback will be rejected. This applies to
 			// trackers that redirect to loopback as well.
 			//
+			// HTTP(S) tracker requests to a link-local address (including
+			// cloud provider instance metadata endpoints) are always
+			// rejected, since no legitimate tracker is deployed there. This
+			// applies to trackers that redirect to a link-local address as
+			// well. Trackers on the rest of the local network (private IP
+			// address ranges) are not restricted, to support self-hosted
+			// trackers on a LAN.
+			//
 			// Web seeds that end up on the client's local network (i.e. in a
 			// private IP address range) may not include query string arguments.
 			// This applies to web seeds redirecting to the local network as

--- a/src/http_tracker_connection.cpp
+++ b/src/http_tracker_connection.cpp
@@ -39,6 +39,7 @@ see LICENSE file.
 #include "libtorrent/ip_filter.hpp"
 #include "libtorrent/aux_/parse_url.hpp"
 #include "libtorrent/aux_/array.hpp"
+#include "libtorrent/aux_/ip_helpers.hpp"
 
 namespace libtorrent::aux {
 
@@ -50,18 +51,25 @@ namespace libtorrent::aux {
 			return len >= 0 && len % entry_size == 0;
 		}
 
-		// SSRF mitigation: an announce/scrape to a loopback address must look
-		// like a standard BitTorrent announce (the /announce path prefix) --
-		// otherwise a tracker URL (or a follower coalescing onto an
-		// already-connected loopback address with a different path, e.g. a
-		// scrape) could be used to make arbitrary requests against services
-		// running on localhost. Used both by on_filter() (the initial,
+		// SSRF mitigation. Only call this when ssrf_mitigation is enabled.
+		// link-local addresses (which includes cloud provider instance
+		// metadata endpoints such as 169.254.169.254) are never a
+		// legitimate tracker target and are unconditionally blocked. A
+		// loopback address is only blocked if the request doesn't look
+		// like a standard BitTorrent announce (the /announce path prefix)
+		// -- this allows local test trackers, while still preventing a
+		// tracker URL (or a follower coalescing onto an already-connected
+		// loopback address with a different path, e.g. a scrape) from
+		// being used to make arbitrary requests against services running
+		// on localhost. Used both by on_filter() (the initial,
 		// per-endpoint-list check at resolve time) and send_request() (a
 		// per-dispatch check, since followers reusing a connection never
 		// go through on_filter() again).
-		bool ssrf_blocks(bool const ssrf_mitigation, address const& addr, string_view const path)
+		bool ssrf_blocks(address const& addr, string_view const path)
 		{
-			return ssrf_mitigation && aux::is_loopback(addr) && path.substr(0, 9) != "/announce";
+			if (aux::is_link_local(addr))
+				return true;
+			return aux::is_loopback(addr) && path.substr(0, 9) != "/announce";
 		}
 	}
 
@@ -124,7 +132,7 @@ namespace libtorrent::aux {
 			error_code ec;
 			std::tie(std::ignore, std::ignore, std::ignore, std::ignore, path) =
 				parse_url_components(url, ec);
-			if (!ec && ssrf_blocks(ssrf_mitigation, m_tracker_ip, path))
+			if (!ec && ssrf_blocks(m_tracker_ip, path))
 			{
 				fail(errors::ssrf_mitigation, operation_t::bittorrent);
 				return;
@@ -578,9 +586,8 @@ namespace libtorrent::aux {
 		auto const ls = bind_socket();
 		if (ls.get() != nullptr)
 		{
-			endpoints.erase(std::remove_if(endpoints.begin(), endpoints.end()
-				, [&](tcp::endpoint const& ep) { return !ls.can_route(ep.address()); })
-				, endpoints.end());
+			std::erase_if(
+				endpoints, [&](tcp::endpoint const& ep) { return !ls.can_route(ep.address()); });
 		}
 
 		if (endpoints.empty())
@@ -594,12 +601,15 @@ namespace libtorrent::aux {
 		if (ssrf_mitigation
 			&& std::find_if(endpoints.begin(),
 				   endpoints.end(),
-				   [](tcp::endpoint const& ep) { return aux::is_loopback(ep.address()); })
+				   [](tcp::endpoint const& ep) {
+					   return aux::is_link_local(ep.address()) || aux::is_loopback(ep.address());
+				   })
 				!= endpoints.end())
 		{
-			// there is at least one loopback address in here. Parse the path
-			// once and remove any endpoint ssrf_blocks() rejects for it (see
-			// that function for the actual mitigation logic).
+			// there is at least one link-local or loopback address in here.
+			// Parse the path once and remove any endpoint that's rejected by
+			// ssrf_blocks() (see that function for the actual mitigation
+			// logic).
 			std::string path;
 
 			error_code ec;
@@ -611,12 +621,8 @@ namespace libtorrent::aux {
 				return;
 			}
 
-			endpoints.erase(std::remove_if(endpoints.begin(),
-								endpoints.end(),
-								[&](tcp::endpoint const& ep) {
-									return ssrf_blocks(ssrf_mitigation, ep.address(), path);
-								}),
-				endpoints.end());
+			std::erase_if(endpoints,
+				[&](tcp::endpoint const& ep) { return ssrf_blocks(ep.address(), path); });
 
 			if (endpoints.empty())
 			{

--- a/src/parse_url.cpp
+++ b/src/parse_url.cpp
@@ -240,7 +240,8 @@ exit:
 			&& std::get<2>(oa) == std::get<2>(ob);
 	}
 
-	bool is_valid_tracker_url(string_view const url)
+	bool is_valid_url(
+		string_view const url, std::initializer_list<string_view> const allowed_schemes)
 	{
 		if (url.empty())
 		{
@@ -255,18 +256,26 @@ exit:
 			if (uc <= 0x20 || uc == 0x7f) return false;
 		}
 
-		if (!string_begins_no_case("http://", url) && !string_begins_no_case("https://", url)
-#if TORRENT_USE_RTC
-			&& !string_begins_no_case("wss://", url) && !string_begins_no_case("ws://", url)
-#endif
-			&& !string_begins_no_case("udp://", url))
-		{
+		bool const scheme_ok = std::any_of(allowed_schemes.begin(),
+			allowed_schemes.end(),
+			[url](string_view const scheme) { return string_begins_no_case(scheme, url); });
+		if (!scheme_ok)
 			return false;
-		}
 
 		error_code ec;
 		parse_url_components(url, ec);
 		return !ec;
 	}
 
+	bool is_valid_tracker_url(string_view const url)
+	{
+		return is_valid_url(url,
+			{"http://"_sv,
+				"https://"_sv,
+#if TORRENT_USE_RTC
+				"ws://"_sv,
+				"wss://"_sv,
+#endif
+				"udp://"_sv});
+	}
 }

--- a/src/pe_crypto.cpp
+++ b/src/pe_crypto.cpp
@@ -142,6 +142,8 @@ namespace libtorrent::aux {
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
 	{
+		// intentionally a non-cryptographic PRNG, see the class comment in
+		// pe_crypto.hpp
 		aux::array<std::uint8_t, 20> random_key;
 		aux::random_bytes({reinterpret_cast<char*>(random_key.data()),
 			static_cast<std::ptrdiff_t>(random_key.size())});
@@ -244,6 +246,8 @@ namespace libtorrent::aux {
 	// Set the prime P and the generator, generate local public key
 	dh_key_exchange::dh_key_exchange()
 	{
+		// intentionally a non-cryptographic PRNG, see the class comment in
+		// pe_crypto.hpp
 		aux::array<std::uint8_t, 20> random_key;
 		aux::random_bytes({reinterpret_cast<char*>(random_key.data())
 			, static_cast<std::ptrdiff_t>(random_key.size())});

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -1111,6 +1111,24 @@ void upnp::on_upnp_xml(error_code const& e
 			+ to_string(d.port).data() + s.control_url;
 	}
 
+	// reject outright rather than sanitize: control_url is untrusted and
+	// later formatted verbatim into a raw HTTP request (see post()), so any
+	// stray characters risk header/request splicing. Unlike tracker URLs,
+	// UPnP control is always HTTP(S) SOAP, so ws(s):// and udp:// are invalid.
+	if (!aux::is_valid_url(d.control_url, {"http://"_sv, "https://"_sv}))
+	{
+#ifndef TORRENT_DISABLE_LOGGING
+		if (should_log())
+		{
+			log("rejecting invalid control URL '%s' in response from %s",
+				d.control_url.c_str(),
+				d.url.c_str());
+		}
+#endif
+		disable_device(d, errors::http_parse_error);
+		return;
+	}
+
 #ifndef TORRENT_DISABLE_LOGGING
 	if (should_log())
 	{

--- a/test/root_bad_control_url.xml
+++ b/test/root_bad_control_url.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+	<specVersion>
+		<major>1</major>
+		<minor>0</minor>
+	</specVersion>
+
+
+	<device>
+
+		<deviceType>urn:schemas-upnp-org:device:InternetGatewayDevice:1</deviceType>
+		<presentationURL>/</presentationURL>
+		<friendlyName>Xtreme N GIGABIT Router</friendlyName>
+		<manufacturer>D-Link Systems</manufacturer>
+		<manufacturerURL>http://www.dlink.com</manufacturerURL>
+		<modelDescription>Xtreme N GIGABIT Router</modelDescription>
+		<modelName>Xtreme N GIGABIT Router</modelName>
+		<modelNumber>DIR-655</modelNumber>
+		<modelURL>http://www.dlink.com</modelURL>
+		<serialNumber>none</serialNumber>
+		<UDN>uuid:E17FAEB7-CABB-3BCC-9C36-7207D5397C0E</UDN>
+
+
+
+		<UPC>00000-00001</UPC>
+		<serviceList>
+			<service>
+				<serviceType>urn:schemas-upnp-org:service:Layer3Forwarding:1</serviceType>
+
+				<serviceId>urn:upnp-org:serviceId:L3Forwarding1</serviceId>
+				<controlURL>http://192.168.0.1:4444/l3fw</controlURL>
+				<eventSubURL>http://192.168.0.1:9393/l3fw</eventSubURL>
+				<SCPDURL>http://192.168.0.1/l3fw.xml</SCPDURL>
+			</service>
+		</serviceList>
+		<deviceList>
+			<device>
+				<deviceType>urn:schemas-upnp-org:device:WANDevice:1</deviceType>
+
+				<friendlyName>Xtreme N GIGABIT Router</friendlyName>
+				<manufacturer>D-Link Systems</manufacturer>
+				<manufacturerURL>http://www.dlink.com</manufacturerURL>
+				<modelDescription>Xtreme N GIGABIT Router</modelDescription>
+				<modelName>Xtreme N GIGABIT Router</modelName>
+				<modelNumber>DIR-655</modelNumber>
+				<modelURL>http://www.dlink.com</modelURL>
+				<serialNumber>none</serialNumber>
+				<UDN>uuid:EC4A6889-B956-363F-9849-62C053B72D72</UDN>
+
+				<UPC>00000-00001</UPC>
+				<serviceList>
+					<service>
+						<serviceType>urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1</serviceType>
+
+						<serviceId>urn:upnp-org:serviceId:WANCommonIFC1</serviceId>
+						<controlURL>http://192.168.0.1:4444/wcommifc</controlURL>
+						<eventSubURL>http://192.168.0.1:9393/wcommifc</eventSubURL>
+						<SCPDURL>http://192.168.0.1/WANCommonIFC1.xml</SCPDURL>
+					</service>
+				</serviceList>
+				<deviceList>
+					<device>
+						<deviceType>urn:schemas-upnp-org:device:WANConnectionDevice:1</deviceType>
+
+						<friendlyName>Xtreme N GIGABIT Router</friendlyName>
+						<manufacturer>D-Link Systems</manufacturer>
+						<manufacturerURL>http://www.dlink.com</manufacturerURL>
+						<modelDescription>Xtreme N GIGABIT Router</modelDescription>
+						<modelName>Xtreme N GIGABIT Router</modelName>
+						<modelNumber>DIR-655</modelNumber>
+						<modelURL>http://www.dlink.com</modelURL>
+						<serialNumber>none</serialNumber>
+						<UDN>uuid:8843AAB0-7191-39C5-A763-9592A8C5AB32</UDN>
+
+						<UPC>00000-00001</UPC>
+						<serviceList>
+							<service>
+								<serviceType>urn:schemas-upnp-org:service:WANIPConnection:1</serviceType>
+
+								<serviceId>urn:upnp-org:serviceId:WANIPConn1</serviceId>
+								<controlURL>udp://%s:%d/wipconn</controlURL>
+								<eventSubURL>http://192.168.0.1:9393/wipconn</eventSubURL>
+								<SCPDURL>http://192.168.0.1/WANIPConn1.xml</SCPDURL>
+							</service>
+						</serviceList>
+					</device>
+				</deviceList>
+			</device>
+
+
+
+			<device>
+				<deviceType>urn:schemas-wifialliance-org:device:WFADevice:1</deviceType>
+				<presentationURL>/</presentationURL>
+				<friendlyName>WFADevice</friendlyName>
+				<manufacturer>D-Link Systems</manufacturer>
+				<manufacturerURL>http://www.dlink.com</manufacturerURL>
+				<modelDescription>Xtreme N GIGABIT Router</modelDescription>
+				<modelName>Xtreme N GIGABIT Router</modelName>
+				<modelNumber>DIR-655</modelNumber>
+				<modelURL>http://www.dlink.com</modelURL>
+				<serialNumber>none</serialNumber>
+
+                                <UDN>uuid:003F35AE-C81C-3EE7-972E-8AEF712289D5</UDN>
+
+
+
+
+
+
+
+				<UPC>00000-00001</UPC>
+				<serviceList>
+					<service>
+						<serviceType>urn:schemas-wifialliance-org:service:WFAWLANConfig:1</serviceType>
+
+
+
+						<serviceId>urn:wifialliance-org:serviceId:WFAWLANConfig1</serviceId>
+						<controlURL>http://192.168.0.1:8832/wfawc</controlURL>
+						<eventSubURL>http://192.168.0.1:8456/wfawc</eventSubURL>
+						<SCPDURL>http://192.168.0.1/WFAwc.xml</SCPDURL>
+					</service>
+				</serviceList>
+			</device>
+
+
+
+		</deviceList>
+	</device>
+
+
+</root>

--- a/test/test_upnp.cpp
+++ b/test/test_upnp.cpp
@@ -137,34 +137,33 @@ bool wait_for(
 	}
 }
 
-	struct upnp_callback final : aux::portmap_callback
+struct upnp_callback final : aux::portmap_callback
+{
+	void on_port_mapping(port_mapping_t const mapping,
+		address const& ip,
+		int port,
+		portmap_protocol const protocol,
+		error_code const& err,
+		portmap_transport,
+		aux::listen_socket_handle const&) override
 	{
-		void on_port_mapping(port_mapping_t const mapping
-			, address const& ip, int port
-			, portmap_protocol const protocol, error_code const& err
-			, portmap_transport, aux::listen_socket_handle const&) override
-		{
-			callback_info info = {mapping, port, err};
-			callbacks.push_back(info);
-			std::cout << "mapping: " << static_cast<int>(mapping)
-				<< ", port: " << port << ", IP: " << ip
-				<< ", proto: " << static_cast<int>(protocol)
-				<< ", error: \"" << err.message() << "\"\n";
-		}
-	#ifndef TORRENT_DISABLE_LOGGING
-		bool should_log_portmap(portmap_transport) const override
-		{
-			return true;
-		}
+		callback_info info = {mapping, port, err};
+		callbacks.push_back(info);
+		std::cout << "mapping: " << static_cast<int>(mapping) << ", port: " << port
+				  << ", IP: " << ip << ", proto: " << static_cast<int>(protocol) << ", error: \""
+				  << err.message() << "\"\n";
+	}
+#ifndef TORRENT_DISABLE_LOGGING
+	bool should_log_portmap(portmap_transport) const override { return true; }
 
-		void log_portmap(portmap_transport, char const* msg
-			, aux::listen_socket_handle const&) const override
-		{
-			std::cout << "UPnP: " << msg << std::endl;
-			g_log_messages.emplace_back(msg);
-		}
-	#endif
-	};
+	void log_portmap(
+		portmap_transport, char const* msg, aux::listen_socket_handle const&) const override
+	{
+		std::cout << "UPnP: " << msg << std::endl;
+		g_log_messages.emplace_back(msg);
+	}
+#endif
+};
 
 aux::ip_interface pick_upnp_interface()
 {
@@ -408,7 +407,121 @@ void run_upnp_ssrf_test()
 }
 #endif // TORRENT_DISABLE_LOGGING
 
+// runs a device description advertising a malformed control URL (an
+// injection attempt, or an unsupported scheme) for its WANIPConnection
+// service, and verifies upnp.cpp rejects it outright rather than acting on
+// it: no port mapping ever succeeds through that device.
+void run_upnp_reject_test(char const* root_filename)
+{
+	auto const ipf = pick_upnp_interface();
+	g_local_address = ipf.interface_address.to_string();
+
+	g_port = start_web_server();
+
+	std::vector<char> buf;
+	error_code ec;
+	load_file(root_filename, buf, ec);
+	buf.push_back(0);
+
+	FILE* xml_file = fopen("upnp.xml", "w+");
+	if (xml_file == nullptr)
+	{
+		std::printf("failed to open file 'upnp.xml': %s\n", strerror(errno));
+		TEST_CHECK(false);
+		stop_web_server();
+		return;
+	}
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+	std::fprintf(xml_file, &buf[0], g_local_address.c_str(), g_port);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+	fclose(xml_file);
+
+	lt::io_context ios;
+	// its udp::sockets reference ios during teardown, so must precede it here
+	broadcast_socket sock(uep("239.255.255.250", 1900));
+	aux::session_settings sett;
+
+	sock.open([&sock](udp::endpoint const& from,
+				  span<char const> buffer) { incoming_msearch(sock, from, buffer); },
+		ios,
+		ec);
+
+	upnp_callback cb;
+	auto upnp_handler = std::make_shared<upnp>(ios,
+		sett,
+		cb,
+		ipf.interface_address.to_v4(),
+		ipf.netmask.to_v4(),
+		ipf.name,
+		aux::listen_socket_handle());
+	upnp_handler->start();
+
+	if (!wait_for(ios, lt::seconds(5), [&] { return !upnp_handler->router_model().empty(); }))
+	{
+		TEST_ERROR("timed out waiting for router discovery");
+		upnp_handler->close();
+		sock.close();
+		stop_web_server();
+		return;
+	}
+
+	// the device itself is discovered (router_model() is populated from the
+	// device description before the control URL is validated), but its
+	// WANIPConnection control URL is rejected, so no mapping can ever be
+	// requested through it
+	std::cout << "router: " << upnp_handler->router_model() << std::endl;
+
+	auto const mapping1 = upnp_handler->add_mapping(
+		portmap_protocol::tcp, 500, tcp::endpoint(ipf.interface_address.to_v4(), 500), "");
+	TORRENT_UNUSED(mapping1);
+
+#ifndef TORRENT_DISABLE_LOGGING
+	// the malformed control URL must have been rejected. This is checked via
+	// the log rather than the callback/mapping count: on a machine where a
+	// real UPnP router is reachable on the same network, that router also
+	// answers the discovery broadcast and may complete a real mapping of its
+	// own, which would make a callback-count assertion depend on unrelated
+	// network state instead of on this fake device's (rejected) response.
+	auto const rejected = [&] {
+		return std::any_of(g_log_messages.begin(), g_log_messages.end(), [](std::string const& m) {
+			return m.find("rejecting invalid control URL") != std::string::npos
+				&& m.find("udp://") != std::string::npos;
+		});
+	};
+	if (!wait_for(ios, lt::seconds(5), rejected))
+		TEST_ERROR("timed out waiting for the malformed control URL to be rejected");
+#else
+	for (int i = 0; i < 40; ++i)
+	{
+		ios.restart();
+		ios.run_for(lt::milliseconds(100));
+	}
+#endif
+
+	upnp_handler->close();
+	sock.close();
+	stop_web_server();
+
+	callbacks.clear();
+#ifndef TORRENT_DISABLE_LOGGING
+	g_log_messages.clear();
+#endif
+}
+
 } // anonymous namespace
+
+TORRENT_TEST(upnp_invalid_control_url_scheme)
+{
+	// the WANIPConnection controlURL uses udp://, which is meaningless for
+	// UPnP SOAP control requests (always plain HTTP(S)); upnp.cpp must
+	// reject it rather than trying to connect to it
+	run_upnp_reject_test(combine_path("..", "root_bad_control_url.xml").c_str());
+}
 
 TORRENT_TEST(upnp_wipconn)
 {


### PR DESCRIPTION
addresses 3 issues:
1. Makes it clear protocol encryption is obfuscation, and it's OK to use non-cryptographic entropy
2. validates `controlURL` returned from the UPnP router
3. tightens the UPnP SSRF protection with link_local check