### PR TITLE
Handle larger netlink datagrams during interface enumeration

### DIFF
--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -48,6 +48,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <functional>
 #include <cstdlib> // for wcstombscstombs
+#include <cerrno>
+#include <vector>
 
 #include "libtorrent/aux_/disable_warnings_push.hpp"
 
@@ -254,11 +256,21 @@ namespace {
 	int read_nl_sock(int sock, std::uint32_t const seq, std::uint32_t const pid
 		, std::function<void(nlmsghdr const*)> on_msg)
 	{
-		std::array<char, 4096> buf;
+		std::vector<char> buf;
 		for (;;)
 		{
-			int const read_len = int(recv(sock, buf.data(), buf.size(), 0));
+			ssize_t packet_size;
+			do { packet_size = recv(sock, nullptr, 0, MSG_PEEK | MSG_TRUNC); }
+			while (packet_size < 0 && errno == EINTR);
+			if (packet_size < 0) return -1;
+			if (packet_size == 0) { errno = EIO; return -1; }
+			if (packet_size > 1024 * 1024) { errno = EMSGSIZE; return -1; }
+			buf.resize(static_cast<std::size_t>(packet_size));
+			int read_len;
+			do { read_len = int(recv(sock, buf.data(), buf.size(), MSG_TRUNC)); }
+			while (read_len < 0 && errno == EINTR);
 			if (read_len < 0) return -1;
+			if (read_len != packet_size) { errno = EMSGSIZE; return -1; }
 
 			auto const* nl_hdr = reinterpret_cast<nlmsghdr const*>(buf.data());
 			int len = read_len;

--- a/src/enum_net.cpp
+++ b/src/enum_net.cpp
@@ -264,7 +264,7 @@ namespace {
 			while (packet_size < 0 && errno == EINTR);
 			if (packet_size < 0) return -1;
 			if (packet_size == 0) { errno = EIO; return -1; }
-			if (packet_size > 1024 * 1024) { errno = EMSGSIZE; return -1; }
+			if (packet_size > 16 * 1024) { errno = EMSGSIZE; return -1; }
 			buf.resize(static_cast<std::size_t>(packet_size));
 			int read_len;
 			do { read_len = int(recv(sock, buf.data(), buf.size(), MSG_TRUNC)); }


### PR DESCRIPTION
Hello, I have ran into a issue where libtorrent could not bind to a VPN interface by name on an arm64 Linux system with 16 KiB pages. Binding directly to the interface's IP address worked, but binding by interface name did not.

In my tests the fixed 4 KiB buffer in [`read_nl_sock()`](https://github.com/arvidn/libtorrent/blob/207c533f312d5740d9b1eec7b757c084e04ea6bb/src/enum_net.cpp#L254-L264) truncated a larger datagram which caused interface records to be missed. I would like to propose checking the datagram length before reading it, with a 1 MiB allocation cap and checks for interrupted or incomplete reads. This resolved the binding issue in my local build. This was tested with libtorrent 2.0.11.

This seems to be a correctness issue affecting interface-name binding in some environments, with direct IP binding as a workaround.

Would this approach be worth considering?