### PR TITLE
the block hashes in merkle_tree have two meanings, either it's the ha…

### DIFF
--- a/include/libtorrent/aux_/merkle.hpp
+++ b/include/libtorrent/aux_/merkle.hpp
@@ -123,9 +123,10 @@ namespace libtorrent {
 	// The root R is expected to be known and set in target_tree.
 	// if we're inserting the hash N, the uncle hashes provide proof of it being
 	// valid by containing 0, 1 and two (as marked in the tree above)
-	// Any non-zero hash encountered in target_tree is assumed to be valid, and
-	// will terminate the validation early, either successful (if there's a
-	// match) or unsuccessful (if there's a mismatch).
+	// Any non-zero hash encountered above target_node_idx is assumed valid
+	// and ends the walk, successfully on a match, unsuccessfully otherwise.
+	// target_node_idx may already match "node" without its sibling being
+	// proven yet; a non-empty uncle_hashes is still walked to establish that.
 	TORRENT_EXTRA_EXPORT
 	bool merkle_validate_and_insert_proofs(span<sha256_hash> target_tree
 		, int target_node_idx, sha256_hash const& node, span<sha256_hash const> uncle_hashes);

--- a/src/merkle.cpp
+++ b/src/merkle.cpp
@@ -326,15 +326,23 @@ namespace libtorrent {
 		if (node.is_all_zeros())
 			return false;
 
-		if (target_tree[target_node_idx] == node)
-			return true;
+		// a proof for the root is meaningless, there's nothing above it to
+		// anchor into. callers are expected to never request one
+		TORRENT_ASSERT(target_node_idx != 0 || uncle_hashes.empty());
 
-		if (!target_tree[target_node_idx].is_all_zeros())
+		bool const target_matches = target_tree[target_node_idx] == node;
+
+		if (!target_matches && !target_tree[target_node_idx].is_all_zeros())
 			return false;
 
+		// with no proof, a match against the existing tree is all there is
+		// to go on; there's no sibling information to walk or miss.
 		if (uncle_hashes.empty())
-			return false;
+			return target_matches;
 
+		// a leaf can already match "node" while its sibling remains
+		// unproven; walk the proof regardless, since that's the only way
+		// to validate it.
 		int cursor = target_node_idx;
 		target_tree[cursor] = node;
 
@@ -393,18 +401,24 @@ namespace libtorrent {
 		// we get here if we never reached a known hash in the tree, i.e. the
 		// uncle_hashes failed to prove the specified node hash.
 		// we now need to clear up the hashes we inserted while walking up.
+		// target_node_idx itself is only ours to clear if target_matches was
+		// false, i.e. we're the ones who wrote it; every other slot visited
+		// here was necessarily written by this call, since the walk only
+		// ever advances into slots it already confirmed were all-zero.
 		int clear_cursor = target_node_idx;
 		int undo_iter = 0;
 		while (clear_cursor > cursor)
 		{
 			int const proof_idx = merkle_get_sibling(clear_cursor);
-			target_tree[clear_cursor].clear();
+			if (clear_cursor != target_node_idx || !target_matches)
+				target_tree[clear_cursor].clear();
 			if (wrote_sibling & (std::uint32_t(1) << undo_iter))
 				target_tree[proof_idx].clear();
 			clear_cursor = merkle_get_parent(clear_cursor);
 			++undo_iter;
 		}
-		target_tree[cursor].clear();
+		if (cursor != target_node_idx || !target_matches)
+			target_tree[cursor].clear();
 		return false;
 	}
 

--- a/src/merkle_tree.cpp
+++ b/src/merkle_tree.cpp
@@ -373,13 +373,54 @@ namespace {
 		// is valid.
 		int const insert_root_idx = dest_start_idx >> base_num_layers;
 
+		// first fill in the subtree of known hashes from the base layer
+		auto const num_leafs = merkle_num_leafs(m_num_blocks);
+		auto const first_leaf = merkle_first_leaf(num_leafs);
+
 		// start with validating the proofs, and inserting them as we go.
 		if (!merkle_validate_and_insert_proofs(m_tree, insert_root_idx, tree[0], uncle_hashes))
 			return {};
 
-		// first fill in the subtree of known hashes from the base layer
-		auto const num_leafs = merkle_num_leafs(m_num_blocks);
-		auto const first_leaf = merkle_first_leaf(num_leafs);
+		// if insert_root_idx is a leaf, the walk above may have just
+		// populated its sibling leaf too (the first uncle hash), which the
+		// main loop below won't see since it only walks "hashes". A
+		// successful return means anything touched is proven correct. With
+		// no uncle hashes there was no walk, so the sibling wasn't touched
+		// and nothing was learned about it.
+		if (!uncle_hashes.empty()
+			&& insert_root_idx >= first_leaf && insert_root_idx - first_leaf < m_num_blocks)
+		{
+			// insert_root_idx == 0 only happens for a single-block tree, where
+			// the root is the leaf itself and has no sibling. callers (e.g.
+			// hash_picker) are expected to reject such requests before they
+			// reach here.
+			TORRENT_ASSERT(insert_root_idx > 0);
+			int const sibling_idx = merkle_get_sibling(insert_root_idx);
+			int const sibling_block = sibling_idx - first_leaf;
+			if (sibling_block >= 0 && sibling_block < m_num_blocks)
+			{
+				// merkle_validate_and_insert_proofs() only returns true once
+				// it has hashed this sibling together with insert_root_idx
+				// into a proven ancestor, so m_tree[sibling_idx] is
+				// necessarily non-zero here.
+				TORRENT_ASSERT(!m_tree[sibling_idx].is_all_zeros());
+				bool const already_verified = m_block_verified.get_bit(sibling_block);
+				m_block_verified.set_bit(sibling_block);
+
+				// when a piece is a single block, a verified block is a
+				// verified piece. Otherwise, the piece can only pass once all
+				// of its blocks are known, which is handled below. Only
+				// report it the first time it becomes verified, since a
+				// later call may re-learn the same sibling hash via a
+				// different proof.
+				if (m_blocks_per_piece_log == 0 && !already_verified)
+				{
+					auto const piece = piece_index_t{sibling_block} + file_piece_offset;
+					if (ret.passed.empty() || ret.passed.back() != piece)
+						ret.passed.push_back(piece);
+				}
+			}
+		}
 
 		// this is the start of the leaf layer of "tree". We'll use this
 		// variable to step upwards towards the root

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -1452,6 +1452,89 @@ TORRENT_TEST(validate_and_insert_proofs_existing_sibling_short_uncles)
 	o, o, o, o,o, f, o, o}));
 }
 
