### PR TITLE
remove file_name_view proxy object

### DIFF
--- a/bindings/python/src/file_storage.cpp
+++ b/bindings/python/src/file_storage.cpp
@@ -149,6 +149,8 @@ namespace {
 	std::string file_storage_file_name(file_storage const& fs, file_index_t index)
 	{
 		file_storage_check_index(fs, index);
+		if (fs.pad_file_at(index))
+			return std::string();
 		return std::string(fs.file_name(index));
 	}
 }

--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -2306,7 +2306,7 @@ done:
 
 					bool const complete = file_progress[idx] == fs.file_size(i);
 
-					std::string title{fs.file_name(i)};
+					std::string title = pad_file ? "(pad file)" : std::string(fs.file_name(i));
 					if (!complete)
 					{
 						std::snprintf(str, sizeof(str), " (%.1f%%)", progress / 10.0);

--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -16,7 +16,6 @@ see LICENSE file.
 
 #include <string>
 #include <vector>
-#include <variant>
 #include <optional>
 #include <unordered_map>
 #include <map>
@@ -41,32 +40,6 @@ namespace libtorrent {
 namespace aux {
 	struct path_index_tag;
 	using path_index_t = aux::strong_typedef<std::uint32_t, path_index_tag>;
-
-	// a file's name. For ordinary files this is a view into a string
-	// owned elsewhere, exactly like a string_view. Pad files have no
-	// stored name; one is generated from the pad file's size each time
-	// this is asked for.
-	struct TORRENT_EXPORT file_name_view
-	{
-		file_name_view(string_view name)
-			: m_name(name)
-		{} // NOLINT
-		explicit file_name_view(std::uint64_t pad_size);
-
-		// converting to string_view or std::string is explicit since, for
-		// pad files, the returned string_view may refer to storage owned by
-		// this object; the caller must not outlive it when taking a view
-		explicit operator string_view() const
-		{
-			return std::visit([](auto const& n) { return string_view(n); }, m_name);
-		}
-		explicit operator std::string() const { return std::string(string_view(*this)); }
-		char const* data() const { return string_view(*this).data(); }
-		std::size_t size() const { return string_view(*this).size(); }
-
-	private:
-		std::variant<string_view, std::string> m_name;
-	};
 
 	// internal
 	// a single path-component node in file_storage's path tree. Both
@@ -144,8 +117,8 @@ namespace aux {
 		// index into file_storage::m_path_elements. For ordinary files this
 		// is the leaf element (its own text is the filename; walk ::parent
 		// for the rest of the path). For pad files this is the parent
-		// *directory* element instead: pad files never store a name, it's
-		// synthesized from ::size on demand, see file_storage::file_name()
+		// *directory* element instead: pad files never store a name, one
+		// is synthesized from ::size on demand, see file_storage::file_path()
 		path_index_t path_element_index = path_element::torrent_root;
 
 		// a symlink never has a v2 merkle root (it carries no payload of
@@ -573,7 +546,12 @@ public:
 		//
 		// ``file_name()`` returns *just* the name of the file, whereas
 		// ``file_path()`` returns the path (inside the torrent file) with
-		// the filename appended.
+		// the filename appended. Pad files have no stored name;
+		// ``file_name()`` returns an empty string for them (calling it on
+		// a pad file is a precondition failure as of
+		// TORRENT_ABI_VERSION 5). Use ``file_path()``, which synthesizes a
+		// name from the pad file's size, if a display name is needed for
+		// one.
 		//
 		// ``symlink()`` returns the path the file at ``index`` is a symlink
 		// to. If the file is not a symlink, the returned string is empty.
@@ -586,7 +564,7 @@ public:
 		std::string symlink(file_index_t index) const;
 		std::time_t mtime(file_index_t index) const;
 		std::string file_path(file_index_t index, std::string const& save_path = "") const;
-		aux::file_name_view file_name(file_index_t index) const;
+		string_view file_name(file_index_t index) const;
 		std::int64_t file_size(file_index_t index) const;
 		bool pad_file_at(file_index_t index) const;
 		std::int64_t file_offset(file_index_t index) const;
@@ -917,11 +895,12 @@ namespace aux {
 		// honoring any rename recorded in this object.
 		// ``file_path()`` returns the full on-disk path (prepending
 		// ``save_path`` to relative paths). ``file_name()`` returns
-		// just the leaf filename. ``file_absolute_path()`` returns
-		// true if the recorded rename is an absolute path (in which
-		// case ``save_path`` is ignored).
+		// just the leaf filename (pad files cannot be renamed, so this
+		// defers to ``fs.file_name()`` for them, empty string and all).
+		// ``file_absolute_path()`` returns true if the recorded rename is
+		// an absolute path (in which case ``save_path`` is ignored).
 		std::string file_path(file_storage const& fs, file_index_t index, std::string const& save_path = "") const;
-		aux::file_name_view file_name(file_storage const& fs, file_index_t index) const;
+		string_view file_name(file_storage const& fs, file_index_t index) const;
 		bool file_absolute_path(file_storage const& fs, file_index_t index) const;
 
 		// records that the file at ``index`` in ``fs`` should be

--- a/include/libtorrent/fwd.hpp
+++ b/include/libtorrent/fwd.hpp
@@ -182,7 +182,6 @@ struct peer_plugin;
 struct crypto_plugin;
 
 // include/libtorrent/file_storage.hpp
-struct file_name_view;
 struct file_slice;
 TORRENT_VERSION_NAMESPACE_4
 class file_storage;

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -319,11 +319,16 @@ TORRENT_VERSION_NAMESPACE_4_END
 		return ret;
 	}
 
-	aux::file_name_view renamed_files::file_name(
-		file_storage const& fs, file_index_t const index) const
+	string_view renamed_files::file_name(file_storage const& fs, file_index_t const index) const
 	{
 		auto i = m_renamed_files.find(index);
-		if (i == m_renamed_files.end()) return fs.file_name(index);
+		if (i == m_renamed_files.end())
+		{
+			// pad files cannot be renamed and have no stored name
+			if (fs.pad_file_at(index))
+				return {};
+			return fs.file_name(index);
+		}
 
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < fs.end_file());
 		aux::rename_entry const& re = i->second;
@@ -418,10 +423,6 @@ TORRENT_VERSION_NAMESPACE_4_END
 	}
 
 namespace aux {
-
-file_name_view::file_name_view(std::uint64_t const pad_size)
-	: m_name(std::to_string(pad_size))
-{}
 
 path_element::path_element(path_element const& pe)
 	: parent(pe.parent)
@@ -533,7 +534,7 @@ void file_storage::rename_file_impl(
 	char const* file_storage::file_name_ptr(file_index_t const index) const
 	{
 		// pad files have no stored name, it's generated from their size on
-		// demand, see file_name()
+		// demand, see file_path()
 		if (m_files[index].pad_file)
 			return nullptr;
 		return path_element_name(m_path_elements[m_files[index].path_element_index]).data();
@@ -1302,13 +1303,18 @@ namespace {
 		return ret;
 	}
 
-	aux::file_name_view file_storage::file_name(file_index_t const index) const
+	string_view file_storage::file_name(file_index_t const index) const
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t(0) && index < end_file());
 		aux::file_entry const& fe = m_files[index];
+#if TORRENT_ABI_VERSION >= 5
+		// pad files have no stored name; synthesize one from file_path()
+		// (which prefixes it with the .pad directory) if you need one
+		TORRENT_ASSERT_PRECOND(!fe.pad_file);
+#endif
 		if (fe.pad_file)
-			return aux::file_name_view(fe.size);
-		return {path_element_name(m_path_elements[fe.path_element_index])};
+			return {};
+		return path_element_name(m_path_elements[fe.path_element_index]);
 	}
 
 	std::int64_t file_storage::file_size(file_index_t const index) const

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -2311,8 +2311,8 @@ TORRENT_VERSION_NAMESPACE_4
 	{
 		for (auto const i : m_files.file_range())
 		{
-			// pad files don't store a name, it's generated from their size
-			// on demand, none of the checks below apply to them
+			// pad files don't store a name, calling file_name() on one is
+			// a precondition failure; none of the checks below apply to them
 			if (m_files.pad_file_at(i))
 				continue;
 
@@ -2326,7 +2326,7 @@ TORRENT_VERSION_NAMESPACE_4
 			else
 			{
 				// name must be a null terminated string
-				aux::file_name_view const name = m_files.file_name(i);
+				string_view const name = m_files.file_name(i);
 				TORRENT_ASSERT(name.data()[name.size()] == '\0');
 			}
 		}

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -166,8 +166,8 @@ TORRENT_TEST(rename_file_absolute)
 
 TORRENT_TEST(rename_pad_file)
 {
-	// pad files cannot be renamed, their name is always synthesized from
-	// their size
+	// pad files cannot be renamed, and have no stored name of their own;
+	// file_path() synthesizes one from their size, file_name() does not
 	file_storage st;
 	st.set_piece_length(0x4000);
 	st.add_file_borrow({}, combine_path("test", "a"), 10000);
@@ -184,7 +184,7 @@ TORRENT_TEST(rename_pad_file)
 
 	// the rename had no effect
 	TEST_EQUAL(st.file_path(file_index_t{1}, ""), pad_path);
-	TEST_EQUAL(std::string(st.file_name(file_index_t{1})), "6384");
+	TEST_EQUAL(std::string(st.file_name(file_index_t{1})), "");
 }
 #endif
 

--- a/test/test_resolve_links.cpp
+++ b/test/test_resolve_links.cpp
@@ -111,10 +111,9 @@ TORRENT_TEST(resolve_links)
 			for (file_index_t idx{0}; idx != links.end_index(); ++idx)
 			{
 				TORRENT_ASSERT(idx < file_index_t{fs.num_files()});
-				std::printf("%*s --> %s\n"
-					, int(fs.file_name(idx).size())
-					, fs.file_name(idx).data()
-					, links[idx].c_str());
+				std::string const name =
+					fs.pad_file_at(idx) ? "(pad file)" : std::string(fs.file_name(idx));
+				std::printf("%*s --> %s\n", int(name.size()), name.data(), links[idx].c_str());
 			}
 		}
 


### PR DESCRIPTION
make file_name() not support padfiles.

I think it was a mistake to introduce the proxy object.