### PR TITLE
remove malloc_usable_size() and friends from buffer

### DIFF
--- a/include/libtorrent/aux_/buffer.hpp
+++ b/include/libtorrent/aux_/buffer.hpp
@@ -24,21 +24,11 @@ see LICENSE file.
 #include "libtorrent/span.hpp"
 #include "libtorrent/aux_/throw.hpp"
 
-#if defined __GLIBC__
-#include <malloc.h>
-#elif defined _MSC_VER
-#include <malloc.h>
-#elif defined __FreeBSD__
-#include <malloc_np.h>
-#elif defined __APPLE__
-#include <malloc/malloc.h>
-#endif
-
 namespace libtorrent {
 namespace aux {
 
 // the buffer is allocated once and cannot be resized. The size() may be
-// larger than requested, in case the underlying allocator over allocated. In
+// larger than requested, since allocations are rounded up to 8 bytes. In
 // order to "grow" an allocation, create a new buffer and initialize it by
 // the range of bytes from the existing, and move-assign the new over the
 // old.
@@ -55,27 +45,13 @@ public:
 
 		if (size <= 0) return;
 
-		// this rounds up the size to be 8 bytes aligned
-		// it mostly makes sense for platforms without support
-		// for a variation of "malloc_size()"
+		// round up the size to be 8 bytes aligned
 		size = (size + 7) & (~difference_type(0x7));
 
-		// we have to use malloc here, to be compatible with the fancy query
-		// functions below
 		m_begin = static_cast<char*>(std::malloc(static_cast<std::size_t>(size)));
 		if (m_begin == nullptr) aux::throw_ex<std::bad_alloc>();
 
-		// the actual allocation may be larger than we requested. If so, let the
-		// user take advantage of every single byte
-#if (defined __GLIBC__ && !defined __UCLIBC__) || defined __FreeBSD__
-		m_size = static_cast<difference_type>(::malloc_usable_size(m_begin));
-#elif defined _MSC_VER
-		m_size = static_cast<difference_type>(::_msize(m_begin));
-#elif defined __APPLE__
-		m_size = static_cast<difference_type>(::malloc_size(m_begin));
-#else
 		m_size = size;
-#endif
 	}
 
 	// allocate an uninitialized buffer of the specified size


### PR DESCRIPTION
## Summary

`malloc_usable_size()` (and the `_msize()` / `malloc_size()` equivalents on MSVC/Apple) is documented as being for debugging and introspection only, not for relying on in release builds. Arch Linux already patches this call out downstream to be compatible with `-D_FORTIFY_SOURCE=3`, which treats it as a fatal memory violation (see #7519).

`aux::buffer` used it as an optimization to make use of the full allocation after the 8-byte-alignment rounding, with a plain fallback to the requested size on platforms lacking one of these functions. This removes the platform-specific branch entirely and always uses that fallback, along with the now-unused platform headers.

Fixes #8051

## Test plan

- `test_buffer` passes locally (built via CMake, `b2` wasn't available in this environment) — its assertions are all `size() >= N`, so they hold regardless of whether the extra bytes come from the allocator or just alignment.
- Confirmed no other file in `src/`, `include/`, `test/`, or `simulation/` references `malloc_usable_size`, `_msize`, or `malloc_size`.
- Not run locally: `pre-commit` / `git-clang-format-18` (not installed in this environment); checked the diff by hand for whitespace/style (`git diff --check` clean).