+// covers a pre-existing (not freshly written) target_node_idx match
+TORRENT_TEST(validate_and_insert_proofs_existing_target)
+{
+// full tree:
+//       ah
+//    ad      eh
+//  ab  cd  ef  gh
+// a b c d  e f g h
+
+	v tree(15);
+	tree[0] = ah;
+	tree[11] = e; // pre-existing, matching
+
+	v const proofs{f, gh, ad};
+
+	TEST_CHECK(merkle_validate_and_insert_proofs(tree, 11, e, proofs));
+	TEST_CHECK((tree == v{
+	          ah,
+	     ad,       eh,
+	  o,    o,  ef,   gh,
+	o, o, o, o,e, f, o, o}));
+}
+
+// companion to validate_and_insert_proofs_existing_sibling_walk_failure: a
+// pre-existing target must survive a failed walk just like a pre-existing
+// sibling does, while everything freshly written during the attempt (here,
+// both a sibling and a computed parent) is still cleaned up.
+TORRENT_TEST(validate_and_insert_proofs_existing_target_walk_failure)
+{
+// full tree:
+//       ah
+//    ad      eh
+//  ab  cd  ef  gh
+// a b c d  e f g h
+
+	v tree(15);
+	tree[0] = ah;
+	tree[2] = ad; // wrong "eh" at layer 1, will fail at the parent check
+	tree[11] = e; // pre-existing, matching
+
+	v const proofs{f, gh, ad};
+
+	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, e, proofs));
+
+	// the pre-existing target must survive, along with the pre-existing
+	// (wrong) node that caused the failure; everything this call itself
+	// wrote along the way must be cleaned back up
+	TEST_CHECK((tree == v{
+	          ah,
+	      o,       ad,
+	  o,    o,   o,    o,
+	o, o, o, o,e, o, o, o}));
+}
+
+// same idea, but the contradiction is detected on the very first step (a
+// pre-existing sibling that disagrees with the proof) rather than higher up
+// the walk, so target_node_idx's cleanup never gets to advance past it at
+// all. The pre-existing target, and the pre-existing (wrong) sibling that
+// caused the failure, must both survive untouched.
+TORRENT_TEST(validate_and_insert_proofs_existing_target_immediate_contradiction)
+{
+// full tree:
+//       ah
+//    ad      eh
+//  ab  cd  ef  gh
+// a b c d  e f g h
+
+	v tree(15);
+	tree[0] = ah;
+	tree[11] = e; // pre-existing, matching
+	tree[12] = g; // contradicts the proof (which is f)
+
+	v const proofs{f, gh, ad};
+
+	TEST_CHECK(!merkle_validate_and_insert_proofs(tree, 11, e, proofs));
+
+	TEST_CHECK((tree == v{
+	          ah,
+	      o,        o,
+	  o,    o,   o,    o,
+	o, o, o, o,e, g, o, o}));
+}
+
 // an all-zero hash is the sentinel for "this node is unknown" throughout the
 // tree, so it must never be accepted as a node hash, no matter what proof
 // comes with it

