### PR TITLE
Handle network-path redirects

### DIFF
--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -54,13 +54,15 @@ namespace libtorrent::aux {
 	{
 		if (location.empty()) return referrer;
 
+		bool const network_path = location.size() > 1 && location[0] == '/' && location[1] == '/';
 		error_code ec;
 		using std::ignore;
 		std::tie(ignore, ignore, ignore, ignore, ignore)
 			= parse_url_components(location, ec);
 
 		// if location is a full URL, just return it
-		if (!ec) return location;
+		if (!network_path && !ec)
+			return location;
 
 		// otherwise it's likely to be just the path, or a relative path
 		std::string url = referrer;
@@ -74,7 +76,13 @@ namespace libtorrent::aux {
 		std::size_t const suffix = url.find_first_of("?#", authority_start);
 		std::size_t const path_end = suffix == std::string::npos ? url.size() : suffix;
 
-		if (location[0] == '/')
+		if (network_path)
+		{
+			// a network-path reference preserves only the referrer's scheme
+			url.resize(scheme_end + 1);
+			url += location;
+		}
+		else if (location[0] == '/')
 		{
 			// it's an absolute path. replace the path component of
 			// referrer with location.

--- a/test/test_http_parser.cpp
+++ b/test/test_http_parser.cpp
@@ -558,6 +558,14 @@ TORRENT_TEST(http_parser)
 	TEST_EQUAL(aux::resolve_redirect_location("my-custom-scheme://example.com/a/b", "c/d")
 		, "my-custom-scheme://example.com/a/c/d");
 
+	TEST_EQUAL(
+		aux::resolve_redirect_location("http://example.com/a/b?old=1#old", "//test.com/a://b"),
+		"http://test.com/a://b");
+
+	TEST_EQUAL(aux::resolve_redirect_location(
+				   "my-custom-scheme://example.com/a/b?old=1#old", "//test.com:8080/c?new=1#new"),
+		"my-custom-scheme://test.com:8080/c?new=1#new");
+
 	// query strings and fragments are not part of the path
 
 	TEST_EQUAL(aux::resolve_redirect_location("http://example.com?path=/old", "/new"),


### PR DESCRIPTION
Follow up on #8813 by resolving //host/path redirects against the referrer's scheme.
Add coverage for authority replacement, stale suffix removal, and paths containing ://.