### PR TITLE
Format max_metadata_size calculation

### DIFF
--- a/src/settings_pack.cpp
+++ b/src/settings_pack.cpp
@@ -327,7 +327,7 @@ namespace {
 		SET(listen_queue_size, 5, nullptr),
 		SET(torrent_connect_boost, 30, nullptr),
 		SET(alert_queue_size, 2000, &session_impl::update_alert_queue_size),
-		SET(max_metadata_size, 3 * 1024 * 10240, nullptr),
+		SET(max_metadata_size, 30 * 1024 * 1024, nullptr),
 		SET(hashing_threads, 1, &session_impl::update_disk_threads),
 		SET(checking_mem_usage, 256, nullptr),
 		SET(predictive_piece_announce, 0, nullptr),


### PR DESCRIPTION
The max_metadata_size setting has been 30MiB since commit 7351389ce8ae (July 2014) changed it from 3MiB, possibly unintentionally. This formats the calculation in the usual way to make the result clearer.