--- a/test/test_merkle_tree.cpp
+++ b/test/test_merkle_tree.cpp
@@ -32,6 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
 #include <iostream>
 
 #include "libtorrent/aux_/merkle.hpp"
@@ -1010,4 +1011,60 @@ TORRENT_TEST(add_hashes_zero_block_hash)
 
 	TEST_CHECK(!result);
 	TEST_CHECK(t.verified_leafs() == none_set(num_blocks));
+}
+
+// a single-leaf (count==1) add_hashes() call for a leaf that a prior
+// set_block() call already gave the correct value must still insert the
+// sibling's hash from the proof's first uncle hash, and mark it verified.
+// The target leaf's own value doesn't change, but the proof is the only
+// place that sibling hash comes from.
+TORRENT_TEST(single_leaf_resubmission_populates_sibling)
+{
+	int const blocks_per_piece = 4;
+	aux::merkle_tree t(num_blocks, blocks_per_piece, f[0].data());
+
+	// downloaded block 0's data and hashed it locally; stored speculatively,
+	// unverified (nothing else is known yet, so this can't be reconciled)
+	auto const set_ret = t.set_block(0, f[511]);
+	TEST_CHECK(std::get<0>(set_ret) == aux::merkle_tree::set_block_result::unknown);
+
+	// a peer now sends us the network-proven hash for that SAME single
+	// block; it matches what we already have, but the sibling's hash
+	// (present as the proof's first uncle hash) is new information
+	int const sibling = merkle_get_sibling(511);
+	auto const result = t.add_hashes(511, pdiff(0), range(f, 511, 1), build_proof(f, 511));
+	TEST_CHECK(result);
+
+	TEST_CHECK(t.has_node(sibling));
+	TEST_CHECK(t[sibling] == f[sibling]);
+	TEST_CHECK(t.blocks_verified(1, 1));
+}
+
+// when there's a single block per piece, verifying the sibling leaf via the
+// proof also verifies its whole piece, so that piece must show up in
+// add_hashes()'s passed list, not just as a set bit in blocks_verified()
+TORRENT_TEST(single_leaf_resubmission_reports_sibling_piece_passed)
+{
+	int const blocks_per_piece = 1;
+	aux::merkle_tree t(num_blocks, blocks_per_piece, f[0].data());
+
+	auto const set_ret = t.set_block(0, f[511]);
+	TEST_CHECK(std::get<0>(set_ret) == aux::merkle_tree::set_block_result::unknown);
+
+	int const sibling = merkle_get_sibling(511);
+	auto const result = t.add_hashes(511, pdiff(0), range(f, 511, 1), build_proof(f, 511));
+	TEST_CHECK(result);
+	if (!result) return;
+
+	TEST_CHECK(t.has_node(sibling));
+	TEST_CHECK(t[sibling] == f[sibling]);
+	TEST_CHECK(t.blocks_verified(1, 1));
+
+	// block 0 (the requested leaf, already known via set_block()) and block 1
+	// (the sibling, populated from the proof) both complete a whole piece
+	TEST_EQUAL(result->passed.size(), 2);
+	TEST_CHECK(std::find(result->passed.begin(), result->passed.end()
+		, 0_piece) != result->passed.end());
+	TEST_CHECK(std::find(result->passed.begin(), result->passed.end()
+		, 1_piece) != result->passed.end());
 }


### PR DESCRIPTION
…sh of the block we've written to disk, or it's the correct hash of the block. when adding a new hash, with proof, an invalid proof must leave the tree in its original form